### PR TITLE
This reverts regression of OTP in 1.8.3

### DIFF
--- a/pkg/jsonapi/responses.go
+++ b/pkg/jsonapi/responses.go
@@ -139,8 +139,6 @@ func (api *API) respondGetData(ctx context.Context, msgBytes []byte) error {
 	currentTotp, _, err := otp.Calculate(ctx, "_", sec)
 	if err == nil {
 		responseData["current_totp"] = currentTotp.OTP()
-	} else if err != otp.ErrNoTotpEntry {
-		responseData["current_totp"] = "failed to retrieve: " + err.Error()
 	}
 
 	converted := convertMixedMapInterfaces(interface{}(responseData))

--- a/pkg/otp/otp.go
+++ b/pkg/otp/otp.go
@@ -2,7 +2,6 @@ package otp
 
 import (
 	"context"
-	"fmt"
 	"io/ioutil"
 	"strings"
 
@@ -10,11 +9,6 @@ import (
 
 	"github.com/gokyle/twofactor"
 	"github.com/pkg/errors"
-)
-
-var (
-	// ErrNoTotpEntry signals a failed OTP for a secret with OTP information
-	ErrNoTotpEntry = fmt.Errorf("no totp entry in secret")
 )
 
 // Calculate will compute a OTP code from a given secret
@@ -34,11 +28,9 @@ func Calculate(ctx context.Context, name string, sec store.Secret) (twofactor.OT
 	// check yaml entry and fall back to password if we don't have one
 	label := name
 	secKey, err := sec.Value("totp")
+
 	if err != nil {
 		secKey = sec.Password()
-	}
-	if secKey == "" {
-		return nil, label, ErrNoTotpEntry
 	}
 
 	if strings.HasPrefix(secKey, "otpauth://") {

--- a/pkg/otp/otp.go
+++ b/pkg/otp/otp.go
@@ -34,9 +34,9 @@ func Calculate(ctx context.Context, name string, sec store.Secret) (twofactor.OT
 	// check yaml entry and fall back to password if we don't have one
 	label := name
 	secKey, err := sec.Value("totp")
-	if secKey == "" {
+	/*if secKey == "" {
 		return nil, label, ErrNoTotpEntry
-	}
+	}*/
 	if err != nil {
 		secKey = sec.Password()
 	}

--- a/pkg/otp/otp.go
+++ b/pkg/otp/otp.go
@@ -34,11 +34,11 @@ func Calculate(ctx context.Context, name string, sec store.Secret) (twofactor.OT
 	// check yaml entry and fall back to password if we don't have one
 	label := name
 	secKey, err := sec.Value("totp")
-	/*if secKey == "" {
-		return nil, label, ErrNoTotpEntry
-	}*/
 	if err != nil {
 		secKey = sec.Password()
+	}
+	if secKey == "" {
+		return nil, label, ErrNoTotpEntry
 	}
 
 	if strings.HasPrefix(secKey, "otpauth://") {


### PR DESCRIPTION
This is my first attempt at contributing. Sorry if it is not made following standard.

It is also my 1st github project contribution.

This proposal is only tring to make 1.8.3 works again with TOTP tokens in password format : `otpauth://totp/...`

Those lines broke that in version 1.8.3.

Feel free to correct, as I am also a total newb in golang.