### PR TITLE
Do not trim secret

### DIFF
--- a/pkg/store/secret/secret.go
+++ b/pkg/store/secret/secret.go
@@ -40,10 +40,10 @@ func Parse(buf []byte) (*Secret, error) {
 	s := &Secret{}
 	lines := bytes.SplitN(buf, []byte("\n"), 2)
 	if len(lines) > 0 {
-		s.password = string(bytes.TrimSpace(lines[0]))
+		s.password = string(lines[0])
 	}
 	if len(lines) > 1 {
-		s.body = string(bytes.TrimSpace(lines[1]))
+		s.body = string(lines[1])
 	}
 	if err := s.decode(); err != nil {
 		return s, err

--- a/pkg/store/secret/secret_test.go
+++ b/pkg/store/secret/secret_test.go
@@ -191,6 +191,23 @@ key2: value2`),
 			Body: `key1: value1
 key2: value2`,
 		},
+		{
+			Desc: "empty line at the beginning of the body",
+			In: []byte(`this
+
+is
+
+a
+
+test`),
+			Password: "this",
+			Body: `
+is
+
+a
+
+test`,
+		},
 	} {
 		sec, err := Parse(tc.In)
 		if tc.Fail {

--- a/pkg/store/secret/yaml_test.go
+++ b/pkg/store/secret/yaml_test.go
@@ -115,7 +115,7 @@ func TestBareYAMLReadKey(t *testing.T) {
 	// read back whole entry
 	content, err := s.Bytes()
 	require.NoError(t, err)
-	assert.Equal(t, in, string(content)+"\n")
+	assert.Equal(t, in, string(content))
 }
 
 func TestYAMLSetMultipleKeys(t *testing.T) {


### PR DESCRIPTION
Fixes #1235

RELEASE_NOTES=[BUGFIX] Do not remove empty lines from the secret.

Signed-off-by: Dominik Schulz <dominik.schulz@gauner.org>