### PR TITLE
Add --decrypt flag to gopass fsck

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -397,6 +397,12 @@ func getCommands(ctx context.Context, action *ap.Action, app *cli.App) []*cli.Co
 				return action.Fsck(withGlobalFlags(ctx, c), c)
 			},
 			BashComplete: action.MountsComplete,
+			Flags: []cli.Flag{
+				&cli.BoolFlag{
+					Name:  "decrypt",
+					Usage: "Decrypt during fsck",
+				},
+			},
 		},
 		{
 			Name:  "generate",

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.12
 
 require (
 	github.com/alecthomas/binary v0.0.0-20190922233330-fb1b1d9c299c
-	github.com/alexflint/go-arg v1.3.0 // indirect
 	github.com/atotto/clipboard v0.1.2
 	github.com/blang/semver v0.0.0-20190414182527-1a9109f8c4a1
 	github.com/cenkalti/backoff v2.2.1+incompatible

--- a/go.sum
+++ b/go.sum
@@ -4,10 +4,6 @@ github.com/DATA-DOG/go-sqlmock v1.3.3 h1:CWUqKXe0s8A2z6qCgkP4Kru7wC11YoAnoupUKFD
 github.com/DATA-DOG/go-sqlmock v1.3.3/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/alecthomas/binary v0.0.0-20190922233330-fb1b1d9c299c h1:SnUAzBu0FguUHChHbuy2HInhc2YBBTmbDcZOOByAVt8=
 github.com/alecthomas/binary v0.0.0-20190922233330-fb1b1d9c299c/go.mod h1:v4e05/vzE8ubOim1No9Xx5eIQ/WRq6AtcnQIy/Z/JPs=
-github.com/alexflint/go-arg v1.3.0 h1:UfldqSdFWeLtoOuVRosqofU4nmhI1pYEbT4ZFS34Bdo=
-github.com/alexflint/go-arg v1.3.0/go.mod h1:9iRbDxne7LcR/GSvEr7ma++GLpdIU1zrghf2y2768kM=
-github.com/alexflint/go-scalar v1.0.0 h1:NGupf1XV/Xb04wXskDFzS0KWOLH632W/EO4fAFi+A70=
-github.com/alexflint/go-scalar v1.0.0/go.mod h1:GpHzbCOZXEKMEcygYQ5n/aa4Aq84zbxjy3MxYW0gjYw=
 github.com/atotto/clipboard v0.1.2 h1:YZCtFu5Ie8qX2VmVTBnrqLSiU9XOWwqNRmdT3gIQzbY=
 github.com/atotto/clipboard v0.1.2/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/blang/semver v0.0.0-20190414182527-1a9109f8c4a1 h1:J50TZ8HB8AZI2nOQkRhoCprLJnjiWNhxonSWcrscUUw=
@@ -22,8 +18,6 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dominikschulz/github-releases v0.0.0-20171016132906-7635b43b2447 h1:zfNSuQsjvXoQ+hn1H77odNnbtWTpImr+sSttFDIu7Fg=
-github.com/dominikschulz/github-releases v0.0.0-20171016132906-7635b43b2447/go.mod h1:uByjb2frn7tRe9DiPHBk5TdhI1SmZEZKgMNrrIlIT04=
 github.com/dominikschulz/github-releases v0.0.2 h1:d/2c2DKs3JyQdPbMeOXRBOcaAsuuz6IdGOi+zVK5PL4=
 github.com/dominikschulz/github-releases v0.0.2/go.mod h1:uByjb2frn7tRe9DiPHBk5TdhI1SmZEZKgMNrrIlIT04=
 github.com/doronbehar/gocui v0.4.2 h1:+AHsDFIRw5PWLmacZ2PrI+QO/oQjsxQxvfCLa5PKBh4=
@@ -110,7 +104,6 @@ github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeV
 github.com/skip2/go-qrcode v0.0.0-20191027152451-9434209cb086 h1:RYiqpb2ii2Z6J4x0wxK46kvPBbFuZcdhS+CIztmYgZs=
 github.com/skip2/go-qrcode v0.0.0-20191027152451-9434209cb086/go.mod h1:PLPIyL7ikehBD1OAjmKKiOEhbvWyHGaNDjquXMcYABo=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/urfave/cli/v2 v2.2.0 h1:JTTnM6wKzdA0Jqodd966MVj4vWbbquZykeX1sKbe2C4=

--- a/pkg/action/fsck.go
+++ b/pkg/action/fsck.go
@@ -11,13 +11,16 @@ import (
 	"github.com/gopasspw/gopass/pkg/ctxutil"
 	"github.com/gopasspw/gopass/pkg/fsutil"
 	"github.com/gopasspw/gopass/pkg/out"
+	"github.com/gopasspw/gopass/pkg/store/sub"
 	"github.com/muesli/goprogressbar"
-
 	"github.com/urfave/cli/v2"
 )
 
 // Fsck checks the store integrity
 func (s *Action) Fsck(ctx context.Context, c *cli.Context) error {
+	if c.IsSet("decrypt") {
+		ctx = sub.WithFsckDecrypt(ctx, c.Bool("decrypt"))
+	}
 	out.Print(ctx, "Checking store integrity ...")
 	// make sure config is in the right place
 	// we may have loaded it from one of the fallback locations
@@ -64,5 +67,6 @@ func (s *Action) Fsck(ctx context.Context, c *cli.Context) error {
 	if err := s.Store.Fsck(ctx, c.Args().Get(0)); err != nil {
 		return ExitError(ctx, ExitFsck, err, "fsck found errors: %s", err)
 	}
+	fmt.Println()
 	return nil
 }

--- a/pkg/store/sub/context.go
+++ b/pkg/store/sub/context.go
@@ -17,6 +17,7 @@ const (
 	ctxKeyRecipientFunc
 	ctxKeyFsckFunc
 	ctxKeyCheckRecipients
+	ctxKeyFsckDecrypt
 )
 
 // WithFsckCheck returns a context with the flag for fscks check set
@@ -27,8 +28,7 @@ func WithFsckCheck(ctx context.Context, check bool) context.Context {
 // HasFsckCheck returns true if a value for fsck check has been set in this
 // context
 func HasFsckCheck(ctx context.Context) bool {
-	_, ok := ctx.Value(ctxKeyFsckCheck).(bool)
-	return ok
+	return hasBool(ctx, ctxKeyFsckCheck)
 }
 
 // IsFsckCheck returns the value of fsck check
@@ -48,8 +48,7 @@ func WithFsckForce(ctx context.Context, force bool) context.Context {
 // HasFsckForce returns true if a value for fsck force has been set in this
 // context
 func HasFsckForce(ctx context.Context) bool {
-	_, ok := ctx.Value(ctxKeyFsckForce).(bool)
-	return ok
+	return hasBool(ctx, ctxKeyFsckForce)
 }
 
 // IsFsckForce returns the value of fsck force
@@ -69,8 +68,7 @@ func WithAutoSync(ctx context.Context, sync bool) context.Context {
 // HasAutoSync has been set if a value for auto sync has been set in this
 // context
 func HasAutoSync(ctx context.Context) bool {
-	_, ok := ctx.Value(ctxKeyAutoSync).(bool)
-	return ok
+	return hasBool(ctx, ctxKeyAutoSync)
 }
 
 // IsAutoSync returns the value of autosync
@@ -184,8 +182,7 @@ func WithCheckRecipients(ctx context.Context, cr bool) context.Context {
 // HasCheckRecipients returns true if check recipients has been set in this
 // context
 func HasCheckRecipients(ctx context.Context) bool {
-	_, ok := ctx.Value(ctxKeyCheckRecipients).(bool)
-	return ok
+	return hasBool(ctx, ctxKeyCheckRecipients)
 }
 
 // IsCheckRecipients will return the value of the check recipients flag or the
@@ -194,6 +191,35 @@ func IsCheckRecipients(ctx context.Context) bool {
 	bv, ok := ctx.Value(ctxKeyCheckRecipients).(bool)
 	if !ok {
 		return false
+	}
+	return bv
+}
+
+// WithFsckDecrypt will return a context with the value for the decrypt
+// during fsck flag set.
+func WithFsckDecrypt(ctx context.Context, d bool) context.Context {
+	return context.WithValue(ctx, ctxKeyFsckDecrypt, d)
+}
+
+// IsFsckDecrypt will return the value for the decrypt during fsck, defaulting
+// to false.
+func IsFsckDecrypt(ctx context.Context) bool {
+	return is(ctx, ctxKeyFsckDecrypt, false)
+}
+
+// hasBool is a helper function for checking if a bool has been set in
+// the provided context.
+func hasBool(ctx context.Context, key contextKey) bool {
+	_, ok := ctx.Value(key).(bool)
+	return ok
+}
+
+// is is a helper function for returning the value of a bool from the context
+// or the provided default.
+func is(ctx context.Context, key contextKey, def bool) bool {
+	bv, ok := ctx.Value(key).(bool)
+	if !ok {
+		return def
 	}
 	return bv
 }

--- a/pkg/store/sub/fsck.go
+++ b/pkg/store/sub/fsck.go
@@ -47,9 +47,11 @@ func (s *Store) Fsck(ctx context.Context, path string) error {
 func (s *Store) fsckCheckEntry(ctx context.Context, name string) error {
 	// make sure we can actually decode this secret
 	// if this fails there is no way we could fix this
-	_, err := s.Get(ctx, name)
-	if err != nil {
-		return errors.Wrapf(err, "failed to decode secret %s: %s", name, err)
+	if IsFsckDecrypt(ctx) {
+		_, err := s.Get(ctx, name)
+		if err != nil {
+			return errors.Wrapf(err, "failed to decode secret %s: %s", name, err)
+		}
 	}
 
 	// now compare the recipients this secret was encoded for and fix it if


### PR DESCRIPTION
This commit changes fsck to not decrypt any secrets by default
to better account for the cases where touch-to-decrypt setups
are being used.

Fixes #1289

Signed-off-by: Dominik Schulz <dominik.schulz@gauner.org>