### PR TITLE
docs: Update config example

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -365,13 +365,12 @@ gopass allows editing the config from the command-line. This is similar to how g
 
 ```bash
 $ gopass config
-alwaystrust: false
 askformore: false
+autoclip: true
 autoimport: false
-autopull: false
-autopush: true
+autoprint: false
+autosync: true
 cliptimeout: 10
-loadkeys: false
 noconfirm: false
 path: /home/user/.password-store
 


### PR DESCRIPTION
alwaystrust & loadkeys were removed, autopush & autopull were
replaced by autosync in 4c0ede5e725aa414b3e657b689283174fb78d2af.

Signed-off-by: Fabian P. Schmidt <kerel@mailbox.org>