### PR TITLE
Add debug package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -203,31 +203,19 @@ codequality:
 	@staticcheck $(PKGS) || exit 1
 	@printf '%s\n' '$(OK)'
 
-codequality-nomod:
-	@echo -n "     ERRCHECK  "
-	@which errcheck > /dev/null; if [ $$? -ne 0  ]; then \
-		$(GO) get -u github.com/kisielk/errcheck; \
+	@echo -n "     UNPARAM "
+	@which unparam > /dev/null; if [ $$? -ne 0 ]; then \
+		$(GO) get -u mvdan.cc/unparam; \
 	fi
-	@errcheck -exclude .errcheck.excl $(PKGS) || exit 1
-	@printf '%s\n' '$(OK)'
-
-	@echo -n "     INTERFACER"
-	@which interfacer > /dev/null; if [ $$? -ne 0 ]; then \
-		$(GO) get -u mvdan.cc/interfacer; \
-	fi
-	@interfacer $(PKGS)
-	@printf '%s\n' '$(OK)'
-
-	@echo -n "     UNCONVERT "
-	@which unconvert > /dev/null; if [ $$? -ne 0  ]; then \
-		$(GO) get -u github.com/mdempsky/unconvert; \
-	fi
-	@unconvert -v $(PKGS) || exit 1
+	@unparam -exported=true $(PKGS) || extit 1
 	@printf '%s\n' '$(OK)'
 
 fmt:
 	@gofmt -s -l -w $(GOFILES_NOVENDOR)
-	@clang-format -i $(PROTOFILES)
+	@goimports -l -w $(GOFILES_NOVENDOR)
+	@which clang-format > /dev/null; if [ $$? -eq 0 ]; then \
+		clang-format -i $(PROTOFILES); \
+	fi
 	@go mod tidy
 
 fuzz-gpg:

--- a/cmd/gopass-git-credentials/git-credential.go
+++ b/cmd/gopass-git-credentials/git-credential.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"strings"
 
+	"github.com/gopasspw/gopass/internal/debug"
 	"github.com/gopasspw/gopass/internal/out"
 	"github.com/gopasspw/gopass/internal/store/secret"
 	"github.com/gopasspw/gopass/internal/termio"
@@ -185,7 +186,7 @@ func (s *gc) Store(c *cli.Context) error {
 	path := "git/" + fsutil.CleanFilename(cred.Host) + "/" + fsutil.CleanFilename(cred.Username)
 	// This should never really be an issue because git automatically removes invalid credentials first
 	if _, err := s.gp.Get(ctx, path); err == nil {
-		out.Debug(ctx, ""+
+		debug.Log(""+
 			"gopass: did not store \"%s\" because it already exists. "+
 			"If you want to overwrite it, delete it first by doing: "+
 			"\"gopass rm %s\"\n",

--- a/cmd/gopass-hibp/hibp.go
+++ b/cmd/gopass-hibp/hibp.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"sort"
 
+	"github.com/gopasspw/gopass/internal/debug"
 	"github.com/gopasspw/gopass/internal/notify"
 	"github.com/gopasspw/gopass/internal/out"
 	"github.com/gopasspw/gopass/internal/termio"
@@ -38,7 +39,7 @@ func (s *hibp) CheckAPI(ctx context.Context, force bool) error {
 	// compare the prepared list against all provided files
 	matchList := make([]string, 0, len(sortedShaSums))
 	for _, shaSum := range sortedShaSums {
-		freq, err := hibpapi.Lookup(ctx, shaSum)
+		freq, err := hibpapi.Lookup(shaSum)
 		if err != nil {
 			out.Error(ctx, "Failed to check HIBP API: %s", err)
 			continue
@@ -73,7 +74,7 @@ func (s *hibp) CheckDump(ctx context.Context, force bool, dumps []string) error 
 	}
 
 	matchedSums := scanner.LookupBatch(ctx, sortedShaSums)
-	out.Debug(ctx, "In: %+v - Out: %+v", sortedShaSums, matchedSums)
+	debug.Log("In: %+v - Out: %+v", sortedShaSums, matchedSums)
 	matchList := make([]string, 0, len(matchedSums))
 	for _, matchedSum := range matchedSums {
 		if pw, found := shaSums[matchedSum]; found {

--- a/cmd/gopass-jsonapi/internal/jsonapi/api_test.go
+++ b/cmd/gopass-jsonapi/internal/jsonapi/api_test.go
@@ -164,7 +164,7 @@ sub:
 `)},
 	}
 
-	totp, _, err := otp.Calculate(context.Background(), "_", totpSecret)
+	totp, _, err := otp.Calculate("_", totpSecret)
 	if err != nil {
 		assert.NoError(t, err)
 	}

--- a/cmd/gopass-jsonapi/internal/jsonapi/responses.go
+++ b/cmd/gopass-jsonapi/internal/jsonapi/responses.go
@@ -156,7 +156,7 @@ func (api *API) respondGetData(ctx context.Context, msgBytes []byte) error {
 	}
 
 	responseData := sec.Data()
-	currentTotp, _, err := otp.Calculate(ctx, "_", sec)
+	currentTotp, _, err := otp.Calculate("_", sec)
 	if err == nil {
 		responseData["current_totp"] = currentTotp.OTP()
 	}

--- a/docs/config.md
+++ b/docs/config.md
@@ -8,6 +8,9 @@ Some configuration options are only available through setting environment variab
 |-------------------------|----------|--------------------------------------------------------------------------------------------------------------|
 | `CHECKPOINT_DISABLE`    | `bool`   | Set to any non-empty value to disable calling the GitHub API when running `gopass version`.                  |
 | `GOPASS_DEBUG`          | `bool`   | Set to any non-empty value to enable verbose debug output                                                    |
+| `GOPASS_DEBUG_LOG` | `string` | Set to a filename to enable debug logging |
+| `GOPASS_DEBUG_FUNCS` | `string` | Comma separated filter for console debug output (functions) |
+| `GOPASS_DEBUG_FILES` | `string` | Comma separated filter for console debug output (files) |
 | `GOPASS_UMASK`          | `octal`  | Set to any valid umask to mask bits of files created by gopass                                               |
 | `GOPASS_GPG_OPTS`       | `string` | Add any extra arguments, e.g. `--armor` you want to pass to GPG on every invocation                          |
 | `GOPASS_EXTERNAL_PWGEN` | `string` | Use an external password generator. See [Features](features.md#using-custom-password-generators) for details |

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,6 @@ require (
 	github.com/schollz/closestmatch v0.0.0-20190308193919-1fbe626be92e
 	github.com/skip2/go-qrcode v0.0.0-20191027152451-9434209cb086
 	github.com/stretchr/testify v1.5.1
-	github.com/urfave/cli v1.22.4
 	github.com/urfave/cli/v2 v2.2.0
 	golang.org/x/crypto v0.0.0-20200423211502-4bdfaf469ed5
 	golang.org/x/net v0.0.0-20200421231249-e086a090c8fd

--- a/go.sum
+++ b/go.sum
@@ -92,8 +92,6 @@ github.com/skip2/go-qrcode v0.0.0-20191027152451-9434209cb086/go.mod h1:PLPIyL7i
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
-github.com/urfave/cli v1.22.4 h1:u7tSpNPPswAFymm8IehJhy4uJMlUuU/GmqSkvJ1InXA=
-github.com/urfave/cli v1.22.4/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/urfave/cli/v2 v2.2.0 h1:JTTnM6wKzdA0Jqodd966MVj4vWbbquZykeX1sKbe2C4=
 github.com/urfave/cli/v2 v2.2.0/go.mod h1:SE9GqnLQmjVa0iPEY0f1w3ygNIYcIJ0OKPMoW2caLfQ=
 github.com/xrash/smetrics v0.0.0-20170218160415-a3153f7040e9 h1:w8V9v0qVympSF6GjdjIyeqR7+EVhAF9CBQmkmW7Zw0w=

--- a/internal/action/action.go
+++ b/internal/action/action.go
@@ -1,13 +1,11 @@
 package action
 
 import (
-	"context"
 	"io"
 	"os"
 	"path/filepath"
 
 	"github.com/gopasspw/gopass/internal/config"
-	"github.com/gopasspw/gopass/internal/out"
 	"github.com/gopasspw/gopass/internal/store/root"
 
 	"github.com/blang/semver"
@@ -27,11 +25,11 @@ type Action struct {
 }
 
 // New returns a new Action wrapper
-func New(ctx context.Context, cfg *config.Config, sv semver.Version) (*Action, error) {
-	return newAction(ctx, cfg, sv)
+func New(cfg *config.Config, sv semver.Version) (*Action, error) {
+	return newAction(cfg, sv)
 }
 
-func newAction(ctx context.Context, cfg *config.Config, sv semver.Version) (*Action, error) {
+func newAction(cfg *config.Config, sv semver.Version) (*Action, error) {
 	name := "gopass"
 	if len(os.Args) > 0 {
 		name = filepath.Base(os.Args[0])
@@ -41,15 +39,8 @@ func newAction(ctx context.Context, cfg *config.Config, sv semver.Version) (*Act
 		Name:    name,
 		cfg:     cfg,
 		version: sv,
+		Store:   root.New(cfg),
 	}
-
-	ctx = out.AddPrefix(ctx, "[action] ")
-
-	store, err := root.New(ctx, cfg)
-	if err != nil {
-		return nil, ExitError(ctx, ExitUnknown, err, "failed to init root store: %s", err)
-	}
-	act.Store = store
 
 	return act, nil
 }

--- a/internal/action/action_test.go
+++ b/internal/action/action_test.go
@@ -27,7 +27,7 @@ func newMock(ctx context.Context, u *gptest.Unit) (*Action, error) {
 	ctx = backend.WithRCSBackend(ctx, backend.Noop)
 	ctx = backend.WithCryptoBackend(ctx, backend.Plain)
 	ctx = backend.WithStorageBackend(ctx, backend.FS)
-	act, err := newAction(ctx, cfg, semver.Version{})
+	act, err := newAction(cfg, semver.Version{})
 	if err != nil {
 		return nil, err
 	}
@@ -68,16 +68,15 @@ func TestNew(t *testing.T) {
 		_ = os.RemoveAll(td)
 	}()
 
-	ctx := context.Background()
 	cfg := config.New()
 	sv := semver.Version{}
 
-	_, err = New(ctx, cfg, sv)
+	_, err = New(cfg, sv)
 	require.NoError(t, err)
 
 	cfg.Path = filepath.Join(td, "store")
 	assert.NoError(t, os.MkdirAll(cfg.Path, 0700))
 	assert.NoError(t, ioutil.WriteFile(filepath.Join(cfg.Path, plain.IDFile), []byte("foobar"), 0600))
-	_, err = New(ctx, cfg, sv)
+	_, err = New(cfg, sv)
 	assert.NoError(t, err)
 }

--- a/internal/action/audit.go
+++ b/internal/action/audit.go
@@ -18,12 +18,12 @@ func (s *Action) Audit(c *cli.Context) error {
 
 	t, err := s.Store.Tree(ctx)
 	if err != nil {
-		return ExitError(ctx, ExitList, err, "failed to get store tree: %s", err)
+		return ExitError(ExitList, err, "failed to get store tree: %s", err)
 	}
 	if filter != "" {
 		subtree, err := t.FindFolder(filter)
 		if err != nil {
-			return ExitError(ctx, ExitUnknown, err, "failed to find subtree: %s", err)
+			return ExitError(ExitUnknown, err, "failed to find subtree: %s", err)
 		}
 		t = subtree
 	}

--- a/internal/action/binary/cat.go
+++ b/internal/action/binary/cat.go
@@ -20,7 +20,7 @@ func Cat(c *cli.Context, store storer) error {
 	ctx := ctxutil.WithGlobalFlags(c)
 	name := c.Args().First()
 	if name == "" {
-		return action.ExitError(ctx, action.ExitNoName, nil, "Usage: %s binary cat <NAME>", c.App.Name)
+		return action.ExitError(action.ExitNoName, nil, "Usage: %s binary cat <NAME>", c.App.Name)
 	}
 
 	if !strings.HasSuffix(name, Suffix) {
@@ -30,7 +30,7 @@ func Cat(c *cli.Context, store storer) error {
 	// handle pipe to stdin
 	info, err := os.Stdin.Stat()
 	if err != nil {
-		return action.ExitError(ctx, action.ExitIO, err, "failed to stat stdin: %s", err)
+		return action.ExitError(action.ExitIO, err, "failed to stat stdin: %s", err)
 	}
 
 	// if content is piped to stdin, read and save it
@@ -38,7 +38,7 @@ func Cat(c *cli.Context, store storer) error {
 		content := &bytes.Buffer{}
 
 		if written, err := io.Copy(content, os.Stdin); err != nil {
-			return action.ExitError(ctx, action.ExitIO, err, "Failed to copy after %d bytes: %s", written, err)
+			return action.ExitError(action.ExitIO, err, "Failed to copy after %d bytes: %s", written, err)
 		}
 
 		return store.Set(
@@ -50,7 +50,7 @@ func Cat(c *cli.Context, store storer) error {
 
 	buf, err := binaryGet(ctx, name, store)
 	if err != nil {
-		return action.ExitError(ctx, action.ExitDecrypt, err, "failed to read secret: %s", err)
+		return action.ExitError(action.ExitDecrypt, err, "failed to read secret: %s", err)
 	}
 
 	out.Yellow(ctx, string(buf))

--- a/internal/action/binary/copy.go
+++ b/internal/action/binary/copy.go
@@ -26,7 +26,7 @@ func Copy(c *cli.Context, store storer) error {
 
 	// argument checking is in s.binaryCopy
 	if err := binaryCopy(ctx, c, from, to, false, store); err != nil {
-		return action.ExitError(ctx, action.ExitUnknown, err, "%s", err)
+		return action.ExitError(action.ExitUnknown, err, "%s", err)
 	}
 	return nil
 }
@@ -41,7 +41,7 @@ func Move(c *cli.Context, store storer) error {
 
 	// argument checking is in s.binaryCopy
 	if err := binaryCopy(ctx, c, from, to, true, store); err != nil {
-		return action.ExitError(ctx, action.ExitUnknown, err, "%s", err)
+		return action.ExitError(action.ExitUnknown, err, "%s", err)
 	}
 	return nil
 }

--- a/internal/action/binary/sum.go
+++ b/internal/action/binary/sum.go
@@ -16,7 +16,7 @@ func Sum(c *cli.Context, store storer) error {
 	ctx := ctxutil.WithGlobalFlags(c)
 	name := c.Args().First()
 	if name == "" {
-		return action.ExitError(ctx, action.ExitUsage, nil, "Usage: %s sha256 name", c.App.Name)
+		return action.ExitError(action.ExitUsage, nil, "Usage: %s sha256 name", c.App.Name)
 	}
 
 	if !strings.HasSuffix(name, Suffix) {
@@ -25,7 +25,7 @@ func Sum(c *cli.Context, store storer) error {
 
 	buf, err := binaryGet(ctx, name, store)
 	if err != nil {
-		return action.ExitError(ctx, action.ExitDecrypt, err, "failed to read secret: %s", err)
+		return action.ExitError(action.ExitDecrypt, err, "failed to read secret: %s", err)
 	}
 
 	h := sha256.New()

--- a/internal/action/clone.go
+++ b/internal/action/clone.go
@@ -6,9 +6,9 @@ import (
 	"path/filepath"
 
 	"github.com/gopasspw/gopass/internal/backend"
-	"github.com/gopasspw/gopass/internal/backend/crypto/xc"
 	"github.com/gopasspw/gopass/internal/config"
 	"github.com/gopasspw/gopass/internal/cui"
+	"github.com/gopasspw/gopass/internal/debug"
 	"github.com/gopasspw/gopass/internal/out"
 	"github.com/gopasspw/gopass/internal/termio"
 	"github.com/gopasspw/gopass/pkg/ctxutil"
@@ -29,7 +29,7 @@ func (s *Action) Clone(c *cli.Context) error {
 	}
 
 	if c.Args().Len() < 1 {
-		return ExitError(ctx, ExitUsage, nil, "Usage: %s clone repo [mount]", s.Name)
+		return ExitError(ExitUsage, nil, "Usage: %s clone repo [mount]", s.Name)
 	}
 
 	repo := c.Args().Get(0)
@@ -56,37 +56,34 @@ func (s *Action) clone(ctx context.Context, repo, mount, path string) error {
 	}
 	inited, err := s.Store.Initialized(ctxutil.WithGitInit(ctx, false))
 	if err != nil {
-		return ExitError(ctx, ExitUnknown, err, "Failed to initialized stores: %s", err)
+		return ExitError(ExitUnknown, err, "Failed to initialized stores: %s", err)
 	}
 	if mount == "" && inited {
-		return ExitError(ctx, ExitAlreadyInitialized, nil, "Can not clone %s to the root store, as this store is already initialized. Please try cloning to a submount: `%s clone %s sub`", repo, s.Name, repo)
+		return ExitError(ExitAlreadyInitialized, nil, "Can not clone %s to the root store, as this store is already initialized. Please try cloning to a submount: `%s clone %s sub`", repo, s.Name, repo)
 	}
 
 	// make sure the parent directory exists
 	if parentPath := filepath.Dir(path); !fsutil.IsDir(parentPath) {
 		if err := os.MkdirAll(parentPath, 0700); err != nil {
-			return ExitError(ctx, ExitUnknown, err, "Failed to create parent directory for clone: %s", err)
+			return ExitError(ExitUnknown, err, "Failed to create parent directory for clone: %s", err)
 		}
 	}
 
 	// clone repo
-	out.Debug(ctx, "Cloning repo '%s' to '%s'", repo, path)
+	debug.Log("Cloning repo '%s' to '%s'", repo, path)
 	if _, err := backend.CloneRCS(ctx, rcsBackendOrDefault(ctx), repo, path); err != nil {
-		return ExitError(ctx, ExitGit, err, "failed to clone repo '%s' to '%s'", repo, path)
+		return ExitError(ExitGit, err, "failed to clone repo '%s' to '%s'", repo, path)
 	}
 
-	// detect crypto backend based on cloned repo
-	ctx = backend.WithCryptoBackend(ctx, detectCryptoBackend(ctx, path))
-
 	// add mount
-	out.Debug(ctx, "Mounting cloned repo '%s' at '%s'", path, mount)
+	debug.Log("Mounting cloned repo '%s' at '%s'", path, mount)
 	if err := s.cloneAddMount(ctx, mount, path); err != nil {
 		return err
 	}
 
 	// save new mount in config file
 	if err := s.cfg.Save(); err != nil {
-		return ExitError(ctx, ExitIO, err, "Failed to update config: %s", err)
+		return ExitError(ExitIO, err, "Failed to update config: %s", err)
 	}
 
 	// try to init git config
@@ -100,7 +97,7 @@ func (s *Action) clone(ctx context.Context, repo, mount, path string) error {
 
 	// initialize git config
 	if err := s.Store.GitInitConfig(ctx, mount, username, email); err != nil {
-		out.Debug(ctx, "Stacktrace: %+v\n", err)
+		debug.Log("Stacktrace: %+v\n", err)
 		out.Error(ctx, "Failed to configure git: %s", err)
 	}
 
@@ -119,13 +116,13 @@ func (s *Action) cloneAddMount(ctx context.Context, mount, path string) error {
 
 	inited, err := s.Store.Initialized(ctx)
 	if err != nil {
-		return ExitError(ctx, ExitUnknown, err, "Failed to initialize store: %s", err)
+		return ExitError(ExitUnknown, err, "Failed to initialize store: %s", err)
 	}
 	if !inited {
-		return ExitError(ctx, ExitNotInitialized, nil, "Root-Store is not initialized. Clone or init root store first")
+		return ExitError(ExitNotInitialized, nil, "Root-Store is not initialized. Clone or init root store first")
 	}
 	if err := s.Store.AddMount(ctx, mount, path); err != nil {
-		return ExitError(ctx, ExitMount, err, "Failed to add mount: %s", err)
+		return ExitError(ExitMount, err, "Failed to add mount: %s", err)
 	}
 	out.Green(ctx, "Mounted password store %s at mount point `%s` ...", path, mount)
 	return nil
@@ -134,30 +131,20 @@ func (s *Action) cloneAddMount(ctx context.Context, mount, path string) error {
 func (s *Action) cloneGetGitConfig(ctx context.Context, name string) (string, string, error) {
 	// for convenience, set defaults to user-selected values from available private keys
 	// NB: discarding returned error since this is merely a best-effort look-up for convenience
-	username, email, _ := cui.AskForGitConfigUser(ctx, s.Store.Crypto(ctx, name), name)
+	username, email, _ := cui.AskForGitConfigUser(ctx, s.Store.Crypto(ctx, name))
 	if username == "" {
 		var err error
 		username, err = termio.AskForString(ctx, color.CyanString("Please enter a user name for password store git config"), username)
 		if err != nil {
-			return "", "", ExitError(ctx, ExitIO, err, "Failed to read user input: %s", err)
+			return "", "", ExitError(ExitIO, err, "Failed to read user input: %s", err)
 		}
 	}
 	if email == "" {
 		var err error
 		email, err = termio.AskForString(ctx, color.CyanString("Please enter an email address for password store git config"), email)
 		if err != nil {
-			return "", "", ExitError(ctx, ExitIO, err, "Failed to read user input: %s", err)
+			return "", "", ExitError(ExitIO, err, "Failed to read user input: %s", err)
 		}
 	}
 	return username, email, nil
-}
-
-// detectCryptoBackend tries to detect the crypto backend used in a cloned repo
-// This detection is very shallow and doesn't support all backends, yet
-// TODO(dschulz) must not depend on xc, move to registry
-func detectCryptoBackend(ctx context.Context, path string) backend.CryptoBackend {
-	if fsutil.IsFile(filepath.Join(path, xc.IDFile)) {
-		return backend.XC
-	}
-	return backend.GPGCLI
 }

--- a/internal/action/clone_test.go
+++ b/internal/action/clone_test.go
@@ -25,7 +25,7 @@ func aGitRepo(ctx context.Context, u *gptest.Unit, t *testing.T, name string) st
 	gd := filepath.Join(u.Dir, name)
 	assert.NoError(t, os.MkdirAll(gd, 0700))
 
-	_, err := git.Open(gd, "")
+	_, err := git.Open(gd)
 	assert.Error(t, err)
 
 	idf := filepath.Join(gd, ".gpg-id")
@@ -94,7 +94,7 @@ func TestCloneBackendIsStoredForMount(t *testing.T) {
 	cfg := config.Load()
 	cfg.Path = u.StoreDir("")
 
-	act, err := newAction(ctx, cfg, semver.Version{})
+	act, err := newAction(cfg, semver.Version{})
 	require.NoError(t, err)
 	require.NotNil(t, act)
 
@@ -125,27 +125,4 @@ func TestCloneGetGitConfig(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "", name)
 	assert.Equal(t, "", email)
-}
-
-func TestDetectCryptoBackend(t *testing.T) {
-	ctx := context.Background()
-
-	tempdir, err := ioutil.TempDir("", "gopass-")
-	require.NoError(t, err)
-	defer func() {
-		_ = os.RemoveAll(tempdir)
-	}()
-
-	gpgdir := filepath.Join(tempdir, ".password-store-gpg")
-	gpgfn := filepath.Join(gpgdir, ".gpg-id")
-	assert.NoError(t, os.Mkdir(gpgdir, 0755))
-	assert.NoError(t, ioutil.WriteFile(gpgfn, []byte("foobar"), 0644))
-
-	xcdir := filepath.Join(tempdir, ".password-store-xc")
-	xcfn := filepath.Join(xcdir, ".xc-ids")
-	assert.NoError(t, os.Mkdir(xcdir, 0755))
-	assert.NoError(t, ioutil.WriteFile(xcfn, []byte("foobar"), 0644))
-
-	assert.Equal(t, backend.GPGCLI, detectCryptoBackend(ctx, gpgdir))
-	assert.Equal(t, backend.XC, detectCryptoBackend(ctx, xcdir))
 }

--- a/internal/action/completion.go
+++ b/internal/action/completion.go
@@ -44,7 +44,7 @@ func (s *Action) Complete(c *cli.Context) {
 }
 
 // CompletionOpenBSDKsh returns an OpenBSD ksh script used for auto completion
-func (s *Action) CompletionOpenBSDKsh(c *cli.Context, a *cli.App) error {
+func (s *Action) CompletionOpenBSDKsh(a *cli.App) error {
 	out := `
 PASS_LIST=$(gopass ls -f)
 set -A complete_gopass -- $PASS_LIST %s
@@ -89,7 +89,7 @@ func (s *Action) CompletionBash(c *cli.Context) error {
 }
 
 // CompletionFish returns an autocompletion script for fish
-func (s *Action) CompletionFish(c *cli.Context, a *cli.App) error {
+func (s *Action) CompletionFish(a *cli.App) error {
 	if a == nil {
 		return fmt.Errorf("app is nil")
 	}
@@ -103,7 +103,7 @@ func (s *Action) CompletionFish(c *cli.Context, a *cli.App) error {
 }
 
 // CompletionZSH returns a zsh completion script
-func (s *Action) CompletionZSH(c *cli.Context, a *cli.App) error {
+func (s *Action) CompletionZSH(a *cli.App) error {
 	comp, err := zshcomp.GetCompletion(a)
 	if err != nil {
 		return err

--- a/internal/action/completion_test.go
+++ b/internal/action/completion_test.go
@@ -61,20 +61,20 @@ func TestComplete(t *testing.T) {
 	buf.Reset()
 
 	// fish
-	assert.NoError(t, act.CompletionFish(nil, app))
+	assert.NoError(t, act.CompletionFish(app))
 	assert.Contains(t, buf.String(), "action.test")
-	assert.Error(t, act.CompletionFish(nil, nil))
+	assert.Error(t, act.CompletionFish(nil))
 	buf.Reset()
 
 	// zsh
-	assert.NoError(t, act.CompletionZSH(nil, app))
+	assert.NoError(t, act.CompletionZSH(app))
 	assert.Contains(t, buf.String(), "action.test")
-	assert.Error(t, act.CompletionZSH(nil, nil))
+	assert.Error(t, act.CompletionZSH(nil))
 	buf.Reset()
 
 	// openbsdksh
-	assert.NoError(t, act.CompletionOpenBSDKsh(nil, app))
+	assert.NoError(t, act.CompletionOpenBSDKsh(app))
 	assert.Contains(t, buf.String(), "complete_gopass")
-	assert.Error(t, act.CompletionOpenBSDKsh(nil, nil))
+	assert.Error(t, act.CompletionOpenBSDKsh(nil))
 	buf.Reset()
 }

--- a/internal/action/config.go
+++ b/internal/action/config.go
@@ -26,11 +26,11 @@ func (s *Action) Config(c *cli.Context) error {
 	}
 
 	if c.Args().Len() > 2 {
-		return ExitError(ctx, ExitUsage, nil, "Usage: %s config key value", s.Name)
+		return ExitError(ExitUsage, nil, "Usage: %s config key value", s.Name)
 	}
 
 	if err := s.setConfigValue(ctx, c.String("store"), c.Args().Get(0), c.Args().Get(1)); err != nil {
-		return ExitError(ctx, ExitUnknown, err, "Error setting config value")
+		return ExitError(ExitUnknown, err, "Error setting config value")
 	}
 	return nil
 }

--- a/internal/action/copy.go
+++ b/internal/action/copy.go
@@ -16,7 +16,7 @@ func (s *Action) Copy(c *cli.Context) error {
 	force := c.Bool("force")
 
 	if c.Args().Len() != 2 {
-		return ExitError(ctx, ExitUsage, nil, "Usage: %s cp <FROM> <TO>", s.Name)
+		return ExitError(ExitUsage, nil, "Usage: %s cp <FROM> <TO>", s.Name)
 	}
 
 	from := c.Args().Get(0)
@@ -27,17 +27,17 @@ func (s *Action) Copy(c *cli.Context) error {
 
 func (s *Action) copy(ctx context.Context, from, to string, force bool) error {
 	if !s.Store.Exists(ctx, from) && !s.Store.IsDir(ctx, from) {
-		return ExitError(ctx, ExitNotFound, nil, "%s does not exist", from)
+		return ExitError(ExitNotFound, nil, "%s does not exist", from)
 	}
 
 	if !force {
 		if s.Store.Exists(ctx, to) && !termio.AskForConfirmation(ctx, fmt.Sprintf("%s already exists. Overwrite it?", to)) {
-			return ExitError(ctx, ExitAborted, nil, "not overwriting your current secret")
+			return ExitError(ExitAborted, nil, "not overwriting your current secret")
 		}
 	}
 
 	if err := s.Store.Copy(ctx, from, to); err != nil {
-		return ExitError(ctx, ExitIO, err, "failed to copy from '%s' to '%s'", from, to)
+		return ExitError(ExitIO, err, "failed to copy from '%s' to '%s'", from, to)
 	}
 
 	return nil

--- a/internal/action/create/create.go
+++ b/internal/action/create/create.go
@@ -62,7 +62,7 @@ func Create(c *cli.Context, store storer) error {
 	case "show":
 		return acts.Run(ctx, c, sel)
 	default:
-		return action.ExitError(ctx, action.ExitAborted, nil, "user aborted")
+		return action.ExitError(action.ExitAborted, nil, "user aborted")
 	}
 }
 
@@ -106,7 +106,7 @@ func (s *creator) createWebsite(ctx context.Context, c *cli.Context) error {
 	// the hostname is used as part of the name
 	hostname := extractHostname(urlStr)
 	if hostname == "" {
-		return action.ExitError(ctx, action.ExitUnknown, err, "Can not parse URL '%s'. Please use 'gopass edit' to manually create the secret", urlStr)
+		return action.ExitError(action.ExitUnknown, err, "Can not parse URL '%s'. Please use 'gopass edit' to manually create the secret", urlStr)
 	}
 
 	username, err = termio.AskForString(ctx, fmtfn(2, "2", "Login"), username)
@@ -155,7 +155,7 @@ func (s *creator) createWebsite(ctx context.Context, c *cli.Context) error {
 	_ = sec.SetValue("username", username)
 	_ = sec.SetValue("comment", comment)
 	if err := s.store.Set(ctxutil.WithCommitMessage(ctx, "Created new entry"), name, sec); err != nil {
-		return action.ExitError(ctx, action.ExitEncrypt, err, "failed to set '%s': %s", name, err)
+		return action.ExitError(action.ExitEncrypt, err, "failed to set '%s': %s", name, err)
 	}
 
 	return s.createPrintOrCopy(ctx, c, name, password, genPw)
@@ -177,7 +177,7 @@ func (s *creator) createPrintOrCopy(ctx context.Context, c *cli.Context, name, p
 	}
 
 	if err := clipboard.CopyTo(ctx, name, []byte(password)); err != nil {
-		return action.ExitError(ctx, action.ExitIO, err, "failed to copy to clipboard: %s", err)
+		return action.ExitError(action.ExitIO, err, "failed to copy to clipboard: %s", err)
 	}
 	return nil
 }
@@ -199,14 +199,14 @@ func (s *creator) createPIN(ctx context.Context, c *cli.Context) error {
 		return err
 	}
 	if authority == "" {
-		return action.ExitError(ctx, action.ExitUnknown, nil, "Authority must not be empty")
+		return action.ExitError(action.ExitUnknown, nil, "Authority must not be empty")
 	}
 	application, err = termio.AskForString(ctx, fmtfn(2, "2", "Entity"), application)
 	if err != nil {
 		return err
 	}
 	if application == "" {
-		return action.ExitError(ctx, action.ExitUnknown, nil, "Application must not be empty")
+		return action.ExitError(action.ExitUnknown, nil, "Application must not be empty")
 	}
 	genPw, err = termio.AskForBool(ctx, fmtfn(2, "3", "Generate PIN?"), false)
 	if err != nil {
@@ -245,7 +245,7 @@ func (s *creator) createPIN(ctx context.Context, c *cli.Context) error {
 	_ = sec.SetValue("application", application)
 	_ = sec.SetValue("comment", comment)
 	if err := s.store.Set(ctxutil.WithCommitMessage(ctx, "Created new entry"), name, sec); err != nil {
-		return action.ExitError(ctx, action.ExitEncrypt, err, "failed to set '%s': %s", name, err)
+		return action.ExitError(action.ExitEncrypt, err, "failed to set '%s': %s", name, err)
 	}
 
 	return s.createPrintOrCopy(ctx, c, name, password, genPw)
@@ -269,14 +269,14 @@ func (s *creator) createAWS(ctx context.Context, c *cli.Context) error {
 		return err
 	}
 	if account == "" {
-		return action.ExitError(ctx, action.ExitUnknown, nil, "Account must not be empty")
+		return action.ExitError(action.ExitUnknown, nil, "Account must not be empty")
 	}
 	username, err = termio.AskForString(ctx, fmtfn(2, "2", "AWS IAM User"), username)
 	if err != nil {
 		return err
 	}
 	if username == "" {
-		return action.ExitError(ctx, action.ExitUnknown, nil, "Username must not be empty")
+		return action.ExitError(action.ExitUnknown, nil, "Username must not be empty")
 	}
 	password, err = termio.AskForString(ctx, fmtfn(2, "3", "AWS Account Password"), password)
 	if err != nil {
@@ -315,7 +315,7 @@ func (s *creator) createAWS(ctx context.Context, c *cli.Context) error {
 	_ = sec.SetValue("secretkey", secretkey)
 	_ = sec.SetValue("region", region)
 	if err := s.store.Set(ctxutil.WithCommitMessage(ctx, "Created new entry"), name, sec); err != nil {
-		return action.ExitError(ctx, action.ExitEncrypt, err, "failed to set '%s': %s", name, err)
+		return action.ExitError(action.ExitEncrypt, err, "failed to set '%s': %s", name, err)
 	}
 	return nil
 }
@@ -349,7 +349,7 @@ func (s *creator) createGCP(ctx context.Context, c *cli.Context) error {
 		}
 	}
 	if username == "" {
-		return action.ExitError(ctx, action.ExitUnknown, nil, "Username must not be empty")
+		return action.ExitError(action.ExitUnknown, nil, "Username must not be empty")
 	}
 	if project == "" {
 		project, err = termio.AskForString(ctx, fmtfn(4, "b", "Project name"), "")
@@ -358,7 +358,7 @@ func (s *creator) createGCP(ctx context.Context, c *cli.Context) error {
 		}
 	}
 	if project == "" {
-		return action.ExitError(ctx, action.ExitUnknown, nil, "Project must not be empty")
+		return action.ExitError(action.ExitUnknown, nil, "Project must not be empty")
 	}
 
 	// select store
@@ -379,7 +379,7 @@ func (s *creator) createGCP(ctx context.Context, c *cli.Context) error {
 	}
 	sec := secret.New("", string(buf))
 	if err := s.store.Set(ctxutil.WithCommitMessage(ctx, "Created new entry"), name, sec); err != nil {
-		return action.ExitError(ctx, action.ExitEncrypt, err, "failed to set '%s': %s", name, err)
+		return action.ExitError(action.ExitEncrypt, err, "failed to set '%s': %s", name, err)
 	}
 	return nil
 }
@@ -417,7 +417,7 @@ func (s *creator) createGeneric(ctx context.Context, c *cli.Context) error {
 		return err
 	}
 	if shortname == "" {
-		return action.ExitError(ctx, action.ExitUnknown, nil, "Name must not be empty")
+		return action.ExitError(action.ExitUnknown, nil, "Name must not be empty")
 	}
 	genPw, err = termio.AskForBool(ctx, fmtfn(2, "2", "Generate password?"), true)
 	if err != nil {
@@ -468,7 +468,7 @@ func (s *creator) createGeneric(ctx context.Context, c *cli.Context) error {
 		_ = sec.SetValue(key, val)
 	}
 	if err := s.store.Set(ctxutil.WithCommitMessage(ctx, "Created new entry"), name, sec); err != nil {
-		return action.ExitError(ctx, action.ExitEncrypt, err, "failed to set '%s': %s", name, err)
+		return action.ExitError(action.ExitEncrypt, err, "failed to set '%s': %s", name, err)
 	}
 
 	return s.createPrintOrCopy(ctx, c, name, password, genPw)

--- a/internal/action/delete.go
+++ b/internal/action/delete.go
@@ -18,11 +18,11 @@ func (s *Action) Delete(c *cli.Context) error {
 
 	name := c.Args().First()
 	if name == "" {
-		return ExitError(ctx, ExitUsage, nil, "Usage: %s rm name", s.Name)
+		return ExitError(ExitUsage, nil, "Usage: %s rm name", s.Name)
 	}
 
 	if !recursive && s.Store.IsDir(ctx, name) {
-		return ExitError(ctx, ExitUsage, nil, "Cannot remove '%s': Is a directory. Use 'gopass rm -r %s' to delete", name, name)
+		return ExitError(ExitUsage, nil, "Cannot remove '%s': Is a directory. Use 'gopass rm -r %s' to delete", name, name)
 	}
 
 	// specifying a key is optional
@@ -40,7 +40,7 @@ func (s *Action) Delete(c *cli.Context) error {
 
 	if recursive {
 		if err := s.Store.Prune(ctx, name); err != nil {
-			return ExitError(ctx, ExitUnknown, err, "failed to prune '%s': %s", name, err)
+			return ExitError(ExitUnknown, err, "failed to prune '%s': %s", name, err)
 		}
 		return nil
 	}
@@ -51,7 +51,7 @@ func (s *Action) Delete(c *cli.Context) error {
 	}
 
 	if err := s.Store.Delete(ctx, name); err != nil {
-		return ExitError(ctx, ExitIO, err, "Can not delete '%s': %s", name, err)
+		return ExitError(ExitIO, err, "Can not delete '%s': %s", name, err)
 	}
 	return nil
 }
@@ -60,13 +60,13 @@ func (s *Action) Delete(c *cli.Context) error {
 func (s *Action) deleteKeyFromYAML(ctx context.Context, name, key string) error {
 	sec, err := s.Store.Get(ctx, name)
 	if err != nil {
-		return ExitError(ctx, ExitIO, err, "Can not delete key '%s' from '%s': %s", key, name, err)
+		return ExitError(ExitIO, err, "Can not delete key '%s' from '%s': %s", key, name, err)
 	}
 	if err := sec.DeleteKey(key); err != nil {
-		return ExitError(ctx, ExitIO, err, "Can not delete key '%s' from '%s': %s", key, name, err)
+		return ExitError(ExitIO, err, "Can not delete key '%s' from '%s': %s", key, name, err)
 	}
 	if err := s.Store.Set(ctxutil.WithCommitMessage(ctx, "Updated Key in YAML"), name, sec); err != nil {
-		return ExitError(ctx, ExitIO, err, "Can not delete key '%s' from '%s': %s", key, name, err)
+		return ExitError(ExitIO, err, "Can not delete key '%s' from '%s': %s", key, name, err)
 	}
 	return nil
 }

--- a/internal/action/edit.go
+++ b/internal/action/edit.go
@@ -20,7 +20,7 @@ func (s *Action) Edit(c *cli.Context) error {
 	ctx := ctxutil.WithGlobalFlags(c)
 	name := c.Args().First()
 	if name == "" {
-		return ExitError(ctx, ExitUsage, nil, "Usage: %s edit secret", s.Name)
+		return ExitError(ExitUsage, nil, "Usage: %s edit secret", s.Name)
 	}
 
 	return s.edit(ctx, c, name)
@@ -38,7 +38,7 @@ func (s *Action) edit(ctx context.Context, c *cli.Context, name string) error {
 	// invoke the editor to let the user edit the content
 	nContent, err := editor.Invoke(ctx, ed, content)
 	if err != nil {
-		return ExitError(ctx, ExitUnknown, err, "failed to invoke editor: %s", err)
+		return ExitError(ExitUnknown, err, "failed to invoke editor: %s", err)
 	}
 
 	return s.editUpdate(ctx, name, content, nContent, changed, ed)
@@ -62,7 +62,7 @@ func (s *Action) editUpdate(ctx context.Context, name string, content, nContent 
 
 	// write result (back) to store
 	if err := s.Store.Set(ctxutil.WithCommitMessage(ctx, fmt.Sprintf("Edited with %s", ed)), name, nSec); err != nil {
-		return ExitError(ctx, ExitEncrypt, err, "failed to encrypt secret %s: %s", name, err)
+		return ExitError(ExitEncrypt, err, "failed to encrypt secret %s: %s", name, err)
 	}
 	return nil
 }
@@ -84,11 +84,11 @@ func (s *Action) editGetContent(ctx context.Context, name string, create bool) (
 	if s.Store.Exists(ctx, name) {
 		sec, err := s.Store.Get(ctx, name)
 		if err != nil {
-			return name, nil, false, ExitError(ctx, ExitDecrypt, err, "failed to decrypt %s: %s", name, err)
+			return name, nil, false, ExitError(ExitDecrypt, err, "failed to decrypt %s: %s", name, err)
 		}
 		content, err := sec.Bytes()
 		if err != nil {
-			return name, nil, false, ExitError(ctx, ExitDecrypt, err, "failed to decode %s: %s", name, err)
+			return name, nil, false, ExitError(ExitDecrypt, err, "failed to decode %s: %s", name, err)
 		}
 		return name, content, false, nil
 	}

--- a/internal/action/env.go
+++ b/internal/action/env.go
@@ -19,18 +19,18 @@ func (s *Action) Env(c *cli.Context) error {
 	args := c.Args().Tail()
 
 	if !s.Store.Exists(ctx, name) && !s.Store.IsDir(ctx, name) {
-		return ExitError(ctx, ExitNotFound, nil, "Secret %s not found", name)
+		return ExitError(ExitNotFound, nil, "Secret %s not found", name)
 	}
 
 	keys := make([]string, 0, 1)
 	if s.Store.IsDir(ctx, name) {
 		l, err := s.Store.Tree(ctx)
 		if err != nil {
-			return ExitError(ctx, ExitList, err, "failed to list store: %s", err)
+			return ExitError(ExitList, err, "failed to list store: %s", err)
 		}
 		subtree, err := l.FindFolder(name)
 		if err != nil {
-			return ExitError(ctx, ExitNotFound, nil, "Entry '%s' not found", name)
+			return ExitError(ExitNotFound, nil, "Entry '%s' not found", name)
 		}
 		subtree.SetRoot(true)
 		subtree.SetName(name)

--- a/internal/action/errors.go
+++ b/internal/action/errors.go
@@ -1,11 +1,9 @@
 package action
 
 import (
-	"context"
 	"fmt"
 
-	"github.com/gopasspw/gopass/internal/out"
-
+	"github.com/gopasspw/gopass/internal/debug"
 	"github.com/urfave/cli/v2"
 )
 
@@ -55,9 +53,9 @@ const (
 )
 
 // ExitError returns a user friendly CLI error
-func ExitError(ctx context.Context, exitCode int, err error, format string, args ...interface{}) error {
+func ExitError(exitCode int, err error, format string, args ...interface{}) error {
 	if err != nil {
-		out.Debug(ctx, "Stacktrace: %+v", err)
+		debug.Log("Stacktrace: %+v", err)
 	}
 	return cli.NewExitError(fmt.Sprintf(format, args...), exitCode)
 }

--- a/internal/action/errors_test.go
+++ b/internal/action/errors_test.go
@@ -2,28 +2,22 @@ package action
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"os"
-	"strings"
 	"testing"
 
 	"github.com/gopasspw/gopass/internal/out"
-	"github.com/gopasspw/gopass/pkg/ctxutil"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestExitError(t *testing.T) {
-	ctx := context.Background()
-	ctx = ctxutil.WithDebug(ctx, true)
 	buf := &bytes.Buffer{}
 	out.Stdout = buf
+	defer func() {
+		out.Stdout = os.Stdout
+	}()
 
-	assert.Error(t, ExitError(ctx, ExitUnknown, fmt.Errorf("test"), "test"))
-	sv := buf.String()
-	if !strings.Contains(sv, "Stacktrace") {
-		t.Errorf("Should contain an stacktrace")
-	}
-	out.Stdout = os.Stdout
+	assert.Error(t, ExitError(ExitUnknown, fmt.Errorf("test"), "test"))
+	assert.NotContains(t, buf.String(), "Stacktrace")
 }

--- a/internal/action/find.go
+++ b/internal/action/find.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/gopasspw/gopass/internal/cui"
+	"github.com/gopasspw/gopass/internal/debug"
 	"github.com/gopasspw/gopass/internal/out"
 	"github.com/gopasspw/gopass/pkg/ctxutil"
 
@@ -32,7 +33,7 @@ func (s *Action) Find(c *cli.Context) error {
 	}
 
 	if !c.Args().Present() {
-		return ExitError(ctx, ExitUsage, nil, "Usage: %s find <NEEDLE>", s.Name)
+		return ExitError(ExitUsage, nil, "Usage: %s find <NEEDLE>", s.Name)
 	}
 
 	return s.find(ctx, c, c.Args().First(), s.show)
@@ -45,7 +46,7 @@ func (s *Action) find(ctx context.Context, c *cli.Context, needle string, cb sho
 	// get all existing entries
 	haystack, err := s.Store.List(ctx, 0)
 	if err != nil {
-		return ExitError(ctx, ExitList, err, "failed to list store: %s", err)
+		return ExitError(ExitList, err, "failed to list store: %s", err)
 	}
 
 	// filter our the ones from the haystack matching the needle
@@ -67,7 +68,7 @@ func (s *Action) find(ctx context.Context, c *cli.Context, needle string, cb sho
 
 	// if there are still no results we abort
 	if len(choices) < 1 {
-		return ExitError(ctx, ExitNotFound, nil, "no results found")
+		return ExitError(ExitNotFound, nil, "no results found")
 	}
 
 	// do not invoke wizard if not printing to terminal or if
@@ -86,7 +87,7 @@ func (s *Action) find(ctx context.Context, c *cli.Context, needle string, cb sho
 func (s *Action) findSelection(ctx context.Context, c *cli.Context, choices []string, needle string, cb showFunc) error {
 	sort.Strings(choices)
 	act, sel := cui.GetSelection(ctx, "Found secrets - Please select an entry", choices)
-	out.Debug(ctx, "Action: %s - Selection: %d", act, sel)
+	debug.Log("Action: %s - Selection: %d", act, sel)
 	switch act {
 	case "default":
 		// display or copy selected entry
@@ -111,7 +112,7 @@ func (s *Action) findSelection(ctx context.Context, c *cli.Context, choices []st
 		fmt.Fprintln(stdout, choices[sel])
 		return s.edit(ctx, c, choices[sel])
 	default:
-		return ExitError(ctx, ExitAborted, nil, "user aborted")
+		return ExitError(ExitAborted, nil, "user aborted")
 	}
 }
 

--- a/internal/action/fsck.go
+++ b/internal/action/fsck.go
@@ -25,7 +25,7 @@ func (s *Action) Fsck(c *cli.Context) error {
 	// make sure config is in the right place
 	// we may have loaded it from one of the fallback locations
 	if err := s.cfg.Save(); err != nil {
-		return ExitError(ctx, ExitConfig, err, "failed to save config: %s", err)
+		return ExitError(ExitConfig, err, "failed to save config: %s", err)
 	}
 
 	// clean up any previous config locations
@@ -39,7 +39,7 @@ func (s *Action) Fsck(c *cli.Context) error {
 	// display progress bar
 	t, err := s.Store.Tree(ctx)
 	if err != nil {
-		return ExitError(ctx, ExitUnknown, err, "failed to list stores: %s", err)
+		return ExitError(ExitUnknown, err, "failed to list stores: %s", err)
 	}
 
 	pwList := t.List(0)
@@ -68,7 +68,7 @@ func (s *Action) Fsck(c *cli.Context) error {
 
 	// the main work in done by the sub stores
 	if err := s.Store.Fsck(ctx, c.Args().Get(0)); err != nil {
-		return ExitError(ctx, ExitFsck, err, "fsck found errors: %s", err)
+		return ExitError(ExitFsck, err, "fsck found errors: %s", err)
 	}
 	out.Print(ctx, "")
 	return nil

--- a/internal/action/generate.go
+++ b/internal/action/generate.go
@@ -49,14 +49,14 @@ func (s *Action) Generate(c *cli.Context) error {
 		var err error
 		name, err = termio.AskForString(ctx, "Which name do you want to use?", "")
 		if err != nil || name == "" {
-			return ExitError(ctx, ExitNoName, err, "please provide a password name")
+			return ExitError(ExitNoName, err, "please provide a password name")
 		}
 	}
 
 	// ask for confirmation before overwriting existing entry
 	if !force { // don't check if it's force anyway
 		if s.Store.Exists(ctx, name) && key == "" && !termio.AskForConfirmation(ctx, fmt.Sprintf("An entry already exists for %s. Overwrite the current password?", name)) {
-			return ExitError(ctx, ExitAborted, nil, "user aborted. not overwriting your current password")
+			return ExitError(ExitAborted, nil, "user aborted. not overwriting your current password")
 		}
 	}
 
@@ -76,7 +76,7 @@ func (s *Action) Generate(c *cli.Context) error {
 	if edit && termio.AskForConfirmation(ctx, fmt.Sprintf("Do you want to add more data for %s?", name)) {
 		c.Context = ctx
 		if err := s.Edit(c); err != nil {
-			return ExitError(ctx, ExitUnknown, err, "failed to edit '%s': %s", name, err)
+			return ExitError(ExitUnknown, err, "failed to edit '%s': %s", name, err)
 		}
 	}
 
@@ -112,7 +112,7 @@ func (s *Action) generateCopyOrPrint(ctx context.Context, c *cli.Context, name, 
 
 	if ctxutil.IsAutoClip(ctx) || IsClip(ctx) {
 		if err := clipboard.CopyTo(ctx, name, []byte(password)); err != nil {
-			return ExitError(ctx, ExitIO, err, "failed to copy to clipboard: %s", err)
+			return ExitError(ExitIO, err, "failed to copy to clipboard: %s", err)
 		}
 		if ctxutil.IsAutoClip(ctx) && !c.Bool("print") {
 			return nil
@@ -144,19 +144,19 @@ func (s *Action) generatePassword(ctx context.Context, c *cli.Context, length st
 		question := "How long should the password be?"
 		iv, err := termio.AskForInt(ctx, question, candidateLength)
 		if err != nil {
-			return "", ExitError(ctx, ExitUsage, err, "password length must be a number")
+			return "", ExitError(ExitUsage, err, "password length must be a number")
 		}
 		pwlen = iv
 	} else {
 		iv, err := strconv.Atoi(length)
 		if err != nil {
-			return "", ExitError(ctx, ExitUsage, err, "password length must be a number")
+			return "", ExitError(ExitUsage, err, "password length must be a number")
 		}
 		pwlen = iv
 	}
 
 	if pwlen < 1 {
-		return "", ExitError(ctx, ExitUsage, nil, "password length must not be zero")
+		return "", ExitError(ExitUsage, nil, "password length must not be zero")
 	}
 
 	if c.Bool("strict") {
@@ -183,19 +183,19 @@ func (s *Action) generatePasswordXKCD(ctx context.Context, c *cli.Context, lengt
 		question := "How many words should be combined to a password?"
 		iv, err := termio.AskForInt(ctx, question, candidateLength)
 		if err != nil {
-			return "", ExitError(ctx, ExitUsage, err, "password length must be a number")
+			return "", ExitError(ExitUsage, err, "password length must be a number")
 		}
 		pwlen = iv
 	} else {
 		iv, err := strconv.Atoi(length)
 		if err != nil {
-			return "", ExitError(ctx, ExitUsage, err, "password length must be a number: %s", err)
+			return "", ExitError(ExitUsage, err, "password length must be a number: %s", err)
 		}
 		pwlen = iv
 	}
 
 	if pwlen < 1 {
-		return "", ExitError(ctx, ExitUsage, nil, "password length must not be zero")
+		return "", ExitError(ExitUsage, nil, "password length must not be zero")
 	}
 
 	return xkcdgen.RandomLengthDelim(pwlen, xkcdSeparator, c.String("xkcdlang"))
@@ -207,14 +207,14 @@ func (s *Action) generateSetPassword(ctx context.Context, name, key, password st
 	if key != "" {
 		sec, ctx, err := s.Store.GetContext(ctx, name)
 		if err != nil {
-			return ctx, ExitError(ctx, ExitEncrypt, err, "failed to set key '%s' of '%s': %s", key, name, err)
+			return ctx, ExitError(ExitEncrypt, err, "failed to set key '%s' of '%s': %s", key, name, err)
 		}
 		setMetadata(sec, kvps)
 		if err := sec.SetValue(key, password); err != nil {
-			return ctx, ExitError(ctx, ExitEncrypt, err, "failed to set key '%s' of '%s': %s", key, name, err)
+			return ctx, ExitError(ExitEncrypt, err, "failed to set key '%s' of '%s': %s", key, name, err)
 		}
 		if err := s.Store.Set(ctxutil.WithCommitMessage(ctx, "Generated password for YAML key"), name, sec); err != nil {
-			return ctx, ExitError(ctx, ExitEncrypt, err, "failed to set key '%s' of '%s': %s", key, name, err)
+			return ctx, ExitError(ExitEncrypt, err, "failed to set key '%s' of '%s': %s", key, name, err)
 		}
 		return ctx, nil
 	}
@@ -241,7 +241,7 @@ func (s *Action) generateSetPassword(ctx context.Context, name, key, password st
 
 	ctx, err = s.Store.SetContext(ctxutil.WithCommitMessage(ctx, "Generated Password"), name, sec)
 	if err != nil {
-		return ctx, ExitError(ctx, ExitEncrypt, err, "failed to create '%s': %s", name, err)
+		return ctx, ExitError(ExitEncrypt, err, "failed to create '%s': %s", name, err)
 	}
 	return ctx, nil
 }
@@ -249,12 +249,12 @@ func (s *Action) generateSetPassword(ctx context.Context, name, key, password st
 func (s *Action) generateReplaceExisting(ctx context.Context, name, key, password string, kvps map[string]string) (context.Context, error) {
 	sec, ctx, err := s.Store.GetContext(ctx, name)
 	if err != nil {
-		return ctx, ExitError(ctx, ExitEncrypt, err, "failed to set key '%s' of '%s': %s", key, name, err)
+		return ctx, ExitError(ExitEncrypt, err, "failed to set key '%s' of '%s': %s", key, name, err)
 	}
 	setMetadata(sec, kvps)
 	sec.SetPassword(password)
 	if err := s.Store.Set(ctxutil.WithCommitMessage(ctx, "Generated password for YAML key"), name, sec); err != nil {
-		return ctx, ExitError(ctx, ExitEncrypt, err, "failed to set key '%s' of '%s': %s", key, name, err)
+		return ctx, ExitError(ExitEncrypt, err, "failed to set key '%s' of '%s': %s", key, name, err)
 	}
 	return ctx, nil
 }

--- a/internal/action/git.go
+++ b/internal/action/git.go
@@ -29,7 +29,7 @@ func (s *Action) GitInit(c *cli.Context) error {
 	}
 
 	if err := s.rcsInit(ctx, store, un, ue); err != nil {
-		return ExitError(ctx, ExitGit, err, "failed to initialize git: %s", err)
+		return ExitError(ExitGit, err, "failed to initialize git: %s", err)
 	}
 	return nil
 }
@@ -57,7 +57,7 @@ func (s *Action) getUserData(ctx context.Context, store, un, ue string) (string,
 
 	// for convenience, set defaults to user-selected values from available private keys
 	// NB: discarding returned error since this is merely a best-effort look-up for convenience
-	userName, userEmail, _ := cui.AskForGitConfigUser(ctx, s.Store.Crypto(ctx, store), store)
+	userName, userEmail, _ := cui.AskForGitConfigUser(ctx, s.Store.Crypto(ctx, store))
 
 	if userName == "" {
 		var err error
@@ -85,7 +85,7 @@ func (s *Action) GitAddRemote(c *cli.Context) error {
 	url := c.Args().Get(1)
 
 	if remote == "" || url == "" {
-		return ExitError(ctx, ExitUsage, nil, "Usage: %s git remote add <REMOTE> <URL>", s.Name)
+		return ExitError(ExitUsage, nil, "Usage: %s git remote add <REMOTE> <URL>", s.Name)
 	}
 
 	return s.Store.GitAddRemote(ctx, store, remote, url)
@@ -98,7 +98,7 @@ func (s *Action) GitRemoveRemote(c *cli.Context) error {
 	remote := c.Args().Get(0)
 
 	if remote == "" {
-		return ExitError(ctx, ExitUsage, nil, "Usage: %s git remote rm <REMOTE>", s.Name)
+		return ExitError(ExitUsage, nil, "Usage: %s git remote rm <REMOTE>", s.Name)
 	}
 
 	return s.Store.GitRemoveRemote(ctx, store, remote)
@@ -128,7 +128,7 @@ func (s *Action) GitPush(c *cli.Context) error {
 	branch := c.Args().Get(1)
 
 	if origin == "" || branch == "" {
-		return ExitError(ctx, ExitUsage, nil, "Usage: %s git push <ORIGIN> <BRANCH>", s.Name)
+		return ExitError(ExitUsage, nil, "Usage: %s git push <ORIGIN> <BRANCH>", s.Name)
 	}
 	return s.Store.GitPush(ctx, store, origin, branch)
 }

--- a/internal/action/grep.go
+++ b/internal/action/grep.go
@@ -14,7 +14,7 @@ import (
 func (s *Action) Grep(c *cli.Context) error {
 	ctx := ctxutil.WithGlobalFlags(c)
 	if !c.Args().Present() {
-		return ExitError(ctx, ExitUsage, nil, "Usage: %s grep arg", s.Name)
+		return ExitError(ExitUsage, nil, "Usage: %s grep arg", s.Name)
 	}
 
 	// get the search term
@@ -22,7 +22,7 @@ func (s *Action) Grep(c *cli.Context) error {
 
 	haystack, err := s.Store.List(ctx, 0)
 	if err != nil {
-		return ExitError(ctx, ExitList, err, "failed to list store: %s", err)
+		return ExitError(ExitList, err, "failed to list store: %s", err)
 	}
 
 	var matches int
@@ -43,10 +43,10 @@ func (s *Action) Grep(c *cli.Context) error {
 	}
 
 	if errors > 0 {
-		return ExitError(ctx, ExitDecrypt, nil, "some secrets failed to decrypt")
+		return ExitError(ExitDecrypt, nil, "some secrets failed to decrypt")
 	}
 	if matches < 1 {
-		return ExitError(ctx, ExitNotFound, nil, "no matches found")
+		return ExitError(ExitNotFound, nil, "no matches found")
 	}
 
 	out.Print(ctx, "\nScanned %d secrets. %d matches, %d errors", len(haystack), matches, errors)

--- a/internal/action/history.go
+++ b/internal/action/history.go
@@ -3,6 +3,7 @@ package action
 import (
 	"time"
 
+	"github.com/gopasspw/gopass/internal/debug"
 	"github.com/gopasspw/gopass/internal/out"
 	"github.com/gopasspw/gopass/pkg/ctxutil"
 
@@ -16,24 +17,24 @@ func (s *Action) History(c *cli.Context) error {
 	showPassword := c.Bool("password")
 
 	if name == "" {
-		return ExitError(ctx, ExitUsage, nil, "Usage: %s history <NAME>", s.Name)
+		return ExitError(ExitUsage, nil, "Usage: %s history <NAME>", s.Name)
 	}
 
 	if !s.Store.Exists(ctx, name) {
-		return ExitError(ctx, ExitNotFound, nil, "Secret not found")
+		return ExitError(ExitNotFound, nil, "Secret not found")
 	}
 
 	revs, err := s.Store.ListRevisions(ctx, name)
 	if err != nil {
-		return ExitError(ctx, ExitUnknown, err, "Failed to get revisions: %s", err)
+		return ExitError(ExitUnknown, err, "Failed to get revisions: %s", err)
 	}
 
 	for _, rev := range revs {
 		pw := ""
 		if showPassword {
-			ctx, sec, err := s.Store.GetRevision(ctx, name, rev.Hash)
+			_, sec, err := s.Store.GetRevision(ctx, name, rev.Hash)
 			if err != nil {
-				out.Debug(ctx, "Failed to get revision '%s' of '%s': %s", rev.Hash, name, err)
+				debug.Log("Failed to get revision '%s' of '%s': %s", rev.Hash, name, err)
 			}
 			if err == nil {
 				pw = " - " + sec.Password()

--- a/internal/action/history_test.go
+++ b/internal/action/history_test.go
@@ -36,7 +36,7 @@ func TestHistory(t *testing.T) {
 
 	cfg := config.New()
 	cfg.Path = u.StoreDir("")
-	act, err := newAction(ctx, cfg, semver.Version{})
+	act, err := newAction(cfg, semver.Version{})
 	require.NoError(t, err)
 	require.NotNil(t, act)
 	require.NoError(t, act.Initialized(c))

--- a/internal/action/init_test.go
+++ b/internal/action/init_test.go
@@ -25,7 +25,7 @@ func TestInit(t *testing.T) {
 	ctx := context.Background()
 	ctx = ctxutil.WithAlwaysYes(ctx, true)
 	ctx = ctxutil.WithInteractive(ctx, false)
-	ctx = ctxutil.WithDebug(ctx, false)
+
 	act, err := newMock(ctx, u)
 	require.NoError(t, err)
 	require.NotNil(t, act)
@@ -44,8 +44,8 @@ func TestInit(t *testing.T) {
 	assert.Error(t, act.InitOnboarding(c))
 
 	crypto := act.Store.Crypto(ctx, "")
-	assert.Equal(t, true, act.initHasUseablePrivateKeys(ctx, crypto, ""))
-	assert.Error(t, act.initCreatePrivateKey(ctx, crypto, "", "foo bar", "foo.bar@example.org"))
+	assert.Equal(t, true, act.initHasUseablePrivateKeys(ctx, crypto))
+	assert.Error(t, act.initCreatePrivateKey(ctx, crypto, "foo bar", "foo.bar@example.org"))
 	buf.Reset()
 
 	act.printRecipients(ctx, "")
@@ -76,8 +76,8 @@ func TestInitParseContext(t *testing.T) {
 			name:  "crypto xc",
 			flags: map[string]string{"crypto": "xc"},
 			check: func(ctx context.Context) error {
-				if backend.GetCryptoBackend(ctx) != backend.XC {
-					return fmt.Errorf("wrong backend")
+				if be := backend.GetCryptoBackend(ctx); be != backend.XC {
+					return fmt.Errorf("wrong backend: %d", be)
 				}
 				return nil
 			},
@@ -86,8 +86,8 @@ func TestInitParseContext(t *testing.T) {
 			name:  "rcs noop",
 			flags: map[string]string{"rcs": "noop"},
 			check: func(ctx context.Context) error {
-				if backend.GetRCSBackend(ctx) != backend.Noop {
-					return fmt.Errorf("wrong backend")
+				if be := backend.GetRCSBackend(ctx); be != backend.Noop {
+					return fmt.Errorf("wrong backend: %d", be)
 				}
 				return nil
 			},
@@ -105,7 +105,7 @@ func TestInitParseContext(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			c := gptest.CliCtxWithFlags(context.Background(), t, tc.flags)
-			assert.NoError(t, tc.check(initParseContext(context.Background(), c)), tc.name)
+			assert.NoError(t, tc.check(initParseContext(c.Context, c)), tc.name)
 			buf.Reset()
 		})
 	}

--- a/internal/action/list.go
+++ b/internal/action/list.go
@@ -41,7 +41,7 @@ func (s *Action) List(c *cli.Context) error {
 
 	l, err := s.Store.Tree(ctx)
 	if err != nil {
-		return ExitError(ctx, ExitList, err, "failed to list store: %s", err)
+		return ExitError(ExitList, err, "failed to list store: %s", err)
 	}
 
 	//set limit to len of store to loop over all values later
@@ -60,7 +60,7 @@ func (s *Action) List(c *cli.Context) error {
 func (s *Action) listFiltered(ctx context.Context, l tree.Tree, limit int, flat, folders, stripPrefix bool, filter string) error {
 	subtree, err := l.FindFolder(filter)
 	if err != nil {
-		return ExitError(ctx, ExitNotFound, nil, "Entry '%s' not found", filter)
+		return ExitError(ExitNotFound, nil, "Entry '%s' not found", filter)
 	}
 
 	// SetRoot formats the root entry properly
@@ -91,7 +91,7 @@ func (s *Action) listFiltered(ctx context.Context, l tree.Tree, limit int, flat,
 	fmt.Fprintln(so, subtree.Format(limit))
 	if buf != nil {
 		if err := s.pager(ctx, buf); err != nil {
-			return ExitError(ctx, ExitUnknown, err, "failed to invoke pager: %s", err)
+			return ExitError(ExitUnknown, err, "failed to invoke pager: %s", err)
 		}
 	}
 	return nil
@@ -137,7 +137,7 @@ func (s *Action) listAll(ctx context.Context, l tree.Tree, limit int, flat, fold
 	fmt.Fprintln(so, l.Format(limit))
 	if buf != nil {
 		if err := s.pager(ctx, buf); err != nil {
-			return ExitError(ctx, ExitUnknown, err, "failed to invoke pager: %s", err)
+			return ExitError(ExitUnknown, err, "failed to invoke pager: %s", err)
 		}
 	}
 	return nil

--- a/internal/action/mount.go
+++ b/internal/action/mount.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 
 	"github.com/gopasspw/gopass/internal/config"
+	"github.com/gopasspw/gopass/internal/debug"
 	"github.com/gopasspw/gopass/internal/out"
 	"github.com/gopasspw/gopass/internal/store"
 	"github.com/gopasspw/gopass/internal/store/root"
@@ -20,7 +21,7 @@ import (
 func (s *Action) MountRemove(c *cli.Context) error {
 	ctx := ctxutil.WithGlobalFlags(c)
 	if c.Args().Len() != 1 {
-		return ExitError(ctx, ExitUsage, nil, "Usage: %s mount remove [alias]", s.Name)
+		return ExitError(ExitUsage, nil, "Usage: %s mount remove [alias]", s.Name)
 	}
 
 	if err := s.Store.RemoveMount(ctx, c.Args().Get(0)); err != nil {
@@ -28,7 +29,7 @@ func (s *Action) MountRemove(c *cli.Context) error {
 	}
 
 	if err := s.cfg.Save(); err != nil {
-		return ExitError(ctx, ExitConfig, err, "failed to write config: %s", err)
+		return ExitError(ExitConfig, err, "failed to write config: %s", err)
 	}
 
 	out.Green(ctx, "Password Store %s umounted", c.Args().Get(0))
@@ -53,7 +54,7 @@ func (s *Action) MountsPrint(c *cli.Context) error {
 			out.Error(ctx, "Failed to add mount to tree: %s", err)
 		}
 	}
-	out.Debug(ctx, "MountsPrint - %+v - %+v", mounts, mps)
+	debug.Log("MountsPrint - %+v - %+v", mounts, mps)
 
 	fmt.Fprintln(stdout, root.Format(-1))
 	return nil
@@ -73,7 +74,7 @@ func (s *Action) MountAdd(c *cli.Context) error {
 	alias := c.Args().Get(0)
 	localPath := c.Args().Get(1)
 	if alias == "" {
-		return ExitError(ctx, ExitUsage, nil, "usage: %s mounts add <alias> [local path]", s.Name)
+		return ExitError(ExitUsage, nil, "usage: %s mounts add <alias> [local path]", s.Name)
 	}
 
 	if localPath == "" {
@@ -97,15 +98,15 @@ func (s *Action) MountAdd(c *cli.Context) error {
 		case root.NotInitializedError:
 			out.Print(ctx, "Mount %s is not yet initialized. Initializing ...", e.Alias())
 			if err := s.init(ctx, e.Alias(), e.Path()); err != nil {
-				return ExitError(ctx, ExitUnknown, err, "failed to add mount '%s': failed to initialize store: %s", e.Alias(), err)
+				return ExitError(ExitUnknown, err, "failed to add mount '%s': failed to initialize store: %s", e.Alias(), err)
 			}
 		default:
-			return ExitError(ctx, ExitMount, err, "failed to add mount '%s' to '%s': %s", alias, localPath, err)
+			return ExitError(ExitMount, err, "failed to add mount '%s' to '%s': %s", alias, localPath, err)
 		}
 	}
 
 	if err := s.cfg.Save(); err != nil {
-		return ExitError(ctx, ExitConfig, err, "failed to save config: %s", err)
+		return ExitError(ExitConfig, err, "failed to save config: %s", err)
 	}
 
 	out.Green(ctx, "Mounted %s as %s", alias, localPath)

--- a/internal/action/move.go
+++ b/internal/action/move.go
@@ -15,7 +15,7 @@ func (s *Action) Move(c *cli.Context) error {
 	force := c.Bool("force")
 
 	if c.Args().Len() != 2 {
-		return ExitError(ctx, ExitUsage, nil, "Usage: %s mv old-path new-path", s.Name)
+		return ExitError(ExitUsage, nil, "Usage: %s mv old-path new-path", s.Name)
 	}
 
 	from := c.Args().Get(0)
@@ -23,12 +23,12 @@ func (s *Action) Move(c *cli.Context) error {
 
 	if !force {
 		if s.Store.Exists(ctx, to) && !termio.AskForConfirmation(ctx, fmt.Sprintf("%s already exists. Overwrite it?", to)) {
-			return ExitError(ctx, ExitAborted, nil, "not overwriting your current secret")
+			return ExitError(ExitAborted, nil, "not overwriting your current secret")
 		}
 	}
 
 	if err := s.Store.Move(ctx, from, to); err != nil {
-		return ExitError(ctx, ExitUnknown, err, "%s", err)
+		return ExitError(ExitUnknown, err, "%s", err)
 	}
 
 	return nil

--- a/internal/action/otp_test.go
+++ b/internal/action/otp_test.go
@@ -44,7 +44,7 @@ func TestOTP(t *testing.T) {
 	buf.Reset()
 
 	// copy to clipboard
-	assert.NoError(t, act.otp(ctx, gptest.CliCtx(ctx, t), "bar", "", true, false, false))
+	assert.NoError(t, act.otp(ctx, "bar", "", true, false, false))
 	buf.Reset()
 
 	// write QR file

--- a/internal/action/pwgen/pwgen.go
+++ b/internal/action/pwgen/pwgen.go
@@ -5,7 +5,6 @@ import (
 	"strconv"
 
 	"github.com/gopasspw/gopass/internal/action"
-	"github.com/gopasspw/gopass/pkg/ctxutil"
 	"github.com/gopasspw/gopass/pkg/pwgen"
 	"github.com/gopasspw/gopass/pkg/pwgen/xkcdgen"
 	"github.com/urfave/cli/v2"
@@ -14,13 +13,11 @@ import (
 
 // Pwgen handles the pwgen subcommand
 func Pwgen(c *cli.Context) error {
-	ctx := ctxutil.WithGlobalFlags(c)
-
 	pwLen := 12
 	if lenStr := c.Args().Get(0); lenStr != "" {
 		i, err := strconv.Atoi(lenStr)
 		if err != nil {
-			return action.ExitError(ctx, action.ExitUsage, err, "Failed to convert password length arg: %s", err)
+			return action.ExitError(action.ExitUsage, err, "Failed to convert password length arg: %s", err)
 		}
 		if i > 0 {
 			pwLen = i
@@ -31,7 +28,7 @@ func Pwgen(c *cli.Context) error {
 	if numStr := c.Args().Get(1); numStr != "" {
 		i, err := strconv.Atoi(numStr)
 		if err != nil {
-			return action.ExitError(ctx, action.ExitUsage, err, "Failed to convert password number arg: %s", err)
+			return action.ExitError(action.ExitUsage, err, "Failed to convert password number arg: %s", err)
 		}
 		if i > 0 {
 			pwNum = i

--- a/internal/action/recipients.go
+++ b/internal/action/recipients.go
@@ -40,7 +40,7 @@ func (s *Action) RecipientsPrint(c *cli.Context) error {
 
 	tree, err := s.Store.RecipientsTree(ctx, true)
 	if err != nil {
-		return ExitError(ctx, ExitList, err, "failed to list recipients: %s", err)
+		return ExitError(ExitList, err, "failed to list recipients: %s", err)
 	}
 
 	fmt.Fprintln(stdout, tree.Format(-1))
@@ -113,12 +113,12 @@ func (s *Action) RecipientsAdd(c *cli.Context) error {
 		}
 
 		if err := s.Store.AddRecipient(ctxutil.WithConfirm(ctx, true), store, recp); err != nil {
-			return ExitError(ctx, ExitRecipients, err, "failed to add recipient '%s': %s", r, err)
+			return ExitError(ExitRecipients, err, "failed to add recipient '%s': %s", r, err)
 		}
 		added++
 	}
 	if added < 1 {
-		return ExitError(ctx, ExitUnknown, nil, "no key added")
+		return ExitError(ExitUnknown, nil, "no key added")
 	}
 
 	out.Green(ctx, "\nAdded %d recipients", added)
@@ -182,13 +182,13 @@ func (s *Action) RecipientsRemove(c *cli.Context) error {
 		}
 
 		if err := s.Store.RemoveRecipient(ctxutil.WithConfirm(ctx, true), store, recp); err != nil {
-			return ExitError(ctx, ExitRecipients, err, "failed to remove recipient '%s': %s", recp, err)
+			return ExitError(ExitRecipients, err, "failed to remove recipient '%s': %s", recp, err)
 		}
 		fmt.Fprintf(stdout, removalWarning, r)
 		removed++
 	}
 	if removed < 1 {
-		return ExitError(ctx, ExitUnknown, nil, "no key removed")
+		return ExitError(ExitUnknown, nil, "no key removed")
 	}
 
 	out.Green(ctx, "\nRemoved %d recipients", removed)
@@ -257,7 +257,7 @@ func (s *Action) recipientsSelectForRemoval(ctx context.Context, store string) (
 	case "show":
 		return []string{ids[sel]}, nil
 	default:
-		return nil, ExitError(ctx, ExitAborted, nil, "user aborted")
+		return nil, ExitError(ExitAborted, nil, "user aborted")
 	}
 }
 
@@ -280,6 +280,6 @@ func (s *Action) recipientsSelectForAdd(ctx context.Context, store string) ([]st
 	case "show":
 		return []string{kl[sel]}, nil
 	default:
-		return nil, ExitError(ctx, ExitAborted, nil, "user aborted")
+		return nil, ExitError(ExitAborted, nil, "user aborted")
 	}
 }

--- a/internal/action/show_test.go
+++ b/internal/action/show_test.go
@@ -305,7 +305,7 @@ func TestShowHandleYAMLError(t *testing.T) {
 		out.Stdout = os.Stdout
 	}()
 
-	assert.Error(t, act.showHandleYAMLError(ctx, "foo", "bar", fmt.Errorf("test")))
+	assert.Error(t, act.showHandleYAMLError("foo", "bar", fmt.Errorf("test")))
 	buf.Reset()
 }
 
@@ -330,6 +330,6 @@ func TestShowPrintQR(t *testing.T) {
 		out.Stdout = os.Stdout
 	}()
 
-	assert.NoError(t, act.showPrintQR(ctx, "foo", "bar"))
+	assert.NoError(t, act.showPrintQR("foo", "bar"))
 	buf.Reset()
 }

--- a/internal/action/sync.go
+++ b/internal/action/sync.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/gopasspw/gopass/internal/backend/rcs/noop"
+	"github.com/gopasspw/gopass/internal/debug"
 	"github.com/gopasspw/gopass/internal/notify"
 	"github.com/gopasspw/gopass/internal/out"
 	"github.com/gopasspw/gopass/internal/store"
@@ -17,12 +18,10 @@ import (
 
 // Sync all stores with their remotes
 func (s *Action) Sync(c *cli.Context) error {
-	ctx := ctxutil.WithGlobalFlags(c)
-	store := c.String("store")
-	return s.sync(ctx, c, store)
+	return s.sync(ctxutil.WithGlobalFlags(c), c.String("store"))
 }
 
-func (s *Action) sync(ctx context.Context, c *cli.Context, store string) error {
+func (s *Action) sync(ctx context.Context, store string) error {
 	out.Green(ctx, "Sync starting ...")
 
 	numEntries := 0
@@ -97,7 +96,7 @@ func (s *Action) syncMount(ctx context.Context, mp string) error {
 		if err := sub.RCS().Push(ctx, "", ""); err != nil {
 			if errors.Cause(err) == store.ErrGitNoRemote {
 				out.Yellow(ctx, "Skipped (no remote)")
-				out.Debug(ctx, "Failed to push '%s' to its remote: %s", name, err)
+				debug.Log("Failed to push '%s' to its remote: %s", name, err)
 				return err
 			}
 
@@ -118,7 +117,7 @@ func (s *Action) syncMount(ctx context.Context, mp string) error {
 		}
 	}
 
-	out.Debug(ctx, "syncMount(%s) - exportkeys: %t", mp, ctxutil.IsExportKeys(ctx))
+	debug.Log("syncMount(%s) - exportkeys: %t", mp, ctxutil.IsExportKeys(ctx))
 	var exported bool
 	if ctxutil.IsExportKeys(ctx) {
 		// import keys

--- a/internal/action/templates.go
+++ b/internal/action/templates.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/gopasspw/gopass/internal/debug"
 	"github.com/gopasspw/gopass/internal/editor"
 	"github.com/gopasspw/gopass/internal/out"
 	"github.com/gopasspw/gopass/internal/tpl"
@@ -40,7 +41,7 @@ func (s *Action) TemplatesPrint(c *cli.Context) error {
 	ctx := ctxutil.WithGlobalFlags(c)
 	tree, err := s.Store.TemplateTree(ctx)
 	if err != nil {
-		return ExitError(ctx, ExitList, err, "failed to list templates: %s", err)
+		return ExitError(ExitList, err, "failed to list templates: %s", err)
 	}
 	fmt.Fprintln(stdout, tree.Format(-1))
 	return nil
@@ -53,7 +54,7 @@ func (s *Action) TemplatePrint(c *cli.Context) error {
 
 	content, err := s.Store.GetTemplate(ctx, name)
 	if err != nil {
-		return ExitError(ctx, ExitIO, err, "failed to retrieve template: %s", err)
+		return ExitError(ExitIO, err, "failed to retrieve template: %s", err)
 	}
 
 	fmt.Fprintln(stdout, string(content))
@@ -71,7 +72,7 @@ func (s *Action) TemplateEdit(c *cli.Context) error {
 		var err error
 		content, err = s.Store.GetTemplate(ctx, name)
 		if err != nil {
-			return ExitError(ctx, ExitIO, err, "failed to retrieve template: %s", err)
+			return ExitError(ExitIO, err, "failed to retrieve template: %s", err)
 		}
 	} else {
 		content = []byte(templateExample)
@@ -80,7 +81,7 @@ func (s *Action) TemplateEdit(c *cli.Context) error {
 	ed := editor.Path(c)
 	nContent, err := editor.Invoke(ctx, ed, content)
 	if err != nil {
-		return ExitError(ctx, ExitUnknown, err, "failed to invoke editor %s: %s", ed, err)
+		return ExitError(ExitUnknown, err, "failed to invoke editor %s: %s", ed, err)
 	}
 
 	// If content is equal, nothing changed, exiting
@@ -96,11 +97,11 @@ func (s *Action) TemplateRemove(c *cli.Context) error {
 	ctx := ctxutil.WithGlobalFlags(c)
 	name := c.Args().First()
 	if name == "" {
-		return ExitError(ctx, ExitUsage, nil, "usage: %s templates remove [name]", s.Name)
+		return ExitError(ExitUsage, nil, "usage: %s templates remove [name]", s.Name)
 	}
 
 	if !s.Store.HasTemplate(ctx, name) {
-		return ExitError(ctx, ExitNotFound, nil, "template '%s' not found", name)
+		return ExitError(ExitNotFound, nil, "template '%s' not found", name)
 	}
 
 	return s.Store.RemoveTemplate(ctx, name)
@@ -123,13 +124,13 @@ func (s *Action) TemplatesComplete(c *cli.Context) {
 func (s *Action) renderTemplate(ctx context.Context, name string, content []byte) ([]byte, bool) {
 	tName, tmpl, found := s.Store.LookupTemplate(ctx, name)
 	if !found {
-		out.Debug(ctx, "No template found for %s", name)
+		debug.Log("No template found for %s", name)
 		return content, false
 	}
 
 	tmplStr := strings.TrimSpace(string(tmpl))
 	if tmplStr == "" {
-		out.Debug(ctx, "Skipping empty template '%s', for %s", tName, name)
+		debug.Log("Skipping empty template '%s', for %s", tName, name)
 		return content, false
 	}
 

--- a/internal/action/unclip.go
+++ b/internal/action/unclip.go
@@ -19,7 +19,7 @@ func (s *Action) Unclip(c *cli.Context) error {
 
 	time.Sleep(time.Second * time.Duration(timeout))
 	if err := clipboard.Clear(ctx, checksum, force); err != nil {
-		return ExitError(ctx, ExitIO, err, "Failed to clear clipboard: %s", err)
+		return ExitError(ExitIO, err, "Failed to clear clipboard: %s", err)
 	}
 	return nil
 }

--- a/internal/action/update.go
+++ b/internal/action/update.go
@@ -27,7 +27,7 @@ func (s *Action) Update(c *cli.Context) error {
 	}
 
 	if err := updater.Update(ctx, pre, s.version, mc); err != nil {
-		return ExitError(ctx, ExitUnknown, err, "Failed to update gopass: %s", err)
+		return ExitError(ExitUnknown, err, "Failed to update gopass: %s", err)
 	}
 	return nil
 }

--- a/internal/action/version.go
+++ b/internal/action/version.go
@@ -58,7 +58,7 @@ func (s *Action) Version(c *cli.Context) error {
 	case <-time.After(2 * time.Second):
 		out.Error(ctx, "Version check timed out")
 	case <-ctx.Done():
-		return ExitError(ctx, ExitAborted, nil, "user aborted")
+		return ExitError(ExitAborted, nil, "user aborted")
 	}
 
 	return nil
@@ -89,7 +89,7 @@ func (s *Action) checkVersion(ctx context.Context, u chan string) {
 		return
 	}
 
-	r, err := updater.LatestRelease(ctx, len(s.version.Pre) > 0)
+	r, err := updater.LatestRelease(len(s.version.Pre) > 0)
 	if err != nil {
 		u <- color.RedString("\nError checking latest version: %s", err)
 		return

--- a/internal/action/xc/xc.go
+++ b/internal/action/xc/xc.go
@@ -25,11 +25,7 @@ func initCrypto() error {
 	}
 
 	cfgdir := config.Directory()
-	c, err := xc.New(cfgdir, nil)
-	if err != nil {
-		return err
-	}
-	crypto = c
+	crypto = xc.New(cfgdir, nil)
 	return nil
 }
 
@@ -37,12 +33,12 @@ func initCrypto() error {
 func ListPrivateKeys(c *cli.Context) error {
 	ctx := ctxutil.WithGlobalFlags(c)
 	if err := initCrypto(); err != nil {
-		return action.ExitError(ctx, action.ExitUnknown, err, "failed to init XC")
+		return action.ExitError(action.ExitUnknown, err, "failed to init XC")
 	}
 
 	kl, err := crypto.ListIdentities(ctx)
 	if err != nil {
-		return action.ExitError(ctx, action.ExitUnknown, err, "failed to list private keys")
+		return action.ExitError(action.ExitUnknown, err, "failed to list private keys")
 	}
 
 	out.Print(ctx, "XC Private Keys:")
@@ -57,12 +53,12 @@ func ListPrivateKeys(c *cli.Context) error {
 func ListPublicKeys(c *cli.Context) error {
 	ctx := ctxutil.WithGlobalFlags(c)
 	if err := initCrypto(); err != nil {
-		return action.ExitError(ctx, action.ExitUnknown, err, "failed to init XC")
+		return action.ExitError(action.ExitUnknown, err, "failed to init XC")
 	}
 
 	kl, err := crypto.ListRecipients(ctx)
 	if err != nil {
-		return action.ExitError(ctx, action.ExitUnknown, err, "failed to list public keys")
+		return action.ExitError(action.ExitUnknown, err, "failed to list public keys")
 	}
 
 	out.Print(ctx, "XC Public Keys:")
@@ -77,7 +73,7 @@ func ListPublicKeys(c *cli.Context) error {
 func GenerateKeypair(c *cli.Context) error {
 	ctx := ctxutil.WithGlobalFlags(c)
 	if err := initCrypto(); err != nil {
-		return action.ExitError(ctx, action.ExitUnknown, err, "failed to init XC")
+		return action.ExitError(action.ExitUnknown, err, "failed to init XC")
 	}
 
 	name := c.String("name")
@@ -88,26 +84,26 @@ func GenerateKeypair(c *cli.Context) error {
 		var err error
 		name, err = termio.AskForString(ctx, "What is your full name?", "")
 		if err != nil || name == "" {
-			return action.ExitError(ctx, action.ExitNoName, err, "please provide a name")
+			return action.ExitError(action.ExitNoName, err, "please provide a name")
 		}
 	}
 	if email == "" {
 		var err error
 		email, err = termio.AskForString(ctx, "What is your email?", "")
 		if err != nil || email == "" {
-			return action.ExitError(ctx, action.ExitNoName, err, "please provide an email")
+			return action.ExitError(action.ExitNoName, err, "please provide an email")
 		}
 	}
 	if pw == "" {
 		var err error
 		pw, err = termio.AskForPassword(ctx, "")
 		if err != nil || pw == "" {
-			return action.ExitError(ctx, action.ExitIO, err, "failed to ask for password: %s", err)
+			return action.ExitError(action.ExitIO, err, "failed to ask for password: %s", err)
 		}
 	}
 
 	if err := crypto.CreatePrivateKeyBatch(ctx, name, email, pw); err != nil {
-		return action.ExitError(ctx, action.ExitUnknown, err, "failed to create private key: %s", err)
+		return action.ExitError(action.ExitUnknown, err, "failed to create private key: %s", err)
 	}
 	return nil
 }
@@ -116,30 +112,30 @@ func GenerateKeypair(c *cli.Context) error {
 func ExportPublicKey(c *cli.Context) error {
 	ctx := ctxutil.WithGlobalFlags(c)
 	if err := initCrypto(); err != nil {
-		return action.ExitError(ctx, action.ExitUnknown, err, "failed to init XC")
+		return action.ExitError(action.ExitUnknown, err, "failed to init XC")
 	}
 
 	id := c.String("id")
 	file := c.String("file")
 
 	if id == "" {
-		return action.ExitError(ctx, action.ExitUsage, nil, "need id")
+		return action.ExitError(action.ExitUsage, nil, "need id")
 	}
 	if file == "" {
-		return action.ExitError(ctx, action.ExitUsage, nil, "need file")
+		return action.ExitError(action.ExitUsage, nil, "need file")
 	}
 
 	if fsutil.IsFile(file) {
-		return action.ExitError(ctx, action.ExitUnknown, nil, "output file already exists")
+		return action.ExitError(action.ExitUnknown, nil, "output file already exists")
 	}
 
 	pk, err := crypto.ExportPublicKey(ctx, id)
 	if err != nil {
-		return action.ExitError(ctx, action.ExitUnknown, err, "failed to export key: %s", err)
+		return action.ExitError(action.ExitUnknown, err, "failed to export key: %s", err)
 	}
 
 	if err := ioutil.WriteFile(file, pk, 0600); err != nil {
-		return action.ExitError(ctx, action.ExitIO, err, "failed to write file")
+		return action.ExitError(action.ExitIO, err, "failed to write file")
 	}
 	return nil
 }
@@ -148,37 +144,36 @@ func ExportPublicKey(c *cli.Context) error {
 func ImportPublicKey(c *cli.Context) error {
 	ctx := ctxutil.WithGlobalFlags(c)
 	if err := initCrypto(); err != nil {
-		return action.ExitError(ctx, action.ExitUnknown, err, "failed to init XC")
+		return action.ExitError(action.ExitUnknown, err, "failed to init XC")
 	}
 
 	file := c.String("file")
 
 	if file == "" {
-		return action.ExitError(ctx, action.ExitUsage, nil, "need file")
+		return action.ExitError(action.ExitUsage, nil, "need file")
 	}
 
 	if !fsutil.IsFile(file) {
-		return action.ExitError(ctx, action.ExitNotFound, nil, "input file not found")
+		return action.ExitError(action.ExitNotFound, nil, "input file not found")
 	}
 
 	buf, err := ioutil.ReadFile(file)
 	if err != nil {
-		return action.ExitError(ctx, action.ExitIO, err, "failed to read file")
+		return action.ExitError(action.ExitIO, err, "failed to read file")
 	}
 	return crypto.ImportPublicKey(ctx, buf)
 }
 
 // RemoveKey removes a key from the keyring
 func RemoveKey(c *cli.Context) error {
-	ctx := ctxutil.WithGlobalFlags(c)
 	if err := initCrypto(); err != nil {
-		return action.ExitError(ctx, action.ExitUnknown, err, "failed to init XC")
+		return action.ExitError(action.ExitUnknown, err, "failed to init XC")
 	}
 
 	id := c.String("id")
 
 	if id == "" {
-		return action.ExitError(ctx, action.ExitUsage, nil, "need id")
+		return action.ExitError(action.ExitUsage, nil, "need id")
 	}
 
 	return crypto.RemoveKey(id)
@@ -186,65 +181,63 @@ func RemoveKey(c *cli.Context) error {
 
 // ExportPrivateKey exports an XC key
 func ExportPrivateKey(c *cli.Context) error {
-	ctx := ctxutil.WithGlobalFlags(c)
 	if err := initCrypto(); err != nil {
-		return action.ExitError(ctx, action.ExitUnknown, err, "failed to init XC")
+		return action.ExitError(action.ExitUnknown, err, "failed to init XC")
 	}
 
 	id := c.String("id")
 	file := c.String("file")
 
 	if id == "" {
-		return action.ExitError(ctx, action.ExitUsage, nil, "need id")
+		return action.ExitError(action.ExitUsage, nil, "need id")
 	}
 	if file == "" {
-		return action.ExitError(ctx, action.ExitUsage, nil, "need file")
+		return action.ExitError(action.ExitUsage, nil, "need file")
 	}
 
 	if fsutil.IsFile(file) {
-		return action.ExitError(ctx, action.ExitUnknown, nil, "output file already exists")
+		return action.ExitError(action.ExitUnknown, nil, "output file already exists")
 	}
 
-	pk, err := crypto.ExportPrivateKey(ctx, id)
+	pk, err := crypto.ExportPrivateKey(id)
 	if err != nil {
-		return action.ExitError(ctx, action.ExitUnknown, err, "failed to export key: %s", err)
+		return action.ExitError(action.ExitUnknown, err, "failed to export key: %s", err)
 	}
 
 	if err := ioutil.WriteFile(file, pk, 0600); err != nil {
-		return action.ExitError(ctx, action.ExitIO, err, "failed to write file")
+		return action.ExitError(action.ExitIO, err, "failed to write file")
 	}
 	return nil
 }
 
 // ImportPrivateKey imports an XC key
 func ImportPrivateKey(c *cli.Context) error {
-	ctx := ctxutil.WithGlobalFlags(c)
 	if err := initCrypto(); err != nil {
-		return action.ExitError(ctx, action.ExitUnknown, err, "failed to init XC")
+		return action.ExitError(action.ExitUnknown, err, "failed to init XC")
 	}
 
 	file := c.String("file")
 
 	if file == "" {
-		return action.ExitError(ctx, action.ExitUsage, nil, "need file")
+		return action.ExitError(action.ExitUsage, nil, "need file")
 	}
 
 	if !fsutil.IsFile(file) {
-		return action.ExitError(ctx, action.ExitNotFound, nil, "input file not found")
+		return action.ExitError(action.ExitNotFound, nil, "input file not found")
 	}
 
 	buf, err := ioutil.ReadFile(file)
 	if err != nil {
-		return action.ExitError(ctx, action.ExitIO, err, "failed to read file")
+		return action.ExitError(action.ExitIO, err, "failed to read file")
 	}
-	return crypto.ImportPrivateKey(ctx, buf)
+	return crypto.ImportPrivateKey(buf)
 }
 
 // EncryptFile encrypts a single file
 func EncryptFile(c *cli.Context) error {
 	ctx := ctxutil.WithGlobalFlags(c)
 	if err := initCrypto(); err != nil {
-		return action.ExitError(ctx, action.ExitUnknown, err, "failed to init XC")
+		return action.ExitError(action.ExitUnknown, err, "failed to init XC")
 	}
 
 	if c.Bool("stream") {
@@ -253,29 +246,29 @@ func EncryptFile(c *cli.Context) error {
 
 	inFile := c.String("file")
 	if inFile == "" {
-		return action.ExitError(ctx, action.ExitUsage, nil, "need file")
+		return action.ExitError(action.ExitUsage, nil, "need file")
 	}
 
 	recipients := c.StringSlice("recipients")
 	outFile := inFile + ".xc"
 
 	if !fsutil.IsFile(inFile) {
-		return action.ExitError(ctx, action.ExitNotFound, nil, "input file not found")
+		return action.ExitError(action.ExitNotFound, nil, "input file not found")
 	}
 	if fsutil.IsFile(outFile) {
-		return action.ExitError(ctx, action.ExitIO, nil, "output file already exists")
+		return action.ExitError(action.ExitIO, nil, "output file already exists")
 	}
 
 	plaintext, err := ioutil.ReadFile(inFile)
 	if err != nil {
-		return action.ExitError(ctx, action.ExitIO, err, "failed to read file")
+		return action.ExitError(action.ExitIO, err, "failed to read file")
 	}
 	ciphertext, err := crypto.Encrypt(ctx, plaintext, recipients)
 	if err != nil {
-		return action.ExitError(ctx, action.ExitUnknown, err, "failed to encrypt file: %s", err)
+		return action.ExitError(action.ExitUnknown, err, "failed to encrypt file: %s", err)
 	}
 	if err := ioutil.WriteFile(outFile, ciphertext, 0600); err != nil {
-		return action.ExitError(ctx, action.ExitUnknown, err, "failed to write ciphertext")
+		return action.ExitError(action.ExitUnknown, err, "failed to write ciphertext")
 	}
 	return nil
 }
@@ -284,7 +277,7 @@ func EncryptFile(c *cli.Context) error {
 func DecryptFile(c *cli.Context) error {
 	ctx := ctxutil.WithGlobalFlags(c)
 	if err := initCrypto(); err != nil {
-		return action.ExitError(ctx, action.ExitUnknown, err, "failed to init XC")
+		return action.ExitError(action.ExitUnknown, err, "failed to init XC")
 	}
 
 	if c.Bool("stream") {
@@ -293,32 +286,32 @@ func DecryptFile(c *cli.Context) error {
 
 	inFile := c.String("file")
 	if inFile == "" {
-		return action.ExitError(ctx, action.ExitUsage, nil, "need file")
+		return action.ExitError(action.ExitUsage, nil, "need file")
 	}
 	if !strings.HasSuffix(inFile, ".xc") {
-		return action.ExitError(ctx, action.ExitUsage, nil, "unknown extension. expecting .xc")
+		return action.ExitError(action.ExitUsage, nil, "unknown extension. expecting .xc")
 	}
 	outFile := strings.TrimSuffix(inFile, ".xc")
 
 	if !fsutil.IsFile(inFile) {
-		return action.ExitError(ctx, action.ExitNotFound, nil, "input file not found")
+		return action.ExitError(action.ExitNotFound, nil, "input file not found")
 	}
 	if fsutil.IsFile(outFile) {
-		return action.ExitError(ctx, action.ExitIO, nil, "output file already exists")
+		return action.ExitError(action.ExitIO, nil, "output file already exists")
 	}
 
 	ciphertext, err := ioutil.ReadFile(inFile)
 	if err != nil {
-		return action.ExitError(ctx, action.ExitIO, err, "failed to read file")
+		return action.ExitError(action.ExitIO, err, "failed to read file")
 	}
 
 	plaintext, err := crypto.Decrypt(ctx, ciphertext)
 	if err != nil {
-		return action.ExitError(ctx, action.ExitUnknown, err, "failed to decrypt file: %s", err)
+		return action.ExitError(action.ExitUnknown, err, "failed to decrypt file: %s", err)
 	}
 
 	if err := ioutil.WriteFile(outFile, plaintext, 0600); err != nil {
-		return action.ExitError(ctx, action.ExitUnknown, err, "failed to write plaintext")
+		return action.ExitError(action.ExitUnknown, err, "failed to write plaintext")
 	}
 	return nil
 }
@@ -327,12 +320,12 @@ func DecryptFile(c *cli.Context) error {
 func EncryptFileStream(c *cli.Context) error {
 	ctx := ctxutil.WithGlobalFlags(c)
 	if err := initCrypto(); err != nil {
-		return action.ExitError(ctx, action.ExitUnknown, err, "failed to init XC")
+		return action.ExitError(action.ExitUnknown, err, "failed to init XC")
 	}
 
 	inFile := c.String("file")
 	if inFile == "" {
-		return action.ExitError(ctx, action.ExitUsage, nil, "need file")
+		return action.ExitError(action.ExitUsage, nil, "need file")
 	}
 
 	recipients := c.StringSlice("recipients")
@@ -340,27 +333,27 @@ func EncryptFileStream(c *cli.Context) error {
 	outFile := inFile + ".xc"
 
 	if !fsutil.IsFile(inFile) {
-		return action.ExitError(ctx, action.ExitNotFound, nil, "input file not found")
+		return action.ExitError(action.ExitNotFound, nil, "input file not found")
 	}
 	if fsutil.IsFile(outFile) {
-		return action.ExitError(ctx, action.ExitIO, nil, "output file already exists")
+		return action.ExitError(action.ExitIO, nil, "output file already exists")
 	}
 
 	plaintext, err := os.Open(inFile)
 	if err != nil {
-		return action.ExitError(ctx, action.ExitIO, err, "failed to open file")
+		return action.ExitError(action.ExitIO, err, "failed to open file")
 	}
 	defer func() { _ = plaintext.Close() }()
 
 	ciphertext, err := os.OpenFile(outFile, os.O_CREATE|os.O_WRONLY, 0600)
 	if err != nil {
-		return action.ExitError(ctx, action.ExitIO, err, "failed to open file")
+		return action.ExitError(action.ExitIO, err, "failed to open file")
 	}
 	defer func() { _ = ciphertext.Close() }()
 
 	if err := crypto.EncryptStream(ctx, plaintext, recipients, ciphertext); err != nil {
 		_ = os.Remove(outFile)
-		return action.ExitError(ctx, action.ExitUnknown, err, "failed to encrypt file: %s", err)
+		return action.ExitError(action.ExitUnknown, err, "failed to encrypt file: %s", err)
 	}
 	return nil
 }
@@ -369,40 +362,40 @@ func EncryptFileStream(c *cli.Context) error {
 func DecryptFileStream(c *cli.Context) error {
 	ctx := ctxutil.WithGlobalFlags(c)
 	if err := initCrypto(); err != nil {
-		return action.ExitError(ctx, action.ExitUnknown, err, "failed to init XC")
+		return action.ExitError(action.ExitUnknown, err, "failed to init XC")
 	}
 
 	inFile := c.String("file")
 	if inFile == "" {
-		return action.ExitError(ctx, action.ExitUsage, nil, "need file")
+		return action.ExitError(action.ExitUsage, nil, "need file")
 	}
 	if !strings.HasSuffix(inFile, ".xc") {
-		return action.ExitError(ctx, action.ExitUsage, nil, "unknown extension. expecting .xc")
+		return action.ExitError(action.ExitUsage, nil, "unknown extension. expecting .xc")
 	}
 	outFile := strings.TrimSuffix(inFile, ".xc")
 
 	if !fsutil.IsFile(inFile) {
-		return action.ExitError(ctx, action.ExitNotFound, nil, "input file not found")
+		return action.ExitError(action.ExitNotFound, nil, "input file not found")
 	}
 	if fsutil.IsFile(outFile) {
-		return action.ExitError(ctx, action.ExitIO, nil, "output file already exists")
+		return action.ExitError(action.ExitIO, nil, "output file already exists")
 	}
 
 	ciphertext, err := os.Open(inFile)
 	if err != nil {
-		return action.ExitError(ctx, action.ExitIO, err, "failed to read file")
+		return action.ExitError(action.ExitIO, err, "failed to read file")
 	}
 	defer func() { _ = ciphertext.Close() }()
 
 	plaintext, err := os.OpenFile(outFile, os.O_CREATE|os.O_WRONLY, 0600)
 	if err != nil {
-		return action.ExitError(ctx, action.ExitIO, err, "failed to read file")
+		return action.ExitError(action.ExitIO, err, "failed to read file")
 	}
 	defer func() { _ = plaintext.Close() }()
 
 	if err := crypto.DecryptStream(ctx, ciphertext, plaintext); err != nil {
 		_ = os.Remove(outFile)
-		return action.ExitError(ctx, action.ExitUnknown, err, "failed to decrypt file: %s", err)
+		return action.ExitError(action.ExitUnknown, err, "failed to decrypt file: %s", err)
 	}
 	return nil
 }

--- a/internal/action/xc/xc_test.go
+++ b/internal/action/xc/xc_test.go
@@ -226,9 +226,7 @@ func TestEncryptDecryptFile(t *testing.T) {
 	plain := filepath.Join(td, "plain.txt")
 	assert.NoError(t, ioutil.WriteFile(plain, []byte("foobar"), 0600))
 
-	cr, err := xc.New(td, &fakeAgent{"foobar"})
-	assert.NoError(t, err)
-	crypto = cr
+	crypto = xc.New(td, &fakeAgent{"foobar"})
 
 	assert.NoError(t, crypto.CreatePrivateKeyBatch(ctx, "foobar", "foo.bar@example.org", "foobar"))
 
@@ -276,9 +274,7 @@ func TestEncryptDecryptStream(t *testing.T) {
 	plain := filepath.Join(td, "plain.txt")
 	assert.NoError(t, ioutil.WriteFile(plain, []byte("foobar"), 0600))
 
-	cr, err := xc.New(td, &fakeAgent{"foobar"})
-	assert.NoError(t, err)
-	crypto = cr
+	crypto = xc.New(td, &fakeAgent{"foobar"})
 
 	assert.NoError(t, crypto.CreatePrivateKeyBatch(ctx, "foobar", "foo.bar@example.org", "foobar"))
 

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -143,7 +143,7 @@ func audit(ctx context.Context, secStore secretGetter, validator *crunchy.Valida
 	done <- struct{}{}
 }
 
-func printAuditResults(ctx context.Context, m map[string][]string, format string, color func(format string, a ...interface{}) string) bool {
+func printAuditResults(m map[string][]string, format string, color func(format string, a ...interface{}) string) bool {
 	b := false
 
 	for msg, secrets := range m {
@@ -181,11 +181,11 @@ func auditPrintResults(ctx context.Context, duplicates, messages, errors map[str
 		out.Green(ctx, "No shared secrets found.")
 	}
 
-	foundWeakPasswords := printAuditResults(ctx, messages, "%s:\n", color.CyanString)
+	foundWeakPasswords := printAuditResults(messages, "%s:\n", color.CyanString)
 	if !foundWeakPasswords {
 		out.Green(ctx, "No weak secrets detected.")
 	}
-	foundErrors := printAuditResults(ctx, errors, "%s:\n", color.RedString)
+	foundErrors := printAuditResults(errors, "%s:\n", color.RedString)
 
 	if foundWeakPasswords || foundDuplicates || foundErrors {
 		_ = notify.Notify(ctx, "gopass - audit", "Finished. Found weak passwords and/or duplicates")

--- a/internal/backend/crypto.go
+++ b/internal/backend/crypto.go
@@ -5,7 +5,7 @@ import (
 	"sort"
 
 	"github.com/blang/semver"
-	"github.com/gopasspw/gopass/internal/out"
+	"github.com/gopasspw/gopass/internal/debug"
 	"github.com/pkg/errors"
 )
 
@@ -95,14 +95,14 @@ func DetectCrypto(ctx context.Context, storage Storage) (Crypto, error) {
 	})
 	for _, id := range bes {
 		be := cryptoRegistry[id]
-		out.Debug(ctx, "DetectCrypto(%s) - trying %s", storage, be)
+		debug.Log("DetectCrypto(%s) - trying %s", storage, be)
 		if err := be.Handles(storage); err != nil {
-			out.Debug(ctx, "failed to use crypto %s for %s", id, storage)
+			debug.Log("failed to use crypto %s for %s", id, storage)
 			continue
 		}
-		out.Debug(ctx, "DetectCrypto(%s) - using %s", storage, be)
+		debug.Log("DetectCrypto(%s) - using %s", storage, be)
 		return be.New(ctx)
 	}
-	out.Debug(ctx, "DetectCrypto(%s) - no valid crypto provider found", storage)
+	debug.Log("DetectCrypto(%s) - no valid crypto provider found", storage)
 	return nil, nil
 }

--- a/internal/backend/crypto/age/loader.go
+++ b/internal/backend/crypto/age/loader.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/gopasspw/gopass/internal/backend"
-	"github.com/gopasspw/gopass/internal/out"
+	"github.com/gopasspw/gopass/internal/debug"
 )
 
 const (
@@ -19,7 +19,7 @@ func init() {
 type loader struct{}
 
 func (l loader) New(ctx context.Context) (backend.Crypto, error) {
-	out.Debug(ctx, "Using Crypto Backend: %s", name)
+	debug.Log("Using Crypto Backend: %s", name)
 	return New()
 }
 

--- a/internal/backend/crypto/gpg/cli/binary.go
+++ b/internal/backend/crypto/gpg/cli/binary.go
@@ -23,13 +23,13 @@ func Binary(ctx context.Context, bin string) (string, error) {
 	}
 	bv := make(byVersion, 0, len(bins))
 	for _, b := range bins {
-		//out.Debug(ctx, "gpg.detectBinary - Looking for '%s' ...", b)
+		//debug.Log("gpg.detectBinary - Looking for '%s' ...", b)
 		if p, err := exec.LookPath(b); err == nil {
 			gb := gpgBin{
 				path: p,
 				ver:  version(ctx, p),
 			}
-			//out.Debug(ctx, "gpg.detectBinary - Found '%s' at '%s' (%s)", b, p, gb.ver.String())
+			//debug.Log("gpg.detectBinary - Found '%s' at '%s' (%s)", b, p, gb.ver.String())
 			bv = append(bv, gb)
 		}
 	}
@@ -38,6 +38,6 @@ func Binary(ctx context.Context, bin string) (string, error) {
 	}
 	sort.Sort(bv)
 	binary := bv[len(bv)-1].path
-	//out.Debug(ctx, "gpg.detectBinary - using '%s'", binary)
+	//debug.Log("gpg.detectBinary - using '%s'", binary)
 	return binary, nil
 }

--- a/internal/backend/crypto/gpg/cli/export.go
+++ b/internal/backend/crypto/gpg/cli/export.go
@@ -4,8 +4,7 @@ import (
 	"context"
 	"os/exec"
 
-	"github.com/gopasspw/gopass/internal/out"
-
+	"github.com/gopasspw/gopass/internal/debug"
 	"github.com/pkg/errors"
 )
 
@@ -18,7 +17,7 @@ func (g *GPG) ExportPublicKey(ctx context.Context, id string) ([]byte, error) {
 	args := append(g.args, "--armor", "--export", id)
 	cmd := exec.CommandContext(ctx, g.binary, args...)
 
-	out.Debug(ctx, "gpg.ExportPublicKey: %s %+v", cmd.Path, cmd.Args)
+	debug.Log("gpg.ExportPublicKey: %s %+v", cmd.Path, cmd.Args)
 	out, err := cmd.Output()
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to run command '%s %+v'", cmd.Path, cmd.Args)

--- a/internal/backend/crypto/gpg/cli/generate.go
+++ b/internal/backend/crypto/gpg/cli/generate.go
@@ -6,8 +6,7 @@ import (
 	"os"
 	"os/exec"
 
-	"github.com/gopasspw/gopass/internal/out"
-
+	"github.com/gopasspw/gopass/internal/debug"
 	"github.com/pkg/errors"
 )
 
@@ -32,7 +31,7 @@ Expire-Date: 0
 	cmd.Stdout = nil
 	cmd.Stderr = nil
 
-	out.Debug(ctx, "gpg.CreatePrivateKeyBatch: %s %+v", cmd.Path, cmd.Args)
+	debug.Log("gpg.CreatePrivateKeyBatch: %s %+v", cmd.Path, cmd.Args)
 	if err := cmd.Run(); err != nil {
 		return errors.Wrapf(err, "failed to run command: '%s %+v'", cmd.Path, cmd.Args)
 	}
@@ -49,7 +48,7 @@ func (g *GPG) CreatePrivateKey(ctx context.Context) error {
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 
-	out.Debug(ctx, "gpg.CreatePrivateKey: %s %+v", cmd.Path, cmd.Args)
+	debug.Log("gpg.CreatePrivateKey: %s %+v", cmd.Path, cmd.Args)
 	if err := cmd.Run(); err != nil {
 		return errors.Wrapf(err, "failed to run command: '%s %+v'", cmd.Path, cmd.Args)
 	}

--- a/internal/backend/crypto/gpg/cli/gpg.go
+++ b/internal/backend/crypto/gpg/cli/gpg.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 
 	"github.com/gopasspw/gopass/internal/backend/crypto/gpg"
-	"github.com/gopasspw/gopass/internal/out"
+	"github.com/gopasspw/gopass/internal/debug"
 	lru "github.com/hashicorp/golang-lru"
 )
 
@@ -82,7 +82,7 @@ func (g *GPG) RecipientIDs(ctx context.Context, buf []byte) ([]string, error) {
 	args := []string{"--batch", "--list-only", "--list-packets", "--no-default-keyring", "--secret-keyring", "/dev/null"}
 	cmd := exec.CommandContext(ctx, g.binary, args...)
 	cmd.Stdin = bytes.NewReader(buf)
-	out.Debug(ctx, "gpg.GetRecipients: %s %+v", cmd.Path, cmd.Args)
+	debug.Log("gpg.GetRecipients: %s %+v", cmd.Path, cmd.Args)
 
 	cmdout, err := cmd.CombinedOutput()
 	if err != nil {
@@ -92,7 +92,7 @@ func (g *GPG) RecipientIDs(ctx context.Context, buf []byte) ([]string, error) {
 	scanner := bufio.NewScanner(bytes.NewBuffer(cmdout))
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
-		out.Debug(ctx, "gpg Output: %s", line)
+		debug.Log("gpg Output: %s", line)
 		if !strings.HasPrefix(line, ":pubkey enc packet:") {
 			continue
 		}
@@ -130,7 +130,7 @@ func (g *GPG) Encrypt(ctx context.Context, plaintext []byte, recipients []string
 	cmd.Stdout = buf
 	cmd.Stderr = os.Stderr
 
-	out.Debug(ctx, "gpg.Encrypt: %s %+v", cmd.Path, cmd.Args)
+	debug.Log("gpg.Encrypt: %s %+v", cmd.Path, cmd.Args)
 	err := cmd.Run()
 	return buf.Bytes(), err
 }
@@ -142,7 +142,7 @@ func (g *GPG) Decrypt(ctx context.Context, ciphertext []byte) ([]byte, error) {
 	cmd.Stdin = bytes.NewReader(ciphertext)
 	cmd.Stderr = os.Stderr
 
-	out.Debug(ctx, "gpg.Decrypt: %s %+v", cmd.Path, cmd.Args)
+	debug.Log("gpg.Decrypt: %s %+v", cmd.Path, cmd.Args)
 	return cmd.Output()
 }
 

--- a/internal/backend/crypto/gpg/cli/import.go
+++ b/internal/backend/crypto/gpg/cli/import.go
@@ -6,8 +6,7 @@ import (
 	"os"
 	"os/exec"
 
-	"github.com/gopasspw/gopass/internal/out"
-
+	"github.com/gopasspw/gopass/internal/debug"
 	"github.com/pkg/errors"
 )
 
@@ -23,7 +22,7 @@ func (g *GPG) ImportPublicKey(ctx context.Context, buf []byte) error {
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 
-	out.Debug(ctx, "gpg.ImportPublicKey: %s %+v", cmd.Path, cmd.Args)
+	debug.Log("gpg.ImportPublicKey: %s %+v", cmd.Path, cmd.Args)
 	if err := cmd.Run(); err != nil {
 		return errors.Wrapf(err, "failed to run command: '%s %+v'", cmd.Path, cmd.Args)
 	}

--- a/internal/backend/crypto/gpg/cli/keyring.go
+++ b/internal/backend/crypto/gpg/cli/keyring.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 
 	"github.com/gopasspw/gopass/internal/backend/crypto/gpg"
-	"github.com/gopasspw/gopass/internal/out"
+	"github.com/gopasspw/gopass/internal/debug"
 )
 
 // listKey lists all keys of the given type and matching the search strings
@@ -24,7 +24,7 @@ func (g *GPG) listKeys(ctx context.Context, typ string, search ...string) (gpg.K
 	var errBuf = bytes.Buffer{}
 	cmd.Stderr = &errBuf
 
-	out.Debug(ctx, "gpg.listKeys: %s %+v\n", cmd.Path, cmd.Args)
+	debug.Log("gpg.listKeys: %s %+v\n", cmd.Path, cmd.Args)
 	cmdout, err := cmd.Output()
 	if err != nil {
 		if bytes.Contains(cmdout, []byte("secret key not available")) {

--- a/internal/backend/crypto/gpg/cli/loader.go
+++ b/internal/backend/crypto/gpg/cli/loader.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/gopasspw/gopass/internal/backend"
-	"github.com/gopasspw/gopass/internal/out"
+	"github.com/gopasspw/gopass/internal/debug"
 	"github.com/gopasspw/gopass/pkg/fsutil"
 )
 
@@ -21,7 +21,7 @@ type loader struct{}
 
 // New implements backend.CryptoLoader.
 func (l loader) New(ctx context.Context) (backend.Crypto, error) {
-	out.Debug(ctx, "Using Crypto Backend: %s", name)
+	debug.Log("Using Crypto Backend: %s", name)
 	return New(ctx, Config{
 		Umask: fsutil.Umask(),
 		Args:  GPGOpts(),

--- a/internal/backend/crypto/plain/backend.go
+++ b/internal/backend/crypto/plain/backend.go
@@ -119,7 +119,7 @@ func (m *Mocker) Binary() string {
 }
 
 // Sign writes the hashsum to the given file
-func (m *Mocker) Sign(ctx context.Context, in string, sigf string) error {
+func (m *Mocker) Sign(in string, sigf string) error {
 	buf, err := ioutil.ReadFile(in)
 	if err != nil {
 		return err
@@ -131,7 +131,7 @@ func (m *Mocker) Sign(ctx context.Context, in string, sigf string) error {
 }
 
 // Verify does a pseudo-verification
-func (m *Mocker) Verify(ctx context.Context, sigf string, in string) error {
+func (m *Mocker) Verify(sigf string, in string) error {
 	sigb, err := ioutil.ReadFile(sigf)
 	if err != nil {
 		return err

--- a/internal/backend/crypto/plain/backend_test.go
+++ b/internal/backend/crypto/plain/backend_test.go
@@ -94,22 +94,19 @@ func TestSignVerify(t *testing.T) {
 		_ = os.RemoveAll(td)
 	}()
 
-	ctx := context.Background()
-	ctx = ctxutil.WithAlwaysYes(ctx, true)
-
 	m := New()
 
 	in := filepath.Join(td, "in")
 	assert.NoError(t, ioutil.WriteFile(in, []byte("in"), 0644))
 	sigf := filepath.Join(td, "sigf")
 
-	assert.NoError(t, m.Sign(ctx, in, sigf))
-	assert.NoError(t, m.Verify(ctx, sigf, in))
+	assert.NoError(t, m.Sign(in, sigf))
+	assert.NoError(t, m.Verify(sigf, in))
 
-	assert.Error(t, m.Sign(ctx, "/tmp", sigf))
-	assert.Error(t, m.Verify(ctx, sigf, "/tmp"))
-	assert.Error(t, m.Verify(ctx, "/tmp", in))
+	assert.Error(t, m.Sign("/tmp", sigf))
+	assert.Error(t, m.Verify(sigf, "/tmp"))
+	assert.Error(t, m.Verify("/tmp", in))
 
 	assert.NoError(t, ioutil.WriteFile(sigf, []byte("in"), 0644))
-	assert.Error(t, m.Verify(ctx, sigf, in))
+	assert.Error(t, m.Verify(sigf, in))
 }

--- a/internal/backend/crypto/plain/loader.go
+++ b/internal/backend/crypto/plain/loader.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/gopasspw/gopass/internal/backend"
-	"github.com/gopasspw/gopass/internal/out"
+	"github.com/gopasspw/gopass/internal/debug"
 )
 
 const (
@@ -20,7 +20,7 @@ type loader struct{}
 
 // New implements backend.CryptoLoader.
 func (l loader) New(ctx context.Context) (backend.Crypto, error) {
-	out.Debug(ctx, "Using Crypto Backend: %s (NO ENCRYPTION)", name)
+	debug.Log("Using Crypto Backend: %s (NO ENCRYPTION)", name)
 	return New(), nil
 }
 

--- a/internal/backend/crypto/xc/encrypt_test.go
+++ b/internal/backend/crypto/xc/encrypt_test.go
@@ -96,8 +96,8 @@ func TestEncryptMultiKeys(t *testing.T) {
 	assert.NoError(t, skr.Set(k1))
 
 	pkr := keyring.NewPubring(skr)
-	assert.NoError(t, pkr.Set(&k2.PublicKey))
-	assert.NoError(t, pkr.Set(&k3.PublicKey))
+	pkr.Set(&k2.PublicKey)
+	pkr.Set(&k3.PublicKey)
 
 	xc := &XC{
 		pubring: pkr,

--- a/internal/backend/crypto/xc/export.go
+++ b/internal/backend/crypto/xc/export.go
@@ -17,6 +17,6 @@ func (x *XC) ExportPublicKey(ctx context.Context, id string) ([]byte, error) {
 }
 
 // ExportPrivateKey exports a given private key
-func (x *XC) ExportPrivateKey(ctx context.Context, id string) ([]byte, error) {
+func (x *XC) ExportPrivateKey(id string) ([]byte, error) {
 	return x.secring.Export(id, true)
 }

--- a/internal/backend/crypto/xc/export_test.go
+++ b/internal/backend/crypto/xc/export_test.go
@@ -38,8 +38,8 @@ func TestExportKey(t *testing.T) {
 	assert.NoError(t, skr.Set(k1))
 
 	pkr := keyring.NewPubring(skr)
-	assert.NoError(t, pkr.Set(&k2.PublicKey))
-	assert.NoError(t, pkr.Set(&k3.PublicKey))
+	pkr.Set(&k2.PublicKey)
+	pkr.Set(&k3.PublicKey)
 
 	xc := &XC{
 		pubring: pkr,
@@ -63,9 +63,9 @@ func TestExportKey(t *testing.T) {
 	_, err = xc.ExportPublicKey(ctx, "foobar")
 	assert.Error(t, err)
 
-	_, err = xc.ExportPrivateKey(ctx, k1.Fingerprint())
+	_, err = xc.ExportPrivateKey(k1.Fingerprint())
 	assert.NoError(t, err)
 
-	_, err = xc.ExportPrivateKey(ctx, k2.Fingerprint())
+	_, err = xc.ExportPrivateKey(k2.Fingerprint())
 	assert.Error(t, err)
 }

--- a/internal/backend/crypto/xc/import.go
+++ b/internal/backend/crypto/xc/import.go
@@ -11,7 +11,7 @@ func (x *XC) ImportPublicKey(ctx context.Context, buf []byte) error {
 }
 
 // ImportPrivateKey imports a given private key into the keyring
-func (x *XC) ImportPrivateKey(ctx context.Context, buf []byte) error {
+func (x *XC) ImportPrivateKey(buf []byte) error {
 	if err := x.secring.Import(buf); err != nil {
 		return err
 	}

--- a/internal/backend/crypto/xc/import_test.go
+++ b/internal/backend/crypto/xc/import_test.go
@@ -42,8 +42,8 @@ func TestImportKey(t *testing.T) {
 	x1pkrfn := filepath.Join(td, "x1pkr")
 	x1pkr, err := keyring.LoadPubring(x1pkrfn, x1skr)
 	require.NoError(t, err)
-	assert.NoError(t, x1pkr.Set(&x1k2.PublicKey))
-	assert.NoError(t, x1pkr.Set(&x1k3.PublicKey))
+	x1pkr.Set(&x1k2.PublicKey)
+	x1pkr.Set(&x1k3.PublicKey)
 
 	xc1 := &XC{
 		pubring: x1pkr,
@@ -67,8 +67,8 @@ func TestImportKey(t *testing.T) {
 	x2pkrfn := filepath.Join(td, "x2pkr")
 	x2pkr, err := keyring.LoadPubring(x2pkrfn, x2skr)
 	require.NoError(t, err)
-	assert.NoError(t, x2pkr.Set(&x2k2.PublicKey))
-	assert.NoError(t, x2pkr.Set(&x2k3.PublicKey))
+	x2pkr.Set(&x2k2.PublicKey)
+	x2pkr.Set(&x2k3.PublicKey)
 
 	xc2 := &XC{
 		pubring: x2pkr,
@@ -84,10 +84,10 @@ func TestImportKey(t *testing.T) {
 	assert.Equal(t, true, x2pkr.Contains(x1k1.Fingerprint()))
 
 	// export & import private key from X2 -> X1
-	buf, err = xc2.ExportPrivateKey(ctx, x2k1.Fingerprint())
+	buf, err = xc2.ExportPrivateKey(x2k1.Fingerprint())
 	require.NoError(t, err)
 
-	assert.NoError(t, xc1.ImportPrivateKey(ctx, buf))
+	assert.NoError(t, xc1.ImportPrivateKey(buf))
 	assert.Equal(t, true, x1pkr.Contains(x2k1.Fingerprint()))
 	assert.Equal(t, true, x1skr.Contains(x2k1.Fingerprint()))
 }

--- a/internal/backend/crypto/xc/keyring/pubring.go
+++ b/internal/backend/crypto/xc/keyring/pubring.go
@@ -152,12 +152,11 @@ func (p *Pubring) Import(buf []byte) error {
 }
 
 // Set inserts a key, possibly overwriting and existing entry
-func (p *Pubring) Set(pk *PublicKey) error {
+func (p *Pubring) Set(pk *PublicKey) {
 	p.Lock()
 	defer p.Unlock()
 
 	p.insert(pubKRToPB(pk))
-	return nil
 }
 
 func (p *Pubring) insert(xpk *xcpb.PublicKey) {

--- a/internal/backend/crypto/xc/keyring/pubring_test.go
+++ b/internal/backend/crypto/xc/keyring/pubring_test.go
@@ -40,8 +40,8 @@ func TestPubring(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, kr)
 
-	assert.NoError(t, kr.Set(&k1.PublicKey))
-	assert.NoError(t, kr.Set(&k2.PublicKey))
+	kr.Set(&k1.PublicKey)
+	kr.Set(&k2.PublicKey)
 
 	assert.NoError(t, kr.Save())
 

--- a/internal/backend/crypto/xc/loader.go
+++ b/internal/backend/crypto/xc/loader.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/gopasspw/gopass/internal/backend"
 	"github.com/gopasspw/gopass/internal/config"
-	"github.com/gopasspw/gopass/internal/out"
+	"github.com/gopasspw/gopass/internal/debug"
 )
 
 const (
@@ -21,8 +21,8 @@ type loader struct{}
 
 // New implements backend.CryptoLoader.
 func (l loader) New(ctx context.Context) (backend.Crypto, error) {
-	out.Debug(ctx, "Using Crypto Backend: %s (EXPERIMENTAL)", name)
-	return New(config.Directory(), nil)
+	debug.Log("Using Crypto Backend: %s (EXPERIMENTAL)", name)
+	return New(config.Directory(), nil), nil
 }
 
 func (l loader) Handles(s backend.Storage) error {

--- a/internal/backend/crypto/xc/xc.go
+++ b/internal/backend/crypto/xc/xc.go
@@ -36,7 +36,7 @@ type XC struct {
 }
 
 // New creates a new XC backend
-func New(dir string, client agentClient) (*XC, error) {
+func New(dir string, client agentClient) *XC {
 	skr, _ := keyring.LoadSecring(filepath.Join(dir, secringFilename))
 	pkr, _ := keyring.LoadPubring(filepath.Join(dir, pubringFilename), skr)
 	if client == nil {
@@ -47,7 +47,7 @@ func New(dir string, client agentClient) (*XC, error) {
 		pubring: pkr,
 		secring: skr,
 		client:  client,
-	}, nil
+	}
 }
 
 // RemoveKey removes a single key from the keyring

--- a/internal/backend/crypto/xc/xc_test.go
+++ b/internal/backend/crypto/xc/xc_test.go
@@ -25,8 +25,7 @@ func TestNew(t *testing.T) {
 	assert.NoError(t, os.Setenv("GOPASS_HOMEDIR", td))
 
 	passphrase := "test"
-	xc, err := New(td, &fakeAgent{passphrase})
-	require.NoError(t, err)
+	xc := New(td, &fakeAgent{passphrase})
 	assert.NotNil(t, xc)
 	assert.NoError(t, xc.Initialized(ctx))
 	assert.Equal(t, "xc", xc.Name())

--- a/internal/backend/rcs.go
+++ b/internal/backend/rcs.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/blang/semver"
-	"github.com/gopasspw/gopass/internal/out"
+	"github.com/gopasspw/gopass/internal/debug"
 	"github.com/pkg/errors"
 )
 
@@ -87,22 +87,22 @@ func DetectRCS(ctx context.Context, path string) (RCS, error) {
 	})
 	for _, id := range bes {
 		be := rcsRegistry[id]
-		out.Debug(ctx, "DetectRCS(%s) - trying %s", path, be)
+		debug.Log("DetectRCS(%s) - trying %s", path, be)
 		if err := be.Handles(path); err != nil {
-			out.Debug(ctx, "failed to use RCS %s for %s", id, path)
+			debug.Log("failed to use RCS %s for %s", id, path)
 			continue
 		}
-		out.Debug(ctx, "DetectRCS(%s) - using %s", path, be)
+		debug.Log("DetectRCS(%s) - using %s", path, be)
 		return be.Open(ctx, path)
 	}
-	out.Debug(ctx, "DetectRCS(%s) - no supported RCS found. using NOOP", path)
+	debug.Log("DetectRCS(%s) - no supported RCS found. using NOOP", path)
 	return rcsRegistry[Noop].InitRCS(ctx, path)
 }
 
 // CloneRCS clones an existing repository from a remote.
 func CloneRCS(ctx context.Context, id RCSBackend, repo, path string) (RCS, error) {
 	if be, found := rcsRegistry[id]; found {
-		out.Debug(ctx, "Cloning with %s", be.String())
+		debug.Log("Cloning with %s", be.String())
 		return be.Clone(ctx, repo, path)
 	}
 	return nil, errors.Wrapf(ErrNotFound, "unknown backend: %d", id)

--- a/internal/backend/rcs/git/cli/config.go
+++ b/internal/backend/rcs/git/cli/config.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/gopasspw/gopass/internal/debug"
 	"github.com/gopasspw/gopass/internal/out"
 	"github.com/gopasspw/gopass/internal/store"
 
@@ -87,7 +88,7 @@ func (g *Git) ConfigGet(ctx context.Context, key string) (string, error) {
 	cmd.Stdout = buf
 	cmd.Stderr = os.Stderr
 
-	out.Debug(ctx, "store.gitConfigGet: %s %+v", cmd.Path, cmd.Args)
+	debug.Log("store.gitConfigGet: %s %+v", cmd.Path, cmd.Args)
 	if err := cmd.Run(); err != nil {
 		return "", err
 	}
@@ -108,7 +109,7 @@ func (g *Git) ConfigList(ctx context.Context) (map[string]string, error) {
 	cmd.Stdout = buf
 	cmd.Stderr = os.Stderr
 
-	out.Debug(ctx, "store.gitConfigList: %s %+v", cmd.Path, cmd.Args)
+	debug.Log("store.gitConfigList: %s %+v", cmd.Path, cmd.Args)
 	if err := cmd.Run(); err != nil {
 		return nil, err
 	}

--- a/internal/backend/rcs/git/cli/config_test.go
+++ b/internal/backend/rcs/git/cli/config_test.go
@@ -27,7 +27,6 @@ func TestGitConfig(t *testing.T) {
 
 	ctx := context.Background()
 	ctx = ctxutil.WithAlwaysYes(ctx, true)
-	ctx = ctxutil.WithDebug(ctx, true)
 
 	buf := &bytes.Buffer{}
 	out.Stdout = buf

--- a/internal/backend/rcs/git/cli/git_test.go
+++ b/internal/backend/rcs/git/cli/git_test.go
@@ -52,7 +52,7 @@ func TestGit(t *testing.T) {
 	assert.Error(t, git.Push(ctx, "origin", "master"))
 	assert.Error(t, git.Pull(ctx, "origin", "master"))
 
-	git, err = Open(gitdir, "")
+	git, err = Open(gitdir)
 	require.NoError(t, err)
 	require.NotNil(t, git)
 	assert.Equal(t, "git", git.Name())

--- a/internal/backend/rcs/git/cli/loader.go
+++ b/internal/backend/rcs/git/cli/loader.go
@@ -6,7 +6,6 @@ import (
 	"path/filepath"
 
 	"github.com/gopasspw/gopass/internal/backend"
-	gpgcli "github.com/gopasspw/gopass/internal/backend/crypto/gpg/cli"
 	"github.com/gopasspw/gopass/pkg/ctxutil"
 	"github.com/gopasspw/gopass/pkg/fsutil"
 )
@@ -23,8 +22,7 @@ type loader struct{}
 
 // Open implements backend.RCSLoader
 func (l loader) Open(ctx context.Context, path string) (backend.RCS, error) {
-	gpgBin, _ := gpgcli.Binary(ctx, "")
-	return Open(path, gpgBin)
+	return Open(path)
 }
 
 // Clone implements backend.RCSLoader

--- a/internal/backend/storage.go
+++ b/internal/backend/storage.go
@@ -6,7 +6,7 @@ import (
 	"sort"
 
 	"github.com/blang/semver"
-	"github.com/gopasspw/gopass/internal/out"
+	"github.com/gopasspw/gopass/internal/debug"
 	"github.com/pkg/errors"
 )
 
@@ -70,12 +70,12 @@ func DetectStorage(ctx context.Context, path string) (Storage, error) {
 	})
 	for _, id := range bes {
 		be := storageRegistry[id]
-		out.Debug(ctx, "DetectStorage(%s) - trying %s", path, be)
+		debug.Log("DetectStorage(%s) - trying %s", path, be)
 		if err := be.Handles(path); err != nil {
-			out.Debug(ctx, "failed to use %s for %s: %s", id, path, err)
+			debug.Log("failed to use %s for %s: %s", id, path, err)
 			continue
 		}
-		out.Debug(ctx, "DetectStorage(%s) - using %s", path, be)
+		debug.Log("DetectStorage(%s) - using %s", path, be)
 		return be.New(ctx, path)
 	}
 	return storageRegistry[FS].Init(ctx, path)

--- a/internal/backend/storage/fs/fsck.go
+++ b/internal/backend/storage/fs/fsck.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"syscall"
 
+	"github.com/gopasspw/gopass/internal/debug"
 	"github.com/gopasspw/gopass/internal/out"
 	"github.com/gopasspw/gopass/pkg/ctxutil"
 	"github.com/gopasspw/gopass/pkg/fsutil"
@@ -22,7 +23,7 @@ func (s *Store) Fsck(ctx context.Context) error {
 	dirs := make(map[string]struct{}, len(entries))
 	for _, entry := range entries {
 		pcb()
-		out.Debug(ctx, "file.Fsck() - Checking %s", entry)
+		debug.Log("file.Fsck() - Checking %s", entry)
 
 		filename := filepath.Join(s.path, entry)
 		dirs[filepath.Dir(filename)] = struct{}{}

--- a/internal/backend/storage/fs/loader.go
+++ b/internal/backend/storage/fs/loader.go
@@ -6,7 +6,7 @@ import (
 	"os"
 
 	"github.com/gopasspw/gopass/internal/backend"
-	"github.com/gopasspw/gopass/internal/out"
+	"github.com/gopasspw/gopass/internal/debug"
 	"github.com/gopasspw/gopass/pkg/fsutil"
 )
 
@@ -26,7 +26,7 @@ func (l loader) New(ctx context.Context, path string) (backend.Storage, error) {
 		return nil, err
 	}
 	be := New(path)
-	out.Debug(ctx, "Using Storage Backend: %s", be.String())
+	debug.Log("Using Storage Backend: %s", be.String())
 	return be, nil
 }
 

--- a/internal/backend/storage/fs/store.go
+++ b/internal/backend/storage/fs/store.go
@@ -13,7 +13,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/gopasspw/gopass/internal/out"
+	"github.com/gopasspw/gopass/internal/debug"
 	"github.com/gopasspw/gopass/pkg/fsutil"
 
 	"github.com/blang/semver"
@@ -40,7 +40,7 @@ func (s *Store) Get(ctx context.Context, name string) ([]byte, error) {
 		name = filepath.FromSlash(name)
 	}
 	path := filepath.Join(s.path, filepath.Clean(name))
-	out.Debug(ctx, "fs.Get(%s) - %s", name, path)
+	debug.Log("fs.Get(%s) - %s", name, path)
 	return ioutil.ReadFile(path)
 }
 
@@ -56,7 +56,7 @@ func (s *Store) Set(ctx context.Context, name string, value []byte) error {
 			return err
 		}
 	}
-	out.Debug(ctx, "fs.Set(%s) - %s", name, filepath.Join(s.path, name))
+	debug.Log("fs.Set(%s) - %s", name, filepath.Join(s.path, name))
 	return ioutil.WriteFile(filepath.Join(s.path, name), value, 0644)
 }
 
@@ -66,7 +66,7 @@ func (s *Store) Delete(ctx context.Context, name string) error {
 		name = filepath.FromSlash(name)
 	}
 	path := filepath.Join(s.path, filepath.Clean(name))
-	out.Debug(ctx, "fs.Delete(%s) - %s", name, path)
+	debug.Log("fs.Delete(%s) - %s", name, path)
 
 	if err := os.Remove(path); err != nil {
 		return err
@@ -106,7 +106,7 @@ func (s *Store) Exists(ctx context.Context, name string) bool {
 		name = filepath.FromSlash(name)
 	}
 	path := filepath.Join(s.path, filepath.Clean(name))
-	out.Debug(ctx, "fs.Exists(%s) - %s", name, path)
+	debug.Log("fs.Exists(%s) - %s", name, path)
 	return fsutil.IsFile(path)
 }
 
@@ -115,7 +115,7 @@ func (s *Store) Exists(ctx context.Context, name string) bool {
 // directory separator are normalized using `/`
 func (s *Store) List(ctx context.Context, prefix string) ([]string, error) {
 	prefix = strings.TrimPrefix(prefix, "/")
-	out.Debug(ctx, "fs.List(%s)", prefix)
+	debug.Log("fs.List(%s)", prefix)
 	files := make([]string, 0, 100)
 	if err := filepath.Walk(s.path, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
@@ -153,14 +153,14 @@ func (s *Store) IsDir(ctx context.Context, name string) bool {
 	}
 	path := filepath.Join(s.path, filepath.Clean(name))
 	isDir := fsutil.IsDir(path)
-	out.Debug(ctx, "fs.Isdir(%s) - %s -> %t", name, path, isDir)
+	debug.Log("fs.Isdir(%s) - %s -> %t", name, path, isDir)
 	return isDir
 }
 
 // Prune removes a named directory
 func (s *Store) Prune(ctx context.Context, prefix string) error {
 	path := filepath.Join(s.path, filepath.Clean(prefix))
-	out.Debug(ctx, "fs.Prune(%s) - %s", prefix, path)
+	debug.Log("fs.Prune(%s) - %s", prefix, path)
 	return os.RemoveAll(path)
 }
 

--- a/internal/backend/storage/kv/ondisk/fsck.go
+++ b/internal/backend/storage/kv/ondisk/fsck.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/gopasspw/gopass/internal/debug"
 	"github.com/gopasspw/gopass/internal/out"
 	"github.com/gopasspw/gopass/pkg/ctxutil"
 	"github.com/gopasspw/gopass/pkg/fsutil"
@@ -19,7 +20,7 @@ import (
 func (o *OnDisk) Fsck(ctx context.Context) error {
 	pcb := ctxutil.GetProgressCallback(ctx)
 
-	if err := o.Compact(ctx); err != nil {
+	if err := o.Compact(); err != nil {
 		return err
 	}
 
@@ -45,7 +46,7 @@ func (o *OnDisk) Fsck(ctx context.Context) error {
 			out.Print(ctx, "Skipping unknown dir: %s", path)
 			return filepath.SkipDir
 		}
-		out.Debug(ctx, "Checking: %s", path)
+		debug.Log("Checking: %s", path)
 		if fi.IsDir() {
 			return o.fsckCheckDir(ctx, path, fi)
 		}

--- a/internal/backend/storage/kv/ondisk/loader.go
+++ b/internal/backend/storage/kv/ondisk/loader.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 
 	"github.com/gopasspw/gopass/internal/backend"
-	"github.com/gopasspw/gopass/internal/out"
+	"github.com/gopasspw/gopass/internal/debug"
 	"github.com/gopasspw/gopass/pkg/fsutil"
 )
 
@@ -25,14 +25,14 @@ type loader struct{}
 // New creates a new ondisk loader
 func (l loader) New(ctx context.Context, path string) (backend.Storage, error) {
 	be, err := New(path)
-	out.Debug(ctx, "Using Storage Backend: %s", path)
+	debug.Log("Using Storage Backend: %s", path)
 	return be, err
 }
 
 // Open loads an existing ondisk repo
 func (l loader) Open(ctx context.Context, path string) (backend.RCS, error) {
 	be, err := New(path)
-	out.Debug(ctx, "Using RCS Backend: %s", be.String())
+	debug.Log("Using RCS Backend: %s", be.String())
 	return be, err
 }
 
@@ -40,7 +40,7 @@ func (l loader) Open(ctx context.Context, path string) (backend.RCS, error) {
 // WARNING: DOES NOT SUPPORT CLONE (yet)
 func (l loader) Clone(ctx context.Context, repo, path string) (backend.RCS, error) {
 	be, err := New(path)
-	out.Debug(ctx, "Using RCS Backend: %s", be.String())
+	debug.Log("Using RCS Backend: %s", be.String())
 	return be, err
 }
 
@@ -50,7 +50,7 @@ func (l loader) InitRCS(ctx context.Context, path string) (backend.RCS, error) {
 		return nil, err
 	}
 	be, err := New(path)
-	out.Debug(ctx, "Using RCS Backend: %s", be.String())
+	debug.Log("Using RCS Backend: %s", be.String())
 	return be, err
 }
 
@@ -59,7 +59,7 @@ func (l loader) Init(ctx context.Context, path string) (backend.Storage, error) 
 		return nil, err
 	}
 	be, err := New(path)
-	out.Debug(ctx, "Using RCS Backend: %s", be.String())
+	debug.Log("Using RCS Backend: %s", be.String())
 	return be, err
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 	"reflect"
 	"strconv"
@@ -16,14 +15,7 @@ var (
 	ErrConfigNotFound = errors.Errorf("config not found")
 	// ErrConfigNotParsed is returned on load if the config could not be decoded
 	ErrConfigNotParsed = errors.Errorf("config not parseable")
-	debug              = false
 )
-
-func init() {
-	if gdb := os.Getenv("GOPASS_DEBUG"); gdb != "" {
-		debug = true
-	}
-}
 
 // Config is the current config struct
 type Config struct {
@@ -62,7 +54,7 @@ func New() *Config {
 // CheckOverflow implements configer. It will check for any extra config values not
 // handled by the current struct
 func (c *Config) CheckOverflow() error {
-	return checkOverflow(c.XXX, "config")
+	return checkOverflow(c.XXX)
 }
 
 // Config will return a current config

--- a/internal/config/legacy.go
+++ b/internal/config/legacy.go
@@ -37,7 +37,7 @@ type Pre193StoreConfig struct {
 
 // CheckOverflow implements configer
 func (c *Pre193) CheckOverflow() error {
-	return checkOverflow(c.XXX, "config")
+	return checkOverflow(c.XXX)
 }
 
 // Config converts the Pre140 config to the current config struct
@@ -101,7 +101,7 @@ type Pre182StoreConfig struct {
 
 // CheckOverflow implements configer
 func (c *Pre182) CheckOverflow() error {
-	return checkOverflow(c.XXX, "config")
+	return checkOverflow(c.XXX)
 }
 
 // Config converts the Pre140 config to the current config struct
@@ -150,7 +150,7 @@ type Pre140 struct {
 
 // CheckOverflow implements configer
 func (c *Pre140) CheckOverflow() error {
-	return checkOverflow(c.XXX, "config")
+	return checkOverflow(c.XXX)
 }
 
 // Config converts the Pre140 config to the current config struct
@@ -191,7 +191,7 @@ type Pre130 struct {
 
 // CheckOverflow implements configer
 func (c *Pre130) CheckOverflow() error {
-	return checkOverflow(c.XXX, "config")
+	return checkOverflow(c.XXX)
 }
 
 // Config converts the Pre130 config to the current config struct

--- a/internal/config/location.go
+++ b/internal/config/location.go
@@ -1,11 +1,11 @@
 package config
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 
+	"github.com/gopasspw/gopass/internal/debug"
 	"github.com/gopasspw/gopass/pkg/appdir"
 	"github.com/gopasspw/gopass/pkg/fsutil"
 
@@ -19,9 +19,7 @@ func Homedir() string {
 	}
 	hd, err := homedir.Dir()
 	if err != nil {
-		if debug {
-			fmt.Printf("[DEBUG] Failed to get homedir: %s\n", err)
-		}
+		debug.Log("Failed to get homedir: %s\n", err)
 		return ""
 	}
 	return hd

--- a/internal/cui/recipients.go
+++ b/internal/cui/recipients.go
@@ -74,7 +74,7 @@ func (r recipientInfos) Less(i, j int) bool {
 	return r[i].name < r[j].name
 }
 
-func getRecipientInfo(ctx context.Context, crypto backend.Crypto, name string, recipients []string) (recipientInfos, error) {
+func getRecipientInfo(ctx context.Context, crypto backend.Crypto, recipients []string) (recipientInfos, error) {
 	ris := make(recipientInfos, 0, len(recipients))
 
 	for _, r := range recipients {
@@ -109,7 +109,7 @@ func ConfirmRecipients(ctx context.Context, crypto backend.Crypto, name string, 
 		return recipients, nil
 	}
 
-	ris, err := getRecipientInfo(ctx, crypto, name, recipients)
+	ris, err := getRecipientInfo(ctx, crypto, recipients)
 	if err != nil {
 		return nil, err
 	}
@@ -185,7 +185,7 @@ func confirmEditRecipients(ctx context.Context, name string, ris recipientInfos)
 }
 
 // AskForPrivateKey promts the user to select from a list of private keys
-func AskForPrivateKey(ctx context.Context, crypto backend.Crypto, name, prompt string) (string, error) {
+func AskForPrivateKey(ctx context.Context, crypto backend.Crypto, prompt string) (string, error) {
 	if !ctxutil.IsInteractive(ctx) {
 		return "", errors.New("can not select private key without terminal")
 	}
@@ -237,7 +237,7 @@ func AskForPrivateKey(ctx context.Context, crypto backend.Crypto, name, prompt s
 // On error or no selection, name and email will be empty.
 // If s.isTerm is false (i.e., the user cannot be prompted), however,
 // the first identity's name/email pair found is returned.
-func AskForGitConfigUser(ctx context.Context, crypto backend.Crypto, name string) (string, string, error) {
+func AskForGitConfigUser(ctx context.Context, crypto backend.Crypto) (string, string, error) {
 	var useCurrent bool
 
 	keyList, err := crypto.ListIdentities(ctx)

--- a/internal/cui/recipients_test.go
+++ b/internal/cui/recipients_test.go
@@ -55,7 +55,7 @@ func TestAskForPrivateKey(t *testing.T) {
 	ctx := context.Background()
 
 	ctx = ctxutil.WithAlwaysYes(ctx, true)
-	key, err := AskForPrivateKey(ctx, plain.New(), "test", "test")
+	key, err := AskForPrivateKey(ctx, plain.New(), "test")
 	require.NoError(t, err)
 	assert.Equal(t, "0xDEADBEEF", key)
 	buf.Reset()
@@ -69,7 +69,7 @@ func TestAskForGitConfigUser(t *testing.T) {
 	ctx = ctxutil.WithTerminal(ctx, true)
 	ctx = ctxutil.WithAlwaysYes(ctx, true)
 
-	_, _, err := AskForGitConfigUser(ctx, plain.New(), "test")
+	_, _, err := AskForGitConfigUser(ctx, plain.New())
 	assert.NoError(t, err)
 }
 

--- a/internal/debug/debug.go
+++ b/internal/debug/debug.go
@@ -1,0 +1,220 @@
+package debug
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"path"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+var (
+	// Stdout is exported for tests
+	Stdout io.Writer = os.Stdout
+	// Stderr is exported for tests
+	Stderr io.Writer = os.Stderr
+)
+
+var opts struct {
+	logger *log.Logger
+	funcs  map[string]bool
+	files  map[string]bool
+}
+
+var logFn = doNotLog
+
+// make sure all initializations happens before the init func
+var enabled = initDebug()
+
+func initDebug() bool {
+	if os.Getenv("GOPASS_DEBUG") == "" && os.Getenv("GOPASS_DEBUG_LOG") == "" {
+		logFn = doNotLog
+		return false
+	}
+
+	initDebugLogger()
+	initDebugTags()
+	logFn = doLog
+
+	fmt.Fprintf(Stderr, "debug enabled\n")
+
+	return true
+}
+
+func initDebugLogger() {
+	debugfile := os.Getenv("GOPASS_DEBUG_LOG")
+	if debugfile == "" {
+		return
+	}
+
+	fmt.Fprintf(Stderr, "debug log file %v\n", debugfile)
+
+	f, err := os.OpenFile(debugfile, os.O_WRONLY|os.O_APPEND, 0600)
+	if err == nil {
+		_, err := f.Seek(2, 0)
+		if err != nil {
+			fmt.Fprintf(Stderr, "unable to seek to end of %v: %v\n", debugfile, err)
+			os.Exit(3)
+		}
+	}
+	if err != nil && os.IsNotExist(err) {
+		f, err = os.OpenFile(debugfile, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
+	}
+
+	if err != nil {
+		fmt.Fprintf(Stderr, "unable to open debug log file %v: %v\n", debugfile, err)
+		os.Exit(2)
+	}
+
+	opts.logger = log.New(f, "", log.LstdFlags)
+}
+
+func parseFilter(envname string, pad func(string) string) map[string]bool {
+	filter := make(map[string]bool)
+
+	env := os.Getenv(envname)
+	if env == "" {
+		return filter
+	}
+
+	for _, fn := range strings.Split(env, ",") {
+		t := pad(strings.TrimSpace(fn))
+		val := true
+		if t[0] == '-' {
+			val = false
+			t = t[1:]
+		} else if t[0] == '+' {
+			val = true
+			t = t[1:]
+		}
+
+		// test pattern
+		_, err := path.Match(t, "")
+		if err != nil {
+			fmt.Fprintf(Stderr, "error: invalid pattern %q: %v\n", t, err)
+			os.Exit(5)
+		}
+
+		filter[t] = val
+	}
+
+	return filter
+}
+
+func padFunc(s string) string {
+	if s == "all" {
+		return s
+	}
+
+	return s
+}
+
+func padFile(s string) string {
+	if s == "all" {
+		return s
+	}
+
+	if !strings.Contains(s, "/") {
+		s = "*/" + s
+	}
+
+	if !strings.Contains(s, ":") {
+		s = s + ":*"
+	}
+
+	return s
+}
+
+func initDebugTags() {
+	opts.funcs = parseFilter("GOPASS_DEBUG_FUNCS", padFunc)
+	opts.files = parseFilter("GOPASS_DEBUG_FILES", padFile)
+}
+
+func getPosition() (fn, dir, file string, line int) {
+	pc, file, line, ok := runtime.Caller(3)
+	if !ok {
+		return "", "", "", 0
+	}
+
+	dirname := filepath.Base(filepath.Dir(file))
+	filename := filepath.Base(file)
+
+	f := runtime.FuncForPC(pc)
+	return path.Base(f.Name()), dirname, filename, line
+}
+
+func checkFilter(filter map[string]bool, key string) bool {
+	// check if exact match
+	if v, ok := filter[key]; ok {
+		return v
+	}
+
+	// check globbing
+	for k, v := range filter {
+		if m, _ := path.Match(k, key); m {
+			return v
+		}
+	}
+
+	// check if tag "all" is enabled
+	if v, ok := filter["all"]; ok && v {
+		return true
+	}
+
+	return false
+}
+
+// Log logs a statement to Stderr (unless filtered) and the
+// debug log file (if enabled).
+func Log(f string, args ...interface{}) {
+	logFn(f, args...)
+}
+
+func doNotLog(f string, args ...interface{}) {}
+
+func doLog(f string, args ...interface{}) {
+	fn, dir, file, line := getPosition()
+	if len(f) == 0 || f[len(f)-1] != '\n' {
+		f += "\n"
+	}
+
+	type Shortener interface {
+		Str() string
+	}
+
+	for i, item := range args {
+		if shortener, ok := item.(Shortener); ok {
+			args[i] = shortener.Str()
+		}
+	}
+
+	pos := fmt.Sprintf("%s/%s:%d", dir, file, line)
+
+	formatString := fmt.Sprintf("%s\t%s\t%s", pos, fn, f)
+
+	dbgprint := func() {
+		fmt.Fprintf(Stderr, formatString, args...)
+	}
+
+	if opts.logger != nil {
+		opts.logger.Printf(formatString, args...)
+	}
+
+	filename := fmt.Sprintf("%s/%s:%d", dir, file, line)
+	if checkFilter(opts.files, filename) {
+		dbgprint()
+		return
+	}
+
+	if checkFilter(opts.funcs, fn) {
+		dbgprint()
+	}
+}
+
+// IsEnabled returns true if debug logging was enabled
+func IsEnabled() bool {
+	return enabled
+}

--- a/internal/debug/debug_test.go
+++ b/internal/debug/debug_test.go
@@ -1,0 +1,25 @@
+package debug
+
+import (
+	"os"
+	"testing"
+)
+
+func BenchmarkLogging(b *testing.B) {
+	os.Setenv("GOPASS_DEBUG", "true")
+	defer func() { os.Unsetenv("GOPASS_DEBUG") }()
+	initDebug()
+
+	for i := 0; i < b.N; i++ {
+		Log("string")
+	}
+}
+
+func BenchmarkNoLogging(b *testing.B) {
+	os.Unsetenv("GOPASS_DEBUG")
+	initDebug()
+
+	for i := 0; i < b.N; i++ {
+		Log("string")
+	}
+}

--- a/internal/debug/doc.go
+++ b/internal/debug/doc.go
@@ -1,0 +1,4 @@
+// Package debug provides logging of debug information.
+//
+// This package is heavily based on github.com/restic/restic/internal/debug
+package debug

--- a/internal/editor/editor.go
+++ b/internal/editor/editor.go
@@ -9,7 +9,7 @@ import (
 	"os/exec"
 	"runtime"
 
-	"github.com/gopasspw/gopass/internal/out"
+	"github.com/gopasspw/gopass/internal/debug"
 	"github.com/gopasspw/gopass/pkg/ctxutil"
 	"github.com/gopasspw/gopass/pkg/tempfile"
 
@@ -69,7 +69,7 @@ func Invoke(ctx context.Context, editor string, content []byte) ([]byte, error) 
 	cmd.Stderr = Stderr
 
 	if err := cmd.Run(); err != nil {
-		out.Debug(ctx, "editor - cmd: %s %+v - error: %+v", cmd.Path, cmd.Args, err)
+		debug.Log("editor - cmd: %s %+v - error: %+v", cmd.Path, cmd.Args, err)
 		return []byte{}, errors.Errorf("failed to run %s with %s file: %s", editor, tmpfile.Name(), err)
 	}
 

--- a/internal/notify/notify_darwin_test.go
+++ b/internal/notify/notify_darwin_test.go
@@ -3,10 +3,11 @@ package notify
 import (
 	"context"
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"os"
 	"os/exec"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 //to test cmd.exec correctly we use the same functionality as go itself see exec_test.go

--- a/internal/notify/notify_dbus.go
+++ b/internal/notify/notify_dbus.go
@@ -6,7 +6,7 @@ import (
 	"context"
 	"os"
 
-	"github.com/gopasspw/gopass/internal/out"
+	"github.com/gopasspw/gopass/internal/debug"
 	"github.com/gopasspw/gopass/pkg/ctxutil"
 
 	"github.com/godbus/dbus"
@@ -15,19 +15,19 @@ import (
 // Notify displays a desktop notification with dbus
 func Notify(ctx context.Context, subj, msg string) error {
 	if os.Getenv("GOPASS_NO_NOTIFY") != "" || !ctxutil.IsNotifications(ctx) {
-		out.Debug(ctx, "Notifications disabled")
+		debug.Log("Notifications disabled")
 		return nil
 	}
 	conn, err := dbus.SessionBus()
 	if err != nil {
-		out.Debug(ctx, "DBus failure: %s", err)
+		debug.Log("DBus failure: %s", err)
 		return err
 	}
 
 	obj := conn.Object("org.freedesktop.Notifications", "/org/freedesktop/Notifications")
 	call := obj.Call("org.freedesktop.Notifications.Notify", 0, "gopass", uint32(0), iconURI(), subj, msg, []string{}, map[string]dbus.Variant{}, int32(5000))
 	if call.Err != nil {
-		out.Debug(ctx, "DBus notification failure: %s", call.Err)
+		debug.Log("DBus notification failure: %s", call.Err)
 		return err
 	}
 

--- a/internal/otp/otp.go
+++ b/internal/otp/otp.go
@@ -1,7 +1,6 @@
 package otp
 
 import (
-	"context"
 	"io/ioutil"
 	"strings"
 
@@ -16,7 +15,7 @@ type otpSecret interface {
 }
 
 // Calculate will compute a OTP code from a given secret
-func Calculate(ctx context.Context, name string, sec otpSecret) (twofactor.OTP, string, error) {
+func Calculate(name string, sec otpSecret) (twofactor.OTP, string, error) {
 	otpURL := ""
 	// check body
 	for _, line := range strings.Split(sec.Body(), "\n") {
@@ -46,7 +45,7 @@ func Calculate(ctx context.Context, name string, sec otpSecret) (twofactor.OTP, 
 }
 
 // WriteQRFile writes the given OTP code as a QR image to disk
-func WriteQRFile(ctx context.Context, otp twofactor.OTP, label, file string) error {
+func WriteQRFile(otp twofactor.OTP, label, file string) error {
 	var qr []byte
 	var err error
 	switch otp.Type() {

--- a/internal/otp/otp_test.go
+++ b/internal/otp/otp_test.go
@@ -1,7 +1,6 @@
 package otp
 
 import (
-	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -31,7 +30,7 @@ func TestCalculate(t *testing.T) {
 
 	for _, tc := range testCases {
 		s := secret.New(tc.password, tc.secretContents)
-		otp, _, err := Calculate(context.Background(), "test", s)
+		otp, _, err := Calculate("test", s)
 		assert.Nil(t, err)
 		assert.NotNil(t, otp)
 	}
@@ -47,5 +46,5 @@ func TestWrite(t *testing.T) {
 
 	otp, label, err := twofactor.FromURL(totpURL)
 	assert.NoError(t, err)
-	assert.NoError(t, WriteQRFile(context.Background(), otp, label, tf))
+	assert.NoError(t, WriteQRFile(otp, label, tf))
 }

--- a/internal/out/print.go
+++ b/internal/out/print.go
@@ -5,10 +5,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"runtime"
-	"strings"
-
-	"github.com/gopasspw/gopass/pkg/ctxutil"
 
 	"github.com/fatih/color"
 )
@@ -29,37 +25,15 @@ func newline(ctx context.Context) string {
 
 // Print formats and prints the given string
 func Print(ctx context.Context, format string, args ...interface{}) {
-	if IsHidden(ctx) && !ctxutil.IsDebug(ctx) {
+	if IsHidden(ctx) {
 		return
 	}
 	fmt.Fprintf(Stdout, Prefix(ctx)+format+newline(ctx), args...)
 }
 
-// Debug prints the given string if the debug flag is set
-func Debug(ctx context.Context, format string, args ...interface{}) {
-	if !ctxutil.IsDebug(ctx) {
-		return
-	}
-
-	var loc string
-	if _, file, line, ok := runtime.Caller(1); ok {
-		for _, prefix := range []string{"pkg", "internal"} {
-			si := strings.Index(file, prefix+"/")
-			if si < 0 {
-				continue
-			}
-			file = file[si:]
-			file = strings.TrimPrefix(file, "pkg/")
-			loc = fmt.Sprintf("%s:%d ", file, line)
-		}
-	}
-
-	fmt.Fprintf(Stdout, Prefix(ctx)+"[DEBUG] "+loc+format+newline(ctx), args...)
-}
-
 // Black prints the string in black
 func Black(ctx context.Context, format string, args ...interface{}) {
-	if IsHidden(ctx) && !ctxutil.IsDebug(ctx) {
+	if IsHidden(ctx) {
 		return
 	}
 	fmt.Fprint(Stdout, color.BlackString(Prefix(ctx)+format+newline(ctx), args...))
@@ -67,7 +41,7 @@ func Black(ctx context.Context, format string, args ...interface{}) {
 
 // Blue prints the string in blue
 func Blue(ctx context.Context, format string, args ...interface{}) {
-	if IsHidden(ctx) && !ctxutil.IsDebug(ctx) {
+	if IsHidden(ctx) {
 		return
 	}
 	fmt.Fprint(Stdout, color.BlueString(Prefix(ctx)+format+newline(ctx), args...))
@@ -75,7 +49,7 @@ func Blue(ctx context.Context, format string, args ...interface{}) {
 
 // Cyan prints the string in cyan
 func Cyan(ctx context.Context, format string, args ...interface{}) {
-	if IsHidden(ctx) && !ctxutil.IsDebug(ctx) {
+	if IsHidden(ctx) {
 		return
 	}
 	fmt.Fprint(Stdout, color.CyanString(Prefix(ctx)+format+newline(ctx), args...))
@@ -83,7 +57,7 @@ func Cyan(ctx context.Context, format string, args ...interface{}) {
 
 // Green prints the string in green
 func Green(ctx context.Context, format string, args ...interface{}) {
-	if IsHidden(ctx) && !ctxutil.IsDebug(ctx) {
+	if IsHidden(ctx) {
 		return
 	}
 	fmt.Fprint(Stdout, color.GreenString(Prefix(ctx)+format+newline(ctx), args...))
@@ -91,7 +65,7 @@ func Green(ctx context.Context, format string, args ...interface{}) {
 
 // Magenta prints the string in magenta
 func Magenta(ctx context.Context, format string, args ...interface{}) {
-	if IsHidden(ctx) && !ctxutil.IsDebug(ctx) {
+	if IsHidden(ctx) {
 		return
 	}
 	fmt.Fprint(Stdout, color.MagentaString(Prefix(ctx)+format+newline(ctx), args...))
@@ -99,7 +73,7 @@ func Magenta(ctx context.Context, format string, args ...interface{}) {
 
 // Red prints the string in red
 func Red(ctx context.Context, format string, args ...interface{}) {
-	if IsHidden(ctx) && !ctxutil.IsDebug(ctx) {
+	if IsHidden(ctx) {
 		return
 	}
 	fmt.Fprint(Stdout, color.RedString(Prefix(ctx)+format+newline(ctx), args...))
@@ -107,7 +81,7 @@ func Red(ctx context.Context, format string, args ...interface{}) {
 
 // Error prints the string in red to stderr
 func Error(ctx context.Context, format string, args ...interface{}) {
-	if IsHidden(ctx) && !ctxutil.IsDebug(ctx) {
+	if IsHidden(ctx) {
 		return
 	}
 	fmt.Fprint(Stderr, color.RedString(Prefix(ctx)+format+newline(ctx), args...))
@@ -115,7 +89,7 @@ func Error(ctx context.Context, format string, args ...interface{}) {
 
 // White prints the string in white
 func White(ctx context.Context, format string, args ...interface{}) {
-	if IsHidden(ctx) && !ctxutil.IsDebug(ctx) {
+	if IsHidden(ctx) {
 		return
 	}
 	fmt.Fprint(Stdout, color.WhiteString(Prefix(ctx)+format+newline(ctx), args...))
@@ -123,7 +97,7 @@ func White(ctx context.Context, format string, args ...interface{}) {
 
 // Yellow prints the string in yellow
 func Yellow(ctx context.Context, format string, args ...interface{}) {
-	if IsHidden(ctx) && !ctxutil.IsDebug(ctx) {
+	if IsHidden(ctx) {
 		return
 	}
 	fmt.Fprint(Stdout, color.YellowString(Prefix(ctx)+format+newline(ctx), args...))

--- a/internal/out/print_test.go
+++ b/internal/out/print_test.go
@@ -6,8 +6,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/gopasspw/gopass/pkg/ctxutil"
-
 	"github.com/fatih/color"
 	"github.com/stretchr/testify/assert"
 )
@@ -31,23 +29,6 @@ func TestPrint(t *testing.T) {
 	Print(WithNewline(ctx, false), "%s = %d", "foo", 42)
 	assert.Equal(t, "foo = 42", buf.String())
 	buf.Reset()
-}
-
-func TestDebug(t *testing.T) {
-	ctx := context.Background()
-	buf := &bytes.Buffer{}
-	Stdout = buf
-	defer func() {
-		Stdout = os.Stdout
-	}()
-
-	Debug(ctx, "foobar")
-	assert.Equal(t, "", buf.String())
-
-	ctx = ctxutil.WithDebug(ctx, true)
-	Debug(ctx, "foobar")
-	assert.Contains(t, buf.String(), "[DEBUG]")
-	assert.Contains(t, buf.String(), "foobar")
 }
 
 func TestColor(t *testing.T) {

--- a/internal/store/leaf/fsck.go
+++ b/internal/store/leaf/fsck.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/gopasspw/gopass/internal/debug"
 	"github.com/gopasspw/gopass/internal/out"
 	"github.com/gopasspw/gopass/pkg/ctxutil"
 
@@ -14,7 +15,7 @@ import (
 // Fsck checks all entries matching the given prefix
 func (s *Store) Fsck(ctx context.Context, path string) error {
 	ctx = out.AddPrefix(ctx, "["+s.alias+"] ")
-	out.Debug(ctx, "Fsck(%s)", path)
+	debug.Log("Fsck(%s)", path)
 
 	// first let the storage backend check itself
 	if err := s.storage.Fsck(ctx); err != nil {
@@ -35,7 +36,7 @@ func (s *Store) Fsck(ctx context.Context, path string) error {
 		if strings.HasPrefix(name, s.alias+"/") {
 			name = strings.TrimPrefix(name, s.alias+"/")
 		}
-		out.Debug(ctx, "sub.Fsck(%s) - Checking %s", path, name)
+		debug.Log("sub.Fsck(%s) - Checking %s", path, name)
 		if err := s.fsckCheckEntry(ctx, name); err != nil {
 			return errors.Wrapf(err, "failed to check %s: %s", name, err)
 		}

--- a/internal/store/leaf/git.go
+++ b/internal/store/leaf/git.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/gopasspw/gopass/internal/backend"
 	_ "github.com/gopasspw/gopass/internal/backend/rcs" // register RCS backends
+	"github.com/gopasspw/gopass/internal/debug"
 	"github.com/gopasspw/gopass/internal/out"
 	"github.com/gopasspw/gopass/internal/store"
 	"github.com/gopasspw/gopass/internal/store/secret"
@@ -43,13 +44,13 @@ func (s *Store) GetRevision(ctx context.Context, name, revision string) (store.S
 
 	content, err := s.crypto.Decrypt(ctx, ciphertext)
 	if err != nil {
-		out.Debug(ctx, "Decryption failed: %s", err)
+		debug.Log("Decryption failed: %s", err)
 		return nil, store.ErrDecrypt
 	}
 
 	sec, err := secret.Parse(content)
 	if err != nil {
-		out.Debug(ctx, "Failed to parse YAML: %s", err)
+		debug.Log("Failed to parse YAML: %s", err)
 	}
 	return sec, nil
 }

--- a/internal/store/leaf/gpg.go
+++ b/internal/store/leaf/gpg.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 
 	"github.com/gopasspw/gopass/internal/backend"
+	"github.com/gopasspw/gopass/internal/debug"
 	"github.com/gopasspw/gopass/internal/out"
 	"github.com/gopasspw/gopass/pkg/ctxutil"
 
@@ -25,7 +26,7 @@ func (s *Store) ImportMissingPublicKeys(ctx context.Context) error {
 		return errors.Wrapf(err, "failed to get recipients")
 	}
 	for _, r := range rs {
-		out.Debug(ctx, "Checking recipients %s ...", r)
+		debug.Log("Checking recipients %s ...", r)
 		// check if this recipient is missing
 		// we could list all keys outside the loop and just do the lookup here
 		// but this way we ensure to use the exact same lookup logic as
@@ -35,7 +36,7 @@ func (s *Store) ImportMissingPublicKeys(ctx context.Context) error {
 			out.Error(ctx, "[%s] Failed to get public key for %s: %s", s.alias, r, err)
 		}
 		if len(kl) > 0 {
-			out.Debug(ctx, "[%s] Keyring contains %d public keys for %s", s.alias, len(kl), r)
+			debug.Log("[%s] Keyring contains %d public keys for %s", s.alias, len(kl), r)
 			continue
 		}
 
@@ -54,7 +55,7 @@ func (s *Store) ImportMissingPublicKeys(ctx context.Context) error {
 			}
 		}
 
-		out.Debug(ctx, "[%s] Public Key %s not found in keyring, importing", s.alias, r)
+		debug.Log("[%s] Public Key %s not found in keyring, importing", s.alias, r)
 
 		// try to load this recipient
 		if err := s.importPublicKey(ctx, r); err != nil {
@@ -70,7 +71,7 @@ func (s *Store) decodePublicKey(ctx context.Context, r string) ([]string, error)
 	for _, kd := range []string{keyDir, oldKeyDir} {
 		filename := filepath.Join(kd, r)
 		if !s.storage.Exists(ctx, filename) {
-			out.Debug(ctx, "Public Key %s not found at %s", r, filename)
+			debug.Log("Public Key %s not found at %s", r, filename)
 			continue
 		}
 		buf, err := s.storage.Get(ctx, filename)
@@ -113,7 +114,7 @@ func (s *Store) importPublicKey(ctx context.Context, r string) error {
 	for _, kd := range []string{keyDir, oldKeyDir} {
 		filename := filepath.Join(kd, r)
 		if !s.storage.Exists(ctx, filename) {
-			out.Debug(ctx, "Public Key %s not found at %s", r, filename)
+			debug.Log("Public Key %s not found at %s", r, filename)
 			continue
 		}
 		pk, err := s.storage.Get(ctx, filename)

--- a/internal/store/leaf/list.go
+++ b/internal/store/leaf/list.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"strings"
 
-	"github.com/gopasspw/gopass/internal/out"
+	"github.com/gopasspw/gopass/internal/debug"
 )
 
 var (
@@ -21,7 +21,7 @@ func (s *Store) List(ctx context.Context, prefix string) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	out.Debug(ctx, "sub.List(%s): %+v\n", prefix, lst)
+	debug.Log("sub.List(%s): %+v\n", prefix, lst)
 	out := make([]string, 0, len(lst))
 	cExt := "." + s.crypto.Ext()
 	for _, path := range lst {

--- a/internal/store/leaf/move.go
+++ b/internal/store/leaf/move.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/gopasspw/gopass/internal/out"
+	"github.com/gopasspw/gopass/internal/debug"
 	"github.com/gopasspw/gopass/internal/store"
 	"github.com/gopasspw/gopass/pkg/ctxutil"
 
@@ -88,9 +88,9 @@ func (s *Store) delete(ctx context.Context, name string, recurse bool) error {
 	if err := s.rcs.Commit(ctx, fmt.Sprintf("Remove %s from store.", name)); err != nil {
 		switch errors.Cause(err) {
 		case store.ErrGitNotInit:
-			out.Debug(ctx, "move - skipping git commit - git not initialized")
+			debug.Log("move - skipping git commit - git not initialized")
 		case store.ErrGitNothingToCommit:
-			out.Debug(ctx, "move - skipping git commit - nothing to commit")
+			debug.Log("move - skipping git commit - nothing to commit")
 		default:
 			return errors.Wrapf(err, "failed to commit changes to git")
 		}
@@ -113,7 +113,7 @@ func (s *Store) deleteRecurse(ctx context.Context, name, path string) error {
 
 	name = strings.TrimPrefix(name, string(filepath.Separator))
 
-	out.Debug(ctx, "Pruning %s", name)
+	debug.Log("Pruning %s", name)
 	if err := s.storage.Prune(ctx, name); err != nil {
 		return err
 	}
@@ -132,7 +132,7 @@ func (s *Store) deleteSingle(ctx context.Context, path string) error {
 		return store.ErrNotFound
 	}
 
-	out.Debug(ctx, "Deleting %s", path)
+	debug.Log("Deleting %s", path)
 	if err := s.storage.Delete(ctx, path); err != nil {
 		return err
 	}

--- a/internal/store/leaf/rcs.go
+++ b/internal/store/leaf/rcs.go
@@ -4,15 +4,13 @@ import (
 	"context"
 
 	"github.com/gopasspw/gopass/internal/backend"
-	"github.com/gopasspw/gopass/internal/out"
+	"github.com/gopasspw/gopass/internal/debug"
 )
 
-func (s *Store) initRCSBackend(ctx context.Context) error {
+func (s *Store) initRCSBackend(ctx context.Context) {
 	rcs, err := backend.DetectRCS(ctx, s.path)
 	if err != nil {
-		out.Debug(ctx, "Failed to initialized RCS backend: %s", err)
-		return nil
+		debug.Log("Failed to initialized RCS backend: %s", err)
 	}
 	s.rcs = rcs
-	return nil
 }

--- a/internal/store/leaf/read.go
+++ b/internal/store/leaf/read.go
@@ -3,6 +3,7 @@ package leaf
 import (
 	"context"
 
+	"github.com/gopasspw/gopass/internal/debug"
 	"github.com/gopasspw/gopass/internal/out"
 	"github.com/gopasspw/gopass/internal/store"
 	"github.com/gopasspw/gopass/internal/store/secret"
@@ -14,7 +15,7 @@ func (s *Store) Get(ctx context.Context, name string) (store.Secret, error) {
 
 	ciphertext, err := s.storage.Get(ctx, p)
 	if err != nil {
-		out.Debug(ctx, "File %s not found: %s", p, err)
+		debug.Log("File %s not found: %s", p, err)
 		return nil, store.ErrNotFound
 	}
 
@@ -26,7 +27,7 @@ func (s *Store) Get(ctx context.Context, name string) (store.Secret, error) {
 
 	sec, err := secret.Parse(content)
 	if err != nil {
-		out.Debug(ctx, "Failed to parse YAML: %s", err)
+		debug.Log("Failed to parse YAML: %s", err)
 	}
 	return sec, nil
 }

--- a/internal/store/leaf/reencrypt.go
+++ b/internal/store/leaf/reencrypt.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/gopasspw/gopass/internal/debug"
 	"github.com/gopasspw/gopass/internal/out"
 	"github.com/gopasspw/gopass/internal/store"
 	"github.com/gopasspw/gopass/pkg/ctxutil"
@@ -97,22 +98,22 @@ func (s *Store) reencrypt(ctx context.Context) error {
 			if err := s.rcs.Add(ctx, p); err != nil {
 				switch errors.Cause(err) {
 				case store.ErrGitNotInit:
-					out.Debug(ctx, "reencrypt - skipping git add - git not initialized")
+					debug.Log("reencrypt - skipping git add - git not initialized")
 					continue
 				default:
 					return errors.Wrapf(err, "failed to add '%s' to git", p)
 				}
 			}
-			out.Debug(ctx, "reencrypt - added %s to git", p)
+			debug.Log("reencrypt - added %s to git", p)
 		}
 	}
 
 	if err := s.rcs.Commit(ctx, ctxutil.GetCommitMessage(ctx)); err != nil {
 		switch errors.Cause(err) {
 		case store.ErrGitNotInit:
-			out.Debug(ctx, "reencrypt - skipping git commit - git not initialized")
+			debug.Log("reencrypt - skipping git commit - git not initialized")
 		case store.ErrGitNothingToCommit:
-			out.Debug(ctx, "reencrypt - skipping git commit - nothing to commit")
+			debug.Log("reencrypt - skipping git commit - nothing to commit")
 		default:
 			return errors.Wrapf(err, "failed to commit changes to git")
 		}

--- a/internal/store/leaf/store.go
+++ b/internal/store/leaf/store.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	"github.com/gopasspw/gopass/internal/backend"
-	"github.com/gopasspw/gopass/internal/out"
+	"github.com/gopasspw/gopass/internal/debug"
 
 	"github.com/pkg/errors"
 )
@@ -23,7 +23,7 @@ type Store struct {
 
 // Init initialized this sub store
 func Init(ctx context.Context, alias, path string) (*Store, error) {
-	out.Debug(ctx, "sub.Init(%s, %s) ...", alias, path)
+	debug.Log("sub.Init(%s, %s) ...", alias, path)
 	s := &Store{
 		alias: alias,
 		path:  path,
@@ -52,7 +52,7 @@ func Init(ctx context.Context, alias, path string) (*Store, error) {
 
 // New creates a new store
 func New(ctx context.Context, alias, path string) (*Store, error) {
-	out.Debug(ctx, "sub.New(%s, %s)", alias, path)
+	debug.Log("sub.New(%s, %s)", alias, path)
 
 	s := &Store{
 		alias: alias,
@@ -65,16 +65,14 @@ func New(ctx context.Context, alias, path string) (*Store, error) {
 	}
 
 	// init sync backend
-	if err := s.initRCSBackend(ctx); err != nil {
-		return nil, errors.Wrapf(err, "failed to init RCS backend: %s", err)
-	}
+	s.initRCSBackend(ctx)
 
 	// init crypto backend
 	if err := s.initCryptoBackend(ctx); err != nil {
 		return nil, errors.Wrapf(err, "failed to init crypto backend: %s", err)
 	}
 
-	out.Debug(ctx, "sub.New(%s, %s) - initialized - storage: %+#v - rcs: %+#v - crypto: %+#v", alias, path, s.storage, s.rcs, s.crypto)
+	debug.Log("sub.New(%s, %s) - initialized - storage: %+#v - rcs: %+#v - crypto: %+#v", alias, path, s.storage, s.rcs, s.crypto)
 	return s, nil
 }
 

--- a/internal/store/leaf/templates.go
+++ b/internal/store/leaf/templates.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/gopasspw/gopass/internal/debug"
 	"github.com/gopasspw/gopass/internal/out"
 	"github.com/gopasspw/gopass/internal/store"
 	"github.com/gopasspw/gopass/internal/tree"
@@ -34,7 +35,7 @@ func (s *Store) LookupTemplate(ctx context.Context, name string) (string, []byte
 		tpl := filepath.Join(name, TemplateFile)
 		if s.storage.Exists(ctx, tpl) {
 			if content, err := s.storage.Get(ctx, tpl); err == nil {
-				out.Debug(ctx, "Found template '%s' for '%s'", tpl, oName)
+				debug.Log("Found template '%s' for '%s'", tpl, oName)
 				return tpl, content, true
 			}
 		}
@@ -46,7 +47,7 @@ func (s *Store) LookupTemplate(ctx context.Context, name string) (string, []byte
 func (s *Store) ListTemplates(ctx context.Context, prefix string) []string {
 	lst, err := s.storage.List(ctx, "")
 	if err != nil {
-		out.Debug(ctx, "failed to list templates: %s", err)
+		debug.Log("failed to list templates: %s", err)
 		return nil
 	}
 	tpls := make(map[string]struct{}, len(lst))
@@ -69,7 +70,7 @@ func (s *Store) ListTemplates(ctx context.Context, prefix string) []string {
 }
 
 // TemplateTree returns a tree of all templates
-func (s *Store) TemplateTree(ctx context.Context) (tree.Tree, error) {
+func (s *Store) TemplateTree(ctx context.Context) tree.Tree {
 	root := simple.New("gopass")
 	for _, t := range s.ListTemplates(ctx, "") {
 		if err := root.AddFile(t, "gopass/template"); err != nil {
@@ -77,7 +78,7 @@ func (s *Store) TemplateTree(ctx context.Context) (tree.Tree, error) {
 		}
 	}
 
-	return root, nil
+	return root
 }
 
 // templatefile returns the name of the given template on disk

--- a/internal/store/leaf/templates_test.go
+++ b/internal/store/leaf/templates_test.go
@@ -40,8 +40,7 @@ func TestTemplates(t *testing.T) {
 	assert.NoError(t, s.SetTemplate(ctx, "foo", []byte("foobar")))
 	assert.Equal(t, 1, len(s.ListTemplates(ctx, "")))
 
-	tt, err := s.TemplateTree(ctx)
-	assert.NoError(t, err)
+	tt := s.TemplateTree(ctx)
 	assert.Equal(t, "gopass\n└── foo\n", tt.Format(0))
 
 	assert.Equal(t, true, s.HasTemplate(ctx, "foo"))

--- a/internal/store/leaf/write.go
+++ b/internal/store/leaf/write.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/gopasspw/gopass/internal/debug"
 	"github.com/gopasspw/gopass/internal/out"
 	"github.com/gopasspw/gopass/internal/store"
 	"github.com/gopasspw/gopass/pkg/ctxutil"
@@ -42,7 +43,7 @@ func (s *Store) Set(ctx context.Context, name string, sec store.Byter) error {
 
 	ciphertext, err := s.crypto.Encrypt(ctx, buf, recipients)
 	if err != nil {
-		out.Debug(ctx, "Failed encrypt secret: %s", err)
+		debug.Log("Failed encrypt secret: %s", err)
 		return store.ErrEncrypt
 	}
 
@@ -54,7 +55,7 @@ func (s *Store) Set(ctx context.Context, name string, sec store.Byter) error {
 	// so we need to skip this step when using concurrency and perform them
 	// at the end of the batch processing.
 	if IsNoGitOps(ctx) {
-		out.Debug(ctx, "sub.Set(%s) - skipping git ops (disabled)")
+		debug.Log("sub.Set(%s) - skipping git ops (disabled)")
 		return nil
 	}
 
@@ -76,9 +77,9 @@ func (s *Store) gitCommitAndPush(ctx context.Context, name string) error {
 	if err := s.rcs.Commit(ctx, fmt.Sprintf("Save secret to %s: %s", name, ctxutil.GetCommitMessage(ctx))); err != nil {
 		switch errors.Cause(err) {
 		case store.ErrGitNotInit:
-			out.Debug(ctx, "commitAndPush - skipping git commit - git not initialized")
+			debug.Log("commitAndPush - skipping git commit - git not initialized")
 		case store.ErrGitNothingToCommit:
-			out.Debug(ctx, "commitAndPush - skipping git commit - nothing to commit")
+			debug.Log("commitAndPush - skipping git commit - nothing to commit")
 		default:
 			return errors.Wrapf(err, "failed to commit changes to git")
 		}

--- a/internal/store/mockstore/store.go
+++ b/internal/store/mockstore/store.go
@@ -144,9 +144,11 @@ func (m *MockStore) Alias() string {
 
 // Copy does nothing
 func (m *MockStore) Copy(ctx context.Context, from string, to string) error {
-	content, _ := m.storage.Get(ctx, from)
-	m.storage.Set(ctx, to, content)
-	return nil
+	content, err := m.storage.Get(ctx, from)
+	if err != nil {
+		return err
+	}
+	return m.storage.Set(ctx, to, content)
 }
 
 // Delete does nothing

--- a/internal/store/root/fsck.go
+++ b/internal/store/root/fsck.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 
+	"github.com/gopasspw/gopass/internal/debug"
 	"github.com/gopasspw/gopass/internal/out"
 	multierror "github.com/hashicorp/go-multierror"
 )
@@ -20,7 +21,7 @@ func (s *Store) Fsck(ctx context.Context, path string) error {
 			continue
 		}
 		path = strings.TrimPrefix(path, alias+"/")
-		out.Debug(ctx, "root.Fsck() - Checking %s", alias)
+		debug.Log("root.Fsck() - Checking %s", alias)
 		if err := sub.Fsck(ctx, path); err != nil {
 			out.Error(ctx, "fsck failed on sub store %s: %s", alias, err)
 			result = multierror.Append(result, err)

--- a/internal/store/root/gpg.go
+++ b/internal/store/root/gpg.go
@@ -4,14 +4,14 @@ import (
 	"context"
 
 	"github.com/gopasspw/gopass/internal/backend"
-	"github.com/gopasspw/gopass/internal/out"
+	"github.com/gopasspw/gopass/internal/debug"
 )
 
 // Crypto returns the crypto backend
 func (r *Store) Crypto(ctx context.Context, name string) backend.Crypto {
 	_, sub, _ := r.getStore(ctx, name)
 	if !sub.Valid() {
-		out.Debug(ctx, "Sub-Store not found for %s. Returning nil crypto backend", name)
+		debug.Log("Sub-Store not found for %s. Returning nil crypto backend", name)
 		return nil
 	}
 	return sub.Crypto()

--- a/internal/store/root/init_test.go
+++ b/internal/store/root/init_test.go
@@ -25,10 +25,8 @@ func TestInit(t *testing.T) {
 
 	cfg := config.New()
 	cfg.Path = u.StoreDir("rs")
-	rs, err := New(ctx, cfg)
-	require.NoError(t, err)
+	rs := New(cfg)
 
-	ctx = ctxutil.WithDebug(ctx, true)
 	inited, err := rs.Initialized(ctx)
 	assert.NoError(t, err)
 	assert.Equal(t, false, inited)

--- a/internal/store/root/mount.go
+++ b/internal/store/root/mount.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/gopasspw/gopass/internal/debug"
 	"github.com/gopasspw/gopass/internal/out"
 	"github.com/gopasspw/gopass/internal/store"
 	"github.com/gopasspw/gopass/internal/store/leaf"
@@ -34,7 +35,7 @@ func (r *Store) addMount(ctx context.Context, alias, path string, keys ...string
 		return AlreadyMountedError(alias)
 	}
 
-	out.Debug(ctx, "addMount - Path: %s", path)
+	debug.Log("addMount - Path: %s", path)
 
 	// initialize sub store
 	s, err := r.initSub(ctx, alias, path, keys)
@@ -48,7 +49,7 @@ func (r *Store) addMount(ctx context.Context, alias, path string, keys ...string
 	}
 	r.cfg.Mounts[alias] = path
 
-	out.Debug(ctx, "Added mount %s -> %s", alias, path)
+	debug.Log("Added mount %s -> %s", alias, path)
 	return nil
 }
 
@@ -63,7 +64,7 @@ func (r *Store) initSub(ctx context.Context, alias, path string, keys []string) 
 		return s, nil
 	}
 
-	out.Debug(ctx, "[%s] Mount %s is not initialized", alias, path)
+	debug.Log("[%s] Mount %s is not initialized", alias, path)
 	if len(keys) < 1 {
 		return s, NotInitializedError{alias, path}
 	}

--- a/internal/store/root/recipients.go
+++ b/internal/store/root/recipients.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/gopasspw/gopass/internal/debug"
 	"github.com/gopasspw/gopass/internal/out"
 	"github.com/gopasspw/gopass/internal/store"
 	"github.com/gopasspw/gopass/internal/tree"
@@ -99,7 +100,7 @@ func (r *Store) RecipientsTree(ctx context.Context, pretty bool) (tree.Tree, err
 		}
 		for _, recp := range substore.Recipients(ctx) {
 			if err := r.addRecipient(ctx, alias+"/", root, recp, pretty); err != nil {
-				out.Debug(ctx, "Failed to add recipient to tree %s: %s", recp, err)
+				debug.Log("Failed to add recipient to tree %s: %s", recp, err)
 			}
 		}
 	}

--- a/internal/store/root/store.go
+++ b/internal/store/root/store.go
@@ -18,7 +18,7 @@ type Store struct {
 }
 
 // New creates a new store
-func New(ctx context.Context, cfg *config.Config) (*Store, error) {
+func New(cfg *config.Config) *Store {
 	if cfg == nil {
 		cfg = &config.Config{}
 	}
@@ -27,7 +27,7 @@ func New(ctx context.Context, cfg *config.Config) (*Store, error) {
 		mounts: make(map[string]*leaf.Store, len(cfg.Mounts)),
 	}
 
-	return r, nil
+	return r
 }
 
 // Exists checks the existence of a single entry

--- a/internal/store/root/store_test.go
+++ b/internal/store/root/store_test.go
@@ -125,15 +125,11 @@ func TestListNested(t *testing.T) {
 func createRootStore(ctx context.Context, u *gptest.Unit) (*Store, error) {
 	ctx = backend.WithRCSBackendString(ctx, "noop")
 	ctx = backend.WithCryptoBackendString(ctx, "plain")
-	s, err := New(
-		ctx,
+	s := New(
 		&config.Config{
 			Path: u.StoreDir(""),
 		},
 	)
-	if err != nil {
-		return nil, err
-	}
 	if _, err := s.Initialized(ctx); err != nil {
 		return nil, err
 	}

--- a/internal/store/root/templates.go
+++ b/internal/store/root/templates.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"sort"
 
+	"github.com/gopasspw/gopass/internal/debug"
 	"github.com/gopasspw/gopass/internal/out"
 	"github.com/gopasspw/gopass/internal/store"
 	"github.com/gopasspw/gopass/internal/tree"
@@ -27,7 +28,7 @@ func (r *Store) TemplateTree(ctx context.Context) (tree.Tree, error) {
 	root := simple.New("gopass")
 
 	for _, t := range r.store.ListTemplates(ctx, "") {
-		out.Debug(ctx, "[<root>] Adding template %s", t)
+		debug.Log("[<root>] Adding template %s", t)
 		if err := root.AddFile(t, "gopass/template"); err != nil {
 			out.Error(ctx, "Failed to add file to tree: %s", err)
 		}
@@ -44,7 +45,7 @@ func (r *Store) TemplateTree(ctx context.Context) (tree.Tree, error) {
 			return nil, errors.Errorf("failed to add mount: %s", err)
 		}
 		for _, t := range substore.ListTemplates(ctx, alias) {
-			out.Debug(ctx, "[%s] Adding template %s", alias, t)
+			debug.Log("[%s] Adding template %s", alias, t)
 			if err := root.AddFile(t, "gopass/template"); err != nil {
 				out.Error(ctx, "Failed to add file to tree: %s", err)
 			}

--- a/internal/store/secret/kv.go
+++ b/internal/store/secret/kv.go
@@ -2,9 +2,10 @@ package secret
 
 import (
 	"bufio"
-	"fmt"
 	"sort"
 	"strings"
+
+	"github.com/gopasspw/gopass/internal/debug"
 )
 
 func (s *Secret) decodeKV() error {
@@ -38,16 +39,12 @@ func (s *Secret) decodeKV() error {
 	}
 	if mayBeYAML {
 		docSep, err := s.decodeYAML()
-		if debug {
-			fmt.Printf("[DEBUG] decodeKV() - mayBeYAML - err: %s\n", err)
-		}
+		debug.Log("decodeKV() - mayBeYAML - err: %s", err)
 		if docSep && err == nil && s.data != nil {
 			return nil
 		}
 	}
-	if debug {
-		fmt.Printf("[DEBUG] decodeKV() - simple KV\n")
-	}
+	debug.Log("decodeKV() - simple KV")
 	s.data = data
 	return nil
 }
@@ -79,15 +76,11 @@ func (s *Secret) encodeKV() error {
 	}
 	if mayBeYAML {
 		if err := s.encodeYAML(); err == nil {
-			if debug {
-				fmt.Printf("[DEBUG] encodeKV() - mayBeYAML - OK\n")
-			}
+			debug.Log("encodeKV() - mayBeYAML - OK")
 			return nil
 		}
 	}
-	if debug {
-		fmt.Printf("[DEBUG] encodeKV() - simple KV\n")
-	}
+	debug.Log("encodeKV() - simple KV")
 	s.body = buf.String()
 	return nil
 }

--- a/internal/store/secret/secret.go
+++ b/internal/store/secret/secret.go
@@ -2,21 +2,12 @@ package secret
 
 import (
 	"bytes"
-	"os"
 	"reflect"
 	"strings"
 	"sync"
 
 	"github.com/gopasspw/gopass/internal/store"
 )
-
-var debug bool
-
-func init() {
-	if gdb := os.Getenv("GOPASS_DEBUG"); gdb != "" {
-		debug = true
-	}
-}
 
 // Secret is a decoded secret
 type Secret struct {

--- a/internal/updater/update_others.go
+++ b/internal/updater/update_others.go
@@ -16,6 +16,7 @@ import (
 
 	"golang.org/x/sys/unix"
 
+	"github.com/gopasspw/gopass/internal/debug"
 	"github.com/gopasspw/gopass/internal/out"
 
 	"github.com/pkg/errors"
@@ -26,14 +27,14 @@ func updateGopass(ctx context.Context, version string, urlStr string) error {
 	if err != nil {
 		return errors.Wrapf(err, "failed to detect executable location")
 	}
-	out.Debug(ctx, "Excuteable is at '%s'", exe)
+	debug.Log("Excuteable is at '%s'", exe)
 
 	u, err := url.Parse(urlStr)
 	if err != nil {
 		return errors.Wrapf(err, "failed to parse URL")
 	}
 
-	if err := updateCheckHost(ctx, u); err != nil {
+	if err := updateCheckHost(u); err != nil {
 		return err
 	}
 
@@ -45,15 +46,15 @@ func updateGopass(ctx context.Context, version string, urlStr string) error {
 		_ = os.RemoveAll(td)
 	}()
 
-	out.Debug(ctx, "Tempdir: %s", td)
-	out.Debug(ctx, "URL: %s", u.String())
+	debug.Log("Tempdir: %s", td)
+	debug.Log("URL: %s", u.String())
 	archive := filepath.Join(td, path.Base(u.Path))
 	if err := tryDownload(ctx, archive, u.String()); err != nil {
 		return err
 	}
 	binDst := exe + "_new"
 	_ = os.Remove(binDst)
-	if err := extract(ctx, archive, binDst); err != nil {
+	if err := extract(archive, binDst); err != nil {
 		return err
 	}
 
@@ -79,7 +80,7 @@ func IsUpdateable(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	out.Debug(ctx, "isUpdateable - File: %s", fn)
+	debug.Log("isUpdateable - File: %s", fn)
 	// check if this is a test binary
 	if strings.HasSuffix(filepath.Base(fn), ".test") {
 		return nil
@@ -87,7 +88,7 @@ func IsUpdateable(ctx context.Context) error {
 
 	// check if we want to force updateability
 	if uf := os.Getenv("GOPASS_FORCE_UPDATE"); uf != "" {
-		out.Debug(ctx, "updateable due to force flag")
+		debug.Log("updateable due to force flag")
 		return nil
 	}
 

--- a/internal/updater/update_test.go
+++ b/internal/updater/update_test.go
@@ -119,8 +119,6 @@ func TestIsUpdateable(t *testing.T) {
 }
 
 func TestCheckHost(t *testing.T) {
-	ctx := context.Background()
-
 	for _, tc := range []struct {
 		in string
 		ok bool
@@ -136,7 +134,7 @@ func TestCheckHost(t *testing.T) {
 	} {
 		u, err := url.Parse(tc.in)
 		require.NoError(t, err)
-		err = updateCheckHost(ctx, u)
+		err = updateCheckHost(u)
 		if tc.ok {
 			assert.NoError(t, err)
 		} else {

--- a/main_test.go
+++ b/main_test.go
@@ -109,7 +109,7 @@ func TestGetCommands(t *testing.T) {
 	ctx = backend.WithRCSBackendString(ctx, "noop")
 	ctx = backend.WithCryptoBackendString(ctx, "plain")
 
-	act, err := action.New(ctx, cfg, semver.Version{})
+	act, err := action.New(cfg, semver.Version{})
 	assert.NoError(t, err)
 
 	app := cli.NewApp()
@@ -117,7 +117,7 @@ func TestGetCommands(t *testing.T) {
 	c := cli.NewContext(app, fs, nil)
 	c.Context = ctx
 
-	commands := getCommands(ctx, act, app)
+	commands := getCommands(act, app)
 	assert.Equal(t, 32, len(commands))
 
 	prefix := ""
@@ -160,7 +160,6 @@ func TestInitContext(t *testing.T) {
 
 	assert.NoError(t, os.Setenv("GOPASS_DEBUG", "true"))
 	ctx = initContext(ctx, cfg)
-	assert.Equal(t, true, ctxutil.IsDebug(ctx))
 
 	assert.NoError(t, os.Setenv("GOPASS_NOCOLOR", "true"))
 	ctx = initContext(ctx, cfg)

--- a/pkg/ctxutil/ctxutil.go
+++ b/pkg/ctxutil/ctxutil.go
@@ -10,8 +10,7 @@ import (
 type contextKey int
 
 const (
-	ctxKeyDebug contextKey = iota
-	ctxKeyColor
+	ctxKeyColor contextKey = iota
 	ctxKeyTerminal
 	ctxKeyInteractive
 	ctxKeyStdin
@@ -51,26 +50,6 @@ func WithGlobalFlags(c *cli.Context) context.Context {
 
 // ProgressCallback is a callback for updateing progress
 type ProgressCallback func()
-
-// WithDebug returns a context with an explicit value for debug
-func WithDebug(ctx context.Context, dbg bool) context.Context {
-	return context.WithValue(ctx, ctxKeyDebug, dbg)
-}
-
-// HasDebug returns true if a value for debug has been set in this context
-func HasDebug(ctx context.Context) bool {
-	_, ok := ctx.Value(ctxKeyDebug).(bool)
-	return ok
-}
-
-// IsDebug returns the value of debug or the default (false)
-func IsDebug(ctx context.Context) bool {
-	bv, ok := ctx.Value(ctxKeyDebug).(bool)
-	if !ok {
-		return false
-	}
-	return bv
-}
 
 // WithColor returns a context with an explicit value for color
 func WithColor(ctx context.Context, color bool) context.Context {

--- a/pkg/ctxutil/ctxutil_test.go
+++ b/pkg/ctxutil/ctxutil_test.go
@@ -9,14 +9,6 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-func TestDebug(t *testing.T) {
-	ctx := context.Background()
-
-	assert.Equal(t, false, IsDebug(ctx))
-	assert.Equal(t, true, IsDebug(WithDebug(ctx, true)))
-	assert.Equal(t, false, IsDebug(WithDebug(ctx, false)))
-}
-
 func TestColor(t *testing.T) {
 	ctx := context.Background()
 
@@ -193,7 +185,6 @@ func TestCommitMessage(t *testing.T) {
 
 func TestComposite(t *testing.T) {
 	ctx := context.Background()
-	ctx = WithDebug(ctx, true)
 	ctx = WithColor(ctx, false)
 	ctx = WithTerminal(ctx, false)
 	ctx = WithInteractive(ctx, false)
@@ -211,9 +202,6 @@ func TestComposite(t *testing.T) {
 	ctx = WithNotifications(ctx, true)
 	ctx = WithEditRecipients(ctx, true)
 	ctx = WithAutoClip(ctx, true)
-
-	assert.Equal(t, true, IsDebug(ctx))
-	assert.Equal(t, true, HasDebug(ctx))
 
 	assert.Equal(t, false, IsColor(ctx))
 	assert.Equal(t, true, HasColor(ctx))

--- a/pkg/gopass/api.go
+++ b/pkg/gopass/api.go
@@ -59,10 +59,7 @@ var _ Store = &Gopass{}
 // WARNING: This will need to change to accommodate for runtime configuration.
 func New(ctx context.Context) (*Gopass, error) {
 	cfg := config.Load()
-	store, err := root.New(ctx, cfg)
-	if err != nil {
-		return nil, err
-	}
+	store := root.New(cfg)
 	initialized, err := store.Initialized(ctx)
 	if err != nil {
 		return nil, err

--- a/pkg/gopass/apimock/mock.go
+++ b/pkg/gopass/apimock/mock.go
@@ -16,6 +16,9 @@ type Secret struct {
 
 // Bytes returns the underlying bytes
 func (m *Secret) Bytes() ([]byte, error) {
+	if m.Buf == nil {
+		return nil, fmt.Errorf("empty")
+	}
 	return m.Buf, nil
 }
 

--- a/pkg/hibp/api/client.go
+++ b/pkg/hibp/api/client.go
@@ -2,7 +2,6 @@
 package api
 
 import (
-	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -10,9 +9,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gopasspw/gopass/internal/out"
-
 	"github.com/cenkalti/backoff"
+	"github.com/gopasspw/gopass/internal/debug"
 	"github.com/pkg/errors"
 )
 
@@ -20,7 +18,7 @@ import (
 var URL = "https://api.pwnedpasswords.com"
 
 // Lookup performs a lookup against the HIBP v2 API
-func Lookup(ctx context.Context, shaSum string) (uint64, error) {
+func Lookup(shaSum string) (uint64, error) {
 	if len(shaSum) != 40 {
 		return 0, errors.Errorf("invalid shasum")
 	}
@@ -33,7 +31,7 @@ func Lookup(ctx context.Context, shaSum string) (uint64, error) {
 	url := fmt.Sprintf("%s/range/%s", URL, prefix)
 
 	op := func() error {
-		out.Debug(ctx, "[%s] HTTP Request: %s", shaSum, url)
+		debug.Log("[%s] HTTP Request: %s", shaSum, url)
 		resp, err := http.Get(url)
 		if err != nil {
 			return err

--- a/pkg/hibp/api/client_test.go
+++ b/pkg/hibp/api/client_test.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"context"
 	"crypto/sha1"
 	"fmt"
 	"net/http"
@@ -13,8 +12,7 @@ import (
 )
 
 func Example() {
-	ctx := context.Background()
-	matches, err := Lookup(ctx, "sha1sum of secret")
+	matches, err := Lookup("sha1sum of secret")
 	if err != nil {
 		panic(err)
 	}
@@ -25,8 +23,6 @@ func TestLookup(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")
 	}
-
-	ctx := context.Background()
 
 	match := "match"
 	noMatch := "no match"
@@ -54,12 +50,12 @@ func TestLookup(t *testing.T) {
 	URL = ts.URL
 
 	// test with one entry
-	count, err := Lookup(ctx, matchSum)
+	count, err := Lookup(matchSum)
 	assert.NoError(t, err)
 	assert.Equal(t, matchCount, count)
 
 	// add another one
-	count, err = Lookup(ctx, sha1sum(noMatch))
+	count, err = Lookup(sha1sum(noMatch))
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(0), count)
 }
@@ -68,8 +64,6 @@ func TestLookupCR(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")
 	}
-
-	ctx := context.Background()
 
 	match := "match"
 	noMatch := "no match"
@@ -97,12 +91,12 @@ func TestLookupCR(t *testing.T) {
 	URL = ts.URL
 
 	// test with one entry
-	count, err := Lookup(ctx, matchSum)
+	count, err := Lookup(matchSum)
 	assert.NoError(t, err)
 	assert.Equal(t, matchCount, count)
 
 	// add another one
-	count, err = Lookup(ctx, sha1sum(noMatch))
+	count, err = Lookup(sha1sum(noMatch))
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(0), count)
 }

--- a/pkg/tempfile/file.go
+++ b/pkg/tempfile/file.go
@@ -8,8 +8,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/gopasspw/gopass/pkg/ctxutil"
-
 	"github.com/pkg/errors"
 )
 
@@ -21,7 +19,6 @@ type File struct {
 	dir string
 	dev string
 	fh  *os.File
-	dbg bool
 }
 
 // New returns a new tempfile wrapper
@@ -33,7 +30,6 @@ func New(ctx context.Context, prefix string) (*File, error) {
 
 	tf := &File{
 		dir: td,
-		dbg: ctxutil.IsDebug(ctx),
 	}
 
 	if err := tf.mount(ctx); err != nil {


### PR DESCRIPTION
This commit adds a new debug package to gopass.
It is heavily inspired by github.com/restic/restic/internal/debug
and adapted for the gopass use case.

This change allows to further trim down the source code since the
new package doesn't propagate the debug flag in the context anymore.
As such we can now omit passing ctx in most places.

In order to ensure we don't accidentially keep passing ununsed
parameters we also introduce unparam to check for extra arguments.

RELEASE_NOTES=[ENHANCEMENT] New Debug package

Signed-off-by: Dominik Schulz <dominik.schulz@gauner.org>