### PR TITLE
Fish completions with more aliases for commands

### DIFF
--- a/pkg/completion/fish/template.go
+++ b/pkg/completion/fish/template.go
@@ -45,9 +45,9 @@ complete -c $PROG -f -s c -l clip -r -a "(__fish_{{ $prog }}_print_entries)"
 {{ range .Commands }}
 complete -c $PROG -f -n '__fish_{{ $prog }}_needs_command' -a {{ .Name }} -d 'Command: {{ .Usage }}'
 {{- $cmd := .Name -}}
-{{- if or (eq $cmd "copy") (eq $cmd "move") (eq $cmd "delete") (eq $cmd "show") }}
+{{- if or (eq $cmd "copy") (eq $cmd "cp") (eq $cmd "move") (eq $cmd "mv") (eq $cmd "delete") (eq $cmd "remove") (eq $cmd "rm") (eq $cmd "show") (eq $cmd "set") (eq $cmd "edit") }}
 complete -c $PROG -f -n '__fish_{{ $prog }}_uses_command {{ $cmd }}' -a "(__fish_{{ $prog }}_print_entries)"{{ end -}}
-{{- if or (eq $cmd "insert") (eq $cmd "generate") (eq $cmd "list") }}
+{{- if or (eq $cmd "insert") (eq $cmd "generate") (eq $cmd "list") (eq $cmd "ls") }}
 complete -c $PROG -f -n '__fish_{{ $prog }}_uses_command {{ $cmd }}' -a "(__fish_{{ $prog }}_print_dir)"{{ end -}}
 {{- range .Subcommands }}
 {{- $subcmd := .Name }}


### PR DESCRIPTION
I was using `gopass` in fish and was wondering why e.g. `gopass delete` has autocompletion but `gopass remove` has not. I added the aliases to the fish completion file, although I'm not familiar with them.

I also added `edit` and `set` which should have the same completions as e.g. `delete`.

##### Commands

* cp
* mv
* rm
* remove
* ls
* edit
* set

##### Help
```
     agent               Start gopass-agent
     audit               Scan for weak passwords
     binary, bin         Assist with Binary/Base64 content
     clone               Clone a store from git
     completion          Bash and ZSH completion
     config              Edit configuration
     copy, cp            Copy secrets from one location to another
     create, new         Easy creation of new secrets
     delete, remove, rm  Remove secrets
     edit, set           Edit new or existing secrets
     find, search        Search for secrets
     fsck                Check store integrity
     generate            Generate a new password
     git-credential      Use '!gopass git-credential $@' as git's credential.helper
     otp, totp, hotp     Generate time- or hmac-based tokens
     git                 Run any git command inside a password store
     grep                Search for secrets files containing search-string when decrypted.
     history, hist       Show password history
     init                Initialize new password store.
     insert              Insert a new secret
     list, ls            List existing secrets
     move, mv            Move secrets from one location to another
     mounts              Edit mounted stores
     recipients          Edit recipient permissions
     show                Display a secret
     sync                Sync all local stores with their remotes
     templates           Edit templates
     update              Check for updates
     version             Display version
     xc                  Experimental Crypto
     help, h             Shows a list of commands or help for one command
```