### PR TITLE
Improve error messages for git commands

### DIFF
--- a/pkg/action/clone.go
+++ b/pkg/action/clone.go
@@ -63,7 +63,7 @@ func (s *Action) clone(ctx context.Context, repo, mount, path string) error {
 	// clone repo
 	out.Debug(ctx, "Cloning repo '%s' to '%s'", repo, path)
 	if _, err := backend.CloneRCS(ctx, rcsBackendOrDefault(ctx, backend.GitCLI), repo, path); err != nil {
-		return ExitError(ctx, ExitGit, err, "failed to clone repo '%s' to '%s'", repo, path)
+		return ExitError(ctx, ExitGit, err, "failed to clone repo '%s' to '%s':\n\n%s", repo, path, err.Error())
 	}
 
 	// detect crypto backend based on cloned repo

--- a/pkg/backend/rcs/git/cli/git.go
+++ b/pkg/backend/rcs/git/cli/git.go
@@ -116,7 +116,7 @@ func (g *Git) Cmd(ctx context.Context, name string, args ...string) error {
 	stdout, stderr, err := g.captureCmd(ctx, name, args...)
 	if err != nil {
 		out.Debug(ctx, "Output:\n  Stdout: '%s'\n  Stderr: '%s'", string(stdout), string(stderr))
-		return err
+		return fmt.Errorf(strings.TrimSpace(string(stderr)))
 	}
 
 	return nil


### PR DESCRIPTION
For https://github.com/gopasspw/gopass/issues/1119

Instead of returning the error directly (which just has the value "exit status 128"), we can return the stderr output from the git command as a new error and print that to the user.

Here is some example output from the clone command which is used in the issue:

```
$ gopass clone test@test:test.git
Error: failed to clone repo 'test@test:test.git' to '/home/phl/.password-store':

Cloning into '/home/phl/.password-store'...
ssh: Could not resolve hostname test: Name or service not known
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```

```
$ gopass clone  test@test:test.git

Error: failed to clone repo '/tmp/test.git/' to '/home/phl/.password-store':

fatal: destination path '/home/phl/.password-store' already exists and is not an empty directory.
```

Let me now if it was what you had in mind, or if I should change something.