### PR TITLE
fs-store: remove empty directories

### DIFF
--- a/pkg/backend/storage/fs/store.go
+++ b/pkg/backend/storage/fs/store.go
@@ -63,6 +63,7 @@ func (s *Store) Delete(ctx context.Context, name string) error {
 	return s.removeEmptyParentDirectories(path)
 }
 
+// Deletes all empty parent directories up to the store root
 func (s *Store) removeEmptyParentDirectories(path string) error {
 	parent := filepath.Dir(path)
 

--- a/pkg/backend/storage/fs/store_test.go
+++ b/pkg/backend/storage/fs/store_test.go
@@ -9,6 +9,37 @@ import (
 	"testing"
 )
 
+func TestSet(t *testing.T) {
+	initialContent := []byte(`initial file content`)
+	otherContent := []byte(`other file content`)
+	ctx := context.Background()
+
+	path, cleanup := newTempDir(t)
+	defer cleanup()
+
+	fileHasContent := func(filename string, content []byte) {
+		written, _ := ioutil.ReadFile(filepath.Join(path, filename))
+		assert.Equalf(t, content, written, "content of file")
+	}
+
+	s := &Store{path}
+
+	filename := filepath.Join("a", "b", "file")
+	otherFilename := filepath.Join("a", ".", "b", "..", "other")
+
+	// when the folder does not exist
+	_ = s.Set(ctx, filename, initialContent)
+	fileHasContent(filename, initialContent)
+
+	// overwrite file
+	_ = s.Set(ctx, filename, otherContent)
+	fileHasContent(filename, otherContent)
+
+	// when folder already exists, with unclean path
+	_ = s.Set(ctx, otherFilename, initialContent)
+	fileHasContent(otherFilename, initialContent)
+}
+
 func TestRemoveEmptyParentDirectories(t *testing.T) {
 	var tests = []struct {
 		name          string

--- a/pkg/backend/storage/fs/store_test.go
+++ b/pkg/backend/storage/fs/store_test.go
@@ -60,7 +60,9 @@ func TestRemoveEmptyParentDirectories(t *testing.T) {
 			if err != nil {
 				t.Error(err)
 			}
-			defer os.RemoveAll(td)
+			defer func() {
+				_ = os.RemoveAll(td)
+			}()
 
 			path := filepath.Join(append([]string{td}, test.storeRoot...)...)
 			subdir := filepath.Join(append([]string{path}, test.subdirs...)...)

--- a/pkg/backend/storage/fs/store_test.go
+++ b/pkg/backend/storage/fs/store_test.go
@@ -1,0 +1,96 @@
+package fs
+
+import (
+	"github.com/stretchr/testify/assert"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRemoveEmptyParentDirectories(t *testing.T) {
+	var tests = []struct {
+		name          string
+		storeRoot     []string
+		subdirs       []string
+		expectPresent []string
+		expectGone    []string
+		prepare       func(string)
+	}{
+		{
+			name:          "only empty subdirs",
+			storeRoot:     []string{"store-root"},
+			subdirs:       []string{"a", "b", "c"},
+			expectPresent: []string{"store-root"},
+			expectGone:    []string{"a", "b", "c"},
+		},
+		{
+			name:          "empty subdirs, nested root",
+			storeRoot:     []string{"root-parent", "store-root"},
+			subdirs:       []string{"a", "b"},
+			expectPresent: []string{"root-parent", "store-root"},
+			expectGone:    []string{"a", "b"},
+		},
+		{
+			name:          "file in outer dir",
+			storeRoot:     []string{"root-parent", "store-root"},
+			subdirs:       []string{"a", "b"},
+			expectPresent: []string{"root-parent", "store-root", "a", "b"},
+			prepare: func(path string) {
+				f, _ := os.Create(filepath.Join(path, "some-file"))
+				_ = f.Close()
+			},
+		},
+		{
+			name:          "file in parent dir",
+			storeRoot:     []string{"store-root"},
+			subdirs:       []string{"a", "b"},
+			expectPresent: []string{"store-root", "a"},
+			expectGone:    []string{"b"},
+			prepare: func(path string) {
+				f, _ := os.Create(filepath.Join(path, "..", "file-in-parent"))
+				_ = f.Close()
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			td, err := ioutil.TempDir("", "gopass-")
+			if err != nil {
+				t.Error(err)
+			}
+			defer os.RemoveAll(td)
+
+			path := filepath.Join(append([]string{td}, test.storeRoot...)...)
+			subdir := filepath.Join(append([]string{path}, test.subdirs...)...)
+
+			if err := os.MkdirAll(subdir, 0777); err != nil {
+				t.Error(err)
+			}
+
+			if test.prepare != nil {
+				test.prepare(subdir)
+			}
+
+			s := &Store{
+				path,
+			}
+			if err = s.removeEmptyParentDirectories(filepath.Join(subdir, "deletedFile")); err != nil {
+				t.Error(err)
+			}
+
+			dir := td
+			for _, d := range test.expectPresent {
+				dir = filepath.Join(dir, d)
+				assert.DirExists(t, dir)
+			}
+			for _, d := range test.expectGone {
+				dir = filepath.Join(dir, d)
+				if _, err := os.Stat(dir); err == nil || !os.IsNotExist(err) {
+					t.Errorf("Directory %s should not exist", dir)
+				}
+			}
+		})
+	}
+}

--- a/pkg/backend/storage/fs/store_test.go
+++ b/pkg/backend/storage/fs/store_test.go
@@ -56,13 +56,8 @@ func TestRemoveEmptyParentDirectories(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			td, err := ioutil.TempDir("", "gopass-")
-			if err != nil {
-				t.Error(err)
-			}
-			defer func() {
-				_ = os.RemoveAll(td)
-			}()
+			td, cleanup := newTempDir(t)
+			defer cleanup()
 
 			path := filepath.Join(append([]string{td}, test.storeRoot...)...)
 			subdir := filepath.Join(append([]string{path}, test.subdirs...)...)
@@ -78,7 +73,7 @@ func TestRemoveEmptyParentDirectories(t *testing.T) {
 			s := &Store{
 				path,
 			}
-			if err = s.removeEmptyParentDirectories(filepath.Join(subdir, "deletedFile")); err != nil {
+			if err := s.removeEmptyParentDirectories(filepath.Join(subdir, "deletedFile")); err != nil {
 				t.Error(err)
 			}
 
@@ -94,5 +89,16 @@ func TestRemoveEmptyParentDirectories(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func newTempDir(t *testing.T) (string, func()) {
+	t.Helper()
+	td, err := ioutil.TempDir("", "gopass-")
+	if err != nil {
+		t.Error(err)
+	}
+	return td, func() {
+		_ = os.RemoveAll(td)
 	}
 }

--- a/pkg/store/root/move_test.go
+++ b/pkg/store/root/move_test.go
@@ -43,7 +43,7 @@ func TestMove(t *testing.T) {
 	// -> move foo misc/zab => ERROR: misc/zab is a file
 	assert.Error(t, rs.Move(ctx, "foo", "misc/zab"))
 
-	// -> move foo/ misc => OK
+	// -> move foo misc => OK
 	assert.NoError(t, rs.Move(ctx, "foo", "misc"))
 	entries, err = rs.List(ctx, 0)
 	require.NoError(t, err)
@@ -53,7 +53,7 @@ func TestMove(t *testing.T) {
 		"misc/zab",
 	}, entries)
 
-	// -> move misc/foo/ bar/ => OK
+	// -> move misc/foo bar/ => OK
 	assert.NoError(t, rs.Move(ctx, "misc/foo", "bar/"))
 	entries, err = rs.List(ctx, 0)
 	require.NoError(t, err)
@@ -91,6 +91,17 @@ func TestMove(t *testing.T) {
 		"boz/bar",
 		"boz/baz",
 		"boz/zab",
+	}, entries)
+
+	// this fails if empty directories are not removed, because 'bar' and 'baz' were directories in the root folder
+	// -> move boz/ / => OK
+	assert.NoError(t, rs.Move(ctx, "boz/", "/"))
+	entries, err = rs.List(ctx, 0)
+	require.NoError(t, err)
+	assert.Equal(t, []string{
+		"bar",
+		"baz",
+		"zab",
 	}, entries)
 }
 


### PR DESCRIPTION
The fs-store backend did not clean up empty directories, so that the following sequence of commands would fail:
$ gopass mv foo/last_file_in_directory bar
$ gopass mv bar foo # fails because foo exists and is a directory

Now, the-fs store backend removes all empty parent directories when a secret is deleted.

Implementation note: because os.Remove will only remove empty directories, this is the fastest and easiest solution.

Fixes #1009