### PR TITLE
RFC: tempfile: Add build-time global prefix for temporary files

### DIFF
--- a/pkg/tempfile/file.go
+++ b/pkg/tempfile/file.go
@@ -11,6 +11,9 @@ import (
 	"github.com/pkg/errors"
 )
 
+// globalPrefix is prefixed to all temporary dirs
+var globalPrefix string = ""
+
 // File is a temporary file
 type File struct {
 	dir string
@@ -21,7 +24,7 @@ type File struct {
 
 // New returns a new tempfile wrapper
 func New(ctx context.Context, prefix string) (*File, error) {
-	td, err := ioutil.TempDir(tempdirBase(), prefix)
+	td, err := ioutil.TempDir(tempdirBase(), globalPrefix+prefix)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/tempfile/file_test.go
+++ b/pkg/tempfile/file_test.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -40,4 +42,31 @@ func TestTempFiler(t *testing.T) {
 	assert.Error(t, err)
 	assert.NoError(t, utf.Remove(ctx))
 	assert.NoError(t, utf.Close())
+}
+
+func TestGlobalPrefix(t *testing.T) {
+	assertPrefix := func(file *File, prefix string) {
+		requirePrefix := filepath.Join(tempdirBase(), prefix)
+		assert.True(t, strings.HasPrefix(file.Name(), requirePrefix))
+	}
+	ctx := context.Background()
+	assert.Equal(t, "", globalPrefix)
+
+	// without global prefix
+	withoutGlobalPrefix, err := New(ctx, "some-prefix")
+	assert.NoError(t, err)
+	defer func() {
+		assert.NoError(t, withoutGlobalPrefix.Close())
+	}()
+	assertPrefix(withoutGlobalPrefix, "some-prefix")
+
+	// with global prefix
+	globalPrefix = "global-prefix."
+	withGlobalPrefix, err := New(ctx, "some-prefix")
+	assert.NoError(t, err)
+	defer func() {
+		globalPrefix = ""
+		assert.NoError(t, withGlobalPrefix.Close())
+	}()
+	assertPrefix(withGlobalPrefix, "global-prefix.some-prefix")
 }


### PR DESCRIPTION
This is mostly useful for sandboxed Linux environments that
restrict access to /dev/shm/{...}, specifically snaps, which
require a "snap.{appname}." prefix.

Can bet set at build-time via ldflags.

Not terribly elegant but rather simple. I'd need something like this for my ongoing snap-packaging efforts, so consider this a conversation starter.