### PR TITLE
Make sure current item is never larger than total number

### DIFF
--- a/internal/action/fsck.go
+++ b/internal/action/fsck.go
@@ -58,6 +58,9 @@ func (s *Action) Fsck(c *cli.Context) error {
 
 	ctx = ctxutil.WithProgressCallback(ctx, func() {
 		bar.Current++
+		if bar.Current > bar.Total {
+			bar.Total = bar.Current
+		}
 		bar.Text = fmt.Sprintf("%d of %d objects checked", bar.Current, bar.Total)
 		bar.LazyPrint()
 	})


### PR DESCRIPTION
RELEASE_NOTES=[BUGFIX] Fix fsck progress bar.

Fixes #911

Signed-off-by: Dominik Schulz <dominik.schulz@gauner.org>