### PR TITLE
Add warning when GNUPGHOME is set, closes #1190

### DIFF
--- a/pkg/action/jsonapi_others.go
+++ b/pkg/action/jsonapi_others.go
@@ -62,6 +62,11 @@ func (s *Action) SetupNativeMessaging(ctx context.Context, c *cli.Context) error
 		return err
 	}
 
+	if os.Getenv("GNUPGHOME") != "" {
+		out.Yellow(ctx, "You seem to have GNUPGHOME set. If you intend to use the path in GNUPGHOME, you need to manually add:\n"+
+			"\n  export GNUPGHOME=/path/to/gpg-home\n\n to the wrapper script")
+	}
+
 	if err := os.MkdirAll(filepath.Dir(wrapperPath), 0755); err != nil {
 		return ExitError(ctx, ExitIO, err, "failed to create wrapper path: %s", err)
 	}


### PR DESCRIPTION
Probably a warning is the best solution as there might be other reasons why GNUPGHOME was set.