### PR TITLE
completion: fix zsh completion for folders

### DIFF
--- a/pkg/completion/zsh/template.go
+++ b/pkg/completion/zsh/template.go
@@ -21,8 +21,8 @@ _{{ $prog }} () {
               {{- end }}
               {{ if .Flags }}_arguments :{{ range .Flags }} "{{ . | formatFlag }}"{{ end }}{{ end }}
               _describe -t commands "{{ $prog }} {{ .Name }}" subcommands
-              {{ if or (eq .Name "copy") (eq .Name "move") (eq .Name "delete") (eq .Name "show") (eq .Name "edit") }}_{{ $prog }}_complete_passwords{{ else if or (eq .Name "insert") (eq .Name "generate")  (eq .Name "list") }}if ! compset -P '*/'; then _{{ $prog }}_complete_folders
-              fi{{ end }}
+              {{ if or (eq .Name "insert") (eq .Name "generate")  (eq .Name "list") }}_{{ $prog }}_complete_folders{{ end }}
+              {{ if or (eq .Name "copy") (eq .Name "move") (eq .Name "delete") (eq .Name "show") (eq .Name "edit") (eq .Name "insert") (eq .Name "generate") }}_{{ $prog }}_complete_passwords{{ end }}
               ;;
 {{- end }}
           *)
@@ -52,7 +52,9 @@ _{{ $prog }}_complete_passwords () {
 }
 
 _{{ $prog }}_complete_folders () {
-    _values -s '/' 'folders' $({{ $prog }} ls --folders --flat)
+    local -a folders
+    folders=("${(@f)$({{ $prog }} ls --folders --flat)}")
+    _describe -t folders "folders" folders -qS /
 }
 
 _{{ $prog }}`


### PR DESCRIPTION
For `insert`, `generate` and `list`, the folder completion doesn't
work as expected. First, we should continue completion even if we
already have a `/` in the current name. Otherwise, we can only
complete the first level. Then, don't specify `/` as a separator for
`_values`, this is for specifying multiple values.

Moreover, allow completing for passwords for `generate` (ability to
change a password) and for `insert` (ability to append data).

cc @AnomalRoil