### PR TITLE
Fix/git cmd description message

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -569,7 +569,7 @@ func getCommands(ctx context.Context, action *ap.Action, app *cli.App) []cli.Com
 		},
 		{
 			Name:  "git",
-			Usage: "Run any git command inside a password store",
+			Usage: "Run a git command inside a password store (init, remote, push, pull)",
 			Description: "" +
 				"If the password store is a git repository, execute a git command " +
 				"specified by git-command-args.",

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -84,7 +84,7 @@ gopass depends on the `gpg` program for encryption and decryption. You **must** 
 suitable key pair. To list your current keys, you can do:
 
 ```bash
-gpg --list-keys
+gpg --list-secret-keys
 ```
 
 If there is no output, then you don't have any keys. To create a new key:


### PR DESCRIPTION
Fix `gopass git` command Usage test. Closes #1093. 

Please let me know if I missed any references in the docs.