### PR TITLE
Skip empty binary name to be searched on Windows (#993)

### DIFF
--- a/pkg/backend/crypto/gpg/cli/gpg_windows.go
+++ b/pkg/backend/crypto/gpg/cli/gpg_windows.go
@@ -37,6 +37,9 @@ func searchRegistry(bin string, bins []string) ([]string, error) {
 
 	if v, _, err := k.GetStringValue("Install Directory"); err == nil && v != "" {
 		for _, b := range []string{bin, "gpg2.exe", "gpg.exe"} {
+			if b == "" {
+				continue
+			}
 			gpgPath := filepath.Join(v, "bin", b)
 			if fsutil.IsFile(gpgPath) {
 				bins = append(bins, gpgPath)
@@ -50,6 +53,9 @@ func searchRegistry(bin string, bins []string) ([]string, error) {
 func searchPath(bin string, bins []string) ([]string, error) {
 	// try to detect location for GPG installed somewhere on the PATH
 	for _, b := range []string{bin, "gpg2.exe", "gpg.exe"} {
+		if b == "" {
+			continue
+		}
 		gpgPath, err := exec.LookPath(b)
 		if err != nil {
 			continue


### PR DESCRIPTION
Without the change, if PATH environment variable contains a component
where the component name + ".exe" exists, the exe is used as well as gpg.

I'm not sure `bin` is ever non empty though.