### PR TITLE
Add append mode for gopass insert

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -715,6 +715,10 @@ func getCommands(ctx context.Context, action *ap.Action, app *cli.App) []cli.Com
 					Name:  "force, f",
 					Usage: "Overwrite any existing secret and do not prompt to confirm recipients",
 				},
+				cli.BoolFlag{
+					Name:  "append, a",
+					Usage: "Append to any existing data",
+				},
 			},
 		},
 		{

--- a/pkg/action/copy_test.go
+++ b/pkg/action/copy_test.go
@@ -66,8 +66,8 @@ func TestCopy(t *testing.T) {
 	buf.Reset()
 
 	// insert bam/baz
-	assert.NoError(t, act.insertStdin(ctx, "bam/baz", []byte("foobar")))
-	assert.NoError(t, act.insertStdin(ctx, "bam/zab", []byte("barfoo")))
+	assert.NoError(t, act.insertStdin(ctx, "bam/baz", []byte("foobar"), false))
+	assert.NoError(t, act.insertStdin(ctx, "bam/zab", []byte("barfoo"), false))
 
 	// recursive copy: bam -> zab
 	fs = flag.NewFlagSet("default", flag.ContinueOnError)

--- a/pkg/action/hibp_test.go
+++ b/pkg/action/hibp_test.go
@@ -157,7 +157,7 @@ func TestHIBPAPI(t *testing.T) {
 	buf.Reset()
 
 	// add another one
-	assert.NoError(t, act.insertStdin(ctx, "baz", []byte("foobar")))
+	assert.NoError(t, act.insertStdin(ctx, "baz", []byte("foobar"), false))
 	assert.Error(t, act.HIBP(ctx, c))
 	buf.Reset()
 }

--- a/pkg/action/insert_test.go
+++ b/pkg/action/insert_test.go
@@ -50,7 +50,7 @@ func TestInsert(t *testing.T) {
 	assert.NoError(t, act.Insert(ctx, c))
 
 	// insert baz via stdin
-	assert.NoError(t, act.insertStdin(ctx, "baz", []byte("foobar")))
+	assert.NoError(t, act.insertStdin(ctx, "baz", []byte("foobar"), false))
 	buf.Reset()
 
 	assert.NoError(t, act.show(ctx, c, "baz", "", false))


### PR DESCRIPTION
This PR adds the `-a` flag to `gopass insert`. This will turn on the append mode where any content coming from stdin will we append to any existing secret instead of overwriting it.