### PR TITLE
Mark gopass git as deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Please see [docs/features.md](https://github.com/gopasspw/gopass/blob/master/doc
 | PAGER support               | *stable*      | Automatically invoke a pager on long output                       |
 | JSON API                    | *integration* | Allow gopass to be used as a native extension for browser plugins |
 | Automatic fuzzy search      | *stable*      | Automatically search for matching store entries if a literal entry was not found |
-| gopass sync                 | *beta*        | Easy to use syncing of remote repos and GPG keys                  |
+| gopass sync                 | *stable*      | Easy to use syncing of remote repos and GPG keys                  |
 | Desktop Notifications       | *stable*      | Display desktop notifications and completing long running operations |
 | REPL                        | *beta*        | Integrated Read-Eval-Print-Loop shell with autocompletion. |
 | Extensions                  |               | Extend gopass with custom commands using our API                  |

--- a/internal/action/commands.go
+++ b/internal/action/commands.go
@@ -344,7 +344,9 @@ func (s *Action) GetCommands() []*cli.Command {
 			Usage: "Run a git command inside a password store (init, remote, push, pull)",
 			Description: "" +
 				"If the password store is a git repository, execute a git command " +
-				"specified by git-command-args.",
+				"specified by git-command-args." +
+				"WARNING: Deprecated. Please use gopass sync.",
+			Hidden: true,
 			Subcommands: []*cli.Command{
 				{
 					Name:        "init",


### PR DESCRIPTION
Users should prefer gopass sync.

gopass git will still be available as long as we support git, but we
shouldn't advertise it.

Signed-off-by: Dominik Schulz <dominik.schulz@gauner.org>