### PR TITLE
Enhanced notifications for Mac Systems

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -63,6 +63,7 @@ brew:
   dependencies:
     - git
     - gnupg
+    - terminal-notifier
   install:  |
     ENV["GOPATH"] = buildpath
     (buildpath/"src/github.com/gopasspw/gopass").install buildpath.children

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Please see [docs/features.md](https://github.com/gopasspw/gopass/blob/master/doc
 
 ## Installation
 
-If you have [Go](https://golang.org/) 1.10 (or greater) installed:
+If you have [Go](https://golang.org/) 1.12 (or greater) installed:
 
 ```bash
 go get github.com/gopasspw/gopass

--- a/pkg/notify/notify_darwin.go
+++ b/pkg/notify/notify_darwin.go
@@ -25,7 +25,7 @@ func Notify(ctx context.Context, subj, msg string) error {
 		return nil
 	}
 
-	//check if terminal-notifier was installed else use the applescript fallback
+	// check if terminal-notifier was installed else use the applescript fallback
 	tn, _ := executableExists(terminalNotifier)
 	if tn {
 		return tnNotification(msg, subj)
@@ -33,6 +33,7 @@ func Notify(ctx context.Context, subj, msg string) error {
 	return osaNotification(msg, subj)
 }
 
+// display notification with osascript
 func osaNotification(msg string, subj string) error {
 	_, err := executableExists(osascript)
 	if err != nil {
@@ -42,15 +43,18 @@ func osaNotification(msg string, subj string) error {
 	return execNotification(osascript, args)
 }
 
+// exec notification program with passed arguments
 func execNotification(executable string, args []string) error {
 	return execCommand(executable, strings.Join(args[:], " ")).Start()
 }
 
+// display notification with terminal-notifier
 func tnNotification(msg string, subj string) error {
 	arguments := []string{"-title", "Gopass", "-message", msg, "-subtitle", subj, "-appIcon", iconURI()}
 	return execNotification(terminalNotifier, arguments)
 }
 
+// check if executable exists
 func executableExists(executable string) (bool, error) {
 	_, err := execLookPath(executable)
 	if err != nil {

--- a/pkg/notify/notify_darwin_test.go
+++ b/pkg/notify/notify_darwin_test.go
@@ -1,0 +1,74 @@
+package notify
+
+import (
+	"context"
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"os"
+	"os/exec"
+	"testing"
+)
+
+//to test cmd.exec correctly we use the same functionality as go itself see exec_test.go
+func TestDarwinNotify(t *testing.T) {
+	ctx := context.Background()
+	_ = os.Setenv("GOPASS_NO_NOTIFY", "true")
+	assert.NoError(t, Notify(ctx, "foo", "bar"))
+}
+
+func TestLegacyNotification(t *testing.T) {
+	ctx := context.Background()
+	//override execCommand with mock
+	execCommand = mockExecCommand
+	defer func() {
+		execCommand = exec.Command
+	}()
+
+	err := Notify(ctx, "foo", "bar")
+	assert.NoError(t, err)
+}
+
+func TestLegacyTerminalNotifierNotification(t *testing.T) {
+	ctx := context.Background()
+	//override execCommand with mock
+	execCommand = mockExecCommand
+	execLookPath = mockExecLookPathTerminalNotifier
+	defer func() {
+		execCommand = exec.Command
+	}()
+
+	err := Notify(ctx, "foo", "bar")
+	assert.NoError(t, err)
+}
+
+func TestNoExecutableFound(t *testing.T) {
+	ctx := context.Background()
+	//override execCommand with mock
+	execCommand = mockExecCommand
+	execLookPath = mockExecLookPath
+	defer func() {
+		execCommand = exec.Command
+	}()
+
+	err := Notify(ctx, "foo", "bar")
+	assert.NoError(t, err)
+}
+
+func mockExecLookPath(_ string) (string, error) {
+	return "", fmt.Errorf("no binary found")
+}
+
+func mockExecLookPathTerminalNotifier(command string) (string, error) {
+	if command == terminalNotifier {
+		return "", fmt.Errorf("no binary found")
+	}
+	return "", nil
+}
+
+func mockExecCommand(command string, args ...string) *exec.Cmd {
+	cs := []string{"-test.run=TestHelperProcess", "--", command}
+	cs = append(cs, args...)
+	cmd := exec.Command(os.Args[0], cs...)
+	cmd.Env = []string{"GO_WANT_HELPER_PROCESS=1"}
+	return cmd
+}


### PR DESCRIPTION
Hi,

i changed the notification tooling to send notifications about important events from gopass. 
When "terminal-notifier" is available gopass will send the notification through the "terminal-notifier" program, else it will use the "oascript" like before.

So i changed the go packager that brew will install the terminal-notifier.

Kind regards