### PR TITLE
Offer secret selection on edit command

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -320,7 +320,7 @@ func getCommands(ctx context.Context, action *ap.Action, app *cli.App) []cli.Com
 		},
 		{
 			Name:  "edit",
-			Usage: "Edit new or existing secret",
+			Usage: "Edit new or existing secrets",
 			Description: "" +
 				"Use this command to insert a new secret or edit an existing one using " +
 				"your $EDITOR. It will attempt to create a secure temporary directory " +
@@ -337,6 +337,10 @@ func getCommands(ctx context.Context, action *ap.Action, app *cli.App) []cli.Com
 				cli.StringFlag{
 					Name:  "editor, e",
 					Usage: "Use this editor binary",
+				},
+				cli.BoolFlag{
+					Name:  "create, c",
+					Usage: "Create a new secret if none found",
 				},
 			},
 		},


### PR DESCRIPTION
This commit adds the secret selection wizard to
the edit command as well. This is triggered in
case no exact match was found. If the user aborts
the wizard then this is handled as if a new secret
was to be created.

Fixes #927 