### PR TITLE
Add documentation for `gopass-agent` to the features doc

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -272,7 +272,7 @@ Detected weak secret for 'golang.org/gopher': Password is too short
 
 ### Check Passwords against leaked passwords
 
-gopass can assist you in checking your passwords against those included in recent data breaches. 
+gopass can assist you in checking your passwords against those included in recent data breaches.
 You can either check against the HIBPv2 API (recommended) or download the dumps (v1 or v2) and
 perform the check fully offline.
 
@@ -452,3 +452,7 @@ This makes it easy to use templates for certain kind of secrets such as database
 ### JSON API
 
 `gopass jsonapi` enables communication with gopass via JSON messages. This is particularly useful for browser plugins like [gopassbridge](https://github.com/gopasspw/gopassbridge) running gopass as native app. More details can be found in [docs/jsonapi.md](./jsonapi.md).
+
+### Passphrase Agent
+
+`gopass agent` launches a long-running socket, similar to gpg-agent's socket, for requesting and caching the passphrase used to encrypt passwords. This allows one-off gopass operations (such as storing a password) to retrieve a cached copy of the passphrase. Communication over the socket uses HTTP. The agent is used for custom backends and stores that are encrypted with the passphrase as well as for testing.


### PR DESCRIPTION
The documentation is based off [doc.go](https://github.com/gopasspw/gopass/blob/master/pkg/agent/doc.go) in hopes that this fixes #973.

I figured `docs/features.md` was the best place to insert the documentation; however it could really go anywhere.