### PR TITLE
Let TravisCI run against latest Go 1.11 release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
   - git config --global user.email foo.bar@example.org
 
 go:
-  - '1.10'
+  - "1.11.1"
 
 script:
   - make travis


### PR DESCRIPTION
Automatically tests against the latest available Go 1.11 release.