### PR TITLE
Limit bash completion to current scope

### DIFF
--- a/pkg/action/completion_test.go
+++ b/pkg/action/completion_test.go
@@ -71,3 +71,39 @@ func TestComplete(t *testing.T) {
 	assert.Error(t, act.CompletionOpenBSDKsh(nil, nil))
 	buf.Reset()
 }
+
+func TestFilterCompletionList(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		in     []string
+		needle string
+		out    []string
+	}{
+		{
+			name:   "empty",
+			in:     []string{"foo", "bar", "misc/baz", "misc/zab"},
+			needle: "",
+			out:    []string{"bar", "foo", "misc"},
+		},
+		{
+			name:   "misc/",
+			in:     []string{"foo", "bar", "misc/baz", "misc/zab", "misc/zab/abc"},
+			needle: "misc/",
+			out:    []string{"misc/baz", "misc/zab"},
+		},
+		{
+			name:   "misc",
+			in:     []string{"foo", "bar", "misc/baz", "misc/zab", "misc/zab/abc"},
+			needle: "misc",
+			out:    []string{"misc/"},
+		},
+		{
+			name:   "web",
+			in:     []string{"foo", "bar", "misc/baz", "webmaster/foo", "websites/bar"},
+			needle: "web",
+			out:    []string{"webmaster", "websites"},
+		},
+	} {
+		assert.Equal(t, tc.out, filterCompletionList(tc.in, tc.needle), tc.name)
+	}
+}


### PR DESCRIPTION
This commit limits the bash completion output
to the current scope.

Fixes #926

Signed-off-by: Dominik Schulz <dominik.schulz@gauner.org>