### PR TITLE
Create new non-root stores in XDG compliant locations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/gopasspw/gopass
 go 1.12
 
 require (
+	github.com/ProtonMail/go-appdir v1.1.0
 	github.com/alecthomas/binary v0.0.0-20190922233330-fb1b1d9c299c
 	github.com/atotto/clipboard v0.1.2
 	github.com/blang/semver v0.0.0-20190414182527-1a9109f8c4a1

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/DATA-DOG/go-sqlmock v1.3.3 h1:CWUqKXe0s8A2z6qCgkP4Kru7wC11YoAnoupUKFDnH08=
 github.com/DATA-DOG/go-sqlmock v1.3.3/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
+github.com/ProtonMail/go-appdir v1.1.0 h1:9hdNDlU9kTqRKVNzmoqah8qqrj5QZyLByQdwQNlFWig=
+github.com/ProtonMail/go-appdir v1.1.0/go.mod h1:3d8Y9F5mbEUjrYbcJ3rcDxcWbqbttF+011nVZmdRdzc=
 github.com/alecthomas/binary v0.0.0-20190922233330-fb1b1d9c299c h1:SnUAzBu0FguUHChHbuy2HInhc2YBBTmbDcZOOByAVt8=
 github.com/alecthomas/binary v0.0.0-20190922233330-fb1b1d9c299c/go.mod h1:v4e05/vzE8ubOim1No9Xx5eIQ/WRq6AtcnQIy/Z/JPs=
 github.com/atotto/clipboard v0.1.2 h1:YZCtFu5Ie8qX2VmVTBnrqLSiU9XOWwqNRmdT3gIQzbY=

--- a/pkg/action/clone.go
+++ b/pkg/action/clone.go
@@ -2,6 +2,7 @@ package action
 
 import (
 	"context"
+	"os"
 	"path/filepath"
 
 	"github.com/gopasspw/gopass/pkg/backend"
@@ -59,6 +60,13 @@ func (s *Action) clone(ctx context.Context, repo, mount, path string) error {
 	}
 	if mount == "" && inited {
 		return ExitError(ctx, ExitAlreadyInitialized, nil, "Can not clone %s to the root store, as this store is already initialized. Please try cloning to a submount: `%s clone %s sub`", repo, s.Name, repo)
+	}
+
+	// make sure the parent directory exists
+	if parentPath := filepath.Dir(path); !fsutil.IsDir(parentPath) {
+		if err := os.MkdirAll(parentPath, 0700); err != nil {
+			return ExitError(ctx, ExitUnknown, err, "Failed to create parent directory for clone: %s", err)
+		}
 	}
 
 	// clone repo

--- a/pkg/config/appdir_darwin.go
+++ b/pkg/config/appdir_darwin.go
@@ -1,0 +1,33 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// UserConfig returns the users config dir
+func UserConfig() string {
+	if hd := os.Getenv("GOPASS_HOMEDIR"); hd != "" {
+		return filepath.Join(hd, ".config", "gopass")
+	}
+
+	return filepath.Join(Homedir(), "Library", "Application Support", "gopass")
+}
+
+// UserCache returns the users cache dir
+func UserCache() string {
+	if hd := os.Getenv("GOPASS_HOMEDIR"); hd != "" {
+		return filepath.Join(hd, ".cache", "gopass")
+	}
+
+	return filepath.Join(Homedir(), "Library", "Caches", "gopass")
+}
+
+// UserData returns the users data dir
+func UserData() string {
+	if hd := os.Getenv("GOPASS_HOMEDIR"); hd != "" {
+		return filepath.Join(hd, ".local", "share", "gopass")
+	}
+
+	return filepath.Join(Homedir(), "Library", "Application Support", "gopass")
+}

--- a/pkg/config/appdir_windows.go
+++ b/pkg/config/appdir_windows.go
@@ -1,0 +1,32 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// UserConfig returns the users config dir
+func UserConfig() string {
+	if hd := os.Getenv("GOPASS_HOMEDIR"); hd != "" {
+		return filepath.Join(hd, ".config", "gopass")
+	}
+
+	return filepath.Join(os.Getenv("APPDATA"), "gopass")
+}
+
+// UserCache returns the users cache dir
+func UserCache() string {
+	if hd := os.Getenv("GOPASS_HOMEDIR"); hd != "" {
+		return filepath.Join(hd, ".cache", "gopass")
+	}
+
+	return filepath.Join(os.Getenv("LOCALAPPDATA"), "gopass")
+}
+
+// UserData returns the users data dir
+func UserData() string {
+	if hd := os.Getenv("GOPASS_HOMEDIR"); hd != "" {
+		return filepath.Join(hd, ".local", "share", "gopass")
+	}
+	return filepath.Join(os.Getenv("LOCALAPPDATA"), "gopass")
+}

--- a/pkg/config/appdir_xdg.go
+++ b/pkg/config/appdir_xdg.go
@@ -1,0 +1,50 @@
+// +build !darwin,!windows
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// UserConfig returns the users config dir
+func UserConfig() string {
+	if hd := os.Getenv("GOPASS_HOMEDIR"); hd != "" {
+		return filepath.Join(hd, ".config", "gopass")
+	}
+
+	base := os.Getenv("XDG_CONFIG_HOME")
+	if base == "" {
+		base = filepath.Join(os.Getenv("HOME"), ".config")
+	}
+
+	return filepath.Join(base, "gopass")
+}
+
+// UserCache returns the users cache dir
+func UserCache() string {
+	if hd := os.Getenv("GOPASS_HOMEDIR"); hd != "" {
+		return filepath.Join(hd, ".cache", "gopass")
+	}
+
+	base := os.Getenv("XDG_CACHE_HOME")
+	if base == "" {
+		base = filepath.Join(os.Getenv("HOME"), ".cache")
+	}
+
+	return filepath.Join(base, "gopass")
+}
+
+// UserData returns the users data dir
+func UserData() string {
+	if hd := os.Getenv("GOPASS_HOMEDIR"); hd != "" {
+		return filepath.Join(hd, ".local", "share", "gopass")
+	}
+
+	base := os.Getenv("XDG_DATA_HOME")
+	if base == "" {
+		base = filepath.Join(os.Getenv("HOME"), ".local", "share")
+	}
+
+	return filepath.Join(base, "gopass")
+}

--- a/pkg/config/location.go
+++ b/pkg/config/location.go
@@ -37,11 +37,7 @@ func configLocation() string {
 	// Second, check for the "XDG_CONFIG_HOME" environment variable
 	// (which is part of the XDG Base Directory Specification for Linux and
 	// other Unix-like operating sytstems)
-	if xch := os.Getenv("XDG_CONFIG_HOME"); xch != "" {
-		return filepath.Join(xch, "gopass", "config.yml")
-	}
-
-	return filepath.Join(Homedir(), ".config", "gopass", "config.yml")
+	return filepath.Join(UserConfig(), "config.yml")
 }
 
 // configLocations returns the possible locations of gopass config files,
@@ -51,9 +47,7 @@ func configLocations() []string {
 	if cf := os.Getenv("GOPASS_CONFIG"); cf != "" {
 		l = append(l, cf)
 	}
-	if xch := os.Getenv("XDG_CONFIG_HOME"); xch != "" {
-		l = append(l, filepath.Join(xch, "gopass", "config.yml"))
-	}
+	l = append(l, filepath.Join(UserConfig(), "config.yml"))
 	l = append(l, filepath.Join(Homedir(), ".config", "gopass", "config.yml"))
 	l = append(l, filepath.Join(Homedir(), ".gopass.yml"))
 	return l
@@ -64,11 +58,13 @@ func configLocations() []string {
 // not set
 func PwStoreDir(mount string) string {
 	if mount != "" {
-		return fsutil.CleanPath(filepath.Join(Homedir(), ".password-store-"+strings.Replace(mount, string(filepath.Separator), "-", -1)))
+		cleanName := strings.Replace(mount, string(filepath.Separator), "-", -1)
+		return fsutil.CleanPath(filepath.Join(UserData(), "stores", cleanName))
 	}
 	if d := os.Getenv("PASSWORD_STORE_DIR"); d != "" {
 		return fsutil.CleanPath(d)
 	}
+	// TODO: the default should also comply with the XDG spec
 	return filepath.Join(Homedir(), ".password-store")
 }
 

--- a/pkg/config/location_test.go
+++ b/pkg/config/location_test.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -11,69 +10,11 @@ import (
 func TestPwStoreDirNoEnv(t *testing.T) {
 	for in, out := range map[string]string{
 		"":                          filepath.Join(Homedir(), ".password-store"),
-		"work":                      filepath.Join(Homedir(), ".password-store-work"),
-		filepath.Join("foo", "bar"): filepath.Join(Homedir(), ".password-store-foo-bar"),
+		"work":                      filepath.Join(Homedir(), ".local", "share", "gopass", "stores", "work"),
+		filepath.Join("foo", "bar"): filepath.Join(Homedir(), ".local", "share", "gopass", "stores", "foo-bar"),
 	} {
 		assert.Equal(t, out, PwStoreDir(in))
 	}
-}
-
-func TestPwStoreDir(t *testing.T) {
-	gph := filepath.Join(os.TempDir(), "home")
-	assert.NoError(t, os.Setenv("GOPASS_HOMEDIR", gph))
-
-	assert.Equal(t, filepath.Join(gph, ".password-store"), PwStoreDir(""))
-	assert.Equal(t, filepath.Join(gph, ".password-store-foo"), PwStoreDir("foo"))
-
-	psd := filepath.Join(gph, ".password-store-test")
-	assert.NoError(t, os.Setenv("PASSWORD_STORE_DIR", psd))
-
-	assert.Equal(t, psd, PwStoreDir(""))
-	assert.Equal(t, filepath.Join(gph, ".password-store-foo"), PwStoreDir("foo"))
-}
-
-func TestConfigLocation(t *testing.T) {
-	evs := map[string]struct {
-		ev  string
-		loc string
-	}{
-		"GOPASS_CONFIG":   {ev: filepath.Join(os.TempDir(), "gopass.yml"), loc: filepath.Join(os.TempDir(), "gopass.yml")},
-		"XDG_CONFIG_HOME": {ev: filepath.Join(os.TempDir(), "xdg"), loc: filepath.Join(os.TempDir(), "xdg", "gopass", "config.yml")},
-		"GOPASS_HOMEDIR":  {ev: filepath.Join(os.TempDir(), "home"), loc: filepath.Join(os.TempDir(), "home", ".config", "gopass", "config.yml")},
-	}
-
-	for k := range evs {
-		assert.NoError(t, os.Unsetenv(k))
-	}
-
-	for k, v := range evs {
-		assert.NoError(t, os.Setenv(k, v.ev))
-		assert.Equal(t, v.loc, configLocation())
-		assert.NoError(t, os.Unsetenv(k))
-	}
-}
-
-func TestConfigLocations(t *testing.T) {
-	gpcfg := filepath.Join(os.TempDir(), "config", ".gopass.yml")
-	xdghome := filepath.Join(os.TempDir(), "xdg")
-	gphome := filepath.Join(os.TempDir(), "home")
-
-	xdgcfg := filepath.Join(xdghome, "gopass", "config.yml")
-	curcfg := filepath.Join(gphome, ".config", "gopass", "config.yml")
-	oldcfg := filepath.Join(gphome, ".gopass.yml")
-
-	assert.NoError(t, os.Setenv("GOPASS_CONFIG", gpcfg))
-	assert.NoError(t, os.Setenv("XDG_CONFIG_HOME", xdghome))
-	assert.NoError(t, os.Setenv("GOPASS_HOMEDIR", gphome))
-
-	locs := configLocations()
-	t.Logf("Locations: %+v", locs)
-
-	assert.Equal(t, 4, len(locs))
-	assert.Equal(t, gpcfg, locs[0])
-	assert.Equal(t, xdgcfg, locs[1])
-	assert.Equal(t, curcfg, locs[2])
-	assert.Equal(t, oldcfg, locs[3])
 }
 
 func TestDirectory(t *testing.T) {

--- a/pkg/config/location_xdg_test.go
+++ b/pkg/config/location_xdg_test.go
@@ -1,0 +1,83 @@
+// +build !darwin,!windows
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPwStoreDir(t *testing.T) {
+	gph := filepath.Join(os.TempDir(), "home")
+	require.NoError(t, os.Setenv("GOPASS_HOMEDIR", gph))
+
+	assert.Equal(t, filepath.Join(gph, ".password-store"), PwStoreDir(""))
+	assert.Equal(t, filepath.Join(gph, ".local", "share", "gopass", "stores", "foo"), PwStoreDir("foo"))
+
+	psd := filepath.Join(gph, ".password-store-test")
+	require.NoError(t, os.Setenv("PASSWORD_STORE_DIR", psd))
+
+	assert.Equal(t, psd, PwStoreDir(""))
+	assert.Equal(t, filepath.Join(gph, ".local", "share", "gopass", "stores", "foo"), PwStoreDir("foo"))
+
+	// GOPASS_HOMEDIR takes precedence
+	require.NoError(t, os.Setenv("XDG_DATA_HOME", filepath.Join(os.TempDir(), ".local", "foo")))
+	assert.Equal(t, psd, PwStoreDir(""))
+	assert.Equal(t, filepath.Join(gph, ".local", "share", "gopass", "stores", "foo"), PwStoreDir("foo"))
+	assert.NoError(t, os.Unsetenv("XDG_DATA_HOME"))
+
+	// GOPASS_HOMEDIR unset, XDG_DATA_HOME takes precedence
+	require.NoError(t, os.Unsetenv("GOPASS_HOMEDIR"))
+	require.NoError(t, os.Setenv("XDG_DATA_HOME", filepath.Join(os.TempDir(), ".local", "foo")))
+	assert.Equal(t, psd, PwStoreDir(""))
+	assert.Equal(t, filepath.Join(os.TempDir(), ".local", "foo", "gopass", "stores", "foo"), PwStoreDir("foo"))
+	assert.NoError(t, os.Unsetenv("XDG_DATA_HOME"))
+}
+
+func TestConfigLocation(t *testing.T) {
+	evs := map[string]struct {
+		ev  string
+		loc string
+	}{
+		"GOPASS_CONFIG":   {ev: filepath.Join(os.TempDir(), "gopass.yml"), loc: filepath.Join(os.TempDir(), "gopass.yml")},
+		"XDG_CONFIG_HOME": {ev: filepath.Join(os.TempDir(), "xdg"), loc: filepath.Join(os.TempDir(), "xdg", "gopass", "config.yml")},
+		"GOPASS_HOMEDIR":  {ev: filepath.Join(os.TempDir(), "home"), loc: filepath.Join(os.TempDir(), "home", ".config", "gopass", "config.yml")},
+	}
+
+	for k := range evs {
+		assert.NoError(t, os.Unsetenv(k))
+	}
+
+	for k, v := range evs {
+		assert.NoError(t, os.Setenv(k, v.ev))
+		assert.Equal(t, v.loc, configLocation())
+		assert.NoError(t, os.Unsetenv(k))
+	}
+}
+
+func TestConfigLocations(t *testing.T) {
+	gpcfg := filepath.Join(os.TempDir(), "config", ".gopass.yml")
+	xdghome := filepath.Join(os.TempDir(), "xdg")
+	gphome := filepath.Join(os.TempDir(), "home")
+
+	xdgcfg := filepath.Join(xdghome, "gopass", "config.yml")
+	curcfg := filepath.Join(gphome, ".config", "gopass", "config.yml")
+	oldcfg := filepath.Join(gphome, ".gopass.yml")
+
+	assert.NoError(t, os.Setenv("GOPASS_CONFIG", gpcfg))
+	assert.NoError(t, os.Setenv("GOPASS_HOMEDIR", gphome))
+
+	assert.Equal(t, []string{gpcfg, curcfg, curcfg, oldcfg}, configLocations())
+
+	assert.NoError(t, os.Setenv("XDG_CONFIG_HOME", xdghome))
+	assert.Equal(t, []string{gpcfg, curcfg, curcfg, oldcfg}, configLocations())
+
+	require.NoError(t, os.Setenv("XDG_CONFIG_HOME", xdghome))
+	require.NoError(t, os.Unsetenv("GOPASS_HOMEDIR"))
+	require.NoError(t, os.Unsetenv("GOPASS_CONFIG"))
+	assert.Equal(t, xdgcfg, configLocations()[0])
+}


### PR DESCRIPTION
This partly addresses #1225 in that it create new substores in XDG compliant
locations.

RELEASE_NOTES=[ENHANCEMENT] Create new sub stores in XDG compliant locations.

Signed-off-by: Dominik Schulz <dominik.schulz@gauner.org>