### PR TITLE
Disable CGO to work around alpine/musl restrictions (#1063)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apk add -U make gcc musl-dev ncurses git
 ADD .   /go/src/github.com/gopasspw/gopass
 WORKDIR /go/src/github.com/gopasspw/gopass
 
-RUN TERM=vt100 make install
+RUN CGO_ENABLED=0 TERM=vt100 make install
 
 FROM alpine:3.7
 RUN apk add -U git gnupg


### PR DESCRIPTION
https://github.com/mattes/migrate/issues/241 describes a very similar issue. One solution is to disable the C language binding (see also https://golang.org/cmd/cgo/).

Fixes #1063