### PR TITLE
Adding autocompletion of the folders for insert and generate in Zsh

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -780,6 +780,10 @@ func getCommands(ctx context.Context, action *ap.Action, app *cli.App) []cli.Com
 					Usage: "Print flat list",
 				},
 				cli.BoolFlag{
+					Name:  "folders, fo",
+					Usage: "Print flat list of folders",
+				},
+				cli.BoolFlag{
 					Name:  "strip-prefix, s",
 					Usage: "Strip prefix from filtered entries",
 				},

--- a/pkg/action/list_test.go
+++ b/pkg/action/list_test.go
@@ -78,6 +78,30 @@ func TestList(t *testing.T) {
 	assert.Equal(t, want, buf.String())
 	buf.Reset()
 
+	// list --folders
+
+	// add more folders and subfolders
+	assert.NoError(t, act.Store.Set(ctx, "foo/zen/bar", secret.New("123", "")))
+	assert.NoError(t, act.Store.Set(ctx, "foo2/bar2", secret.New("123", "")))
+	buf.Reset()
+
+	fs = flag.NewFlagSet("default", flag.ContinueOnError)
+	bf = cli.BoolFlag{
+		Name:  "folders",
+		Usage: "folders",
+	}
+	assert.NoError(t, bf.ApplyWithError(fs))
+	assert.NoError(t, fs.Parse([]string{"--folders=true"}))
+	c = cli.NewContext(app, fs, nil)
+
+	assert.NoError(t, act.List(ctx, c))
+	want = `foo/
+foo/zen/
+foo2/
+`
+	assert.Equal(t, want, buf.String())
+	buf.Reset()
+
 	// list not-present
 	fs = flag.NewFlagSet("default", flag.ContinueOnError)
 	assert.NoError(t, fs.Parse([]string{"not-present"}))

--- a/pkg/action/list_test.go
+++ b/pkg/action/list_test.go
@@ -95,9 +95,9 @@ func TestList(t *testing.T) {
 	c = cli.NewContext(app, fs, nil)
 
 	assert.NoError(t, act.List(ctx, c))
-	want = `foo/
-foo/zen/
-foo2/
+	want = `foo
+foo/zen
+foo2
 `
 	assert.Equal(t, want, buf.String())
 	buf.Reset()

--- a/pkg/completion/zsh/completion.go
+++ b/pkg/completion/zsh/completion.go
@@ -3,8 +3,8 @@ package zsh
 import (
 	"bytes"
 	"fmt"
-	"text/template"
 	"strings"
+	"text/template"
 
 	"github.com/urfave/cli"
 )

--- a/pkg/completion/zsh/completion.go
+++ b/pkg/completion/zsh/completion.go
@@ -3,7 +3,7 @@ package zsh
 import (
 	"bytes"
 	"fmt"
-	"html/template"
+	"text/template"
 	"strings"
 
 	"github.com/urfave/cli"

--- a/pkg/completion/zsh/template.go
+++ b/pkg/completion/zsh/template.go
@@ -51,7 +51,7 @@ _{{ $prog }}_complete_passwords () {
 }
 
 _{{ $prog }}_complete_folders () {
-    _values 'folders' $({{ $prog }} ls --folders --flat)
+    _values -s '/' 'folders' $({{ $prog }} ls --folders --flat)
 }
 
 _{{ $prog }}`

--- a/pkg/completion/zsh/template.go
+++ b/pkg/completion/zsh/template.go
@@ -21,7 +21,7 @@ _{{ $prog }} () {
               {{- end }}
               {{ if .Flags }}_arguments :{{ range .Flags }} "{{ . | formatFlag }}"{{ end }}{{ end }}
               _describe -t commands "{{ $prog }} {{ .Name }}" subcommands
-              {{ if or (eq .Name "copy") (eq .Name "move") (eq .Name "delete") (eq .Name "show") (eq .Name "edit") }}_{{ $prog }}_complete_passwords{{ end -}}
+              {{ if or (eq .Name "copy") (eq .Name "move") (eq .Name "delete") (eq .Name "show") (eq .Name "edit") }}_{{ $prog }}_complete_passwords{{ else if or (eq .Name "insert") (eq .Name "generate") }}_{{ $prog }}_complete_folders{{ end }}
               ;;
 {{- end }}
           *)
@@ -48,6 +48,10 @@ _{{ $prog }}_complete_passwords () {
     _arguments : \
         "--clip[Copy the first line of the secret into the clipboard]"
     _values 'passwords' $({{ $prog }} ls --flat)
+}
+
+_{{ $prog }}_complete_folders () {
+    _values 'folders' $({{ $prog }} ls --folders --flat)
 }
 
 _{{ $prog }}`

--- a/pkg/tree/simple/folder.go
+++ b/pkg/tree/simple/folder.go
@@ -3,6 +3,7 @@ package simple
 import (
 	"bytes"
 	"path"
+	"sort"
 	"strings"
 
 	"github.com/gopasspw/gopass/pkg/tree"
@@ -34,8 +35,13 @@ func (f *Folder) Len() int {
 func (f *Folder) IsMount() bool { return f.Path != "" }
 
 // List returns a flattened list of all sub nodes
-func (f Folder) List(maxDepth int) []string {
+func (f *Folder) List(maxDepth int) []string {
 	return f.list("", maxDepth, 0)
+}
+
+// List returns a flattened list of all nodes without leaf
+func (f *Folder) ListFolders(maxDepth int) []string {
+	return f.listFolders("", maxDepth, 0)
 }
 
 // Format returns a pretty printed tree
@@ -100,6 +106,32 @@ func (f *Folder) list(prefix string, maxDepth, curDepth int) []string {
 	for _, key := range sortedFiles(f.Files) {
 		out = append(out, path.Join(prefix, f.Files[key].Name))
 	}
+	return out
+}
+
+// list returns a flattened list of all folders with their full path in
+// the tree, e.g. foo foo/bar
+func (f* Folder) listFolders(prefix string, maxDepth, curDepth int) []string {
+	out := make([]string, 0)
+	if maxDepth > 0 && curDepth > maxDepth {
+		return out
+	}
+
+	if !f.Root {
+		if prefix != "" {
+			prefix += sep
+		}
+		prefix += f.Name
+	}
+
+	for _, key := range sortedFolders(f.Folders) {
+		out = append(out, f.Folders[key].listFolders(prefix, maxDepth, curDepth+1)...)
+		// we add the separator since we are listing folders and path.Join removes it
+		out = append(out, path.Join(prefix, f.Folders[key].Name) + sep)
+	}
+
+	sort.Strings(out)
+
 	return out
 }
 

--- a/pkg/tree/simple/folder.go
+++ b/pkg/tree/simple/folder.go
@@ -126,8 +126,8 @@ func (f* Folder) listFolders(prefix string, maxDepth, curDepth int) []string {
 
 	for _, key := range sortedFolders(f.Folders) {
 		out = append(out, f.Folders[key].listFolders(prefix, maxDepth, curDepth+1)...)
-		// we add the separator since we are listing folders and path.Join removes it
-		out = append(out, path.Join(prefix, f.Folders[key].Name) + sep)
+		// we want to also list the base folders, not just the leaves
+		out = append(out, path.Join(prefix, f.Folders[key].Name))
 	}
 
 	sort.Strings(out)

--- a/pkg/tree/simple/folder.go
+++ b/pkg/tree/simple/folder.go
@@ -111,7 +111,7 @@ func (f *Folder) list(prefix string, maxDepth, curDepth int) []string {
 
 // listFolders returns a flattened list of all folders with their full path in
 // the tree, e.g. foo foo/bar
-func (f* Folder) listFolders(prefix string, maxDepth, curDepth int) []string {
+func (f *Folder) listFolders(prefix string, maxDepth, curDepth int) []string {
 	out := make([]string, 0)
 	if maxDepth > 0 && curDepth > maxDepth {
 		return out

--- a/pkg/tree/simple/folder.go
+++ b/pkg/tree/simple/folder.go
@@ -39,7 +39,7 @@ func (f *Folder) List(maxDepth int) []string {
 	return f.list("", maxDepth, 0)
 }
 
-// List returns a flattened list of all nodes without leaf
+// ListFolders returns a flattened list of all nodes without leaf
 func (f *Folder) ListFolders(maxDepth int) []string {
 	return f.listFolders("", maxDepth, 0)
 }
@@ -109,7 +109,7 @@ func (f *Folder) list(prefix string, maxDepth, curDepth int) []string {
 	return out
 }
 
-// list returns a flattened list of all folders with their full path in
+// listFolders returns a flattened list of all folders with their full path in
 // the tree, e.g. foo foo/bar
 func (f* Folder) listFolders(prefix string, maxDepth, curDepth int) []string {
 	out := make([]string, 0)

--- a/pkg/tree/simple/folder_test.go
+++ b/pkg/tree/simple/folder_test.go
@@ -57,21 +57,21 @@ func TestFolder(t *testing.T) {
 	// test folders
 	lst = root.ListFolders(0)
 	wants = []string{
-		"zab/",
-		"zab/foo/",
-		"zab2/",
-		"zab2/foo/",
-		"zab2/foo/zen/",
+		"zab",
+		"zab/foo",
+		"zab2",
+		"zab2/foo",
+		"zab2/foo/zen",
 	}
 	assert.Equal(t, wants, lst)
 
 	// test folders maxDepth = 1
 	lst = root.ListFolders(1)
 	wants = []string{
-		"zab/",
-		"zab/foo/",
-		"zab2/",
-		"zab2/foo/",
+		"zab",
+		"zab/foo",
+		"zab2",
+		"zab2/foo",
 	}
 	assert.Equal(t, wants, lst)
 

--- a/pkg/tree/simple/folder_test.go
+++ b/pkg/tree/simple/folder_test.go
@@ -24,7 +24,7 @@ func TestFolder(t *testing.T) {
 		"foo/baz.b64",
 		"foo/zab.yml",
 	}
-	assert.Equal(t, lst, wants)
+	assert.Equal(t, wants, lst)
 
 	// test name
 	assert.Equal(t, "gopass", root.String())
@@ -38,18 +38,40 @@ func TestFolder(t *testing.T) {
     ├── baz.b64 (binary)
     └── zab.yml (yaml)
 `
-	assert.Equal(t, out, want)
+	assert.Equal(t, want, out)
 
 	// test list 1
 	root = New("gopass")
 	assert.NoError(t, root.AddFile("zab/foozen", "text/plain"))
 	assert.NoError(t, root.AddFile("zab/foo/bar", "text/plain"))
-	assert.NoError(t, root.AddFile("zab/foo/baz", "text/plain"))
+	assert.NoError(t, root.AddFile("zab2/foo/baz", "text/plain"))
+	assert.NoError(t, root.AddFile("zab2/foo/zen/baz", "text/plain"))
 
 	lst = root.List(1)
 	sort.Strings(lst)
 	wants = []string{
 		"zab/foozen",
+	}
+	assert.Equal(t, wants, lst)
+
+	// test folders
+	lst = root.ListFolders(0)
+	wants = []string{
+		"zab/",
+		"zab/foo/",
+		"zab2/",
+		"zab2/foo/",
+		"zab2/foo/zen/",
+	}
+	assert.Equal(t, wants, lst)
+
+	// test folders maxDepth = 1
+	lst = root.ListFolders(1)
+	wants = []string{
+		"zab/",
+		"zab/foo/",
+		"zab2/",
+		"zab2/foo/",
 	}
 	assert.Equal(t, wants, lst)
 

--- a/pkg/tree/tree.go
+++ b/pkg/tree/tree.go
@@ -3,6 +3,7 @@ package tree
 // Tree is tree-like object supporting pretty printing
 type Tree interface {
 	List(int) []string
+	ListFolders(int) []string
 	Format(int) string
 	String() string
 	AddFile(string, string) error

--- a/tests/list_test.go
+++ b/tests/list_test.go
@@ -55,4 +55,4 @@ foo
 	assert.NoError(t, err)
 	assert.Equal(t, strings.TrimSpace(list), out)
 
-	}
+}

--- a/tests/list_test.go
+++ b/tests/list_test.go
@@ -48,8 +48,8 @@ foo
 	assert.NoError(t, err)
 	assert.Equal(t, strings.TrimSpace(list), out)
 
-	list = `fixed/
-foo/
+	list = `fixed
+foo
 `
 	out, err = ts.run("list --folders")
 	assert.NoError(t, err)

--- a/tests/list_test.go
+++ b/tests/list_test.go
@@ -47,4 +47,12 @@ foo
 	out, err = ts.run("list foo")
 	assert.NoError(t, err)
 	assert.Equal(t, strings.TrimSpace(list), out)
-}
+
+	list = `fixed/
+foo/
+`
+	out, err = ts.run("list --folders")
+	assert.NoError(t, err)
+	assert.Equal(t, strings.TrimSpace(list), out)
+
+	}


### PR DESCRIPTION
This PR is adding a `list --folders` flag that allows to print a **flat** list of the all folders in our password store, allowing to easily `insert` or `generate` new secrets in the right folders.

Then, I've changed the Zsh completion to have a `_gopass_complete_folders` function to call when using `insert` or `generate`, that will allow to autocomplete the path to the secret. 
I'm not using bash, so I didn't change it.

The whole comes with tests for the new features, excepted the actual autocompletion using zsh, since it wasn't tested in the first place.

I'm afraid I've also changed a couple details I stumbled upon: using `text/template` in the zsh autocomplete template instead of html (since it's not html we're working on) and correcting the order of the args in a couple tests too.

Notice the flat folder list is sorted using sort, in order to ease the testing. Zsh is already sorting the whole on its own, so it is not required per se.