### PR TITLE
Update README to include external docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,3 +121,7 @@ gopass was initially started by Matthias Loibl and Dominik Schulz. The majority 
 * [FAQ](https://github.com/gopasspw/gopass/blob/master/docs/faq.md)
 * [JSON API](https://github.com/gopasspw/gopass/blob/master/docs/jsonapi.md)
 * [Gopass as Summon provider](https://github.com/gopasspw/gopass/blob/master/docs/summon-provider.md)
+
+## External Documentation
+* [gopass cheat sheet](https://woile.github.io/gopass-cheat-sheet/) ([source on github])https://github.com/Woile/gopass-presentation)
+* [gopass presentation](https://woile.github.io/gopass-presentation/) ([source on github](https://github.com/Woile/gopass-presentation))


### PR DESCRIPTION
Resolves #1092

Note, I separated these under the "external documentation" header with the assumption that there may be interest in adding more links here in the future (blog posts, etc).