### PR TITLE
Let `find` support the -force flag

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -367,6 +367,10 @@ func getCommands(ctx context.Context, action *ap.Action, app *cli.App) []cli.Com
 					Name:  "clip, c",
 					Usage: "Copy the password into the clipboard",
 				},
+				cli.BoolFlag{
+					Name:  "force, f",
+					Usage: "In the case of an exact match, display the password even if safecontent is enabled",
+				},
 			},
 		},
 		{

--- a/pkg/action/find.go
+++ b/pkg/action/find.go
@@ -20,6 +20,10 @@ func (s *Action) Find(ctx context.Context, c *cli.Context) error {
 		ctx = WithClip(ctx, c.Bool("clip"))
 	}
 
+	if c.IsSet("force") {
+		ctx = WithForce(ctx, c.Bool("force"))
+	}
+
 	if !c.Args().Present() {
 		return ExitError(ctx, ExitUsage, nil, "Usage: %s find <NEEDLE>", s.Name)
 	}

--- a/pkg/action/find_test.go
+++ b/pkg/action/find_test.go
@@ -55,6 +55,48 @@ func TestFind(t *testing.T) {
 	assert.Equal(t, "Found exact match in 'foo'\nsecret", strings.TrimSpace(buf.String()))
 	buf.Reset()
 
+	// testing the safecontent case
+	ctx = ctxutil.WithShowSafeContent(ctx, true)
+	assert.NoError(t, act.Find(ctx, c))
+	out := strings.TrimSpace(buf.String())
+	assert.Contains(t, out, "Found exact match in 'foo'")
+	assert.Contains(t, out, "with -f")
+	assert.Contains(t, out, "Copying password instead.")
+	buf.Reset()
+
+	// testing with the clip flag set
+	bf := cli.BoolFlag{
+		Name:  "clip",
+		Usage: "clip",
+	}
+	assert.NoError(t, bf.ApplyWithError(fs))
+	assert.NoError(t, fs.Parse([]string{"-clip", "fo"}))
+	c = cli.NewContext(app, fs, nil)
+
+	assert.NoError(t, act.Find(ctx, c))
+	out = strings.TrimSpace(buf.String())
+	assert.Contains(t, out, "Found exact match in 'foo'")
+	assert.NotContains(t, out, "Copying password instead.")
+	buf.Reset()
+
+	// safecontent case with force flag set
+	fs = flag.NewFlagSet("default", flag.ContinueOnError)
+	bf = cli.BoolFlag{
+		Name:  "force",
+		Usage: "force",
+	}
+	assert.NoError(t, bf.ApplyWithError(fs))
+	assert.NoError(t, fs.Parse([]string{"-force", "fo"}))
+	c = cli.NewContext(app, fs, nil)
+
+	assert.NoError(t, act.Find(ctx, c))
+	out = strings.TrimSpace(buf.String())
+	assert.Contains(t, out, "Found exact match in 'foo'\nsecret")
+	buf.Reset()
+
+	// stopping with the safecontent tests
+	ctx = ctxutil.WithShowSafeContent(ctx, false)
+
 	// find yo
 	fs = flag.NewFlagSet("default", flag.ContinueOnError)
 	assert.NoError(t, fs.Parse([]string{"yo"}))

--- a/pkg/action/show.go
+++ b/pkg/action/show.go
@@ -117,7 +117,8 @@ func (s *Action) showHandleOutput(ctx context.Context, name string, sec store.Se
 			content = sec.Body()
 			if content == "" {
 				if ctxutil.IsAutoClip(ctx) {
-					out.Yellow(ctx, "No safe content to display, you can force display with show -f.\nCopying password instead.")
+					out.Yellow(ctx, "Info: %s.", store.ErrNoBody.Error())
+					out.Yellow(ctx, "Copying password instead.")
 					return clipboard.CopyTo(ctx, name, []byte(sec.Password()))
 				}
 				return ExitError(ctx, ExitNotFound, store.ErrNoBody, store.ErrNoBody.Error())

--- a/pkg/action/show_test.go
+++ b/pkg/action/show_test.go
@@ -92,7 +92,7 @@ func TestShow(t *testing.T) {
 	c = cli.NewContext(app, fs, nil)
 
 	assert.NoError(t, act.Show(ctx, c))
-	assert.Contains(t, buf.String(), "No safe content to display, you can force display with show -f.")
+	assert.Contains(t, buf.String(), "no safe content to display, you can force display with -f.")
 	buf.Reset()
 
 	// show foo with safecontent enabled, with the force flag

--- a/pkg/store/err.go
+++ b/pkg/store/err.go
@@ -22,7 +22,7 @@ var (
 	// ErrGitNothingToCommit is returned if there are no staged changes
 	ErrGitNothingToCommit = errors.Errorf("git has nothing to commit")
 	// ErrNoBody is returned if a secret exists but has no content beyond a password
-	ErrNoBody = errors.Errorf("no safe content to display, you can force display with show -f")
+	ErrNoBody = errors.Errorf("no safe content to display, you can force display with -f")
 	// ErrNoPassword is returned is a secret exists but has no password, only a body
 	ErrNoPassword = errors.Errorf("no password to display")
 	// ErrYAMLNoMark is returned if a secret contains no valid YAML document marker

--- a/tests/find_test.go
+++ b/tests/find_test.go
@@ -39,4 +39,15 @@ func TestFind(t *testing.T) {
 	out, err = ts.run("find b")
 	assert.NoError(t, err)
 	assert.Equal(t, "Found exact match in 'foo/bar'\nbaz", out)
+
+	_, err = ts.run("config safecontent true")
+	require.NoError(t, err)
+
+	out, err = ts.run("find bar")
+	assert.NoError(t, err)
+	assert.Contains(t, out, "no safe content to display")
+
+	out, err = ts.run("find bar -f")
+	assert.NoError(t, err)
+	assert.Equal(t, "Found exact match in 'foo/bar'\nbaz", out)
 }

--- a/tests/show_test.go
+++ b/tests/show_test.go
@@ -35,7 +35,8 @@ func TestShow(t *testing.T) {
 
 	out, err = ts.run("show fixed/secret")
 	assert.NoError(t, err)
-	assert.Contains(t, out, "safe content to display, you can force display with show -f.\nCopying password instead.")
+	assert.Contains(t, out, "safe content to display, you can force display with -f.")
+	assert.Contains(t, out, "Copying password instead.")
 
 	_, err = ts.run("config autoclip false")
 	assert.NoError(t, err)


### PR DESCRIPTION
Currently when the `safecontent` option is enabled and the `find` action is used and returns a single exact match, it will say: 
 "Found exact match in 'path'. No safe content to display, you can force display with show -f."

This is a bit misleading, since the `-f` flag is not supported by the find action currently, but by the `show`. 
This adds support for it so that it works now with `find path -f`.

Adding some tests as well.