### PR TITLE
Remove store.Store

### DIFF
--- a/app.go
+++ b/app.go
@@ -7,7 +7,7 @@ import (
 	ap "github.com/gopasspw/gopass/internal/action"
 	"github.com/gopasspw/gopass/internal/config"
 	"github.com/gopasspw/gopass/internal/out"
-	"github.com/gopasspw/gopass/internal/store/sub"
+	"github.com/gopasspw/gopass/internal/store/leaf"
 	"github.com/gopasspw/gopass/internal/termio"
 
 	"github.com/blang/semver"
@@ -30,12 +30,12 @@ func setupApp(ctx context.Context, sv semver.Version) (context.Context, *cli.App
 
 	// set some action callbacks
 	if !cfg.Root.AutoImport {
-		ctx = sub.WithImportFunc(ctx, termio.AskForKeyImport)
+		ctx = leaf.WithImportFunc(ctx, termio.AskForKeyImport)
 	}
 	if !cfg.Root.NoConfirm {
-		ctx = sub.WithRecipientFunc(ctx, action.ConfirmRecipients)
+		ctx = leaf.WithRecipientFunc(ctx, action.ConfirmRecipients)
 	}
-	ctx = sub.WithFsckFunc(ctx, termio.AskForConfirmation)
+	ctx = leaf.WithFsckFunc(ctx, termio.AskForConfirmation)
 
 	app := cli.NewApp()
 

--- a/cmd/gopass-git-credentials/git-credential.go
+++ b/cmd/gopass-git-credentials/git-credential.go
@@ -10,8 +10,8 @@ import (
 	"strings"
 
 	"github.com/gopasspw/gopass/internal/out"
+	"github.com/gopasspw/gopass/internal/store/leaf"
 	"github.com/gopasspw/gopass/internal/store/secret"
-	"github.com/gopasspw/gopass/internal/store/sub"
 	"github.com/gopasspw/gopass/internal/termio"
 	"github.com/gopasspw/gopass/pkg/ctxutil"
 	"github.com/gopasspw/gopass/pkg/fsutil"
@@ -134,7 +134,7 @@ func filter(ls []string, prefix string) []string {
 // Get returns a credential to git
 func (s *gc) Get(c *cli.Context) error {
 	ctx := ctxutil.WithGlobalFlags(c)
-	ctx = sub.WithAutoSync(ctx, false)
+	ctx = leaf.WithAutoSync(ctx, false)
 	cred, err := parseGitCredentials(termio.Stdin)
 	if err != nil {
 		return fmt.Errorf("error: %v while parsing git-credential", err)

--- a/cmd/gopass-jsonapi/.gitignore
+++ b/cmd/gopass-jsonapi/.gitignore
@@ -1,1 +1,2 @@
 gopass-jsonapi
+gopass-jsonapi-*-amd64

--- a/context.go
+++ b/context.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/gopasspw/gopass/internal/backend/crypto/gpg"
 	"github.com/gopasspw/gopass/internal/config"
-	"github.com/gopasspw/gopass/internal/store/sub"
+	"github.com/gopasspw/gopass/internal/store/leaf"
 	"github.com/gopasspw/gopass/pkg/ctxutil"
 
 	"github.com/fatih/color"
@@ -22,7 +22,7 @@ func initContext(ctx context.Context, cfg *config.Config) context.Context {
 	// check recipients conflicts with always trust, make sure it's not enabled
 	// when always trust is
 	if gpg.IsAlwaysTrust(ctx) {
-		ctx = sub.WithCheckRecipients(ctx, false)
+		ctx = leaf.WithCheckRecipients(ctx, false)
 	}
 
 	// debug flag

--- a/internal/action/fsck.go
+++ b/internal/action/fsck.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/gopasspw/gopass/internal/config"
 	"github.com/gopasspw/gopass/internal/out"
-	"github.com/gopasspw/gopass/internal/store/sub"
+	"github.com/gopasspw/gopass/internal/store/leaf"
 	"github.com/gopasspw/gopass/pkg/ctxutil"
 	"github.com/gopasspw/gopass/pkg/fsutil"
 	"github.com/muesli/goprogressbar"
@@ -19,7 +19,7 @@ import (
 func (s *Action) Fsck(c *cli.Context) error {
 	ctx := ctxutil.WithGlobalFlags(c)
 	if c.IsSet("decrypt") {
-		ctx = sub.WithFsckDecrypt(ctx, c.Bool("decrypt"))
+		ctx = leaf.WithFsckDecrypt(ctx, c.Bool("decrypt"))
 	}
 	out.Print(ctx, "Checking store integrity ...")
 	// make sure config is in the right place

--- a/internal/action/init.go
+++ b/internal/action/init.go
@@ -11,7 +11,7 @@ import (
 	"github.com/gopasspw/gopass/internal/config"
 	"github.com/gopasspw/gopass/internal/cui"
 	"github.com/gopasspw/gopass/internal/out"
-	"github.com/gopasspw/gopass/internal/store/sub"
+	"github.com/gopasspw/gopass/internal/store/leaf"
 	"github.com/gopasspw/gopass/internal/termio"
 	"github.com/gopasspw/gopass/pkg/ctxutil"
 	"github.com/gopasspw/gopass/pkg/pwgen/xkcdgen"
@@ -178,7 +178,7 @@ func (s *Action) getCryptoFor(ctx context.Context, name string) backend.Crypto {
 	if crypto != nil {
 		return crypto
 	}
-	c, err := sub.GetCryptoBackend(ctx, backend.GetCryptoBackend(ctx), config.Directory())
+	c, err := leaf.GetCryptoBackend(ctx, backend.GetCryptoBackend(ctx), config.Directory())
 	if err != nil {
 		out.Debug(ctx, "getCryptoFor(%s) failed to init crypto backend: %s", name, err)
 		return nil

--- a/internal/action/insert.go
+++ b/internal/action/insert.go
@@ -10,8 +10,8 @@ import (
 	"github.com/gopasspw/gopass/internal/editor"
 	"github.com/gopasspw/gopass/internal/out"
 	"github.com/gopasspw/gopass/internal/store"
+	"github.com/gopasspw/gopass/internal/store/leaf"
 	"github.com/gopasspw/gopass/internal/store/secret"
-	"github.com/gopasspw/gopass/internal/store/sub"
 	"github.com/gopasspw/gopass/internal/termio"
 	"github.com/gopasspw/gopass/pkg/ctxutil"
 
@@ -40,7 +40,7 @@ func (s *Action) Insert(c *cli.Context) error {
 func (s *Action) insert(ctx context.Context, c *cli.Context, name, key string, echo, multiline, force, append bool, kvps map[string]string) error {
 	// if force mode is requested we mock the recipient func to just return anything that goes in
 	if force {
-		ctx = sub.WithRecipientFunc(ctx, func(ctx context.Context, msg string, rs []string) ([]string, error) {
+		ctx = leaf.WithRecipientFunc(ctx, func(ctx context.Context, msg string, rs []string) ([]string, error) {
 			return rs, nil
 		})
 	}

--- a/internal/action/recipients.go
+++ b/internal/action/recipients.go
@@ -8,7 +8,7 @@ import (
 	"github.com/gopasspw/gopass/internal/cui"
 	"github.com/gopasspw/gopass/internal/out"
 	"github.com/gopasspw/gopass/internal/store"
-	"github.com/gopasspw/gopass/internal/store/sub"
+	"github.com/gopasspw/gopass/internal/store/leaf"
 	"github.com/gopasspw/gopass/internal/termio"
 	"github.com/gopasspw/gopass/pkg/ctxutil"
 
@@ -211,7 +211,7 @@ func (s *Action) RecipientsUpdate(c *cli.Context) error {
 		}
 		recp, err := subs.GetRecipients(ctx, "")
 		if err != nil {
-			if err != sub.ErrRecipientChecksumChanged {
+			if err != leaf.ErrRecipientChecksumChanged {
 				return err
 			}
 		}

--- a/internal/action/sync.go
+++ b/internal/action/sync.go
@@ -8,7 +8,7 @@ import (
 	"github.com/gopasspw/gopass/internal/notify"
 	"github.com/gopasspw/gopass/internal/out"
 	"github.com/gopasspw/gopass/internal/store"
-	subs "github.com/gopasspw/gopass/internal/store/sub"
+	subs "github.com/gopasspw/gopass/internal/store/leaf"
 	"github.com/gopasspw/gopass/pkg/ctxutil"
 
 	"github.com/fatih/color"

--- a/internal/config/context.go
+++ b/internal/config/context.go
@@ -3,7 +3,7 @@ package config
 import (
 	"context"
 
-	"github.com/gopasspw/gopass/internal/store/sub"
+	"github.com/gopasspw/gopass/internal/store/leaf"
 	"github.com/gopasspw/gopass/pkg/ctxutil"
 )
 
@@ -20,10 +20,10 @@ func (c StoreConfig) WithContext(ctx context.Context) context.Context {
 		ctx = ctxutil.WithAutoPrint(ctx, c.AutoPrint)
 	}
 	if !c.AutoImport {
-		ctx = sub.WithImportFunc(ctx, nil)
+		ctx = leaf.WithImportFunc(ctx, nil)
 	}
-	if !sub.HasAutoSync(ctx) {
-		ctx = sub.WithAutoSync(ctx, c.AutoSync)
+	if !leaf.HasAutoSync(ctx) {
+		ctx = leaf.WithAutoSync(ctx, c.AutoSync)
 	}
 	if !ctxutil.HasClipTimeout(ctx) {
 		ctx = ctxutil.WithClipTimeout(ctx, c.ClipTimeout)
@@ -34,8 +34,8 @@ func (c StoreConfig) WithContext(ctx context.Context) context.Context {
 	if !ctxutil.HasEditRecipients(ctx) {
 		ctx = ctxutil.WithEditRecipients(ctx, c.EditRecipients)
 	}
-	if !sub.HasExportKeys(ctx) {
-		ctx = sub.WithExportKeys(ctx, c.ExportKeys)
+	if !leaf.HasExportKeys(ctx) {
+		ctx = leaf.WithExportKeys(ctx, c.ExportKeys)
 	}
 	if !ctxutil.HasNoConfirm(ctx) {
 		ctx = ctxutil.WithNoConfirm(ctx, c.NoConfirm)

--- a/internal/store/leaf/context.go
+++ b/internal/store/leaf/context.go
@@ -1,4 +1,4 @@
-package sub
+package leaf
 
 import (
 	"context"

--- a/internal/store/leaf/context_test.go
+++ b/internal/store/leaf/context_test.go
@@ -1,4 +1,4 @@
-package sub
+package leaf
 
 import (
 	"context"

--- a/internal/store/leaf/crypto.go
+++ b/internal/store/leaf/crypto.go
@@ -1,4 +1,4 @@
-package sub
+package leaf
 
 import (
 	"context"

--- a/internal/store/leaf/fsck.go
+++ b/internal/store/leaf/fsck.go
@@ -1,4 +1,4 @@
-package sub
+package leaf
 
 import (
 	"context"

--- a/internal/store/leaf/fsck_test.go
+++ b/internal/store/leaf/fsck_test.go
@@ -1,4 +1,4 @@
-package sub
+package leaf
 
 import (
 	"bytes"

--- a/internal/store/leaf/git.go
+++ b/internal/store/leaf/git.go
@@ -1,4 +1,4 @@
-package sub
+package leaf
 
 import (
 	"context"

--- a/internal/store/leaf/git_test.go
+++ b/internal/store/leaf/git_test.go
@@ -1,4 +1,4 @@
-package sub
+package leaf
 
 import (
 	"context"

--- a/internal/store/leaf/gpg.go
+++ b/internal/store/leaf/gpg.go
@@ -1,4 +1,4 @@
-package sub
+package leaf
 
 import (
 	"context"

--- a/internal/store/leaf/gpg_test.go
+++ b/internal/store/leaf/gpg_test.go
@@ -1,4 +1,4 @@
-package sub
+package leaf
 
 import (
 	"bytes"

--- a/internal/store/leaf/init.go
+++ b/internal/store/leaf/init.go
@@ -1,4 +1,4 @@
-package sub
+package leaf
 
 import (
 	"context"

--- a/internal/store/leaf/init_test.go
+++ b/internal/store/leaf/init_test.go
@@ -1,4 +1,4 @@
-package sub
+package leaf
 
 import (
 	"context"

--- a/internal/store/leaf/list.go
+++ b/internal/store/leaf/list.go
@@ -1,4 +1,4 @@
-package sub
+package leaf
 
 import (
 	"context"

--- a/internal/store/leaf/list_test.go
+++ b/internal/store/leaf/list_test.go
@@ -1,4 +1,4 @@
-package sub
+package leaf
 
 import (
 	"bytes"

--- a/internal/store/leaf/move.go
+++ b/internal/store/leaf/move.go
@@ -1,4 +1,4 @@
-package sub
+package leaf
 
 import (
 	"context"

--- a/internal/store/leaf/move_test.go
+++ b/internal/store/leaf/move_test.go
@@ -1,4 +1,4 @@
-package sub
+package leaf
 
 import (
 	"bytes"

--- a/internal/store/leaf/rcs.go
+++ b/internal/store/leaf/rcs.go
@@ -1,4 +1,4 @@
-package sub
+package leaf
 
 import (
 	"context"

--- a/internal/store/leaf/read.go
+++ b/internal/store/leaf/read.go
@@ -1,4 +1,4 @@
-package sub
+package leaf
 
 import (
 	"context"

--- a/internal/store/leaf/recipients.go
+++ b/internal/store/leaf/recipients.go
@@ -1,4 +1,4 @@
-package sub
+package leaf
 
 import (
 	"bufio"

--- a/internal/store/leaf/recipients_test.go
+++ b/internal/store/leaf/recipients_test.go
@@ -1,4 +1,4 @@
-package sub
+package leaf
 
 import (
 	"bufio"

--- a/internal/store/leaf/storage.go
+++ b/internal/store/leaf/storage.go
@@ -1,4 +1,4 @@
-package sub
+package leaf
 
 import (
 	"context"

--- a/internal/store/leaf/store.go
+++ b/internal/store/leaf/store.go
@@ -1,4 +1,4 @@
-package sub
+package leaf
 
 import (
 	"context"
@@ -103,7 +103,7 @@ func (s *Store) idFile(ctx context.Context, name string) string {
 }
 
 // Equals returns true if this.storage has the same on-disk path as the other
-func (s *Store) Equals(other store.Store) bool {
+func (s *Store) Equals(other *Store) bool {
 	if other == nil {
 		return false
 	}

--- a/internal/store/leaf/store_test.go
+++ b/internal/store/leaf/store_test.go
@@ -1,4 +1,4 @@
-package sub
+package leaf
 
 import (
 	"context"

--- a/internal/store/leaf/templates.go
+++ b/internal/store/leaf/templates.go
@@ -1,4 +1,4 @@
-package sub
+package leaf
 
 import (
 	"context"

--- a/internal/store/leaf/templates_test.go
+++ b/internal/store/leaf/templates_test.go
@@ -1,4 +1,4 @@
-package sub
+package leaf
 
 import (
 	"context"

--- a/internal/store/leaf/write.go
+++ b/internal/store/leaf/write.go
@@ -1,4 +1,4 @@
-package sub
+package leaf
 
 import (
 	"context"

--- a/internal/store/leaf/write_test.go
+++ b/internal/store/leaf/write_test.go
@@ -1,4 +1,4 @@
-package sub
+package leaf
 
 import (
 	"context"

--- a/internal/store/mockstore/store.go
+++ b/internal/store/mockstore/store.go
@@ -155,7 +155,7 @@ func (m *MockStore) Delete(ctx context.Context, name string) error {
 }
 
 // Equals does nothing
-func (m *MockStore) Equals(other store.Store) bool {
+func (m *MockStore) Equals(other *MockStore) bool {
 	return false
 }
 

--- a/internal/store/root/init.go
+++ b/internal/store/root/init.go
@@ -6,7 +6,7 @@ import (
 	"github.com/gopasspw/gopass/internal/backend"
 	"github.com/gopasspw/gopass/internal/config"
 	"github.com/gopasspw/gopass/internal/out"
-	"github.com/gopasspw/gopass/internal/store/sub"
+	"github.com/gopasspw/gopass/internal/store/leaf"
 
 	"github.com/pkg/errors"
 )
@@ -30,7 +30,7 @@ func (r *Store) Init(ctx context.Context, alias, path string, ids ...string) err
 	if err != nil {
 		return errors.Wrapf(err, "failed to parse backend URL '%s': %s", path, err)
 	}
-	sub, err := sub.New(ctx, r.cfg, alias, pathURL, r.cfg.Directory())
+	sub, err := leaf.New(ctx, r.cfg, alias, pathURL, r.cfg.Directory())
 	if err != nil {
 		return errors.Wrapf(err, "failed to instantiate new sub store: %s", err)
 	}
@@ -107,7 +107,7 @@ func (r *Store) initialize(ctx context.Context) error {
 			return errors.Wrapf(err, "failed to parse backend URL '%s': %s", r.url.String(), err)
 		}
 		out.Debug(ctx, "initialize - %s", bu.String())
-		s, err := sub.New(ctx, r.cfg, "", bu, r.cfg.Directory())
+		s, err := leaf.New(ctx, r.cfg, "", bu, r.cfg.Directory())
 		if err != nil {
 			return errors.Wrapf(err, "failed to initialize the root store at '%s': %s", r.url.String(), err)
 		}

--- a/internal/store/root/move.go
+++ b/internal/store/root/move.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/gopasspw/gopass/internal/out"
 	"github.com/gopasspw/gopass/internal/store"
-	"github.com/gopasspw/gopass/internal/store/sub"
+	"github.com/gopasspw/gopass/internal/store/leaf"
 	"github.com/gopasspw/gopass/pkg/ctxutil"
 	"github.com/pkg/errors"
 )
@@ -60,7 +60,7 @@ func (r *Store) move(ctx context.Context, from, to string, delete bool) error {
 		}
 	}
 
-	if !sub.IsAutoSync(ctx) {
+	if !leaf.IsAutoSync(ctx) {
 		out.Debug(ctx, "reencrypt - auto sync is disabled")
 		return nil
 	}
@@ -100,9 +100,9 @@ func (r *Store) move(ctx context.Context, from, to string, delete bool) error {
 	return nil
 }
 
-func (r *Store) moveFromTo(ctxFrom, ctxTo context.Context, subFrom, subTo store.Store, from, to, fromPrefix string, srcIsDir, delete bool) error {
-	ctxFrom = ctxutil.WithGitCommit(sub.WithAutoSync(ctxFrom, false), false)
-	ctxTo = ctxutil.WithGitCommit(sub.WithAutoSync(ctxTo, false), false)
+func (r *Store) moveFromTo(ctxFrom, ctxTo context.Context, subFrom, subTo *leaf.Store, from, to, fromPrefix string, srcIsDir, delete bool) error {
+	ctxFrom = ctxutil.WithGitCommit(leaf.WithAutoSync(ctxFrom, false), false)
+	ctxTo = ctxutil.WithGitCommit(leaf.WithAutoSync(ctxTo, false), false)
 
 	entries := []string{from}
 	if r.IsDir(ctxFrom, from) {

--- a/internal/store/root/store.go
+++ b/internal/store/root/store.go
@@ -7,16 +7,15 @@ import (
 
 	"github.com/gopasspw/gopass/internal/backend"
 	"github.com/gopasspw/gopass/internal/config"
-	"github.com/gopasspw/gopass/internal/store"
-	"github.com/gopasspw/gopass/internal/store/sub"
+	"github.com/gopasspw/gopass/internal/store/leaf"
 )
 
 // Store is the public facing password store
 type Store struct {
 	cfg    *config.Config
-	mounts map[string]store.Store
+	mounts map[string]*leaf.Store
 	url    *backend.URL // url of the root store
-	store  *sub.Store
+	store  *leaf.Store
 }
 
 // New creates a new store
@@ -29,7 +28,7 @@ func New(ctx context.Context, cfg *config.Config) (*Store, error) {
 	}
 	r := &Store{
 		cfg:    cfg,
-		mounts: make(map[string]store.Store, len(cfg.Mounts)),
+		mounts: make(map[string]*leaf.Store, len(cfg.Mounts)),
 		url:    cfg.Root.Path,
 	}
 

--- a/internal/store/secret/secret.go
+++ b/internal/store/secret/secret.go
@@ -26,6 +26,9 @@ type Secret struct {
 	data     map[string]interface{}
 }
 
+// make sure that *Secret implements store.Secret
+var _ store.Secret = &Secret{}
+
 // New creates a new secret
 func New(password, body string) *Secret {
 	return &Secret{

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -2,10 +2,6 @@ package store
 
 import (
 	"context"
-	"fmt"
-
-	"github.com/gopasspw/gopass/internal/backend"
-	"github.com/gopasspw/gopass/internal/tree"
 )
 
 // RecipientCallback is a callback to verify the list of recipients
@@ -18,59 +14,3 @@ type ImportCallback func(context.Context, string, []string) bool
 // FsckCallback is a callback to ask the user to confirm certain fsck
 // corrective actions
 type FsckCallback func(context.Context, string) bool
-
-// TemplateStore is a store supporting templating operations
-type TemplateStore interface {
-	GetTemplate(context.Context, string) ([]byte, error)
-	HasTemplate(context.Context, string) bool
-	ListTemplates(context.Context, string) []string
-	LookupTemplate(context.Context, string) (string, []byte, bool)
-	RemoveTemplate(context.Context, string) error
-	SetTemplate(context.Context, string, []byte) error
-	TemplateTree(context.Context) (tree.Tree, error)
-}
-
-// RecipientStore is a store supporting recipient operations
-type RecipientStore interface {
-	AddRecipient(context.Context, string) error
-	GetRecipients(context.Context, string) ([]string, error)
-	RemoveRecipient(context.Context, string) error
-	SaveRecipients(context.Context) error
-	SetRecipients(context.Context, []string) error
-	Recipients(context.Context) []string
-	ImportMissingPublicKeys(context.Context) error
-	ExportMissingPublicKeys(context.Context, []string) (bool, error)
-}
-
-// Store is secrets store
-type Store interface {
-	fmt.Stringer
-
-	TemplateStore
-	RecipientStore
-
-	Fsck(context.Context, string) error
-	Path() string
-	URL() string
-	RCS() backend.RCS
-	Crypto() backend.Crypto
-	Storage() backend.Storage
-	GitInit(context.Context, string, string) error
-	GitStatus(context.Context, string) error
-	Alias() string
-	Copy(context.Context, string, string) error
-	Delete(context.Context, string) error
-	Equals(Store) bool
-	Exists(context.Context, string) bool
-	Get(context.Context, string) (Secret, error)
-	GetRevision(context.Context, string, string) (Secret, error)
-	Init(context.Context, string, ...string) error
-	Initialized(context.Context) bool
-	IsDir(context.Context, string) bool
-	List(context.Context, string) ([]string, error)
-	ListRevisions(context.Context, string) ([]backend.Revision, error)
-	Move(context.Context, string, string) error
-	Set(context.Context, string, Byter) error
-	Prune(context.Context, string) error
-	Valid() bool
-}

--- a/pkg/gopass/api.go
+++ b/pkg/gopass/api.go
@@ -52,6 +52,9 @@ type Gopass struct {
 	rs *root.Store
 }
 
+// make sure that *Gopass implements Store
+var _ Store = &Gopass{}
+
 // New creates a new secret store
 // WARNING: This will need to change to accommodate for runtime configuration.
 func New(ctx context.Context) (*Gopass, error) {


### PR DESCRIPTION
This commit removes the unnecessary store.Store interface and renames
store/sub to the more apt store/leaf.

RELEASE_NOTES=n/a

Signed-off-by: Dominik Schulz <dominik.schulz@gauner.org>