### PR TITLE
use double quotes for git-credential helper

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -431,10 +431,10 @@ func getCommands(ctx context.Context, action *ap.Action, app *cli.App) []cli.Com
 		},
 		{
 			Name:  "git-credential",
-			Usage: "Use '!gopass git-credential $@' as git's credential.helper",
+			Usage: `Use "!gopass git-credential $@" as git's credential.helper`,
 			Description: "" +
 				"This command allows you to cache your git-credentials with gopass." +
-				"Activate by using `git config --global credential.helper '!gopass git-credential $@'`",
+				"Activate by using `git config --global credential.helper \"!gopass git-credential $@\"`",
 			Subcommands: []cli.Command{
 				{
 					Name:   "get",

--- a/pkg/action/git-credential.go
+++ b/pkg/action/git-credential.go
@@ -230,7 +230,7 @@ func (s *Action) GitCredentialConfigure(ctx context.Context, c *cli.Context) err
 	if flags == 0 {
 		log.Println("No target given, assuming --global.")
 	}
-	cmd := exec.Command("git", "config", flag, "credential.helper", "'!gopass git-credential $@'")
+	cmd := exec.Command("git", "config", flag, "credential.helper", `"!gopass git-credential $@"`)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	return cmd.Run()


### PR DESCRIPTION
We use the "!" command in the gitconfig to start a subshell and execute
a process, therefore we need to double quote the command in the
git configuration file. Otherwise the file will not get interpreted as
command and will be used directly as a helper. This commit makes sure,
that we use double quotes in our git configuration file and our gopass
help prompt.

This is supposed to fix https://github.com/gopasspw/gopass/issues/1077