### PR TITLE
implement dedicated summon provider (#1436)

### DIFF
--- a/cmd/gopass-summon-provider/.gitignore
+++ b/cmd/gopass-summon-provider/.gitignore
@@ -1,0 +1,1 @@
+gopass-summon-provider

--- a/cmd/gopass-summon-provider/main.go
+++ b/cmd/gopass-summon-provider/main.go
@@ -45,14 +45,14 @@ func main() {
 	app := cli.NewApp()
 	app.Name = name
 	app.Version = "0.0.1"
-	app.Usage = `Use "summon-gopass" as provider for "summon"`
+	app.Usage = `Use "gopass-summon-provider" as provider for "summon"`
 	app.Description = "" +
-		"This command allows use gopass as a secret provider for summon." +
-		"To use it set the 'SUMMON_PROVIDER' variable to this executabel or" +
-		"copy or link it into the summon provider direcotry '/usr/local/lib/summon/'."+
-		"See 'summon' documentaion for more details."
+		"This command allows to use gopass as a secret provider for summon." +
+		"To use it set the 'SUMMON_PROVIDER' variable to this executable or" +
+		"copy or link it (as `gopass`) into the summon provider directory" +
+		"'/usr/local/lib/summon/'. See 'summon' documentation for more details."
 	app.Action = gc.Get
-	
+
 	if err := app.RunContext(ctx, os.Args); err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/gopass-summon-provider/main.go
+++ b/cmd/gopass-summon-provider/main.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+	"os/signal"
+
+	"github.com/gopasspw/gopass/pkg/gopass/api"
+	"github.com/urfave/cli/v2"
+)
+
+const (
+	name = "summon-gopass"
+)
+
+func main() {
+	ctx := context.Background()
+
+	// trap Ctrl+C and call cancel on the context
+	ctx, cancel := context.WithCancel(ctx)
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, os.Interrupt)
+	defer func() {
+		signal.Stop(sigChan)
+		cancel()
+	}()
+	go func() {
+		select {
+		case <-sigChan:
+			cancel()
+		case <-ctx.Done():
+		}
+	}()
+
+	gp, err := api.New(ctx)
+	if err != nil {
+		panic(err)
+	}
+
+	gc := &gc{
+		gp: gp,
+	}
+
+	app := cli.NewApp()
+	app.Name = name
+	app.Version = "0.0.1"
+	app.Usage = `Use "summon-gopass" as provider for "summon"`
+	app.Description = "" +
+		"This command allows use gopass as a secret provider for summon." +
+		"To use it set the 'SUMMON_PROVIDER' variable to this executabel or" +
+		"copy or link it into the summon provider direcotry '/usr/local/lib/summon/'."+
+		"See 'summon' documentaion for more details."
+	app.Action = gc.Get
+	
+	if err := app.RunContext(ctx, os.Args); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/cmd/gopass-summon-provider/summon-provider.go
+++ b/cmd/gopass-summon-provider/summon-provider.go
@@ -1,15 +1,11 @@
 package main
 
 import (
-	"io"
-	"fmt"
-
 	"github.com/gopasspw/gopass/internal/out"
 	"github.com/gopasspw/gopass/pkg/ctxutil"
 	"github.com/gopasspw/gopass/pkg/gopass"
 	"github.com/urfave/cli/v2"
 )
-
 
 type gc struct {
 	gp gopass.Store
@@ -24,11 +20,6 @@ func (s *gc) Get(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	password := secret.Get("password")
-	i, err := io.WriteString(out.Stdout, password+"\n")
-	_ = i
-	if err != nil {
-		return fmt.Errorf("could not write to stdout: %s", err)
-	}
+	out.Print(ctx, secret.Get("password"))
 	return nil
 }

--- a/cmd/gopass-summon-provider/summon-provider.go
+++ b/cmd/gopass-summon-provider/summon-provider.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"io"
+	"fmt"
+
+	"github.com/gopasspw/gopass/internal/out"
+	"github.com/gopasspw/gopass/pkg/ctxutil"
+	"github.com/gopasspw/gopass/pkg/gopass"
+	"github.com/urfave/cli/v2"
+)
+
+
+type gc struct {
+	gp gopass.Store
+}
+
+// Get outputs the password for given path on stdout
+func (s *gc) Get(c *cli.Context) error {
+	ctx := ctxutil.WithGlobalFlags(c)
+	ctx = ctxutil.WithNoNetwork(ctx, true)
+	path := c.Args().Get(0)
+	secret, err := s.gp.Get(ctx, path, "latest")
+	if err != nil {
+		return err
+	}
+	password := secret.Get("password")
+	i, err := io.WriteString(out.Stdout, password+"\n")
+	_ = i
+	if err != nil {
+		return fmt.Errorf("could not write to stdout: %s", err)
+	}
+	return nil
+}

--- a/cmd/gopass-summon-provider/summon-provider_test.go
+++ b/cmd/gopass-summon-provider/summon-provider_test.go
@@ -3,37 +3,35 @@ package main
 import (
 	"bytes"
 	"context"
-	//"io"
 	"os"
-	//"strings"
 	"testing"
 
 	"github.com/fatih/color"
 	"github.com/gopasspw/gopass/internal/gptest"
 	"github.com/gopasspw/gopass/internal/out"
 	"github.com/gopasspw/gopass/internal/termio"
-	//"github.com/gopasspw/gopass/pkg/ctxutil"
 	"github.com/gopasspw/gopass/pkg/gopass/apimock"
-	//"github.com/stretchr/testify/assert"
+
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
+func TestSummonProviderOutputsOnlySecret(t *testing.T) {
 
-func TestSummonProviderOutput(t *testing.T) {
 	ctx := context.Background()
 	act := &gc{
 		gp: apimock.New(),
 	}
-	require.NoError(t, act.gp.Set(ctx, "foo", &apimock.Secret{Buf: []byte("bar")}))
+	require.NoError(t, act.gp.Set(ctx, "foo", &apimock.Secret{Buf: []byte("bar\nbaz: zab")}))
 
-	stdout := &bytes.Buffer{}
-	out.Stdout = stdout
+	buf := &bytes.Buffer{}
+	out.Stdout = buf
 	color.NoColor = true
 	defer func() {
 		out.Stdout = os.Stdout
 		termio.Stdin = os.Stdin
 	}()
 
-	c := gptest.CliCtx(ctx, t)
-	_ = c
+	assert.NoError(t, act.Get(gptest.CliCtx(ctx, t, "foo")))
+	assert.Equal(t, "bar\n", buf.String())
 }

--- a/cmd/gopass-summon-provider/summon-provider_test.go
+++ b/cmd/gopass-summon-provider/summon-provider_test.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	//"io"
+	"os"
+	//"strings"
+	"testing"
+
+	"github.com/fatih/color"
+	"github.com/gopasspw/gopass/internal/gptest"
+	"github.com/gopasspw/gopass/internal/out"
+	"github.com/gopasspw/gopass/internal/termio"
+	//"github.com/gopasspw/gopass/pkg/ctxutil"
+	"github.com/gopasspw/gopass/pkg/gopass/apimock"
+	//"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+
+func TestSummonProviderOutput(t *testing.T) {
+	ctx := context.Background()
+	act := &gc{
+		gp: apimock.New(),
+	}
+	require.NoError(t, act.gp.Set(ctx, "foo", &apimock.Secret{Buf: []byte("bar")}))
+
+	stdout := &bytes.Buffer{}
+	out.Stdout = stdout
+	color.NoColor = true
+	defer func() {
+		out.Stdout = os.Stdout
+		termio.Stdin = os.Stdin
+	}()
+
+	c := gptest.CliCtx(ctx, t)
+	_ = c
+}


### PR DESCRIPTION
initial implementation of a dedicated summon-provider implementation for gopass as the default output behavior of `gopass` violates the `summon` contract by adding all meta data.
This implementation outputs only the secret, no other special handling is implemented.