### PR TITLE
Use tty system command on Unix platforms except for Linux (#895)

### DIFF
--- a/pkg/backend/crypto/gpg/cli/utils.go
+++ b/pkg/backend/crypto/gpg/cli/utils.go
@@ -7,10 +7,6 @@ import (
 	"time"
 )
 
-var (
-	fd0 = "/proc/self/fd/0"
-)
-
 // parseTS parses the passed string as an Epoch int and returns
 // the time struct or the zero time struct
 func parseTS(str string) time.Time {
@@ -46,15 +42,6 @@ func splitPacket(in string) map[string]string {
 		m[p[i]] = strings.Trim(p[i+1], ",")
 	}
 	return m
-}
-
-// see https://www.gnupg.org/documentation/manuals/gnupg/Invoking-GPG_002dAGENT.html
-func tty() string {
-	dest, err := os.Readlink(fd0)
-	if err != nil {
-		return ""
-	}
-	return dest
 }
 
 // GPGOpts parses extra GPG options from the environment

--- a/pkg/backend/crypto/gpg/cli/utils_linux.go
+++ b/pkg/backend/crypto/gpg/cli/utils_linux.go
@@ -1,0 +1,18 @@
+// +build linux
+
+package cli
+
+import "os"
+
+var (
+	fd0 = "/proc/self/fd/0"
+)
+
+// see https://www.gnupg.org/documentation/manuals/gnupg/Invoking-GPG_002dAGENT.html
+func tty() string {
+	dest, err := os.Readlink(fd0)
+	if err != nil {
+		return ""
+	}
+	return dest
+}

--- a/pkg/backend/crypto/gpg/cli/utils_linux_test.go
+++ b/pkg/backend/crypto/gpg/cli/utils_linux_test.go
@@ -1,0 +1,14 @@
+// +build linux
+
+package cli
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTTY(t *testing.T) {
+	fd0 = "/tmp/foobar"
+	assert.Equal(t, "", tty())
+}

--- a/pkg/backend/crypto/gpg/cli/utils_others.go
+++ b/pkg/backend/crypto/gpg/cli/utils_others.go
@@ -1,0 +1,18 @@
+// +build !linux,!windows
+
+package cli
+
+import (
+	"os"
+	"os/exec"
+)
+
+func tty() string {
+	cmd := exec.Command("/usr/bin/tty")
+	cmd.Stdin = os.Stdin
+	out, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	return string(out)
+}

--- a/pkg/backend/crypto/gpg/cli/utils_test.go
+++ b/pkg/backend/crypto/gpg/cli/utils_test.go
@@ -33,8 +33,3 @@ func TestSplitPacket(t *testing.T) {
 		assert.Equal(t, out, splitPacket(in))
 	}
 }
-
-func TestTTY(t *testing.T) {
-	fd0 = "/tmp/foobar"
-	assert.Equal(t, "", tty())
-}

--- a/pkg/backend/crypto/gpg/cli/utils_windows.go
+++ b/pkg/backend/crypto/gpg/cli/utils_windows.go
@@ -1,0 +1,7 @@
+// +build windows
+
+package cli
+
+func tty() string {
+	return ""
+}


### PR DESCRIPTION
Fixes #895

Tested on Linux (Ubuntu Bionic), macOS (Mojave), NetBSD 8.0.