### PR TITLE
Do not return error if grep does not match

### DIFF
--- a/internal/action/grep.go
+++ b/internal/action/grep.go
@@ -42,9 +42,6 @@ func (s *Action) Grep(c *cli.Context) error {
 	if errors > 0 {
 		return ExitError(ExitDecrypt, nil, "some secrets failed to decrypt")
 	}
-	if matches < 1 {
-		return ExitError(ExitNotFound, nil, "no matches found")
-	}
 
 	out.Print(ctx, "\nScanned %d secrets. %d matches, %d errors", len(haystack), matches, errors)
 	return nil

--- a/internal/action/grep_test.go
+++ b/internal/action/grep_test.go
@@ -32,7 +32,7 @@ func TestGrep(t *testing.T) {
 	}()
 
 	c := gptest.CliCtx(ctx, t, "foo")
-	assert.Error(t, act.Grep(c))
+	assert.NoError(t, act.Grep(c))
 	buf.Reset()
 
 	// add some secret
@@ -40,6 +40,6 @@ func TestGrep(t *testing.T) {
 	sec.Set("password", "foobar")
 	sec.WriteString("foobar")
 	assert.NoError(t, act.Store.Set(ctx, "foo", sec))
-	assert.Error(t, act.Grep(c))
+	assert.NoError(t, act.Grep(c))
 	buf.Reset()
 }

--- a/tests/grep_test.go
+++ b/tests/grep_test.go
@@ -18,12 +18,12 @@ func TestGrep(t *testing.T) {
 	assert.Equal(t, "\nError: Usage: "+filepath.Base(ts.Binary)+" grep arg\n", out)
 
 	out, err = ts.run("grep BOOM")
-	assert.Error(t, err)
-	assert.Equal(t, "\nError: no matches found\n", out)
+	assert.NoError(t, err)
+	assert.Contains(t, out, "Scanned 0 secrets. 0 matches, 0 errors")
 
 	ts.initSecrets("")
 
 	out, err = ts.run("grep moar")
-	assert.Error(t, err)
+	assert.NoError(t, err)
 	assert.Contains(t, out, "fixed/secret matches")
 }


### PR DESCRIPTION
Fixes #1426

RELEASE_NOTES=[BUGFIX] Do not return error on no grep matches

Signed-off-by: Dominik Schulz <dominik.schulz@gauner.org>