### PR TITLE
improve 'gopass git' command usage text

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -569,7 +569,7 @@ func getCommands(ctx context.Context, action *ap.Action, app *cli.App) []cli.Com
 		},
 		{
 			Name:  "git",
-			Usage: "Run any git command inside a password store",
+			Usage: "Run a git command inside a password store (init, remote, push, pull)",
 			Description: "" +
 				"If the password store is a git repository, execute a git command " +
 				"specified by git-command-args.",


### PR DESCRIPTION
Fix the Usage text for `gopass git`, Closes #1093.

Please let me know if there are any references in the docs that I missed.