### PR TITLE
Fix nested yaml structure serialization to json

### DIFF
--- a/pkg/jsonapi/api_test.go
+++ b/pkg/jsonapi/api_test.go
@@ -99,6 +99,12 @@ func TestRespondMessageGetData(t *testing.T) {
 	secrets := []storedSecret{
 		{[]string{"foo"}, secret.New("20", "hallo: welt")},
 		{[]string{"bar"}, secret.New("20", "---\nlogin: muh")},
+		{[]string{"complex"}, secret.New("20", `---
+login: hallo
+number: 42
+sub:
+  subentry: 123
+`)},
 	}
 
 	runRespondMessage(t,
@@ -109,6 +115,10 @@ func TestRespondMessageGetData(t *testing.T) {
 	runRespondMessage(t,
 		`{"type":"getData","entry":"bar"}`,
 		`{"login":"muh"}`,
+		"", secrets)
+	runRespondMessage(t,
+		`{"type":"getData","entry":"complex"}`,
+		`{"login":"hallo","number":42,"sub":{"subentry":123}}`,
 		"", secrets)
 }
 

--- a/pkg/jsonapi/helpers.go
+++ b/pkg/jsonapi/helpers.go
@@ -17,3 +17,25 @@ func isPublicSuffix(host string) bool {
 func regexSafeLower(str string) string {
 	return regexp.QuoteMeta(strings.ToLower(str))
 }
+
+func convertMixedMapInterfaces(i interface{}) interface{} {
+	switch x := i.(type) {
+	case map[string]interface{}:
+		stringMap := map[string]interface{}{}
+		for k, v := range x {
+			stringMap[k] = convertMixedMapInterfaces(v)
+		}
+		return stringMap
+	case map[interface{}]interface{}:
+		stringMap := map[string]interface{}{}
+		for k, v := range x {
+			stringMap[k.(string)] = convertMixedMapInterfaces(v)
+		}
+		return stringMap
+	case []interface{}:
+		for i, v := range x {
+			x[i] = convertMixedMapInterfaces(v)
+		}
+	}
+	return i
+}

--- a/pkg/jsonapi/responses.go
+++ b/pkg/jsonapi/responses.go
@@ -131,7 +131,8 @@ func (api *API) respondGetData(ctx context.Context, msgBytes []byte) error {
 		return errors.Wrapf(err, "failed to get secret")
 	}
 
-	return sendSerializedJSONMessage(sec.Data(), api.Writer)
+	converted := convertMixedMapInterfaces(interface{}(sec.Data()))
+	return sendSerializedJSONMessage(converted, api.Writer)
 }
 
 func (api *API) getUsername(name string, sec store.Secret) string {


### PR DESCRIPTION
Fix issue with nested yaml structs. The top level type is map[string]interface{} while all values are map[interface{}]interface{} (if nested). Test added.