### PR TITLE
ZSH autocomplete instructions added

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -286,6 +286,16 @@ source /dev/stdin <<<"$(gopass completion bash)"
 
 If you use zsh, `make install` or `make install-completion` should install the completion in the correct location.
 
+If zsh autocompletion is still not functional, you can run the following commands:
+
+```
+$ gopass completion zsh > $/_gopass 
+$ sudo mv ~/_gopass /usr/share/zsh/site-functions/_gopass
+$ rm -i ${ZDOTDIR:-${HOME:?No ZDOTDIR or HOME}}/.zcompdump && compinit
+
+```
+Exit and re-run zsh if the last command failed.
+
 ### Enable fish completion
 
 If you use the [fish](https://fishshell.com/) shell, you can enable experimental shell completion. Copy the file `fish.completion` to `~/.config/fish/completions/gopass.fish` and start a new shell.


### PR DESCRIPTION
The autocomplete instructions "make install" did not work for me.

This PR contains the zsh commands that made autocompletion work for me and adds them to `docs/setup.md`