### PR TITLE
otp: add tests

### DIFF
--- a/pkg/otp/otp_test.go
+++ b/pkg/otp/otp_test.go
@@ -1,0 +1,34 @@
+package otp
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/gopasspw/gopass/pkg/store/secret"
+	"github.com/stretchr/testify/assert"
+)
+
+const pw string = "password"
+const totpSecret string = "GJWTGMTNN5YWW2TNPJXWG2DHMIFA===="
+const totpURL string = "otpauth://totp/example-otp.com?secret=2m32moqkjmzochgb&issuer=authenticator&digits=6"
+
+func TestCalculate(t *testing.T) {
+	testCases := []struct {
+		password       string
+		secretContents string
+	}{
+		{totpSecret, ""},
+		{pw, fmt.Sprintf("---\ntotp:%s", totpSecret)},
+		{pw, fmt.Sprintf("---\ntotp: %s", totpSecret)},
+		{pw, totpURL},
+		{pw, fmt.Sprintf("---\n%s", totpURL)},
+	}
+
+	for _, tc := range testCases {
+		s := secret.New(tc.password, tc.secretContents)
+		otp, _, err := Calculate(context.Background(), "test", s)
+		assert.Nil(t, err)
+		assert.NotNil(t, otp)
+	}
+}


### PR DESCRIPTION
Add tests for OTP functionality. Attempt to prevent future regressions like being discussed in https://github.com/gopasspw/gopass/pull/1006.

Note, this won't pass until one of the proposed fixes is merged:

```
--- FAIL: TestCalculate (0.00s)
    otp_test.go:21: 
        	Error Trace:	otp_test.go:21
        	            				otp_test.go:26
        	Error:      	Expected nil, but got: &errors.errorString{s:"no totp entry in secret"}
        	Test:       	TestCalculate
    otp_test.go:22: 
        	Error Trace:	otp_test.go:22
        	            				otp_test.go:26
        	Error:      	Expected value not to be nil.
        	Test:       	TestCalculate
FAIL
FAIL	github.com/gopasspw/gopass/pkg/otp	0.002s
```

Note, a case that I expected to work is not working. It's not listed in the docs, but I was still a bit surprised:

```go
 	check(t, pw, fmt.Sprintf("totp:%s", totpSecret)) 
 	check(t, pw, fmt.Sprintf("totp: %s", totpSecret)) 
```