### PR TITLE
Pass optional key to fuzzy search

### DIFF
--- a/pkg/action/context.go
+++ b/pkg/action/context.go
@@ -10,6 +10,7 @@ const (
 	ctxKeyPasswordOnly
 	ctxKeyPrintQR
 	ctxKeyRevision
+	ctxKeyKey
 )
 
 // WithClip returns a context with the value for clip (for copy to clipboard)
@@ -83,6 +84,26 @@ func HasRevision(ctx context.Context) bool {
 // GetRevision returns the revison set in this context or an empty string
 func GetRevision(ctx context.Context) string {
 	sv, ok := ctx.Value(ctxKeyRevision).(string)
+	if !ok {
+		return ""
+	}
+	return sv
+}
+
+// WithKey returns a context with the key set
+func WithKey(ctx context.Context, sv string) context.Context {
+	return context.WithValue(ctx, ctxKeyKey, sv)
+}
+
+// HasKey returns true if the key is set
+func HasKey(ctx context.Context) bool {
+	_, ok := ctx.Value(ctxKeyKey).(string)
+	return ok
+}
+
+// GetKey returns the value of key or the default (empty string)
+func GetKey(ctx context.Context) string {
+	sv, ok := ctx.Value(ctxKeyKey).(string)
 	if !ok {
 		return ""
 	}

--- a/pkg/action/copy_test.go
+++ b/pkg/action/copy_test.go
@@ -79,7 +79,7 @@ func TestCopy(t *testing.T) {
 	assert.NoError(t, act.Copy(ctx, c))
 	buf.Reset()
 
-	assert.NoError(t, act.show(ctx, c, "zab/bam/zab", "", false))
+	assert.NoError(t, act.show(ctx, c, "zab/bam/zab", false))
 	assert.Equal(t, "barfoo\n", buf.String())
 	buf.Reset()
 }

--- a/pkg/action/edit.go
+++ b/pkg/action/edit.go
@@ -67,7 +67,7 @@ func (s *Action) editGetContent(ctx context.Context, name string, create bool) (
 	if !s.Store.Exists(ctx, name) {
 		newName := ""
 		// capture only the name of the selected secret
-		cb := func(ctx context.Context, c *cli.Context, name, key string, recurse bool) error {
+		cb := func(ctx context.Context, c *cli.Context, name string, recurse bool) error {
 			newName = name
 			return nil
 		}

--- a/pkg/action/find.go
+++ b/pkg/action/find.go
@@ -28,7 +28,7 @@ func (s *Action) Find(ctx context.Context, c *cli.Context) error {
 }
 
 // see action.show - context, cli context, name, key, rescurse
-type showFunc func(context.Context, *cli.Context, string, string, bool) error
+type showFunc func(context.Context, *cli.Context, string, bool) error
 
 func (s *Action) find(ctx context.Context, c *cli.Context, needle string, cb showFunc) error {
 	// get all existing entries
@@ -44,7 +44,7 @@ func (s *Action) find(ctx context.Context, c *cli.Context, needle string, cb sho
 	// if we have an exact match print it
 	if len(choices) == 1 {
 		out.Green(ctx, "Found exact match in '%s'", choices[0])
-		return cb(ctx, c, choices[0], "", false)
+		return cb(ctx, c, choices[0], false)
 	}
 
 	// if we don't have a match yet try a fuzzy search
@@ -80,21 +80,21 @@ func (s *Action) findSelection(ctx context.Context, c *cli.Context, choices []st
 	case "default":
 		// display or copy selected entry
 		fmt.Fprintln(stdout, choices[sel])
-		return cb(ctx, c, choices[sel], "", false)
+		return cb(ctx, c, choices[sel], false)
 	case "copy":
 		// display selected entry
 		fmt.Fprintln(stdout, choices[sel])
-		return cb(WithClip(ctx, true), c, choices[sel], "", false)
+		return cb(WithClip(ctx, true), c, choices[sel], false)
 	case "show":
 		// display selected entry
 		fmt.Fprintln(stdout, choices[sel])
-		return cb(WithClip(ctx, false), c, choices[sel], "", false)
+		return cb(WithClip(ctx, false), c, choices[sel], false)
 	case "sync":
 		// run sync and re-run show/find workflow
 		if err := s.Sync(ctx, c); err != nil {
 			return err
 		}
-		return cb(ctx, c, needle, "", true)
+		return cb(ctx, c, needle, true)
 	case "edit":
 		// edit selected entry
 		fmt.Fprintln(stdout, choices[sel])

--- a/pkg/action/insert_test.go
+++ b/pkg/action/insert_test.go
@@ -55,7 +55,7 @@ func TestInsert(t *testing.T) {
 	assert.NoError(t, act.insertStdin(ctx, "baz", []byte("foobar"), false))
 	buf.Reset()
 
-	assert.NoError(t, act.show(ctx, c, "baz", "", false))
+	assert.NoError(t, act.show(ctx, c, "baz", false))
 	assert.Equal(t, "foobar", buf.String())
 	buf.Reset()
 

--- a/pkg/action/otp.go
+++ b/pkg/action/otp.go
@@ -82,7 +82,7 @@ func (s *Action) otpHandleError(ctx context.Context, c *cli.Context, name, qrf s
 		return ExitError(ctx, ExitUnknown, err, "failed to retrieve secret '%s': %s", name, err)
 	}
 	out.Yellow(ctx, "Entry '%s' not found. Starting search...", name)
-	cb := func(ctx context.Context, c *cli.Context, name, key string, recurse bool) error {
+	cb := func(ctx context.Context, c *cli.Context, name string, recurse bool) error {
 		return s.otp(ctx, c, name, qrf, clip, pw, false)
 	}
 	if err := s.find(ctxutil.WithFuzzySearch(ctx, false), nil, name, cb); err == nil {

--- a/pkg/action/show_test.go
+++ b/pkg/action/show_test.go
@@ -151,7 +151,7 @@ func TestShowHandleRevision(t *testing.T) {
 	fs := flag.NewFlagSet("default", flag.ContinueOnError)
 	c := cli.NewContext(app, fs, nil)
 
-	assert.NoError(t, act.showHandleRevision(ctx, c, "foo", "", "baz"))
+	assert.NoError(t, act.showHandleRevision(ctx, c, "foo", "baz"))
 	buf.Reset()
 }
 


### PR DESCRIPTION
This commit allows to specify a second argument for the default fuzzy search.
This will be used to lookup this key in the selected secret.

Signed-off-by: Dominik Schulz <dominik.schulz@gauner.org>