### PR TITLE
Remove obsolete docker setup documentation

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -68,20 +68,6 @@ For OpenBSD 6.2 and earlier, install via `go get`.
 Please note that the OpenBSD builds uses `pledge(2)` to disable some syscalls,
 so some features (e.g. version checks, auto-update) are unavailable.
 
-#### Docker
-
-Build it
-
-```bash
-docker build -t gopass github.com/gopasspw/gopass#master
-```
-
-Use it
-
-```bash
-alias gopass="docker run --rm -ti -v $HOME:/root gopass"
-```
-
 ### Set up a GPG key pair
 
 gopass depends on the `gpg` program for encryption and decryption. You **must** have a


### PR DESCRIPTION
Support for docker was removed in
https://github.com/gopasspw/gopass/pull/1309.