### PR TITLE
Correctly handle exportkeys in gopass sync

### DIFF
--- a/internal/action/recipients.go
+++ b/internal/action/recipients.go
@@ -205,7 +205,7 @@ func (s *Action) RecipientsUpdate(c *cli.Context) error {
 	mps := s.Store.MountPoints()
 	sort.Sort(store.ByPathLen(mps))
 	for _, alias := range append(mps, "") {
-		subs, err := s.Store.GetSubStore(alias)
+		ctx, subs, err := s.Store.GetSubStore(ctx, alias)
 		if err != nil || subs == nil {
 			continue
 		}

--- a/internal/action/sync.go
+++ b/internal/action/sync.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gopasspw/gopass/pkg/notify"
 	"github.com/gopasspw/gopass/pkg/out"
 	"github.com/gopasspw/gopass/pkg/store"
+	subs "github.com/gopasspw/gopass/pkg/store/sub"
 
 	"github.com/fatih/color"
 	"github.com/pkg/errors"
@@ -74,7 +75,7 @@ func (s *Action) syncMount(ctx context.Context, mp string) error {
 	}
 	out.Print(ctxno, color.GreenString("[%s] ", name))
 
-	sub, err := s.Store.GetSubStore(mp)
+	ctx, sub, err := s.Store.GetSubStore(ctx, mp)
 	if err != nil {
 		out.Error(ctx, "Failed to get sub store '%s': %s", name, err)
 		return fmt.Errorf("failed to get sub stores (%s)", err)
@@ -92,52 +93,55 @@ func (s *Action) syncMount(ctx context.Context, mp string) error {
 
 	if sub.RCS().Name() == noop.New().Name() {
 		out.Error(ctxno, "\n   WARNING: Mount uses RCS backend 'noop'. Not syncing!\n")
-		return nil
-	}
+	} else {
+		out.Print(ctxno, "\n   "+color.GreenString("git pull and push ... "))
+		if err := sub.RCS().Push(ctx, "", ""); err != nil {
+			if errors.Cause(err) == store.ErrGitNoRemote {
+				out.Yellow(ctx, "Skipped (no remote)")
+				out.Debug(ctx, "Failed to push '%s' to its remote: %s", name, err)
+				return err
+			}
 
-	out.Print(ctxno, "\n   "+color.GreenString("git pull and push ... "))
-	if err := sub.RCS().Push(ctx, "", ""); err != nil {
-		if errors.Cause(err) == store.ErrGitNoRemote {
-			out.Yellow(ctx, "Skipped (no remote)")
-			out.Debug(ctx, "Failed to push '%s' to its remote: %s", name, err)
+			out.Error(ctx, "Failed to push '%s' to its remote: %s", name, err)
 			return err
 		}
+		out.Print(ctxno, color.GreenString("OK"))
 
-		out.Error(ctx, "Failed to push '%s' to its remote: %s", name, err)
-		return err
-	}
-	out.Print(ctxno, color.GreenString("OK"))
-
-	if l, err := sub.List(ctx, ""); err == nil {
-		diff := len(l) - numMP
-		if diff > 0 {
-			out.Print(ctxno, color.GreenString(" (Added %d entries)", diff))
-		} else if diff < 0 {
-			out.Print(ctxno, color.GreenString(" (Removed %d entries)", -1*diff))
-		} else {
-			out.Print(ctxno, color.GreenString(" (no changes)"))
+		if l, err := sub.List(ctx, ""); err == nil {
+			diff := len(l) - numMP
+			if diff > 0 {
+				out.Print(ctxno, color.GreenString(" (Added %d entries)", diff))
+			} else if diff < 0 {
+				out.Print(ctxno, color.GreenString(" (Removed %d entries)", -1*diff))
+			} else {
+				out.Print(ctxno, color.GreenString(" (no changes)"))
+			}
 		}
 	}
 
-	// import keys
-	out.Print(ctxno, "\n   "+color.GreenString("importing missing keys ... "))
-	if err := sub.ImportMissingPublicKeys(ctx); err != nil {
-		out.Error(ctx, "Failed to import missing public keys for '%s': %s", name, err)
-		return err
-	}
-	out.Print(ctxno, color.GreenString("OK"))
+	out.Debug(ctx, "syncMount(%s) - exportkeys: %t", mp, subs.IsExportKeys(ctx))
+	var exported bool
+	if subs.IsExportKeys(ctx) {
+		// import keys
+		out.Print(ctxno, "\n   "+color.GreenString("importing missing keys ... "))
+		if err := sub.ImportMissingPublicKeys(ctx); err != nil {
+			out.Error(ctx, "Failed to import missing public keys for '%s': %s", name, err)
+			return err
+		}
+		out.Print(ctxno, color.GreenString("OK"))
 
-	// export keys
-	out.Print(ctxno, "\n   "+color.GreenString("exporting missing keys ... "))
-	rs, err := sub.GetRecipients(ctx, "")
-	if err != nil {
-		out.Error(ctx, "Failed to load recipients for '%s': %s", name, err)
-		return err
-	}
-	exported, err := sub.ExportMissingPublicKeys(ctx, rs)
-	if err != nil {
-		out.Error(ctx, "Failed to export missing public keys for '%s': %s", name, err)
-		return err
+		// export keys
+		out.Print(ctxno, "\n   "+color.GreenString("exporting missing keys ... "))
+		rs, err := sub.GetRecipients(ctx, "")
+		if err != nil {
+			out.Error(ctx, "Failed to load recipients for '%s': %s", name, err)
+			return err
+		}
+		exported, err = sub.ExportMissingPublicKeys(ctx, rs)
+		if err != nil {
+			out.Error(ctx, "Failed to export missing public keys for '%s': %s", name, err)
+			return err
+		}
 	}
 
 	// only run second push if we did export any keys

--- a/pkg/store/root/mount.go
+++ b/pkg/store/root/mount.go
@@ -181,14 +181,14 @@ func (r *Store) WithConfig(ctx context.Context, name string) context.Context {
 
 // GetSubStore returns an exact match for a mount point or an error if this
 // mount point does not exist
-func (r *Store) GetSubStore(name string) (store.Store, error) {
+func (r *Store) GetSubStore(ctx context.Context, name string) (context.Context, store.Store, error) {
 	if name == "" {
-		return r.store, nil
+		return r.cfg.Root.WithContext(ctx), r.store, nil
 	}
 	if sub, found := r.mounts[name]; found {
-		return sub, nil
+		return r.cfg.Mounts[name].WithContext(ctx), sub, nil
 	}
-	return nil, errors.Errorf("no such mount point '%s'", name)
+	return nil, nil, errors.Errorf("no such mount point '%s'", name)
 }
 
 // checkMounts performs some sanity checks on our mounts. At the moment it

--- a/pkg/store/root/mount_test.go
+++ b/pkg/store/root/mount_test.go
@@ -26,11 +26,11 @@ func TestMount(t *testing.T) {
 	assert.Equal(t, map[string]string{}, rs.Mounts())
 	assert.Equal(t, []string{}, rs.MountPoints())
 
-	sub, err := rs.GetSubStore("")
+	_, sub, err := rs.GetSubStore(ctx, "")
 	require.NoError(t, err)
 	require.NotNil(t, sub)
 
-	sub, err = rs.GetSubStore("foo")
+	_, sub, err = rs.GetSubStore(ctx, "foo")
 	assert.Error(t, err)
 	assert.Nil(t, sub)
 


### PR DESCRIPTION
This also adds import support for the noop backend.

Fixes #1368
Fixes #1113

RELEASE_NOTES=Correctly handle exportkeys and auto import for noop.

Signed-off-by: Dominik Schulz <dominik.schulz@gauner.org>