### PR TITLE
[WIP] update config to build with latest goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -2,107 +2,102 @@
 # Release automation
 #
 # Build customization
-build:
-  binary: gopass
-  flags: |
-    -tags netgo -gcflags="-trimpath=$GOPATH" -asmflags="-trimpath=$GOPATH"
-  env:
-    - CGO_ENABLED=0
-  ldflags: |
-    -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}} -extldflags '-static'
-  goos:
-    - darwin
-    - freebsd
-    - linux
-    - openbsd
-    - windows
-  goarch:
-    - amd64
-  goarm:
-    - 6
-    - 7
-archive:
-  name_template: "{{.Binary}}-{{.Version}}-{{.Os}}-{{.Arch}}"
-  format: tar.gz
-  format_overrides:
-    - goos: windows
-      format: zip
-  files:
-    - CHANGELOG.md
-    - LICENSE
-    - README.md
-    - bash.completion
-    - fish.completion
-    - zsh.completion
+project_name: gopass
+builds:
+  - id: gopass
+    binary: gopass
+    flags: |
+      -tags netgo -gcflags="-trimpath=$GOPATH" -asmflags="-trimpath=$GOPATH"
+    env:
+      - CGO_ENABLED=0
+    ldflags: |
+      -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}} -extldflags '-static'
+    goos:
+      - darwin
+      - freebsd
+      - linux
+      - openbsd
+      - windows
+    goarch:
+      - amd64
+    goarm:
+      - 6
+      - 7
+archives:
+  - id: gopass
+    name_template: "{{.Binary}}-{{.Version}}-{{.Os}}-{{.Arch}}"
+    format: tar.gz
+    format_overrides:
+      - goos: windows
+        format: zip
+    files:
+      - CHANGELOG.md
+      - LICENSE
+      - README.md
+      - bash.completion
+      - fish.completion
+      - zsh.completion
 release:
   github:
     owner: gopasspw
     name: gopass
   draft: false
-brew:
-  github:
-    owner: gopasspw
-    name: homebrew-gopass
-  caveats:  |
-    Gopass has been installed, have fun!
-    If upgrading from `pass`, everything should work as expected.
-    If installing from scratch, you need to either initialize a new repository now...
-      gopass init
-    ...or clone one from a source:
-      gopass clone git@code.example.com:example/pass.git
-    In order to use the great autocompletion features (they're helpful with gopass),
-    please make sure you have autocompletion for homebrew enabled:
-      https://github.com/bobthecow/git-flow-completion/wiki/Install-Bash-git-completion
-    More information:
-      https://www.gopass.pw/
-      https://github.com/gopasspw/gopass/README.md
-  homepage: "https://www.gopass.pw/"
-  description: "The slightly more awesome Standard Unix Password Manager for Teams."
-  build_dependencies:
-    - go
-  dependencies:
-    - git
-    - gnupg
-    - terminal-notifier
-  install:  |
-    ENV["GOPATH"] = buildpath
-    (buildpath/"src/github.com/gopasspw/gopass").install buildpath.children
+brews:
+  - name: gopass
+    github:
+      owner: gopasspw
+      name: homebrew-gopass
+    caveats:  |
+      Gopass has been installed, have fun!
+      If upgrading from `pass`, everything should work as expected.
+      If installing from scratch, you need to either initialize a new repository now...
+        gopass init
+      ...or clone one from a source:
+        gopass clone git@code.example.com:example/pass.git
+      In order to use the great autocompletion features (they're helpful with gopass),
+      please make sure you have autocompletion for homebrew enabled:
+        https://github.com/bobthecow/git-flow-completion/wiki/Install-Bash-git-completion
+      More information:
+        https://www.gopass.pw/
+        https://github.com/gopasspw/gopass/README.md
+    homepage: "https://www.gopass.pw/"
+    description: "The slightly more awesome Standard Unix Password Manager for Teams."
+    dependencies:
+      - git
+      - gnupg
+      - terminal-notifier
+    install:  |
+      ENV["GOPATH"] = buildpath
+      (buildpath/"src/github.com/gopasspw/gopass").install buildpath.children
 
-    cd "src/github.com/gopasspw/gopass" do
-      ENV["PREFIX"] = prefix
-      system "make", "install"
-    end
+      cd "src/github.com/gopasspw/gopass" do
+        ENV["PREFIX"] = prefix
+        system "make", "install"
+      end
 
-    system bin/"gopass completion bash > bash_completion.bash"
-    system bin/"gopass completion zsh > zsh_completion.zsh"
-    bash_completion.install "bash_completion.bash"
-    zsh_completion.install "zsh_completion.zsh"
-  test:  |
-    assert_match version.to_s, shell_output("#{bin}/gopass version")
-fpm:
-  vendor: Gopass Authors
-  homepage: "https://www.gopass.pw"
-  maintainer: "Gopass Authors <gopass@gopass.pw>"
-  license: MIT
-  formats:
-    - deb
-    - rpm
-    - pacman
-  dependencies:
-    - git
-    - gnupg2
-  recommends:
-    - rng-tools
+      system bin/"gopass completion bash > bash_completion.bash"
+      system bin/"gopass completion zsh > zsh_completion.zsh"
+      bash_completion.install "bash_completion.bash"
+      zsh_completion.install "zsh_completion.zsh"
+    test:  |
+      assert_match version.to_s, shell_output("#{bin}/gopass version")
+nfpms:
+  - id: gopass
+    vendor: Gopass Authors
+    homepage: "https://www.gopass.pw"
+    maintainer: "Gopass Authors <gopass@gopass.pw>"
+    license: MIT
+    formats:
+      - deb
+      - rpm
+    dependencies:
+      - git
+      - gnupg2
+    recommends:
+      - rng-tools
 source:
-  name_template: "{{.Binary}}-{{.Version}}"
-  excludes:
-    - "*/gopass-*"
-    - "*/.git/*"
-    - "*/.git"
-    - "*/releases/*"
-    - "*/dist/*"
+  enabled: true
+  name_template: "{{.ProjectName}}-{{.Version}}"
+  
 checksum:
-  name_template: "{{.Binary}}_{{.Version}}_SHA256SUMS"
-cleanup:
-  hooks:
-    - make clean
+  name_template: "{{.ProjectName}}_{{.Version}}_SHA256SUMS"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,6 +3,12 @@
 #
 # Build customization
 project_name: gopass
+
+before:
+  hooks:
+    - make clean
+    - make completion
+
 builds:
   - id: gopass
     binary: gopass


### PR DESCRIPTION
This PR is WIP in order to simplify releases, see #1298.

Current state: `goreleaser --snapshot --skip-publish --rm-dist` runs fine.

Unfortunately arch linux packages (packman) cannot be built anymore. Any ideas how to proceed or if they are used at all? @metalmatze created the AUR package as far as I read.

