### PR TITLE
Use the new Age API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/gopasspw/gopass
 go 1.12
 
 require (
+	filippo.io/age v1.0.0-beta4
 	github.com/alecthomas/binary v0.0.0-20190922233330-fb1b1d9c299c
 	github.com/atotto/clipboard v0.1.2
 	github.com/blang/semver v0.0.0-20190414182527-1a9109f8c4a1
@@ -12,7 +13,6 @@ require (
 	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e
 	github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.0 // indirect
-	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dominikschulz/github-releases v0.0.3
 	github.com/fatih/color v1.9.0
 	github.com/godbus/dbus v0.0.0-20190623212516-8a1682060722

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
+filippo.io/age v1.0.0-beta4 h1:czSjaSa0owsI5gw/cE9yI/mfTiuhgYjozHI96v0PVJo=
+filippo.io/age v1.0.0-beta4/go.mod h1:TOa3exZvzRCLfjmbJGsqwSQ0HtWjJfTTCQnQsNCC4E0=
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/alecthomas/binary v0.0.0-20190922233330-fb1b1d9c299c h1:SnUAzBu0FguUHChHbuy2HInhc2YBBTmbDcZOOByAVt8=
@@ -73,6 +75,7 @@ github.com/jsimonetti/pwscheme v0.0.0-20160922125227-76804708ecad h1:hye7cQTVxBL
 github.com/jsimonetti/pwscheme v0.0.0-20160922125227-76804708ecad/go.mod h1:alT8eQtqtVCsVweGnMnfJcjNkTcmWbuVn+lYaBtBl9E=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNUXsshfwJMBgNA0RU6/i7WVaAegv3PtuIHPMs=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
+github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
@@ -110,12 +113,15 @@ github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/schollz/closestmatch v0.0.0-20190308193919-1fbe626be92e h1:HFUDYOpUVZ0oTXeZy2A59Lkf69SsOF03Lg1GsI3Xh9o=
 github.com/schollz/closestmatch v0.0.0-20190308193919-1fbe626be92e/go.mod h1:RtP1ddjLong6gTkbtmuhtR2uUrrJOpYzYRvbcPAid+g=
+github.com/sergi/go-diff v1.1.0 h1:we8PVUC3FE2uYfodKH/nBHMSetSfHDR6scGdBi+erh0=
+github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/shurcooL/sanitized_anchor_name v1.0.0 h1:PdmoCO6wvbs+7yrJyMORt4/BmY5IYyJwS/kOiWx8mHo=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/skip2/go-qrcode v0.0.0-20200526175731-7ac0b40b2038 h1:YV7j5thtTo5/Len66qC+EHMFBH4JZXO3rZ1I4ogb3HM=
 github.com/skip2/go-qrcode v0.0.0-20200526175731-7ac0b40b2038/go.mod h1:XV66xRDqSt+GTGFMVlhk3ULuV0y9ZmzeVGR4mloJI3M=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/urfave/cli/v2 v2.2.0 h1:JTTnM6wKzdA0Jqodd966MVj4vWbbquZykeX1sKbe2C4=
@@ -123,6 +129,7 @@ github.com/urfave/cli/v2 v2.2.0/go.mod h1:SE9GqnLQmjVa0iPEY0f1w3ygNIYcIJ0OKPMoW2
 github.com/xrash/smetrics v0.0.0-20170218160415-a3153f7040e9 h1:w8V9v0qVympSF6GjdjIyeqR7+EVhAF9CBQmkmW7Zw0w=
 github.com/xrash/smetrics v0.0.0-20170218160415-a3153f7040e9/go.mod h1:N3UwUGtsrSj3ccvlPHLoLsHnpR27oXr4ZE984MbSER8=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/crypto v0.0.0-20200323165209-0ec3e9974c59/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200604202706-70a84ac30bf9 h1:vEg9joUBmeBcK9iSJftGNf3coIG4HqZElCPehJsfAYM=
 golang.org/x/crypto v0.0.0-20200604202706-70a84ac30bf9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -175,15 +182,15 @@ google.golang.org/protobuf v1.21.0/go.mod h1:47Nbq4nVaFHyn7ilMalzfO3qCViNmqZ2kzi
 google.golang.org/protobuf v1.22.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
-google.golang.org/protobuf v1.24.0 h1:UhZDfRO8JRQru4/+LlLE0BRKGF8L+PICnvYZmx/fEGA=
-google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGjtUeSXeh4=
 google.golang.org/protobuf v1.25.0 h1:Ejskq+SyPohKW+1uil0JJMtmHCgJPJ/qWTxr8qp+R4c=
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f h1:BLraFXnmrev5lT+xlilqcH8XK9/i0At2xKjWk4p6zsU=
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200121175148-a6ecf24a6d71/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
@@ -191,6 +198,7 @@ gopkg.in/yaml.v3 v3.0.0-20200605160147-a5ece683394c h1:grhR+C34yXImVGp7EzNk+DTIk
 gopkg.in/yaml.v3 v3.0.0-20200605160147-a5ece683394c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
+gotest.tools/v3 v3.0.2 h1:kG1BFyqVHuQoVQiR1bWGnfz/fmHvvuiSPIV7rvl360E=
 gotest.tools/v3 v3.0.2/go.mod h1:3SzNCllyD9/Y+b5r9JIKQ474KzkZyqLqEfYqMsX94Bk=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/internal/backend/crypto/age/askpass.go
+++ b/internal/backend/crypto/age/askpass.go
@@ -1,0 +1,75 @@
+package age
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/gopasspw/gopass/internal/cache"
+	"github.com/gopasspw/gopass/internal/debug"
+	"github.com/gopasspw/gopass/pkg/pinentry"
+)
+
+type piner interface {
+	Close()
+	Confirm() bool
+	Set(string, string) error
+	GetPin() ([]byte, error)
+}
+
+type cacher interface {
+	Get(string) (string, bool)
+	Set(string, string)
+	Remove(string)
+}
+
+type askPass struct {
+	testing  bool
+	cache    cacher
+	pinentry func() (piner, error)
+}
+
+func newAskPass() *askPass {
+	return &askPass{
+		cache: cache.NewInMemTTL(time.Hour, 24*time.Hour),
+		pinentry: func() (piner, error) {
+			return pinentry.New()
+		},
+	}
+}
+
+func (a *askPass) Ping(_ context.Context) error {
+	return nil
+}
+
+func (a *askPass) Passphrase(key string, reason string) (string, error) {
+	if value, found := a.cache.Get(key); found || a.testing {
+		debug.Log("Read value for %s from cache", key)
+		return value, nil
+	}
+
+	pi, err := a.pinentry()
+	if err != nil {
+		return "", fmt.Errorf("pinentry Error: %s", err)
+	}
+	defer pi.Close()
+
+	_ = pi.Set("title", "gopass")
+	_ = pi.Set("desc", "Need your passphrase "+reason)
+	_ = pi.Set("prompt", "Please enter your passphrase:")
+	_ = pi.Set("ok", "OK")
+
+	pw, err := pi.GetPin()
+	if err != nil {
+		return "", fmt.Errorf("pinentry Error: %s", err)
+	}
+
+	pass := string(pw)
+	debug.Log("Updated value for %s in cache", key)
+	a.cache.Set(key, pass)
+	return pass, nil
+}
+
+func (a *askPass) Remove(key string) {
+	a.cache.Remove(key)
+}

--- a/internal/backend/crypto/age/keyring.go
+++ b/internal/backend/crypto/age/keyring.go
@@ -1,0 +1,104 @@
+package age
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+
+	"filippo.io/age"
+	"github.com/gopasspw/gopass/internal/debug"
+	"github.com/gopasspw/gopass/internal/termio"
+)
+
+// Keyring is an age keyring
+type Keyring []Keypair
+
+// Keypair is a public / private keypair
+type Keypair struct {
+	Name     string `json:"name"`
+	Email    string `json:"email"`
+	Identity string `json:"identity"`
+}
+
+func (a *Age) pkself(ctx context.Context) (age.Recipient, error) {
+	kr, err := a.loadKeyring()
+
+	var id *age.X25519Identity
+	if err != nil || len(kr) < 1 {
+		id, err = a.genKey(ctx)
+	} else {
+		id, err = age.ParseX25519Identity(kr[len(kr)-1].Identity)
+	}
+	if err != nil {
+		return nil, err
+	}
+	return id.Recipient(), nil
+}
+
+func (a *Age) genKey(ctx context.Context) (*age.X25519Identity, error) {
+	debug.Log("No native age key found. Generating ...")
+	id, err := a.generateIdentity(termio.DetectName(ctx, nil), termio.DetectEmail(ctx, nil))
+	if err != nil {
+		return nil, err
+	}
+	return id, nil
+}
+
+// GenerateIdentity will create a new native private key
+func (a *Age) GenerateIdentity(ctx context.Context, name, email, _ string) error {
+	_, err := a.generateIdentity(name, email)
+	return err
+}
+
+func (a *Age) generateIdentity(name, email string) (*age.X25519Identity, error) {
+	id, err := age.GenerateX25519Identity()
+	if err != nil {
+		return id, err
+	}
+
+	kr, err := a.loadKeyring()
+	if err != nil {
+		debug.Log("Warning: Failed to load keyring from %s: %s", a.keyring, err)
+	}
+
+	kr = append(kr, Keypair{
+		Name:     name,
+		Email:    email,
+		Identity: id.String(),
+	})
+
+	return id, a.saveKeyring(kr)
+}
+
+func (a *Age) loadKeyring() (Keyring, error) {
+	kr := make(Keyring, 1)
+	buf, err := a.decryptFile(a.keyring)
+	if err != nil {
+		debug.Log("can't decrypt keyring at %s: %s", a.keyring, err)
+		return kr, err
+	}
+	if err := json.Unmarshal(buf, &kr); err != nil {
+		debug.Log("can't parse keyring at %s: %s", a.keyring, err)
+		return kr, err
+	}
+	debug.Log("loaded keyring from %s", a.keyring)
+	return kr, nil
+}
+
+func (a *Age) saveKeyring(k Keyring) error {
+	if err := os.MkdirAll(filepath.Dir(a.keyring), 0700); err != nil {
+		return err
+	}
+
+	// encrypt final keyring
+	buf, err := json.Marshal(k)
+	if err != nil {
+		return err
+	}
+	if err := a.encryptFile(a.keyring, buf); err != nil {
+		return err
+	}
+	debug.Log("saved encrypted keyring to %s", a.keyring)
+	return nil
+}

--- a/internal/backend/crypto/age/ssh.go
+++ b/internal/backend/crypto/age/ssh.go
@@ -1,0 +1,75 @@
+package age
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"filippo.io/age"
+	"filippo.io/age/agessh"
+	"github.com/gopasspw/gopass/internal/debug"
+	"github.com/gopasspw/gopass/pkg/ctxutil"
+	"golang.org/x/crypto/ssh"
+)
+
+func (a *Age) getSSHIdentities(ctx context.Context) (map[string]age.Identity, error) {
+	uhd, err := os.UserHomeDir()
+	if err != nil {
+		return nil, err
+	}
+	sshDir := filepath.Join(uhd, ".ssh")
+	files, err := ioutil.ReadDir(sshDir)
+	if err != nil {
+		return nil, err
+	}
+	ids := make(map[string]age.Identity, len(files))
+	for _, file := range files {
+		fn := filepath.Join(sshDir, file.Name())
+		if !strings.HasSuffix(fn, ".pub") {
+			continue
+		}
+		recp, id, err := a.parseSSHIdentity(ctx, fn)
+		if err != nil {
+			debug.Log("Failed to parse SSH identity %s: %s", fn, err)
+			continue
+		}
+		debug.Log("parsed SSH identity %s from %s", recp, fn)
+		ids[recp] = id
+	}
+	return ids, nil
+}
+
+func (a *Age) parseSSHIdentity(ctx context.Context, pubFn string) (string, age.Identity, error) {
+	privFn := strings.TrimSuffix(pubFn, ".pub")
+	_, err := os.Stat(privFn)
+	if err != nil {
+		return "", nil, err
+	}
+	pubBuf, err := ioutil.ReadFile(pubFn)
+	if err != nil {
+		return "", nil, err
+	}
+	privBuf, err := ioutil.ReadFile(privFn)
+	if err != nil {
+		return "", nil, err
+	}
+	pubkey, _, _, _, err := ssh.ParseAuthorizedKey(pubBuf)
+	if err != nil {
+		return "", nil, err
+	}
+	recp := strings.TrimSuffix(string(ssh.MarshalAuthorizedKey(pubkey)), "\n")
+	id, err := agessh.ParseIdentity(privBuf)
+	if err != nil {
+		// handle encrypted SSH identities here
+		if _, ok := err.(*ssh.PassphraseMissingError); ok {
+			id, err := agessh.NewEncryptedSSHIdentity(pubkey, privBuf, func() ([]byte, error) {
+				return ctxutil.GetPasswordCallback(ctx)(pubFn)
+			})
+			return recp, id, err
+		}
+		return "", nil, err
+	}
+	return recp, id, nil
+}

--- a/internal/backend/crypto/age/unsupported.go
+++ b/internal/backend/crypto/age/unsupported.go
@@ -3,7 +3,38 @@ package age
 import (
 	"context"
 	"fmt"
+
+	"github.com/gopasspw/gopass/internal/debug"
 )
+
+// ExportPublicKey is not implemented
+func (a *Age) ExportPublicKey(ctx context.Context, id string) ([]byte, error) {
+	return []byte(id), nil
+}
+
+// FindRecipients it TODO
+func (a *Age) FindRecipients(ctx context.Context, keys ...string) ([]string, error) {
+	nk, err := a.getAllIdentities(ctx)
+	if err != nil {
+		return nil, err
+	}
+	matches := make([]string, 0, len(nk))
+	for _, k := range keys {
+		debug.Log("Key: %s", k)
+		if _, found := nk[k]; found {
+			debug.Log("Found")
+			matches = append(matches, k)
+			continue
+		}
+		debug.Log("not found in %+v", nk)
+	}
+	return matches, nil
+}
+
+// FindIdentities is TODO
+func (a *Age) FindIdentities(ctx context.Context, keys ...string) ([]string, error) {
+	return a.FindRecipients(ctx, keys...)
+}
 
 // FormatKey is TODO
 func (a *Age) FormatKey(ctx context.Context, id, tpl string) string {


### PR DESCRIPTION
This migrates from calling age as an external binary to using
age as a library using it's new API.

The implementation is still ugly, hacky and likely buggy.
But it should be as secure as age and provides a nice proof
of concept. It also has an encrypted keyring and when using
the (highly experimental) ondisk backend it's possible to
have an fully encrypted store without any external dependencies.

Fixes #1345 

RELEASE_NOTES=n/a

Signed-off-by: Dominik Schulz <dominik.schulz@gauner.org>