### PR TITLE
Ensure GOPASS_DEBUG works as documented

### DIFF
--- a/context.go
+++ b/context.go
@@ -26,7 +26,7 @@ func initContext(ctx context.Context, cfg *config.Config) context.Context {
 	}
 
 	// debug flag
-	if gdb := os.Getenv("GOPASS_DEBUG"); gdb == "true" {
+	if gdb := os.Getenv("GOPASS_DEBUG"); gdb != "" {
 		ctx = ctxutil.WithDebug(ctx, true)
 	}
 


### PR DESCRIPTION
The documentation says to set `GOPASS_DEBUG` environment variable to a
non-empty string to get debug output. However, when there is a
context, only the `true` value would trigger debug output. Change the
condition to work as documented.

Signed-off-by: Vincent Bernat <vincent@bernat.ch>