### PR TITLE
Add Gopass UI to the list of available GUIs for gopass

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -347,6 +347,8 @@ Because gopass is fully backwards compatible with pass, you can use some existin
 * iOS - [Pass for iOS](https://github.com/davidjb/pass-ios#readme)
 * Windows / MacOS / Linux -  [QtPass](https://qtpass.org/)
 
+There is also [Gopass UI](https://github.com/codecentric/gopass-ui) which was exclusively implemented for gopass and is available for MacOS, Linux and Windows.
+
 Others can be found at the "Compatible Clients" section of the [official pass website](https://www.passwordstore.org/).
 
 ## Using gopass


### PR DESCRIPTION
As it is a pleasure for us to work with gopass in real projects, a fellow employee and me started to work on [Gopass UI](https://github.com/codecentric/gopass-ui). In our team we are already using it heavily because we have some not-so-techie people who are not too command line affine.
We think it's in a good condition to make it public and surely want to put more effort into it.

We would be very happy to get feedback on the UI and functionality across all platforms (especially Windows and Linux as we are MacOS users ourselves). It would be great to have it added to your docs. Feel free to propose a different structure or change the wording.

Cheers,
Jonas