### PR TITLE
Add debug log to file fsck

### DIFF
--- a/pkg/backend/storage/fs/fsck.go
+++ b/pkg/backend/storage/fs/fsck.go
@@ -22,6 +22,8 @@ func (s *Store) Fsck(ctx context.Context) error {
 	dirs := make(map[string]struct{}, len(entries))
 	for _, entry := range entries {
 		pcb()
+		out.Debug(ctx, "file.Fsck() - Checking %s", entry)
+
 		filename := filepath.Join(s.path, entry)
 		dirs[filepath.Dir(filename)] = struct{}{}
 


### PR DESCRIPTION
It also counts for .gitattributes and .gpg-id per store

```
$ gopass fsck | grep Fsck
[DEBUG] root.Fsck() - Checking private
[private] [DEBUG] Fsck()
[private] [DEBUG] file.Fsck() - Checking .gitattributes
[private] [DEBUG] file.Fsck() - Checking .gpg-id
...
```

I have the following solutions in mind:

1. assume that there will always be two additional files pre repo, but this then produces the wrong total count
2. overall ignore progress for files since files are checked really quickly compared to the actual gpg operations

I would go for 2. @dominikschulz what do you think? I can append the solution to this pr if desired.