### PR TITLE
Enhance Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,17 @@
 FROM golang:1.10-alpine AS builder
 
-RUN apk add -U make git gnupg
+RUN apk add -U make gcc musl-dev ncurses git
 
 ADD .   /go/src/github.com/gopasspw/gopass
 WORKDIR /go/src/github.com/gopasspw/gopass
 
-RUN make install
+RUN TERM=vt100 make install
 
-RUN chown -R 1000:1000 /go/src/github.com/gopasspw/gopass
-ENV HOME /go/src/github.com/gopasspw/gopass
+FROM alpine:3.7
+RUN apk add -U git gnupg
+COPY --from=0 /go/src/github.com/gopasspw/gopass /usr/bin/
+
+RUN chown -Rh 1000:1000 -- /root
+ENV HOME /root
 USER 1000:1000
-
-CMD [ "/go/src/github.com/gopasspw/gopass/gopass" ]
+ENTRYPOINT [ "/usr/bin/gopass" ]

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -58,6 +58,20 @@ For OpenBSD 6.2 and earlier, install via `go get`.
 Please note that the OpenBSD builds uses `pledge(2)` to disable some syscalls,
 so some features (e.g. version checks, auto-update) are unavailable.
 
+#### Docker
+
+Build it
+
+```
+docker build -t gopass github.com/gopasspw/gopass#master
+```
+
+Use it
+
+```
+alias gopass="docker run --rm -ti -v $HOME:/root gopass"
+```
+
 ### Set up a GPG key pair
 
 gopass depends on the `gpg` program for encryption and decryption. You **must** have a


### PR DESCRIPTION
- Dockerfile can build gopass
- Reduce gopass Docker image by ~588MiB using multi-stage builds

Fixes #867 

---

```
$ alias gopass="docker run --rm -ti -v $HOME:/root gopass"
$ gopass version
gopass 1.8.1 (aaf7422b 2018-06-12 13:24:50) go1.10.3 linux amd64
<root>     -  gpg 2.2.3 - git 2.15.2 -   fs 0.1.0
```