### PR TITLE
Handle multiple private keys matching an identifier

### DIFF
--- a/pkg/backend/crypto/gpg/cli/keyring.go
+++ b/pkg/backend/crypto/gpg/cli/keyring.go
@@ -92,11 +92,11 @@ func (g *GPG) FindPrivateKeys(ctx context.Context, search ...string) ([]string, 
 
 func (g *GPG) findKey(ctx context.Context, id string) gpg.Key {
 	kl, _ := g.listKeys(ctx, "secret", id)
-	if len(kl) == 1 {
+	if len(kl) >= 1 {
 		return kl[0]
 	}
 	kl, _ = g.listKeys(ctx, "public", id)
-	if len(kl) == 1 {
+	if len(kl) >= 1 {
 		return kl[0]
 	}
 	return gpg.Key{


### PR DESCRIPTION
The default behavior of gnupg when multiple keys are matching (like
when using an email address as an identifier) is to use the first one.
We make gopass use the same logic.

In my case, I have two keys matching my email address. The second one
is revoked. gopass is trying, for some reason, to use the second one.
I don't quite understand where it decides that, but making it choose
the first one earlier makes it work.