### PR TITLE
Split password completions using newline

### DIFF
--- a/pkg/completion/zsh/template.go
+++ b/pkg/completion/zsh/template.go
@@ -46,6 +46,7 @@ _{{ $prog }}_complete_keys () {
 }
 
 _{{ $prog }}_complete_passwords () {
+    local IFS=$'\n'
     _arguments : \
         "--clip[Copy the first line of the secret into the clipboard]"
     _values 'passwords' $({{ $prog }} ls --flat)


### PR DESCRIPTION
Relates to a bug #955 I raised a long time ago and did nothing about :/ 

I finally read up a bit more around completions, and in doing so noticed this technique was already being used for key completions (see https://github.com/gopasspw/gopass/blob/master/pkg/completion/zsh/template.go#L44). This PR applies the same technique but to password completions. 

Apologies for no test, I had a look at the existing tests but couldn't see any coverage around this sort of thing, which is tricky to test anyway. Happy for suggestions / help if a test is needed.