### PR TITLE
Update Play Store link to Android Password Store app

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ gopass is developed in the open. Here are some of the channels we use to communi
 ## Mobile apps
 
 - [Pass - Password Store](https://apps.apple.com/us/app/pass-password-store/id1205820573) - iOS, [source code](https://github.com/mssun/passforios), [supports only 1 repository now](https://github.com/mssun/passforios/issues/88)
-- [Password Store](https://play.google.com/store/apps/details?id=com.zeapo.pwdstore) - Android
+- [Password Store](https://play.google.com/store/apps/details?id=dev.msfjarvis.aps) - Android
 
 ## Contributing
 


### PR DESCRIPTION
The Android Password Store app was just handed over from @zeapo to @msfjarvis.

See:
- https://github.com/android-password-store/Android-Password-Store/issues/597#issuecomment-578407624
- https://github.com/android-password-store/Android-Password-Store/pull/613
- https://github.com/android-password-store/Android-Password-Store/commit/b4aac6339935ae9c7ddc8e8e9588a7bd9d35ae5a