### PR TITLE
Rewrite tty() by using C ttyname() instead of "/proc/self/fd/0"

### DIFF
--- a/pkg/backend/crypto/gpg/cli/utils.go
+++ b/pkg/backend/crypto/gpg/cli/utils.go
@@ -7,10 +7,6 @@ import (
 	"time"
 )
 
-var (
-	fd0 = "/proc/self/fd/0"
-)
-
 // parseTS parses the passed string as an Epoch int and returns
 // the time struct or the zero time struct
 func parseTS(str string) time.Time {
@@ -46,15 +42,6 @@ func splitPacket(in string) map[string]string {
 		m[p[i]] = strings.Trim(p[i+1], ",")
 	}
 	return m
-}
-
-// see https://www.gnupg.org/documentation/manuals/gnupg/Invoking-GPG_002dAGENT.html
-func tty() string {
-	dest, err := os.Readlink(fd0)
-	if err != nil {
-		return ""
-	}
-	return dest
 }
 
 // GPGOpts parses extra GPG options from the environment

--- a/pkg/backend/crypto/gpg/cli/utils_others.go
+++ b/pkg/backend/crypto/gpg/cli/utils_others.go
@@ -1,0 +1,15 @@
+// +build !windows
+
+package cli
+
+// #include <unistd.h>
+import "C"
+
+// see https://www.gnupg.org/documentation/manuals/gnupg/Invoking-GPG_002dAGENT.html
+func tty() string {
+	name, err := C.ttyname(C.int(0))
+	if err != nil {
+		return ""
+	}
+	return C.GoString(name)
+}

--- a/pkg/backend/crypto/gpg/cli/utils_test.go
+++ b/pkg/backend/crypto/gpg/cli/utils_test.go
@@ -33,8 +33,3 @@ func TestSplitPacket(t *testing.T) {
 		assert.Equal(t, out, splitPacket(in))
 	}
 }
-
-func TestTTY(t *testing.T) {
-	fd0 = "/tmp/foobar"
-	assert.Equal(t, "", tty())
-}

--- a/pkg/backend/crypto/gpg/cli/utils_windows.go
+++ b/pkg/backend/crypto/gpg/cli/utils_windows.go
@@ -1,0 +1,8 @@
+// +build windows
+
+package cli
+
+func tty() string {
+	// not implemented.
+	return ""
+}


### PR DESCRIPTION
Fixes #895.

I tried to write unit test for this, but failed as stdin is "/dev/null" in `go test`.

Manually tested about `Failed to decrypt` error case on NetBSD 8.0, Linux (Ubuntu 18.04), macOS (Mojave) and worked.