### PR TITLE
[WIP] Try to fix nested bash completion

### DIFF
--- a/pkg/action/completion.go
+++ b/pkg/action/completion.go
@@ -97,8 +97,8 @@ set -A complete_gopass -- $PASS_LIST %s
 func (s *Action) CompletionBash(c *cli.Context) error {
 	out := `_gopass_bash_autocomplete() {
      local cur opts base
-	 COMPREPLY=()
-	 compopt -o nospace
+     COMPREPLY=()
+     compopt -o nospace
      cur="${COMP_WORDS[COMP_CWORD]}"
      opts=$( ${COMP_WORDS[0]} ${cur} --generate-bash-completion )
      local IFS=$'\n'

--- a/pkg/action/completion.go
+++ b/pkg/action/completion.go
@@ -55,7 +55,7 @@ func filterCompletionList(list []string, needle string) []string {
 		}
 		v = strings.TrimPrefix(v, needle)
 		if idx := strings.Index(v, "/"); idx >= 0 {
-			v = v[:idx]
+			v = v[:idx+1]
 		}
 		set[v] = struct{}{}
 	}

--- a/pkg/action/completion.go
+++ b/pkg/action/completion.go
@@ -97,9 +97,10 @@ set -A complete_gopass -- $PASS_LIST %s
 func (s *Action) CompletionBash(c *cli.Context) error {
 	out := `_gopass_bash_autocomplete() {
      local cur opts base
-     COMPREPLY=()
+	 COMPREPLY=()
+	 compopt -o nospace
      cur="${COMP_WORDS[COMP_CWORD]}"
-     opts=$( ${COMP_WORDS[@]:0:$COMP_CWORD} --generate-bash-completion )
+     opts=$( ${COMP_WORDS[0]} ${cur} --generate-bash-completion )
      local IFS=$'\n'
      COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
      return 0

--- a/pkg/action/completion_test.go
+++ b/pkg/action/completion_test.go
@@ -85,13 +85,13 @@ func TestFilterCompletionList(t *testing.T) {
 			name:   "empty",
 			in:     []string{"foo", "bar", "misc/baz", "misc/zab"},
 			needle: "",
-			out:    []string{"bar", "foo", "misc"},
+			out:    []string{"bar", "foo", "misc/"},
 		},
 		{
 			name:   "misc/",
 			in:     []string{"foo", "bar", "misc/baz", "misc/zab", "misc/zab/abc"},
 			needle: "misc/",
-			out:    []string{"misc/baz", "misc/zab"},
+			out:    []string{"misc/baz", "misc/zab", "misc/zab/"},
 		},
 		{
 			name:   "misc",
@@ -103,7 +103,7 @@ func TestFilterCompletionList(t *testing.T) {
 			name:   "web",
 			in:     []string{"foo", "bar", "misc/baz", "webmaster/foo", "websites/bar"},
 			needle: "web",
-			out:    []string{"webmaster", "websites"},
+			out:    []string{"webmaster/", "websites/"},
 		},
 	} {
 		assert.Equal(t, tc.out, filterCompletionList(tc.in, tc.needle), tc.name)

--- a/tests/completion_test.go
+++ b/tests/completion_test.go
@@ -19,8 +19,9 @@ func TestCompletion(t *testing.T) {
 	bash := `_gopass_bash_autocomplete() {
      local cur opts base
      COMPREPLY=()
+     compopt -o nospace
      cur="${COMP_WORDS[COMP_CWORD]}"
-     opts=$( ${COMP_WORDS[@]:0:$COMP_CWORD} --generate-bash-completion )
+     opts=$( ${COMP_WORDS[0]} ${cur} --generate-bash-completion )
      local IFS=$'\n'
      COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
      return 0


### PR DESCRIPTION
Note: This is work in progress trying to fix #963, but it does not work perfectly.

Nested bash completion is broken by https://github.com/gopasspw/gopass/commit/af794f63fe66e959f9ec30121e4d1bc3a90239d0:

```
# git checkout af794f63fe66e959f9ec30121e4d1bc3a90239d0
Previous HEAD position was 2415d23 Use valid crypto backend for key selection (#889)
HEAD is now at af794f6 Limit bash completion to current scope (#930)
# go install
# gopass show websites[TAB] websites/[TAB] websites/[TAB] websites/[TAB] websites/[TAB] ^C
```
```
# git checkout af794f63fe66e959f9ec30121e4d1bc3a90239d0~
Previous HEAD position was af794f6 Limit bash completion to current scope (#930)
HEAD is now at 4c05308 Update setup documentation. Add macOS related commands. (#924)
# go install
# gopass show websites/[TAB][TAB]
websites/accounts.xxxx.xxxx/xxxx@xxxx.com      websites/xxxx.io/xxxx@xxxx.com                  websites/xxxx.xxxx.fr/xxxx@xxxx.org
websites/xxxx.com/xxxx@xxxx.org        websites/xxxx.xxxx.org/xxxx                    
```

Reverting this commit on top of master@v1.8.3 works fine.

However it breaks https://github.com/gopasspw/gopass/issues/926 for which it was done.

This PR tries to preserve the benefit from that change but right now it makes it less than optimal:

```
# gopass w[TAB]ebsites/[TAB]
websites/accounts.xxxx.xxxx/xxxx@xxxx.com      websites/xxxx.io/xxxx@xxxx.com                  websites/xxxx.xxxx.fr/xxxx@xxxx.org
websites/xxxx.com/xxxx@xxxx.org        websites/xxxx.xxxx.org/xxxx
```

But then spaces needed to be added manually after completion of single matches, e.g.:

```
# gopass sh[TAB]ow
```