### PR TITLE
Update plegde call on OpenBSD.

### DIFF
--- a/pkg/protect/protect_openbsd.go
+++ b/pkg/protect/protect_openbsd.go
@@ -10,5 +10,5 @@ var ProtectEnabled = true
 // Pledge on OpenBSD lets us "promise" to only run a subset of
 // system calls: http://man.openbsd.org/pledge
 func Pledge(s string) error {
-	return unix.Pledge(s, "")
+	return unix.PledgePromises(s)
 }


### PR DESCRIPTION
Without this gpg will be killed on OpenBSD every time it is called.