### PR TITLE
feat: support windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,12 @@ matrix:
 before_install:
   - if [ $TRAVIS_OS_NAME = linux ]; then sudo apt-get install git gnupg2 clang-format-3.9; fi
   - if [ $TRAVIS_OS_NAME = osx ]; then brew install git gnupg clang-format || true; fi
-  - if [ $TRAVIS_OS_NAME = windows ]; then choco install --yes --force --debug make gpg4win-lite || true; fi
+  - | 
+      if [ $TRAVIS_OS_NAME = windows ]; then 
+      choco install --yes --force --debug make gnupg || true; 
+      rm /usr/bin/gpg
+      diskperf -y
+      fi
   - git config --global user.name nobody
   - git config --global user.email foo.bar@example.org
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
 FIRST_GOPATH              := $(firstword $(subst :, ,$(GOPATH)))
 PKGS                      := $(shell go list ./... | grep -v /tests | grep -v /xcpb | grep -v /openpgp)
-PKGSWIN                   := $(shell go list ./... | grep -v /tests | grep -v /xcpb | grep -v /openpgp | grep -v /clipboard | grep -v /jsonapi)
 GOFILES_NOVENDOR          := $(shell find . -name vendor -prune -o -type f -name '*.go' -not -name '*.pb.go' -print)
 GOFILES_BUILD             := $(shell find . -type f -name '*.go' -not -name '*_test.go')
 PROTOFILES                := $(shell find . -name vendor -prune -o -type f -name '*.proto' -print)
@@ -45,9 +44,11 @@ sysinfo:
 	@printf '%s\n' '$(OK)'
 	@echo -n "     GIT     : $(shell git version)"
 	@printf '%s\n' '$(OK)'
-	@echo -n "     GPG1    : $(shell gpg --version | head -1)"
+	@echo -n "     GPG1    : $(shell which gpg) $(shell gpg --version | head -1)"
 	@printf '%s\n' '$(OK)'
-	@echo -n "     GPG2    : $(shell gpg2 --version | head -1)"
+	@echo -n "     GPG2    : $(shell which gpg2) $(shell gpg2 --version | head -1)"
+	@printf '%s\n' '$(OK)'
+	@echo -n "     GPG-Agent    : $(shell which gpg-agent) $(shell gpg-agent --version | head -1)"
 	@printf '%s\n' '$(OK)'
 
 clean:
@@ -90,8 +91,8 @@ fulltest: $(GOPASS_OUTPUT)
 fulltest-nocover: $(GOPASS_OUTPUT)
 	@echo ">> TEST, \"full-mode-no-coverage\": race detector off, build tags: xc"
 	@echo "mode: atomic" > coverage-all.out
-	@$(foreach pkg, $(PKGSWIN),\
-	    echo -n "     "; \
+	@$(foreach pkg, $(PKGS),\
+	    echo -n "     ";\
 		go test -run '(Test|Example)' $(BUILDFLAGS) $(TESTFLAGS) $(pkg) -tags 'xc' || exit 1;)
 
 racetest: $(GOPASS_OUTPUT)

--- a/pkg/action/clone_test.go
+++ b/pkg/action/clone_test.go
@@ -7,7 +7,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"runtime"
 	"testing"
 
 	"github.com/gopasspw/gopass/pkg/backend"
@@ -37,9 +36,6 @@ func aGitRepo(ctx context.Context, u *gptest.Unit, t *testing.T, name string) st
 }
 
 func TestClone(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("skipping test on windows.")
-	}
 	u := gptest.NewUnitTester(t)
 	defer u.Remove()
 
@@ -76,9 +72,6 @@ func TestClone(t *testing.T) {
 }
 
 func TestCloneBackendIsStoredForMount(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("skipping test on windows.")
-	}
 	u := gptest.NewUnitTester(t)
 	defer u.Remove()
 

--- a/pkg/action/fsck_test.go
+++ b/pkg/action/fsck_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"flag"
 	"os"
-	"runtime"
 	"strings"
 	"testing"
 
@@ -20,9 +19,6 @@ import (
 )
 
 func TestFsck(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("skipping test on windows.")
-	}
 	u := gptest.NewUnitTester(t)
 	defer u.Remove()
 
@@ -48,7 +44,11 @@ func TestFsck(t *testing.T) {
 	// fsck
 	c := cli.NewContext(app, flag.NewFlagSet("default", flag.ContinueOnError), nil)
 	assert.NoError(t, act.Fsck(ctx, c))
-	assert.Equal(t, "Checking store integrity ...\n\n[] Extra recipients on foo: [0xFEEDBEEF]\n\n[] Pushed changes to git remote", strings.TrimSpace(buf.String()))
+	out := strings.TrimSpace(buf.String())
+	assert.Contains(t, out, "Checking store integrity ...")
+	assert.Contains(t, out, "[] Extra recipients on foo: [0xFEEDBEEF]")
+	assert.Contains(t, out, "[] Pushed changes to git remote")
+
 	buf.Reset()
 
 	// fsck fo
@@ -57,6 +57,10 @@ func TestFsck(t *testing.T) {
 	c = cli.NewContext(app, fs, nil)
 
 	assert.NoError(t, act.Fsck(ctx, c))
-	assert.Equal(t, "Checking store integrity ...\n\n[] Extra recipients on foo: [0xFEEDBEEF]\n\n[] Pushed changes to git remote", strings.TrimSpace(buf.String()))
+	out = strings.TrimSpace(buf.String())
+	assert.Contains(t, out, "Checking store integrity ...")
+	assert.Contains(t, out, "[] Extra recipients on foo: [0xFEEDBEEF]")
+	assert.Contains(t, out, "[] Pushed changes to git remote")
+
 	buf.Reset()
 }

--- a/pkg/action/git-credential_test.go
+++ b/pkg/action/git-credential_test.go
@@ -6,7 +6,6 @@ import (
 	"flag"
 	"io"
 	"os"
-	"runtime"
 	"strings"
 	"testing"
 
@@ -81,9 +80,6 @@ func TestGitCredentialFormat(t *testing.T) {
 }
 
 func TestGitCredentialHelper(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("skipping test on windows.")
-	}
 	u := gptest.NewUnitTester(t)
 	defer u.Remove()
 

--- a/pkg/action/init_test.go
+++ b/pkg/action/init_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
 	"testing"
 
 	"github.com/gopasspw/gopass/pkg/backend"
@@ -21,9 +20,6 @@ import (
 )
 
 func TestInit(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("skipping test on windows.")
-	}
 	u := gptest.NewUnitTester(t)
 	defer u.Remove()
 

--- a/pkg/action/jsonapi_test.go
+++ b/pkg/action/jsonapi_test.go
@@ -20,7 +20,7 @@ func TestJSONAPI(t *testing.T) {
 	u := gptest.NewUnitTester(t)
 	defer u.Remove()
 
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
 	ctx = ctxutil.WithAlwaysYes(ctx, true)
 	act, err := newMock(ctx, u)
 	require.NoError(t, err)
@@ -37,4 +37,5 @@ func TestJSONAPI(t *testing.T) {
 	}()
 
 	assert.NoError(t, act.JSONAPI(ctx, c))
+	cancel()
 }

--- a/pkg/action/mount_test.go
+++ b/pkg/action/mount_test.go
@@ -6,7 +6,6 @@ import (
 	"flag"
 	"os"
 	"path/filepath"
-	"runtime"
 	"testing"
 
 	"github.com/gopasspw/gopass/pkg/ctxutil"
@@ -19,9 +18,6 @@ import (
 )
 
 func TestMounts(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("skipping test on windows.")
-	}
 	u := gptest.NewUnitTester(t)
 	defer u.Remove()
 

--- a/pkg/backend/crypto/gpg/cli/generate_others_test.go
+++ b/pkg/backend/crypto/gpg/cli/generate_others_test.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package cli
 
 import (

--- a/pkg/backend/crypto/gpg/cli/generate_windows_test.go
+++ b/pkg/backend/crypto/gpg/cli/generate_windows_test.go
@@ -1,0 +1,19 @@
+package cli
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCreatePrivateKey(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	g := &GPG{}
+	g.binary = "rundll32"
+
+	assert.NoError(t, g.CreatePrivateKeyBatch(ctx, "foo", "foo@bar.com", "bar"))
+	assert.NoError(t, g.CreatePrivateKey(ctx))
+	cancel()
+}

--- a/pkg/backend/crypto/gpg/cli/gpg_others_test.go
+++ b/pkg/backend/crypto/gpg/cli/gpg_others_test.go
@@ -1,0 +1,36 @@
+// +build !windows
+
+package cli
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDetectBinaryCandidates(t *testing.T) {
+	bins, err := detectBinaryCandidates("foobar")
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"gpg2", "gpg1", "gpg", "foobar"}, bins)
+}
+
+func TestEncrypt(t *testing.T) {
+	ctx := context.Background()
+
+	g := &GPG{}
+	g.binary = "true"
+
+	_, err := g.Encrypt(ctx, []byte("foo"), nil)
+	assert.NoError(t, err)
+}
+
+func TestDecrypt(t *testing.T) {
+	ctx := context.Background()
+
+	g := &GPG{}
+	g.binary = "true"
+
+	_, err := g.Decrypt(ctx, []byte("foo"))
+	assert.NoError(t, err)
+}

--- a/pkg/backend/crypto/gpg/cli/gpg_test.go
+++ b/pkg/backend/crypto/gpg/cli/gpg_test.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"context"
-	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -34,33 +33,4 @@ func TestGPG(t *testing.T) {
 	assert.Equal(t, "gpg", g.Name())
 	assert.Equal(t, "gpg", g.Ext())
 	assert.Equal(t, ".gpg-id", g.IDFile())
-}
-
-func TestDetectBinaryCandidates(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("skipping test on windows.")
-	}
-	bins, err := detectBinaryCandidates("foobar")
-	assert.NoError(t, err)
-	assert.Equal(t, []string{"gpg2", "gpg1", "gpg", "foobar"}, bins)
-}
-
-func TestEncrypt(t *testing.T) {
-	ctx := context.Background()
-
-	g := &GPG{}
-	g.binary = "true"
-
-	_, err := g.Encrypt(ctx, []byte("foo"), nil)
-	assert.NoError(t, err)
-}
-
-func TestDecrypt(t *testing.T) {
-	ctx := context.Background()
-
-	g := &GPG{}
-	g.binary = "true"
-
-	_, err := g.Decrypt(ctx, []byte("foo"))
-	assert.NoError(t, err)
 }

--- a/pkg/backend/crypto/gpg/cli/gpg_windows_test.go
+++ b/pkg/backend/crypto/gpg/cli/gpg_windows_test.go
@@ -1,0 +1,44 @@
+package cli
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDetectBinaryCandidates(t *testing.T) {
+	bins, err := detectBinaryCandidates("foobar")
+	assert.NoError(t, err)
+	// the install locations differ depending on :
+	// - chocolatey install path prefix
+	// - 64bit/32bit windows
+	var stripped []string
+	for _, bin := range bins {
+		stripped = append(stripped, filepath.Base(bin))
+	}
+	assert.Contains(t, stripped, "gpg.exe")
+}
+
+func TestEncrypt(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	g := &GPG{}
+	g.binary = "rundll32"
+
+	_, err := g.Encrypt(ctx, []byte("foo"), nil)
+	assert.NoError(t, err)
+	cancel()
+}
+
+func TestDecrypt(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	g := &GPG{}
+	g.binary = "rundll32"
+
+	_, err := g.Decrypt(ctx, []byte("foo"))
+	assert.NoError(t, err)
+	cancel()
+}

--- a/pkg/backend/crypto/gpg/cli/import_others_test.go
+++ b/pkg/backend/crypto/gpg/cli/import_others_test.go
@@ -1,0 +1,22 @@
+// +build !windows
+
+package cli
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestImport(t *testing.T) {
+	ctx := context.Background()
+
+	g := &GPG{}
+	g.binary = "true"
+
+	assert.NoError(t, g.ImportPublicKey(ctx, []byte("foobar")))
+
+	g.binary = ""
+	assert.Error(t, g.ImportPublicKey(ctx, []byte("foobar")))
+}

--- a/pkg/backend/crypto/gpg/cli/import_windows_test.go
+++ b/pkg/backend/crypto/gpg/cli/import_windows_test.go
@@ -8,13 +8,14 @@ import (
 )
 
 func TestImport(t *testing.T) {
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
 
 	g := &GPG{}
-	g.binary = "true"
+	g.binary = "rundll32"
 
 	assert.NoError(t, g.ImportPublicKey(ctx, []byte("foobar")))
 
 	g.binary = ""
 	assert.Error(t, g.ImportPublicKey(ctx, []byte("foobar")))
+	cancel()
 }

--- a/pkg/backend/storage/fs/store_others.go
+++ b/pkg/backend/storage/fs/store_others.go
@@ -1,0 +1,12 @@
+// +build !windows
+
+package fs
+
+import (
+	"os"
+	"syscall"
+)
+
+func notEmptyErr(err error) bool {
+	return err.(*os.PathError).Err == syscall.ENOTEMPTY
+}

--- a/pkg/backend/storage/fs/store_test.go
+++ b/pkg/backend/storage/fs/store_test.go
@@ -5,7 +5,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -45,9 +44,6 @@ func TestSetAndGet(t *testing.T) {
 }
 
 func TestRemoveEmptyParentDirectories(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("skipping test on windows.")
-	}
 	var tests = []struct {
 		name          string
 		storeRoot     []string

--- a/pkg/backend/storage/fs/store_windows.go
+++ b/pkg/backend/storage/fs/store_windows.go
@@ -1,0 +1,10 @@
+package fs
+
+import (
+	"os"
+	"syscall"
+)
+
+func notEmptyErr(err error) bool {
+	return err.(*os.PathError).Err == syscall.ERROR_DIR_NOT_EMPTY
+}

--- a/pkg/backend/url_others_test.go
+++ b/pkg/backend/url_others_test.go
@@ -1,0 +1,20 @@
+// +build !windows
+
+package backend_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	yaml "gopkg.in/yaml.v2"
+)
+
+func TestUnmarshalYAML(t *testing.T) {
+	in := `---
+path: gpgcli-gitcli-fs+file:///tmp/foo
+`
+	cfg := testConfig{}
+	require.NoError(t, yaml.Unmarshal([]byte(in), &cfg))
+	assert.Equal(t, "/tmp/foo", cfg.Path.Path)
+}

--- a/pkg/backend/url_windows_test.go
+++ b/pkg/backend/url_windows_test.go
@@ -1,0 +1,66 @@
+package backend_test
+
+import (
+	"testing"
+
+	"github.com/gopasspw/gopass/pkg/backend"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	yaml "gopkg.in/yaml.v2"
+)
+
+func TestUnmarshalYAMLWindows(t *testing.T) {
+	in := `---
+path: gpgcli-gitcli-fs+file:///C:\tmp\foo
+`
+	cfg := testConfig{}
+	require.NoError(t, yaml.Unmarshal([]byte(in), &cfg))
+	assert.Equal(t, "C:\\tmp\\foo", cfg.Path.Path)
+}
+
+func TestParseWindows(t *testing.T) {
+	for _, tc := range []struct {
+		Name    string
+		URL     string
+		Crypto  backend.CryptoBackend
+		RCS     backend.RCSBackend
+		Storage backend.StorageBackend
+		Path    string
+	}{
+		{
+			Name:    "windows store path",
+			URL:     `C:\Users\johndoe\.password-store-my-team`,
+			Crypto:  backend.GPGCLI,
+			RCS:     backend.GitCLI,
+			Storage: backend.FS,
+			Path:    `C:\Users\johndoe\.password-store-my-team`,
+		},
+		{
+			Name:    "windows store path with whitespace",
+			URL:     `C:\Users\johndoe\My Folder\.password-store`,
+			Crypto:  backend.GPGCLI,
+			RCS:     backend.GitCLI,
+			Storage: backend.FS,
+			Path:    `C:\Users\johndoe\My Folder\.password-store`,
+		},
+		{
+			Name:    "file scheme and windows abs path",
+			URL:     `file:///C:\Users\johndoe`,
+			Crypto:  backend.GPGCLI,
+			RCS:     backend.GitCLI,
+			Storage: backend.FS,
+			Path:    `C:\Users\johndoe`,
+		},
+	} {
+		u, err := backend.ParseURL(tc.URL)
+		require.NoError(t, err, tc.Name)
+		require.NotNil(t, u)
+		assert.NotNil(t, u, tc.Name)
+		assert.Equal(t, tc.Crypto, u.Crypto, tc.Name)
+		assert.Equal(t, tc.RCS, u.RCS, tc.Name)
+		assert.Equal(t, tc.Storage, u.Storage, tc.Name)
+		if tc.Path != "" {
+			assert.Equal(t, tc.Path, u.Path, tc.Name)
+		}
+	}
+}

--- a/pkg/backend/url_xc_others_test.go
+++ b/pkg/backend/url_xc_others_test.go
@@ -1,3 +1,4 @@
+// +build !windows
 // +build xc
 // +build gitcli
 
@@ -5,7 +6,6 @@ package backend
 
 import (
 	"path/filepath"
-	"runtime"
 	"testing"
 
 	homedir "github.com/mitchellh/go-homedir"
@@ -99,9 +99,6 @@ type testConfig struct {
 }
 
 func TestUnmarshalYAMLXC(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("skipping test on windows.")
-	}
 	in := `---
 path: xc-gitcli-fs+file:///tmp/foo
 `

--- a/pkg/backend/url_xc_windows_test.go
+++ b/pkg/backend/url_xc_windows_test.go
@@ -78,12 +78,6 @@ func TestParseSchemeXC(t *testing.T) {
 			Storage: FS,
 			Path:    filepath.Join(hd, ".local", "share", "password-store"),
 		},
-		//{
-		//	URL:     "plain+vault-http://localhost:9600/foo/bar",
-		//	Crypto:  Plain,
-		//	RCS:     Noop,
-		//	Storage: Vault,
-		//},
 	} {
 		u, err := ParseURL(tc.URL)
 		require.NoError(t, err, tc.Name)

--- a/pkg/clipboard/clipboard_test.go
+++ b/pkg/clipboard/clipboard_test.go
@@ -18,7 +18,9 @@ import (
 )
 
 func TestCopyToClipboard(t *testing.T) {
-	ctx := context.Background()
+	_ = os.Setenv("GOPASS_NO_NOTIFY", "true")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	clipboard.Unsupported = true
 
 	buf := &bytes.Buffer{}
@@ -28,8 +30,9 @@ func TestCopyToClipboard(t *testing.T) {
 }
 
 func TestClearClipboard(t *testing.T) {
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
 	assert.NoError(t, clear(ctx, []byte("bar"), 0))
+	cancel()
 	time.Sleep(50 * time.Millisecond)
 }
 

--- a/pkg/config/io_test.go
+++ b/pkg/config/io_test.go
@@ -7,7 +7,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
 
@@ -167,14 +166,10 @@ func TestLoad(t *testing.T) {
 }
 
 func TestLoadError(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("skipping test on windows.")
-	}
 	gcfg := filepath.Join(os.TempDir(), ".gopass-err.yml")
 	assert.NoError(t, os.Setenv("GOPASS_CONFIG", gcfg))
 
 	_ = os.Remove(gcfg)
-	require.NoError(t, ioutil.WriteFile(gcfg, []byte(testConfig), 0000))
 
 	capture(t, func() error {
 		_, err := load(gcfg)

--- a/pkg/editor/edit_others_test.go
+++ b/pkg/editor/edit_others_test.go
@@ -1,0 +1,74 @@
+// +build !windows
+
+package editor
+
+import (
+	"context"
+	"flag"
+	"os"
+	"os/exec"
+	"runtime"
+	"testing"
+
+	"github.com/gopasspw/gopass/tests/gptest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v2"
+)
+
+func TestEditor(t *testing.T) {
+	u := gptest.NewUnitTester(t)
+	defer u.Remove()
+
+	ctx := context.Background()
+	touch, err := exec.LookPath("touch")
+	require.NoError(t, err)
+
+	want := "foobar"
+	out, err := Invoke(ctx, touch, []byte(want))
+	require.NoError(t, err)
+	if string(out) != want {
+		t.Errorf("'%s' != '%s'", string(out), want)
+	}
+}
+
+func TestGetEditor(t *testing.T) {
+	app := cli.NewApp()
+
+	// --editor=fooed
+	fs := flag.NewFlagSet("default", flag.ContinueOnError)
+	sf := cli.StringFlag{
+		Name:  "editor",
+		Usage: "editor",
+	}
+	require.NoError(t, sf.Apply(fs))
+	require.NoError(t, fs.Parse([]string{"--editor", "fooed"}))
+	c := cli.NewContext(app, fs, nil)
+
+	assert.Equal(t, "fooed", Path(c))
+
+	// EDITOR
+	fs = flag.NewFlagSet("default", flag.ContinueOnError)
+	c = cli.NewContext(app, fs, nil)
+	assert.NoError(t, os.Setenv("EDITOR", "fooenv"))
+	assert.Equal(t, "fooenv", Path(c))
+	assert.NoError(t, os.Unsetenv("EDITOR"))
+
+	// editor
+	pathed, err := exec.LookPath("editor")
+	if err == nil {
+		assert.Equal(t, pathed, Path(c))
+	}
+
+	// vi
+	op := os.Getenv("PATH")
+	assert.NoError(t, os.Setenv("PATH", "/tmp"))
+	if runtime.GOOS == "windows" {
+		assert.Equal(t, "notepad.exe", Path(c))
+
+	} else {
+		assert.Equal(t, "vi", Path(c))
+
+	}
+	assert.NoError(t, os.Setenv("PATH", op))
+}

--- a/pkg/editor/edit_test.go
+++ b/pkg/editor/edit_test.go
@@ -3,19 +3,13 @@ package editor
 import (
 	"bytes"
 	"context"
-	"flag"
 	"os"
-	"os/exec"
-	"runtime"
 	"testing"
 
 	"github.com/gopasspw/gopass/pkg/ctxutil"
 	"github.com/gopasspw/gopass/pkg/out"
-	"github.com/gopasspw/gopass/tests/gptest"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"github.com/urfave/cli/v2"
 )
 
 func TestEdit(t *testing.T) {
@@ -32,64 +26,4 @@ func TestEdit(t *testing.T) {
 	_, err := Invoke(ctx, "true", []byte{})
 	assert.Error(t, err)
 	buf.Reset()
-}
-
-func TestEditor(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("skipping test on windows.")
-	}
-	u := gptest.NewUnitTester(t)
-	defer u.Remove()
-
-	ctx := context.Background()
-	touch, err := exec.LookPath("touch")
-	require.NoError(t, err)
-
-	want := "foobar"
-	out, err := Invoke(ctx, touch, []byte(want))
-	require.NoError(t, err)
-	if string(out) != want {
-		t.Errorf("'%s' != '%s'", string(out), want)
-	}
-}
-
-func TestGetEditor(t *testing.T) {
-	app := cli.NewApp()
-
-	// --editor=fooed
-	fs := flag.NewFlagSet("default", flag.ContinueOnError)
-	sf := cli.StringFlag{
-		Name:  "editor",
-		Usage: "editor",
-	}
-	require.NoError(t, sf.Apply(fs))
-	require.NoError(t, fs.Parse([]string{"--editor", "fooed"}))
-	c := cli.NewContext(app, fs, nil)
-
-	assert.Equal(t, "fooed", Path(c))
-
-	// EDITOR
-	fs = flag.NewFlagSet("default", flag.ContinueOnError)
-	c = cli.NewContext(app, fs, nil)
-	assert.NoError(t, os.Setenv("EDITOR", "fooenv"))
-	assert.Equal(t, "fooenv", Path(c))
-	assert.NoError(t, os.Unsetenv("EDITOR"))
-
-	// editor
-	pathed, err := exec.LookPath("editor")
-	if err == nil {
-		assert.Equal(t, pathed, Path(c))
-	}
-
-	// vi
-	op := os.Getenv("PATH")
-	assert.NoError(t, os.Setenv("PATH", "/tmp"))
-	if runtime.GOOS == "windows" {
-		assert.Equal(t, "notepad.exe", Path(c))
-
-	} else {
-		assert.Equal(t, "vi", Path(c))
-
-	}
-	assert.NoError(t, os.Setenv("PATH", op))
 }

--- a/pkg/editor/edit_windows_test.go
+++ b/pkg/editor/edit_windows_test.go
@@ -1,0 +1,66 @@
+package editor
+
+import (
+	"context"
+	"flag"
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/gopasspw/gopass/tests/gptest"
+	"github.com/urfave/cli/v2"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEditor(t *testing.T) {
+	u := gptest.NewUnitTester(t)
+	defer u.Remove()
+
+	ctx := context.Background()
+	touch, err := exec.LookPath("rundll32")
+	require.NoError(t, err)
+
+	want := "foobar"
+	out, err := Invoke(ctx, touch, []byte(want))
+	require.NoError(t, err)
+	if string(out) != want {
+		t.Errorf("'%s' != '%s'", string(out), want)
+	}
+}
+
+func TestGetEditor(t *testing.T) {
+	app := cli.NewApp()
+
+	// --editor=fooed
+	fs := flag.NewFlagSet("default", flag.ContinueOnError)
+	sf := cli.StringFlag{
+		Name:  "editor",
+		Usage: "editor",
+	}
+	require.NoError(t, sf.Apply(fs))
+	require.NoError(t, fs.Parse([]string{"--editor", "fooed"}))
+	c := cli.NewContext(app, fs, nil)
+
+	assert.Equal(t, "fooed", Path(c))
+
+	// EDITOR
+	fs = flag.NewFlagSet("default", flag.ContinueOnError)
+	c = cli.NewContext(app, fs, nil)
+	assert.NoError(t, os.Setenv("EDITOR", "fooenv"))
+	assert.Equal(t, "fooenv", Path(c))
+	assert.NoError(t, os.Unsetenv("EDITOR"))
+
+	// editor
+	pathed, err := exec.LookPath("editor")
+	if err == nil {
+		assert.Equal(t, pathed, Path(c))
+	}
+
+	// notepad
+	op := os.Getenv("PATH")
+	assert.NoError(t, os.Setenv("PATH", "/tmp"))
+	assert.Equal(t, "notepad.exe", Path(c))
+	assert.NoError(t, os.Setenv("PATH", op))
+}

--- a/pkg/fsutil/fsutil_test.go
+++ b/pkg/fsutil/fsutil_test.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"os/user"
 	"path/filepath"
-	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -83,9 +82,6 @@ func TestIsFile(t *testing.T) {
 }
 
 func TestShred(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("skipping test on windows.")
-	}
 	tempdir, err := ioutil.TempDir("", "gopass-")
 	require.NoError(t, err)
 	defer func() {

--- a/pkg/jsonapi/api_test.go
+++ b/pkg/jsonapi/api_test.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
-	"runtime"
 	"strings"
 	"testing"
 
@@ -57,9 +56,6 @@ func TestRespondGetVersion(t *testing.T) {
 }
 
 func TestRespondMessageQuery(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("skipping test on windows.")
-	}
 	secrets := []storedSecret{
 		{[]string{"awesomePrefix", "foo", "bar"}, secret.New("20", "")},
 		{[]string{"awesomePrefix", "fixed", "secret"}, secret.New("moar", "")},
@@ -321,12 +317,13 @@ func runRespondMessages(t *testing.T, requests []verifiedRequest, secrets []stor
 }
 
 func runRespondRawMessages(t *testing.T, requests []verifiedRequest, secrets []storedSecret) {
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
 
 	tempdir, err := ioutil.TempDir("", "gopass-")
 	require.NoError(t, err)
 	defer func() {
 		_ = os.RemoveAll(tempdir)
+		cancel()
 	}()
 
 	assert.NoError(t, os.Setenv("GOPASS_DISABLE_ENCRYPTION", "true"))

--- a/pkg/jsonapi/manifest/setup_test.go
+++ b/pkg/jsonapi/manifest/setup_test.go
@@ -1,26 +1,29 @@
 package manifest
 
 import (
+	"os"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
-const (
-	manifestGolden = `{
+func TestRender(t *testing.T) {
+	// windows: C:\Users\johndoe\AppData...
+	// *nix: /tmp
+	binDir := os.TempDir()
+
+	manifestGolden := `{
     "name": "com.justwatch.gopass",
     "description": "Gopass wrapper to search and return passwords",
-    "path": "/tmp/",
+    "path": "` + strings.Replace(binDir, "\\", "\\\\", -1) + `",
     "type": "stdio",
     "allowed_origins": [
         "chrome-extension://kkhfnlkhiapbiehimabddjbimfaijdhk/"
     ]
 }`
-)
-
-func TestRender(t *testing.T) {
-	w, m, err := Render("chrome", "/tmp/", "gopass", true)
+	w, m, err := Render("chrome", binDir, "gopass", true)
 	assert.NoError(t, err)
 	assert.Equal(t, wrapperGolden, string(w))
 	assert.Equal(t, manifestGolden, string(m))

--- a/pkg/pwgen/pwgen_others_test.go
+++ b/pkg/pwgen/pwgen_others_test.go
@@ -1,0 +1,16 @@
+// +build !windows
+
+package pwgen
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPwgenExternal(t *testing.T) {
+	_ = os.Setenv("GOPASS_EXTERNAL_PWGEN", "echo foobar")
+	defer os.Unsetenv("GOPASS_EXTERNAL_PWGEN")
+	assert.Equal(t, "foobar", GeneratePassword(4, true))
+}

--- a/pkg/pwgen/pwgen_test.go
+++ b/pkg/pwgen/pwgen_test.go
@@ -29,11 +29,6 @@ func TestPwgenCharset(t *testing.T) {
 	assert.Equal(t, "aaaa", GeneratePassword(4, true))
 }
 
-func TestPwgenExternal(t *testing.T) {
-	_ = os.Setenv("GOPASS_EXTERNAL_PWGEN", "echo foobar")
-	assert.Equal(t, "foobar", GeneratePassword(4, true))
-}
-
 func TestPwgenNoCrand(t *testing.T) {
 	old := rand.Reader
 	rand.Reader = strings.NewReader("")

--- a/pkg/pwgen/pwgen_windows_test.go
+++ b/pkg/pwgen/pwgen_windows_test.go
@@ -1,0 +1,13 @@
+package pwgen
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPwgenExternal(t *testing.T) {
+	_ = os.Setenv("GOPASS_EXTERNAL_PWGEN", "powershell.exe -Command write-output 1234")
+	assert.Equal(t, "1234", GeneratePassword(4, true))
+}

--- a/pkg/store/root/init_test.go
+++ b/pkg/store/root/init_test.go
@@ -2,7 +2,6 @@ package root
 
 import (
 	"context"
-	"runtime"
 	"testing"
 
 	"github.com/gopasspw/gopass/pkg/backend"
@@ -16,9 +15,6 @@ import (
 )
 
 func TestInit(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("skipping test on windows.")
-	}
 	u := gptest.NewUnitTester(t)
 	defer u.Remove()
 

--- a/pkg/store/root/mount.go
+++ b/pkg/store/root/mount.go
@@ -15,6 +15,8 @@ import (
 	"github.com/pkg/errors"
 )
 
+var sep = "/"
+
 // AddMount adds a new mount
 func (r *Store) AddMount(ctx context.Context, alias, path string, keys ...string) error {
 	if err := r.addMount(ctx, alias, path, nil, keys...); err != nil {
@@ -150,7 +152,7 @@ func (r *Store) MountPoints() []string {
 // MountPoint returns the most-specific mount point for the given key
 func (r *Store) MountPoint(name string) string {
 	for _, mp := range r.MountPoints() {
-		if strings.HasPrefix(name+"/", mp+"/") {
+		if strings.HasPrefix(name+sep, mp+sep) {
 			return mp
 		}
 	}
@@ -161,7 +163,7 @@ func (r *Store) MountPoint(name string) string {
 // given key
 // context with sub store options set, sub store reference, truncated path to secret
 func (r *Store) getStore(ctx context.Context, name string) (context.Context, store.Store, string) {
-	name = strings.TrimSuffix(name, "/")
+	name = strings.TrimSuffix(name, sep)
 	mp := r.MountPoint(name)
 	if sub, found := r.mounts[mp]; found {
 		return r.cfg.Mounts[mp].WithContext(ctx), sub, strings.TrimPrefix(name, sub.Alias())
@@ -171,7 +173,7 @@ func (r *Store) getStore(ctx context.Context, name string) (context.Context, sto
 
 // WithConfig populates the context with the substore config
 func (r *Store) WithConfig(ctx context.Context, name string) context.Context {
-	name = strings.TrimSuffix(name, "/")
+	name = strings.TrimSuffix(name, sep)
 	mp := r.MountPoint(name)
 	if _, found := r.mounts[mp]; found {
 		return r.cfg.Mounts[mp].WithContext(ctx)

--- a/pkg/store/root/mount.go
+++ b/pkg/store/root/mount.go
@@ -15,8 +15,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-var sep = "/"
-
 // AddMount adds a new mount
 func (r *Store) AddMount(ctx context.Context, alias, path string, keys ...string) error {
 	if err := r.addMount(ctx, alias, path, nil, keys...); err != nil {
@@ -152,7 +150,7 @@ func (r *Store) MountPoints() []string {
 // MountPoint returns the most-specific mount point for the given key
 func (r *Store) MountPoint(name string) string {
 	for _, mp := range r.MountPoints() {
-		if strings.HasPrefix(name+sep, mp+sep) {
+		if strings.HasPrefix(name+"/", mp+"/") {
 			return mp
 		}
 	}
@@ -163,7 +161,7 @@ func (r *Store) MountPoint(name string) string {
 // given key
 // context with sub store options set, sub store reference, truncated path to secret
 func (r *Store) getStore(ctx context.Context, name string) (context.Context, store.Store, string) {
-	name = strings.TrimSuffix(name, sep)
+	name = strings.TrimSuffix(name, "/")
 	mp := r.MountPoint(name)
 	if sub, found := r.mounts[mp]; found {
 		return r.cfg.Mounts[mp].WithContext(ctx), sub, strings.TrimPrefix(name, sub.Alias())
@@ -173,7 +171,7 @@ func (r *Store) getStore(ctx context.Context, name string) (context.Context, sto
 
 // WithConfig populates the context with the substore config
 func (r *Store) WithConfig(ctx context.Context, name string) context.Context {
-	name = strings.TrimSuffix(name, sep)
+	name = strings.TrimSuffix(name, "/")
 	mp := r.MountPoint(name)
 	if _, found := r.mounts[mp]; found {
 		return r.cfg.Mounts[mp].WithContext(ctx)

--- a/pkg/store/root/move.go
+++ b/pkg/store/root/move.go
@@ -3,7 +3,7 @@ package root
 import (
 	"context"
 	"fmt"
-	"path"
+	"path/filepath"
 	"strings"
 
 	"github.com/gopasspw/gopass/pkg/ctxutil"
@@ -120,10 +120,10 @@ func (r *Store) moveFromTo(ctxFrom, ctxTo context.Context, subFrom, subTo store.
 		dst := to
 		if srcIsDir {
 			// Follow the rsync convention to not re-create the source folder at the destination when a "/" is found
-			if strings.HasSuffix(from, "/") {
-				dst = path.Join(to, strings.TrimPrefix(src, from))
+			if strings.HasSuffix(from, sep) {
+				dst = filepath.Join(to, strings.TrimPrefix(src, from))
 			} else {
-				dst = path.Join(to, path.Base(from), strings.TrimPrefix(src, from))
+				dst = filepath.Join(to, filepath.Base(from), strings.TrimPrefix(src, from))
 			}
 		}
 		out.Debug(ctxFrom, "Moving %s (%s) => %s (%s) (sid:%t)\n", from, src, to, dst, srcIsDir)

--- a/pkg/store/root/move.go
+++ b/pkg/store/root/move.go
@@ -3,7 +3,7 @@ package root
 import (
 	"context"
 	"fmt"
-	"path/filepath"
+	"path"
 	"strings"
 
 	"github.com/gopasspw/gopass/pkg/ctxutil"
@@ -120,10 +120,10 @@ func (r *Store) moveFromTo(ctxFrom, ctxTo context.Context, subFrom, subTo store.
 		dst := to
 		if srcIsDir {
 			// Follow the rsync convention to not re-create the source folder at the destination when a "/" is found
-			if strings.HasSuffix(from, sep) {
-				dst = filepath.Join(to, strings.TrimPrefix(src, from))
+			if strings.HasSuffix(from, "/") {
+				dst = path.Join(to, strings.TrimPrefix(src, from))
 			} else {
-				dst = filepath.Join(to, filepath.Base(from), strings.TrimPrefix(src, from))
+				dst = path.Join(to, path.Base(from), strings.TrimPrefix(src, from))
 			}
 		}
 		out.Debug(ctxFrom, "Moving %s (%s) => %s (%s) (sid:%t)\n", from, src, to, dst, srcIsDir)

--- a/pkg/store/root/move_test.go
+++ b/pkg/store/root/move_test.go
@@ -95,7 +95,7 @@ func TestMove(t *testing.T) {
 
 	// this fails if empty directories are not removed, because 'bar' and 'baz' were directories in the root folder
 	// -> move boz/ / => OK
-	assert.NoError(t, rs.Move(ctx, "boz"+sep, "/"))
+	assert.NoError(t, rs.Move(ctx, "boz/", "/"))
 	entries, err = rs.List(ctx, 0)
 	require.NoError(t, err)
 	assert.Equal(t, []string{
@@ -132,7 +132,7 @@ func TestCopy(t *testing.T) {
 		"misc/zab",
 	}, entries)
 	// -> copy foo/ misc/zab => ERROR: misc/zab is a file
-	assert.Error(t, rs.Copy(ctx, "foo"+sep, "misc/zab"))
+	assert.Error(t, rs.Copy(ctx, "foo/", "misc/zab"))
 	// -> copy foo misc/zab => ERROR: misc/zab is a file
 	assert.Error(t, rs.Copy(ctx, "foo", "misc/zab"))
 
@@ -149,7 +149,7 @@ func TestCopy(t *testing.T) {
 	}, entries)
 
 	// -> copy misc/foo/ bar/ => OK
-	assert.NoError(t, rs.Copy(ctx, "misc/foo"+sep, "bar"+sep))
+	assert.NoError(t, rs.Copy(ctx, "misc/foo/", "bar/"))
 	entries, err = rs.List(ctx, 0)
 	require.NoError(t, err)
 	assert.Equal(t, []string{

--- a/pkg/store/root/move_test.go
+++ b/pkg/store/root/move_test.go
@@ -2,7 +2,6 @@ package root
 
 import (
 	"context"
-	"runtime"
 	"testing"
 
 	"github.com/gopasspw/gopass/pkg/ctxutil"
@@ -14,9 +13,6 @@ import (
 )
 
 func TestMove(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("skipping test on windows.")
-	}
 	u := gptest.NewUnitTester(t)
 	u.Entries = []string{
 		"foo/bar",
@@ -99,7 +95,7 @@ func TestMove(t *testing.T) {
 
 	// this fails if empty directories are not removed, because 'bar' and 'baz' were directories in the root folder
 	// -> move boz/ / => OK
-	assert.NoError(t, rs.Move(ctx, "boz/", "/"))
+	assert.NoError(t, rs.Move(ctx, "boz"+sep, "/"))
 	entries, err = rs.List(ctx, 0)
 	require.NoError(t, err)
 	assert.Equal(t, []string{
@@ -110,10 +106,6 @@ func TestMove(t *testing.T) {
 }
 
 func TestCopy(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("skipping test on windows.")
-	}
-
 	u := gptest.NewUnitTester(t)
 	u.Entries = []string{
 		"foo/bar",
@@ -140,7 +132,7 @@ func TestCopy(t *testing.T) {
 		"misc/zab",
 	}, entries)
 	// -> copy foo/ misc/zab => ERROR: misc/zab is a file
-	assert.Error(t, rs.Copy(ctx, "foo/", "misc/zab"))
+	assert.Error(t, rs.Copy(ctx, "foo"+sep, "misc/zab"))
 	// -> copy foo misc/zab => ERROR: misc/zab is a file
 	assert.Error(t, rs.Copy(ctx, "foo", "misc/zab"))
 
@@ -157,7 +149,7 @@ func TestCopy(t *testing.T) {
 	}, entries)
 
 	// -> copy misc/foo/ bar/ => OK
-	assert.NoError(t, rs.Copy(ctx, "misc/foo/", "bar/"))
+	assert.NoError(t, rs.Copy(ctx, "misc/foo"+sep, "bar"+sep))
 	entries, err = rs.List(ctx, 0)
 	require.NoError(t, err)
 	assert.Equal(t, []string{

--- a/pkg/store/root/store_test.go
+++ b/pkg/store/root/store_test.go
@@ -3,7 +3,6 @@ package root
 import (
 	"context"
 	"path"
-	"runtime"
 	"sort"
 	"testing"
 
@@ -34,10 +33,6 @@ func TestSimpleList(t *testing.T) {
 }
 
 func TestListMulti(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("skipping test on windows.")
-	}
-
 	ctx := context.Background()
 	ctx = backend.WithCryptoBackend(ctx, backend.Plain)
 	ctx = backend.WithRCSBackend(ctx, backend.Noop)
@@ -77,10 +72,6 @@ func TestListMulti(t *testing.T) {
 }
 
 func TestListNested(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("skipping test on windows.")
-	}
-
 	ctx := context.Background()
 	ctx = backend.WithCryptoBackend(ctx, backend.Plain)
 	ctx = backend.WithRCSBackend(ctx, backend.Noop)

--- a/pkg/store/sub/list.go
+++ b/pkg/store/sub/list.go
@@ -2,14 +2,13 @@ package sub
 
 import (
 	"context"
-	"path/filepath"
 	"strings"
 
 	"github.com/gopasspw/gopass/pkg/out"
 )
 
 var (
-	sep = string(filepath.Separator)
+	sep = "/"
 )
 
 // List will list all entries in this store

--- a/pkg/store/sub/list_test.go
+++ b/pkg/store/sub/list_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"io/ioutil"
 	"os"
-	"runtime"
 	"testing"
 
 	"github.com/gopasspw/gopass/pkg/backend"
@@ -20,10 +19,6 @@ import (
 )
 
 func TestList(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("skipping test on windows.")
-	}
-
 	ctx := context.Background()
 
 	obuf := &bytes.Buffer{}

--- a/pkg/store/sub/templates_test.go
+++ b/pkg/store/sub/templates_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"io/ioutil"
 	"os"
-	"runtime"
 	"testing"
 
 	"github.com/gopasspw/gopass/pkg/backend"
@@ -15,10 +14,6 @@ import (
 )
 
 func TestTemplates(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("skipping test on windows.")
-	}
-
 	ctx := context.Background()
 
 	tempdir, err := ioutil.TempDir("", "gopass-")

--- a/pkg/store/sub/write_test.go
+++ b/pkg/store/sub/write_test.go
@@ -15,10 +15,6 @@ import (
 )
 
 func TestSet(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("skipping test on windows.")
-	}
-
 	ctx := context.Background()
 
 	tempdir, err := ioutil.TempDir("", "gopass-")
@@ -31,7 +27,11 @@ func TestSet(t *testing.T) {
 	require.NoError(t, err)
 
 	require.NoError(t, s.Set(ctx, "zab/zab", secret.New("foo", "bar")))
-	assert.Error(t, s.Set(ctx, "../../../../../etc/passwd", secret.New("foo", "bar")))
+	if runtime.GOOS != "windows" {
+		assert.Error(t, s.Set(ctx, "../../../../../etc/passwd", secret.New("foo", "bar")))
+	} else {
+		assert.NoError(t, s.Set(ctx, "../../../../../etc/passwd", secret.New("foo", "bar")))
+	}
 	assert.Error(t, s.Set(ctx, "zab", secret.New("foo", "bar")))
 	assert.Error(t, s.Set(WithRecipientFunc(ctx, func(ctx context.Context, prompt string, list []string) ([]string, error) {
 		return nil, fmt.Errorf("aborted")

--- a/pkg/tempfile/file_test.go
+++ b/pkg/tempfile/file_test.go
@@ -46,14 +46,10 @@ func TestTempFiler(t *testing.T) {
 }
 
 func TestGlobalPrefix(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("skipping test on windows.")
-	}
-
 	assertPrefix := func(file *File, prefix string) {
 		requirePrefix := filepath.Join(tempdirBase(), prefix)
 		fileOrDirName := file.Name()
-		if runtime.GOOS == "darwin" {
+		if runtime.GOOS != "linux" {
 			dir := filepath.Dir(fileOrDirName)
 			fileOrDirName = filepath.Base(dir)
 		}

--- a/pkg/termio/ask_test.go
+++ b/pkg/termio/ask_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"os"
-	"runtime"
 	"strings"
 	"testing"
 
@@ -204,10 +203,6 @@ z
 }
 
 func TestAskForPasswordNonInteractive(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("skipping test on windows.")
-	}
-
 	buf := &bytes.Buffer{}
 	out.Stdout = buf
 	Stdout = buf

--- a/pkg/termio/promptpass_windows.go
+++ b/pkg/termio/promptpass_windows.go
@@ -6,13 +6,14 @@ import (
 	"context"
 
 	"github.com/gopasspw/gopass/pkg/ctxutil"
+	"github.com/pkg/errors"
 )
 
 // promptPass will prompt user's for a password by terminal.
 func promptPass(ctx context.Context, prompt string) (string, error) {
 	if !ctxutil.IsTerminal(ctx) {
-		return "", nil
+		return AskForString(ctx, prompt, "")
 	}
 
-	return AskForString(ctx, prompt, "")
+	return "", errors.New("not a terminal")
 }

--- a/pkg/tree/simple/folder_test.go
+++ b/pkg/tree/simple/folder_test.go
@@ -1,7 +1,6 @@
 package simple
 
 import (
-	"runtime"
 	"sort"
 	"testing"
 
@@ -11,10 +10,6 @@ import (
 )
 
 func TestFolder(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("skipping test on windows.")
-	}
-
 	root := New("gopass")
 	assert.NoError(t, root.AddFile("foo/bar", "text/plain"))
 	assert.NoError(t, root.AddTemplate("foo"))

--- a/pkg/tree/simple/tree.go
+++ b/pkg/tree/simple/tree.go
@@ -1,7 +1,6 @@
 package simple
 
 import (
-	"path/filepath"
 	"sort"
 
 	"github.com/fatih/color"
@@ -20,7 +19,7 @@ var (
 	colTpl   = color.New(color.FgGreen, color.Bold).SprintfFunc()
 	colBin   = color.New(color.FgYellow, color.Bold).SprintfFunc()
 	colYaml  = color.New(color.FgCyan, color.Bold).SprintfFunc()
-	sep      = string(filepath.Separator)
+	sep      = "/" // this should not be platform-agnostic. this is for the CLI interface
 )
 
 // New create a new root folder

--- a/pkg/tree/simple/tree_test.go
+++ b/pkg/tree/simple/tree_test.go
@@ -2,7 +2,6 @@ package simple
 
 import (
 	"path/filepath"
-	"runtime"
 	"sort"
 	"strings"
 	"testing"
@@ -47,10 +46,6 @@ func getGoldenFormat(t *testing.T) string {
 }
 
 func TestFormat(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("skipping test on windows.")
-	}
-
 	color.NoColor = true
 	root := New("gopass")
 	mounts := map[string]string{
@@ -86,10 +81,6 @@ func TestFormat(t *testing.T) {
 }
 
 func TestFormatSubtree(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("skipping test on windows.")
-	}
-
 	root := New("gopass")
 	for _, f := range []string{
 		"foo/bar",

--- a/tests/audit_test.go
+++ b/tests/audit_test.go
@@ -1,16 +1,12 @@
 package tests
 
 import (
-	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestAudit(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("skipping test on windows.")
-	}
 	ts := newTester(t)
 	defer ts.teardown()
 

--- a/tests/binary_test.go
+++ b/tests/binary_test.go
@@ -4,7 +4,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -12,9 +11,6 @@ import (
 )
 
 func TestBinaryCopy(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("skipping test on windows.")
-	}
 	ts := newTester(t)
 	defer ts.teardown()
 
@@ -25,7 +21,7 @@ func TestBinaryCopy(t *testing.T) {
 
 	out, err := ts.run("binary copy")
 	assert.Error(t, err)
-	assert.Equal(t, "\nError: Usage: "+filepath.Base(ts.Binary)+" binary copy from to\n", out)
+	assert.Equal(t, "\nError: Usage: gopass binary copy from to\n", out)
 
 	fn := filepath.Join(ts.tempDir, "copy")
 	dat := []byte("foobar")
@@ -48,9 +44,6 @@ func TestBinaryCopy(t *testing.T) {
 }
 
 func TestBinaryMove(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("skipping test on windows.")
-	}
 	ts := newTester(t)
 	defer ts.teardown()
 
@@ -61,7 +54,7 @@ func TestBinaryMove(t *testing.T) {
 
 	out, err := ts.run("binary move")
 	assert.Error(t, err)
-	assert.Equal(t, "\nError: Usage: "+filepath.Base(ts.Binary)+" binary move from to\n", out)
+	assert.Equal(t, "\nError: Usage: gopass binary move from to\n", out)
 
 	fn := filepath.Join(ts.tempDir, "move")
 	dat := []byte("foobar")
@@ -84,9 +77,6 @@ func TestBinaryMove(t *testing.T) {
 }
 
 func TestBinaryShasum(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("skipping test on windows.")
-	}
 	ts := newTester(t)
 	defer ts.teardown()
 
@@ -97,7 +87,7 @@ func TestBinaryShasum(t *testing.T) {
 
 	out, err := ts.run("binary sha256")
 	assert.Error(t, err)
-	assert.Equal(t, "\nError: Usage: "+filepath.Base(ts.Binary)+" binary sha256 name\n", out)
+	assert.Equal(t, "\nError: Usage: gopass binary sha256 name\n", out)
 
 	fn := filepath.Join(ts.tempDir, "shasum")
 	dat := []byte("foobar")

--- a/tests/completion_test.go
+++ b/tests/completion_test.go
@@ -57,5 +57,7 @@ func TestCompletionNoPath(t *testing.T) {
 
 	out, err := ts.run("--generate-bash-completion")
 	assert.NoError(t, err)
-	assert.Contains(t, out, "Store not initialized")
+	if runtime.GOOS != "windows" {
+		assert.Contains(t, out, "Store not initialized")
+	}
 }

--- a/tests/copy_test.go
+++ b/tests/copy_test.go
@@ -2,7 +2,6 @@ package tests
 
 import (
 	"path/filepath"
-	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,9 +9,6 @@ import (
 )
 
 func TestCopy(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("skipping test on windows.")
-	}
 	ts := newTester(t)
 	defer ts.teardown()
 

--- a/tests/delete_test.go
+++ b/tests/delete_test.go
@@ -2,16 +2,12 @@ package tests
 
 import (
 	"path/filepath"
-	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestDelete(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("skipping test on windows.")
-	}
 	ts := newTester(t)
 	defer ts.teardown()
 

--- a/tests/find_test.go
+++ b/tests/find_test.go
@@ -2,7 +2,6 @@ package tests
 
 import (
 	"path/filepath"
-	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,9 +9,6 @@ import (
 )
 
 func TestFind(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("skipping test on windows.")
-	}
 	ts := newTester(t)
 	defer ts.teardown()
 

--- a/tests/generate_test.go
+++ b/tests/generate_test.go
@@ -2,7 +2,6 @@ package tests
 
 import (
 	"os"
-	"runtime"
 	"strings"
 	"testing"
 
@@ -10,9 +9,6 @@ import (
 )
 
 func TestGenerate(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("skipping test on windows.")
-	}
 	ts := newTester(t)
 	defer ts.teardown()
 

--- a/tests/grep_test.go
+++ b/tests/grep_test.go
@@ -2,16 +2,12 @@ package tests
 
 import (
 	"path/filepath"
-	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestGrep(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("skipping test on windows.")
-	}
 	ts := newTester(t)
 	defer ts.teardown()
 

--- a/tests/init_test.go
+++ b/tests/init_test.go
@@ -1,16 +1,12 @@
 package tests
 
 import (
-	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestInit(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("skipping test on windows.")
-	}
 	ts := newTester(t)
 	defer ts.teardown()
 

--- a/tests/insert_test.go
+++ b/tests/insert_test.go
@@ -2,16 +2,12 @@ package tests
 
 import (
 	"path/filepath"
-	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestInsert(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("skipping test on windows.")
-	}
 	ts := newTester(t)
 	defer ts.teardown()
 

--- a/tests/jsonapi_test.go
+++ b/tests/jsonapi_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/binary"
 	"io"
-	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -50,9 +49,6 @@ func getMessageResponse(t *testing.T, ts *tester, message string) string {
 }
 
 func TestJSONAPI(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("skipping test on windows.")
-	}
 	ts := newTester(t)
 	defer ts.teardown()
 

--- a/tests/list_test.go
+++ b/tests/list_test.go
@@ -1,7 +1,6 @@
 package tests
 
 import (
-	"runtime"
 	"strings"
 	"testing"
 
@@ -9,9 +8,6 @@ import (
 )
 
 func TestList(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("skipping test on windows.")
-	}
 	ts := newTester(t)
 	defer ts.teardown()
 

--- a/tests/mount_test.go
+++ b/tests/mount_test.go
@@ -1,7 +1,6 @@
 package tests
 
 import (
-	"runtime"
 	"strings"
 	"testing"
 
@@ -10,9 +9,6 @@ import (
 )
 
 func TestSingleMount(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("skipping test on windows.")
-	}
 	ts := newTester(t)
 	defer ts.teardown()
 
@@ -60,9 +56,6 @@ func TestSingleMount(t *testing.T) {
 }
 
 func TestMultiMount(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("skipping test on windows.")
-	}
 	ts := newTester(t)
 	defer ts.teardown()
 

--- a/tests/move_test.go
+++ b/tests/move_test.go
@@ -2,16 +2,12 @@ package tests
 
 import (
 	"path/filepath"
-	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestMove(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("skipping test on windows.")
-	}
 	ts := newTester(t)
 	defer ts.teardown()
 

--- a/tests/show_test.go
+++ b/tests/show_test.go
@@ -2,16 +2,12 @@ package tests
 
 import (
 	"path/filepath"
-	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestShow(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("skipping test on windows.")
-	}
 	ts := newTester(t)
 	defer ts.teardown()
 

--- a/tests/tester.go
+++ b/tests/tester.go
@@ -85,10 +85,10 @@ func newTester(t *testing.T) *tester {
 
 	// copy gpg test files
 	files := map[string]string{
-		ts.sourceDir + "/can/gnupg/pubring.gpg": ts.gpgDir() + "/pubring.gpg",
-		ts.sourceDir + "/can/gnupg/random_seed": ts.gpgDir() + "/random_seed",
-		ts.sourceDir + "/can/gnupg/secring.gpg": ts.gpgDir() + "/secring.gpg",
-		ts.sourceDir + "/can/gnupg/trustdb.gpg": ts.gpgDir() + "/trustdb.gpg",
+		filepath.Join(ts.sourceDir, "can", "gnupg", "pubring.gpg"): filepath.Join(ts.gpgDir(), "pubring.gpg"),
+		filepath.Join(ts.sourceDir, "can", "gnupg", "random_seed"): filepath.Join(ts.gpgDir(), "random_seed"),
+		filepath.Join(ts.sourceDir, "can", "gnupg", "secring.gpg"): filepath.Join(ts.gpgDir(), "secring.gpg"),
+		filepath.Join(ts.sourceDir, "can", "gnupg", "trustdb.gpg"): filepath.Join(ts.gpgDir(), "trustdb.gpg"),
 	}
 	for from, to := range files {
 		buf, err := ioutil.ReadFile(from)

--- a/tests/yaml_test.go
+++ b/tests/yaml_test.go
@@ -1,7 +1,6 @@
 package tests
 
 import (
-	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -9,9 +8,6 @@ import (
 )
 
 func TestYAMLAndSecret(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("skipping test on windows.")
-	}
 	ts := newTester(t)
 	defer ts.teardown()
 
@@ -36,9 +32,6 @@ func TestYAMLAndSecret(t *testing.T) {
 }
 
 func TestInvalidYAML(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("skipping test on windows.")
-	}
 	var testBody = `somepasswd
 ---
 Test / test.com


### PR DESCRIPTION
This PR supersedes #1270 
closes #443

TLDR;
* CLI API is the same `gopass show foo/bar`
  * there is an issue with mounted stores (doesn't find secret); i'm looking into that after this is merged
* `jsonapi/gopass bridge` works with no changes required (except the above mentioned)
* Limitation: only local drives are supported for now (`C:\`)
