### PR TITLE
JSONAPI messages for clipboard copy and login subkeys added

### DIFF
--- a/pkg/jsonapi/messages.go
+++ b/pkg/jsonapi/messages.go
@@ -25,9 +25,15 @@ type getLoginMessage struct {
 	Entry string `json:"entry"`
 }
 
+type copyToClipboard struct {
+	Entry string `json:"entry"`
+	Key   string `json:"key"`
+}
+
 type loginResponse struct {
-	Username string `json:"username"`
-	Password string `json:"password"`
+	Username    string                 `json:"username"`
+	Password    string                 `json:"password"`
+	LoginFields map[string]interface{} `json:"login_fields,omitempty"`
 }
 
 type getDataMessage struct {
@@ -48,6 +54,10 @@ type createEntryMessage struct {
 	PasswordLength int    `json:"length"`
 	Generate       bool   `json:"generate"`
 	UseSymbols     bool   `json:"use_symbols"`
+}
+
+type statusResponse struct {
+	Status string `json:"status"`
 }
 
 type errorResponse struct {


### PR DESCRIPTION
Adds jsonapi message for copying an entry or yaml value of a key to clipboard. Will be used by https://github.com/gopasspw/gopassbridge/issues/49

Extends jsonapi login response with `login_fields`, listed in yaml. Will be used by https://github.com/gopasspw/gopassbridge/issues/34