### PR TITLE
Update Docker image to Go 1.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.10-alpine AS builder
+FROM golang:1.12-alpine AS builder
 
 RUN apk add -U make gcc musl-dev ncurses git
 


### PR DESCRIPTION
Hi,

update Docker image to match the required Go version like mentioned in FIX: #1173.

Kind regards

