### PR TITLE
Follow the rsync convention for the source directory in cp/mv commands

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -263,8 +263,10 @@ func getCommands(ctx context.Context, action *ap.Action, app *cli.App) []cli.Com
 			Usage:   "Copy secrets from one location to another",
 			Description: "" +
 				"This command copies an existing secret in the store to another location. " +
-				"It will also handle copying secrets to different sub-stores. " +
-				"If the destination is a directory, it will automatically copy recursively.",
+				"This also works across different sub-stores. If the source is a directory it will " +
+				"automatically copy recursively. In that case, the source directory is re-created " +
+				"at the destination if no trailing slash is found, otherwise the contents are " +
+				"flattened (similar to rsync).",
 			Before: func(c *cli.Context) error { return action.Initialized(withGlobalFlags(ctx, c), c) },
 			Action: func(c *cli.Context) error {
 				return action.Copy(withGlobalFlags(ctx, c), c)
@@ -793,8 +795,10 @@ func getCommands(ctx context.Context, action *ap.Action, app *cli.App) []cli.Com
 			Aliases: []string{"mv"},
 			Usage:   "Move secrets from one location to another",
 			Description: "" +
-				"This command moves a secret from one path to another. This works even " +
-				"across different sub-stores.",
+				"This command moves a secret from one path to another. This also works " +
+				"across different sub-stores. If the source is a directory, the source directory " +
+				"is re-created at the destination if no trailing slash is found, otherwise the " +
+				"contents are flattened (similar to rsync).",
 			Before: func(c *cli.Context) error { return action.Initialized(withGlobalFlags(ctx, c), c) },
 			Action: func(c *cli.Context) error {
 				return action.Move(withGlobalFlags(ctx, c), c)

--- a/pkg/action/copy_test.go
+++ b/pkg/action/copy_test.go
@@ -73,7 +73,7 @@ func TestCopy(t *testing.T) {
 
 	// recursive copy: bam/ -> zab
 	fs = flag.NewFlagSet("default", flag.ContinueOnError)
-	assert.NoError(t, fs.Parse([]string{"bam/", "zab"}))
+	assert.NoError(t, fs.Parse([]string{"bam", "zab"}))
 	c = cli.NewContext(app, fs, nil)
 
 	assert.NoError(t, act.Copy(ctx, c))

--- a/pkg/store/root/move_test.go
+++ b/pkg/store/root/move_test.go
@@ -31,9 +31,6 @@ func TestMove(t *testing.T) {
 	assert.NoError(t, rs.Delete(ctx, "foo"))
 
 	// Initial state:
-	// foo/bar
-	// foo/baz
-	// misc/zab
 	entries, err := rs.List(ctx, 0)
 	require.NoError(t, err)
 	require.Equal(t, []string{
@@ -41,16 +38,13 @@ func TestMove(t *testing.T) {
 		"foo/baz",
 		"misc/zab",
 	}, entries)
-	// -> move foo misc => ERROR: foo is a directory
-	assert.Error(t, rs.Move(ctx, "foo", "misc"))
 	// -> move foo/ misc/zab => ERROR: misc/zab is a file
 	assert.Error(t, rs.Move(ctx, "foo/", "misc/zab"))
+	// -> move foo misc/zab => ERROR: misc/zab is a file
+	assert.Error(t, rs.Move(ctx, "foo", "misc/zab"))
+
 	// -> move foo/ misc => OK
-	assert.NoError(t, rs.Move(ctx, "foo/", "misc"))
-	// New state:
-	// misc/foo/bar
-	// misc/foo/baz
-	// misc/zab
+	assert.NoError(t, rs.Move(ctx, "foo", "misc"))
 	entries, err = rs.List(ctx, 0)
 	require.NoError(t, err)
 	require.Equal(t, []string{
@@ -58,12 +52,9 @@ func TestMove(t *testing.T) {
 		"misc/foo/baz",
 		"misc/zab",
 	}, entries)
+
 	// -> move misc/foo/ bar/ => OK
-	assert.NoError(t, rs.Move(ctx, "misc/foo/", "bar/"))
-	// New state:
-	// bar/foo/bar
-	// bar/foo/baz
-	// misc/zab
+	assert.NoError(t, rs.Move(ctx, "misc/foo", "bar/"))
 	entries, err = rs.List(ctx, 0)
 	require.NoError(t, err)
 	assert.Equal(t, []string{
@@ -71,18 +62,35 @@ func TestMove(t *testing.T) {
 		"bar/foo/baz",
 		"misc/zab",
 	}, entries)
+
 	// -> move misc/zab bar/foo/zab => OK
 	assert.NoError(t, rs.Move(ctx, "misc/zab", "bar/foo/zab"))
-	// New state:
-	// bar/foo/bar
-	// bar/foo/baz
-	// bar/foo/zab
 	entries, err = rs.List(ctx, 0)
 	require.NoError(t, err)
 	assert.Equal(t, []string{
 		"bar/foo/bar",
 		"bar/foo/baz",
 		"bar/foo/zab",
+	}, entries)
+
+	// -> move bar/foo/ baz => OK
+	assert.NoError(t, rs.Move(ctx, "bar/foo/", "baz"))
+	entries, err = rs.List(ctx, 0)
+	require.NoError(t, err)
+	assert.Equal(t, []string{
+		"baz/bar",
+		"baz/baz",
+		"baz/zab",
+	}, entries)
+
+	// -> move baz/ boz/ => OK
+	assert.NoError(t, rs.Move(ctx, "baz/", "boz/"))
+	entries, err = rs.List(ctx, 0)
+	require.NoError(t, err)
+	assert.Equal(t, []string{
+		"boz/bar",
+		"boz/baz",
+		"boz/zab",
 	}, entries)
 }
 
@@ -105,9 +113,6 @@ func TestCopy(t *testing.T) {
 	assert.NoError(t, rs.Delete(ctx, "foo"))
 
 	// Initial state:
-	// foo/bar
-	// foo/baz
-	// misc/zab
 	entries, err := rs.List(ctx, 0)
 	require.NoError(t, err)
 	assert.Equal(t, []string{
@@ -115,16 +120,13 @@ func TestCopy(t *testing.T) {
 		"foo/baz",
 		"misc/zab",
 	}, entries)
-	// -> move foo misc => ERROR: foo is a directory
-	assert.Error(t, rs.Copy(ctx, "foo", "misc"))
-	// -> move foo/ misc/zab => ERROR: misc/zab is a file
+	// -> copy foo/ misc/zab => ERROR: misc/zab is a file
 	assert.Error(t, rs.Copy(ctx, "foo/", "misc/zab"))
-	// -> move foo/ misc => OK
-	assert.NoError(t, rs.Copy(ctx, "foo/", "misc"))
-	// New state:
-	// misc/foo/bar
-	// misc/foo/baz
-	// misc/zab
+	// -> copy foo misc/zab => ERROR: misc/zab is a file
+	assert.Error(t, rs.Copy(ctx, "foo", "misc/zab"))
+
+	// -> copy foo/ misc => OK
+	assert.NoError(t, rs.Copy(ctx, "foo", "misc"))
 	entries, err = rs.List(ctx, 0)
 	require.NoError(t, err)
 	assert.Equal(t, []string{
@@ -134,35 +136,29 @@ func TestCopy(t *testing.T) {
 		"misc/foo/baz",
 		"misc/zab",
 	}, entries)
-	// -> move misc/foo/ bar/ => OK
+
+	// -> copy misc/foo/ bar/ => OK
 	assert.NoError(t, rs.Copy(ctx, "misc/foo/", "bar/"))
-	// New state:
-	// bar/foo/bar
-	// bar/foo/baz
-	// misc/zab
 	entries, err = rs.List(ctx, 0)
 	require.NoError(t, err)
 	assert.Equal(t, []string{
-		"bar/foo/bar",
-		"bar/foo/baz",
+		"bar/bar",
+		"bar/baz",
 		"foo/bar",
 		"foo/baz",
 		"misc/foo/bar",
 		"misc/foo/baz",
 		"misc/zab",
 	}, entries)
-	// -> move misc/zab bar/foo/zab => OK
+
+	// -> copy misc/zab bar/foo/zab => OK
 	assert.NoError(t, rs.Copy(ctx, "misc/zab", "bar/foo/zab"))
-	// New state:
-	// bar/foo/bar
-	// bar/foo/baz
-	// bar/foo/zab
 	entries, err = rs.List(ctx, 0)
 	require.NoError(t, err)
 	assert.Equal(t, []string{
-		"bar/foo/bar",
-		"bar/foo/baz",
 		"bar/foo/zab",
+		"bar/bar",
+		"bar/baz",
 		"foo/bar",
 		"foo/baz",
 		"misc/foo/bar",

--- a/tests/move_test.go
+++ b/tests/move_test.go
@@ -30,7 +30,7 @@ func TestMove(t *testing.T) {
 
 	ts.initSecrets("")
 
-	_, err = ts.run("move foo/ bar")
+	_, err = ts.run("move foo bar")
 	assert.NoError(t, err)
 
 	out, _ = ts.run("move foo/bar foo/baz")


### PR DESCRIPTION
When moving/copying folders, gopass currently enforces a trailing slash on the source folder and _always_ re-creates the source folder at the destination. This makes it impossible to rename a folder.

On the other hand, rsync handles this differently. It re-creates the source folder at the destination only if the source folder has _no_ trailing slash. Otherwise the folder contents are flattened at the destination location. 
 Quoting its man page:

> A trailing slash on the source changes this behavior to avoid creating an additional directory level at the destination.  You can think of a trailing / on a source as meaning "copy  the  contents  of
       this  directory"  as  opposed  to  "copy the directory by name",

With that convention it will be possible to also rename folders.

This PR therefore changes the logic for the source folder to follow the rsync convention.