### PR TITLE
Fixed import order using goimports

### DIFF
--- a/pkg/backend/storage/fs/store_test.go
+++ b/pkg/backend/storage/fs/store_test.go
@@ -2,11 +2,12 @@ package fs
 
 import (
 	"context"
-	"github.com/stretchr/testify/assert"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestSetAndGet(t *testing.T) {


### PR DESCRIPTION
Keeps the import order clean and just avoids future merge conflicts.