### PR TITLE
Add notifications when using clipboard

### DIFF
--- a/pkg/clipboard/clipboard.go
+++ b/pkg/clipboard/clipboard.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"github.com/gopasspw/gopass/pkg/ctxutil"
+	"github.com/gopasspw/gopass/pkg/notify"
 	"github.com/gopasspw/gopass/pkg/out"
 
 	"github.com/atotto/clipboard"
@@ -23,18 +24,22 @@ var (
 func CopyTo(ctx context.Context, name string, content []byte) error {
 	if clipboard.Unsupported {
 		out.Yellow(ctx, "%s", ErrNotSupported)
+		_ = notify.Notify(ctx, "gopass - clipboard", fmt.Sprintf("%s", ErrNotSupported))
 		return nil
 	}
 
 	if err := clipboard.WriteAll(string(content)); err != nil {
+		_ = notify.Notify(ctx, "gopass - clipboard", "failed to write to clipboard")
 		return errors.Wrapf(err, "failed to write to clipboard")
 	}
 
 	if err := clear(ctx, content, ctxutil.GetClipTimeout(ctx)); err != nil {
+		_ = notify.Notify(ctx, "gopass - clipboard", "failed to clear clipboard")
 		return errors.Wrapf(err, "failed to clear clipboard")
 	}
 
 	out.Print(ctx, "✔ Copied %s to clipboard. Will clear in %d seconds.", color.YellowString(name), ctxutil.GetClipTimeout(ctx))
+	_ = notify.Notify(ctx, "gopass - clipboard", fmt.Sprintf("✔ Copied %s to clipboard. Will clear in %d seconds.", name, ctxutil.GetClipTimeout(ctx)))
 	return nil
 }
 

--- a/pkg/clipboard/unclip.go
+++ b/pkg/clipboard/unclip.go
@@ -37,7 +37,7 @@ func Clear(ctx context.Context, checksum string, force bool) error {
 		return errors.Wrapf(err, "failed to clear clipboard history: %s", err)
 	}
 
-	if err := notify.Notify(ctx, "gopass -clipboard", "Clipboard has been cleared"); err != nil {
+	if err := notify.Notify(ctx, "gopass - clipboard", "Clipboard has been cleared"); err != nil {
 		return errors.Wrapf(err, "failed to send unclip notification: %s", err)
 	}
 


### PR DESCRIPTION
The `show` command with the `clip` option can be used outside of a terminal execution (with an external `pinentry` command for example).

In this case, notifications can be a good way to have a feedback on the `gopass` command.

This PR add some notification messages, but only if the `clip` option has been requested.