### PR TITLE
Do not skip folders overlapping with leaf nodes

### DIFF
--- a/pkg/store/sub/write.go
+++ b/pkg/store/sub/write.go
@@ -20,10 +20,6 @@ func (s *Store) Set(ctx context.Context, name string, sec store.Secret) error {
 
 	p := s.passfile(name)
 
-	if s.IsDir(ctx, name) && !ctxutil.IsForce(ctx) {
-		return errors.Errorf("a folder named %s already exists", name)
-	}
-
 	recipients, err := s.useableKeys(ctx, name)
 	if err != nil {
 		return errors.Wrapf(err, "failed to list useable keys for '%s'", p)
@@ -58,7 +54,7 @@ func (s *Store) Set(ctx context.Context, name string, sec store.Secret) error {
 	// so we need to skip this step when using concurrency and perform them
 	// at the end of the batch processing.
 	if IsNoGitOps(ctx) {
-		out.Debug(ctx, "sub.Set(%s) - skipping git ops due to concurrency", p)
+		out.Debug(ctx, "sub.Set(%s) - skipping git ops (disabled)")
 		return nil
 	}
 

--- a/pkg/store/sub/write_test.go
+++ b/pkg/store/sub/write_test.go
@@ -32,7 +32,7 @@ func TestSet(t *testing.T) {
 	} else {
 		assert.NoError(t, s.Set(ctx, "../../../../../etc/passwd", secret.New("foo", "bar")))
 	}
-	assert.Error(t, s.Set(ctx, "zab", secret.New("foo", "bar")))
+	assert.NoError(t, s.Set(ctx, "zab", secret.New("foo", "bar")))
 	assert.Error(t, s.Set(WithRecipientFunc(ctx, func(ctx context.Context, prompt string, list []string) ([]string, error) {
 		return nil, fmt.Errorf("aborted")
 	}), "zab/baz", secret.New("foo", "bar")))


### PR DESCRIPTION
Fixes #1260

RELEASE_NOTES=[BUGFIX] Encrypt parent directory if leaf node exists.

Signed-off-by: Dominik Schulz <dominik.schulz@gauner.org>