### PR TITLE
Use present imperative tense for commits on move events

### DIFF
--- a/pkg/store/root/move.go
+++ b/pkg/store/root/move.go
@@ -41,7 +41,7 @@ func (r *Store) move(ctx context.Context, from, to string, delete bool) error {
 	if err := r.moveFromTo(ctxFrom, ctxTo, subFrom, subTo, from, to, fromPrefix, srcIsDir, delete); err != nil {
 		return err
 	}
-	if err := subFrom.RCS().Commit(ctxFrom, fmt.Sprintf("Moved from %s to %s", from, to)); err != nil {
+	if err := subFrom.RCS().Commit(ctxFrom, fmt.Sprintf("Move from %s to %s", from, to)); err != nil {
 		switch errors.Cause(err) {
 		case store.ErrGitNotInit:
 			out.Debug(ctx, "reencrypt - skipping git commit - git not initialized")
@@ -50,7 +50,7 @@ func (r *Store) move(ctx context.Context, from, to string, delete bool) error {
 		}
 	}
 	if !subFrom.Equals(subTo) {
-		if err := subTo.RCS().Commit(ctxTo, fmt.Sprintf("Moved from %s to %s", from, to)); err != nil {
+		if err := subTo.RCS().Commit(ctxTo, fmt.Sprintf("Move from %s to %s", from, to)); err != nil {
 			switch errors.Cause(err) {
 			case store.ErrGitNotInit:
 				out.Debug(ctx, "reencrypt - skipping git commit - git not initialized")
@@ -133,7 +133,7 @@ func (r *Store) moveFromTo(ctxFrom, ctxTo context.Context, subFrom, subTo store.
 			return errors.Errorf("Source %s does not exist in source store %s: %s", from, subFrom.Alias(), err)
 		}
 
-		if err := r.Set(sub.WithReason(ctxTo, fmt.Sprintf("Moved from %s to %s", src, dst)), dst, content); err != nil {
+		if err := r.Set(sub.WithReason(ctxTo, fmt.Sprintf("Move from %s to %s", src, dst)), dst, content); err != nil {
 			return errors.Wrapf(err, "failed to save secret '%s'", to)
 		}
 

--- a/pkg/store/sub/move.go
+++ b/pkg/store/sub/move.go
@@ -46,7 +46,7 @@ func (s *Store) Move(ctx context.Context, from, to string) error {
 	if err != nil {
 		return errors.Wrapf(err, "failed to decrypt '%s'", from)
 	}
-	if err := s.Set(WithReason(ctx, fmt.Sprintf("Moved from %s to %s", from, to)), to, content); err != nil {
+	if err := s.Set(WithReason(ctx, fmt.Sprintf("Move from %s to %s", from, to)), to, content); err != nil {
 		return errors.Wrapf(err, "failed to write '%s'", to)
 	}
 	if err := s.Delete(ctx, from); err != nil {


### PR DESCRIPTION
I know what you're thinking: "you sent a PR for _this_? come now!"

This changes the commit messages for moving files to be present imperative tense instead of past tense. Related things that bother me are "Exported public keys" and "Added recipient" which disagree with "Save secret" and "Remove blah from store" in terms of tense. If we're good with using present imperative tense everywhere, I will gladly send patches that change the convention everywhere.