### PR TITLE
Update list.go

### DIFF
--- a/pkg/store/sub/list.go
+++ b/pkg/store/sub/list.go
@@ -31,7 +31,7 @@ func (s *Store) List(ctx context.Context, prefix string) ([]string, error) {
 		}
 		path = strings.TrimSuffix(path, cExt)
 		if s.alias != "" {
-			path = s.alias + sep + path
+			path = s.alias + "/" + path
 		}
 		out = append(out, path)
 	}


### PR DESCRIPTION
fixe issue #1005
With Windows sep is \ and break search when is use between alias and path