### PR TITLE
jsonapi: return totp in the api response to enable 2FA use in gopassbridge

### DIFF
--- a/pkg/jsonapi/api_test.go
+++ b/pkg/jsonapi/api_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -13,6 +14,7 @@ import (
 
 	"github.com/gopasspw/gopass/pkg/backend"
 	"github.com/gopasspw/gopass/pkg/config"
+	"github.com/gopasspw/gopass/pkg/otp"
 	"github.com/gopasspw/gopass/pkg/store"
 	"github.com/gopasspw/gopass/pkg/store/root"
 	"github.com/gopasspw/gopass/pkg/store/secret"
@@ -106,7 +108,12 @@ func TestRespondMessageQuery(t *testing.T) {
 }
 
 func TestRespondMessageGetData(t *testing.T) {
+	totpSuffix := "//totp/github-fake-account?secret=rpna55555qyho42j"
+	totpURL := "otpauth:" + totpSuffix
+	totpSecret := secret.New("totp_are_cool", totpURL)
+
 	secrets := []storedSecret{
+		{[]string{"totp"}, totpSecret},
 		{[]string{"foo"}, secret.New("20", "hallo: welt")},
 		{[]string{"bar"}, secret.New("20", "---\nlogin: muh")},
 		{[]string{"complex"}, secret.New("20", `---
@@ -116,6 +123,12 @@ sub:
   subentry: 123
 `)},
 	}
+
+	totp, _, err := otp.Calculate(context.Background(), "_", totpSecret)
+	if err != nil {
+		assert.NoError(t, err)
+	}
+	expectedTotp := totp.OTP()
 
 	runRespondMessage(t,
 		`{"type":"getData","entry":"foo"}`,
@@ -129,6 +142,11 @@ sub:
 	runRespondMessage(t,
 		`{"type":"getData","entry":"complex"}`,
 		`{"login":"hallo","number":42,"sub":{"subentry":123}}`,
+		"", secrets)
+
+	runRespondMessage(t,
+		`{"type":"getData","entry":"totp"}`,
+		fmt.Sprintf(`{"current_totp":"%s","otpauth":"(.+)"}`, expectedTotp),
 		"", secrets)
 }
 

--- a/pkg/otp/otp.go
+++ b/pkg/otp/otp.go
@@ -2,6 +2,7 @@ package otp
 
 import (
 	"context"
+	"fmt"
 	"io/ioutil"
 	"strings"
 
@@ -9,6 +10,10 @@ import (
 
 	"github.com/gokyle/twofactor"
 	"github.com/pkg/errors"
+)
+
+var (
+	ErrNoTotpEntry = fmt.Errorf("no totp entry in secret")
 )
 
 // Calculate will compute a OTP code from a given secret
@@ -28,6 +33,9 @@ func Calculate(ctx context.Context, name string, sec store.Secret) (twofactor.OT
 	// check yaml entry and fall back to password if we don't have one
 	label := name
 	secKey, err := sec.Value("totp")
+	if secKey == "" {
+		return nil, label, ErrNoTotpEntry
+	}
 	if err != nil {
 		secKey = sec.Password()
 	}

--- a/pkg/otp/otp.go
+++ b/pkg/otp/otp.go
@@ -13,6 +13,7 @@ import (
 )
 
 var (
+	// ErrNoTotpEntry signals a failed OTP for a secret with OTP information
 	ErrNoTotpEntry = fmt.Errorf("no totp entry in secret")
 )
 


### PR DESCRIPTION
See: https://github.com/gopasspw/gopassbridge/issues/87

This returns the OTP code, if available over the jsonapi.

This is done in a way so as to be minimally invasive: we either return a good totp, or we return the original payload. This has the side effect of swallowing errors, but errors are effectively swallowed in this path anyway due to how `gopassbridge` presents errors.