### PR TITLE
Handle already mounted and not initialized errors

### DIFF
--- a/pkg/action/mount.go
+++ b/pkg/action/mount.go
@@ -8,7 +8,9 @@ import (
 	"github.com/gopasspw/gopass/pkg/config"
 	"github.com/gopasspw/gopass/pkg/out"
 	"github.com/gopasspw/gopass/pkg/store"
+	"github.com/gopasspw/gopass/pkg/store/root"
 	"github.com/gopasspw/gopass/pkg/tree/simple"
+	"github.com/pkg/errors"
 
 	"github.com/fatih/color"
 	"github.com/urfave/cli"
@@ -84,7 +86,18 @@ func (s *Action) MountAdd(ctx context.Context, c *cli.Context) error {
 	}
 
 	if err := s.Store.AddMount(ctx, alias, localPath, keys...); err != nil {
-		return ExitError(ctx, ExitMount, err, "failed to add mount '%s' to '%s': %s", alias, localPath, err)
+		switch e := errors.Cause(err).(type) {
+		case root.AlreadyMountedError:
+			out.Print(ctx, "Store is already mounted")
+			return nil
+		case root.NotInitializedError:
+			out.Print(ctx, "Mount %s is not yet initialized. Initializing ...", e.Alias())
+			if err := s.init(ctx, e.Alias(), e.Path()); err != nil {
+				return ExitError(ctx, ExitUnknown, err, "failed to add mount '%s': failed to initialize store: %s", err)
+			}
+		default:
+			return ExitError(ctx, ExitMount, err, "failed to add mount '%s' to '%s': %s", alias, localPath, err)
+		}
 	}
 
 	if err := s.cfg.Save(); err != nil {

--- a/pkg/store/root/errors.go
+++ b/pkg/store/root/errors.go
@@ -1,0 +1,29 @@
+package root
+
+import "fmt"
+
+// AlreadyMountedError is an error that is returned when
+// a store is already mounted on a given mount point
+type AlreadyMountedError string
+
+func (a AlreadyMountedError) Error() string {
+	// important: must pass a as string(a)!
+	return fmt.Sprintf("%s is already mounted", string(a))
+}
+
+// NotInitializedError is an error that is returned when
+// a not initialized store should be mounted
+type NotInitializedError struct {
+	alias string
+	path  string
+}
+
+// Alias returns the store alias this error was generated for
+func (n NotInitializedError) Alias() string { return n.alias }
+
+// Path returns the store path this error was generated for
+func (n NotInitializedError) Path() string { return n.path }
+
+func (n NotInitializedError) Error() string {
+	return fmt.Sprintf("password store %s is not initialized. Try gopass init --store %s --path %s", n.alias, n.alias, n.path)
+}

--- a/pkg/store/root/mount.go
+++ b/pkg/store/root/mount.go
@@ -34,7 +34,7 @@ func (r *Store) addMount(ctx context.Context, alias, path string, sc *config.Sto
 		r.mounts = make(map[string]store.Store, 1)
 	}
 	if _, found := r.mounts[alias]; found {
-		return errors.Errorf("%s is already mounted", alias)
+		return AlreadyMountedError(alias)
 	}
 
 	out.Debug(ctx, "addMount - Path: %s - StoreConfig: %+v", path, sc)
@@ -111,7 +111,7 @@ func (r *Store) initSub(ctx context.Context, sc *config.StoreConfig, alias strin
 
 	out.Debug(ctx, "[%s] Mount %s is not initialized", alias, path)
 	if len(keys) < 1 {
-		return s, errors.Errorf("password store %s is not initialized. Try gopass init --store %s --path %s", alias, alias, path)
+		return s, NotInitializedError{alias, path.String()}
 	}
 	if err := s.Init(ctx, path.String(), keys...); err != nil {
 		return s, errors.Wrapf(err, "failed to initialize store '%s' at '%s'", alias, path)


### PR DESCRIPTION
This commit adds proper handling of already mounted
and not initialized errors during the mounts add command.

Fixes #942

Signed-off-by: Dominik Schulz <dominik.schulz@gauner.org>