### PR TITLE
Catch 'The name is not activatable' DBus error when unclipping

### DIFF
--- a/pkg/clipboard/unclip_linux.go
+++ b/pkg/clipboard/unclip_linux.go
@@ -21,6 +21,9 @@ func clearClipboardHistory(ctx context.Context) error {
 		if strings.HasPrefix(call.Err.Error(), "The name org.kde.klipper was not provided") {
 			return nil
 		}
+		if strings.HasPrefix(call.Err.Error(), "The name is not activatable") {
+			return nil
+		}
 		return call.Err
 	}
 


### PR DESCRIPTION
On Fedora 31, `gopass unclip` fails with a "Failed to clear clipboard history"
notification. This is because DBus returns the following error message as
`klipper` is not available:

```
The name is not activatable
```

This commit adds this error message to the strings being ignored.

Fixes #1209

Signed-off-by: Simon Krenger <skrenger@redhat.com>