### PR TITLE
Do not copy to clipboard on show -f

### DIFF
--- a/pkg/action/show.go
+++ b/pkg/action/show.go
@@ -128,7 +128,7 @@ func (s *Action) showHandleOutput(ctx context.Context, name string, sec store.Se
 		return s.showPrintQR(ctx, name, pw)
 	}
 
-	if IsClip(ctx) && pw != "" {
+	if IsClip(ctx) && pw != "" && !ctxutil.IsForce(ctx) {
 		if err := clipboard.CopyTo(ctx, name, []byte(pw)); err != nil {
 			return err
 		}

--- a/pkg/action/show_test.go
+++ b/pkg/action/show_test.go
@@ -152,11 +152,11 @@ func TestShowAutoClip(t *testing.T) {
 	})
 
 	// gopass show -f foo
-	// -> Copy to clipboard AND print
+	// -> ONLY print
 	t.Run("gopass show -f foo", func(t *testing.T) {
 		c := clictxf(ctx, t, map[string]string{"force": "true"}, "foo")
 		assert.NoError(t, act.Show(c))
-		assert.Contains(t, buf.String(), "WARNING")
+		assert.NotContains(t, buf.String(), "WARNING")
 		assert.Contains(t, buf.String(), "secret")
 		assert.Contains(t, buf.String(), "second")
 		buf.Reset()
@@ -196,7 +196,7 @@ func TestShowAutoClip(t *testing.T) {
 	})
 
 	// gopass show -f foo
-	// -> Copy to clipboard AND print
+	// -> ONLY Print
 	t.Run("gopass show -f foo", func(t *testing.T) {
 		c := clictxf(ctx, t, map[string]string{"force": "true"}, "foo")
 		assert.NoError(t, act.Show(c))


### PR DESCRIPTION
Fixes #1329

RELEASE_NOTES=[BUGFIX] Do not copy to clipboard with -f

Signed-off-by: Dominik Schulz <dominik.schulz@gauner.org>