### PR TITLE
.goreleaser.yml: Build for arm and arm64 as well

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -26,12 +26,14 @@ builds:
       - windows
     goarch:
       - amd64
+      - arm
+      - arm64
     goarm:
       - 6
       - 7
 archives:
   - id: gopass
-    name_template: "{{.Binary}}-{{.Version}}-{{.Os}}-{{.Arch}}"
+    name_template: "{{.Binary}}-{{.Version}}-{{.Os}}-{{.Arch}}{{ if .Arm }}v{{.Arm }}{{ end }}"
     format: tar.gz
     format_overrides:
       - goos: windows


### PR DESCRIPTION
This should add release binaries for arm v6/v7 and arm64 as well to github so users can install gopass on  arm (e.g. raspberry pi) as well from published releases.