### PR TITLE
Add background queue

### DIFF
--- a/internal/queue/background.go
+++ b/internal/queue/background.go
@@ -9,58 +9,90 @@ package queue
 
 import (
 	"context"
-	"sync"
 
 	"github.com/gopasspw/gopass/internal/debug"
 )
 
-var (
-	tasks  = make(chan chan error, 1024)
-	done   = make(chan struct{}, 1)
-	closed = false
-	mux    = sync.Mutex{}
+type contextKey int
+
+const (
+	ctxKeyQueue contextKey = iota
 )
 
-// Task is a background task
-type Task func() error
+// Queuer is a queue interface
+type Queuer interface {
+	Add(Task) Task
+	Wait(context.Context) error
+}
 
-func init() {
-	go func() {
-		for t := range tasks {
-			if err := <-t; err != nil {
-				debug.Log("Task failed: %s", err)
-			}
-			debug.Log("Task done")
+// WithQueue adds the given queue to the context
+func WithQueue(ctx context.Context, q *Queue) context.Context {
+	return context.WithValue(ctx, ctxKeyQueue, q)
+}
+
+// GetQueue returns an existing queue from the context or
+// returns a noop one.
+func GetQueue(ctx context.Context) Queuer {
+	if q, ok := ctx.Value(ctxKeyQueue).(*Queue); ok {
+		return q
+	}
+	return &noop{}
+}
+
+type noop struct{}
+
+// Add always returns the task
+func (n *noop) Add(t Task) Task {
+	return t
+}
+
+// Wait always returns nil
+func (n *noop) Wait(_ context.Context) error {
+	return nil
+}
+
+// Task is a background task
+type Task func(ctx context.Context) error
+
+// Queue is a serialized background processing unit
+type Queue struct {
+	work chan Task
+	done chan struct{}
+}
+
+// New creates a new queue
+func New(ctx context.Context) *Queue {
+	q := &Queue{
+		work: make(chan Task, 1024),
+		done: make(chan struct{}, 1),
+	}
+	go q.run(ctx)
+	return q
+}
+
+func (q *Queue) run(ctx context.Context) {
+	for t := range q.work {
+		if err := t(ctx); err != nil {
+			debug.Log("Task failed: %s", err)
 		}
-		debug.Log("all tasks done")
-		done <- struct{}{}
-	}()
+		debug.Log("Task done")
+	}
+	debug.Log("all tasks done")
+	q.done <- struct{}{}
 }
 
 // Add enqueues a new task
-func Add(t Task) {
-	mux.Lock()
-	defer mux.Unlock()
-	if closed {
-		debug.Log("ERROR: Attempting to enqueue in closed queue")
-		return
-	}
-	go func() {
-		ec := make(chan error, 1)
-		tasks <- ec
-		ec <- t()
-	}()
+func (q *Queue) Add(t Task) Task {
+	q.work <- t
 	debug.Log("enqueued task")
+	return func(_ context.Context) error { return nil }
 }
 
-// Close closes the queue for new entries and processes the remaining ones
-func Close(ctx context.Context) error {
-	mux.Lock()
-	closed = true
-	mux.Unlock()
-	close(tasks)
+// Wait waits for all tasks to be processed
+func (q *Queue) Wait(ctx context.Context) error {
+	close(q.work)
 	select {
-	case <-done:
+	case <-q.done:
 		return nil
 	case <-ctx.Done():
 		debug.Log("context canceled")

--- a/main.go
+++ b/main.go
@@ -77,11 +77,13 @@ func main() {
 	sv := getVersion()
 	cli.VersionPrinter = makeVersionPrinter(os.Stdout, sv)
 
+	q := queue.New(ctx)
+	ctx = queue.WithQueue(ctx, q)
 	ctx, app := setupApp(ctx, sv)
 	if err := app.RunContext(ctx, os.Args); err != nil {
 		log.Fatal(err)
 	}
-	queue.Close(ctx)
+	q.Wait(ctx)
 }
 
 func setupApp(ctx context.Context, sv semver.Version) (context.Context, *cli.App) {

--- a/pkg/gopass/api/api.go
+++ b/pkg/gopass/api/api.go
@@ -83,6 +83,6 @@ func (g *Gopass) String() string {
 }
 
 // Close shuts down all background processes
-func (g *Gopass) Close(ctx context.Context) {
-	queue.Close(ctx)
+func (g *Gopass) Close(ctx context.Context) error {
+	return queue.GetQueue(ctx).Wait(ctx)
 }

--- a/pkg/gopass/apimock/mock.go
+++ b/pkg/gopass/apimock/mock.go
@@ -84,4 +84,6 @@ func (a *MockAPI) Sync(ctx context.Context) error {
 }
 
 // Close does nothing
-func (a *MockAPI) Close(ctx context.Context) {}
+func (a *MockAPI) Close(ctx context.Context) error {
+	return nil
+}

--- a/pkg/gopass/store.go
+++ b/pkg/gopass/store.go
@@ -56,5 +56,5 @@ type Store interface {
 	// manually pull in changes.
 	Sync(ctx context.Context) error
 	// Clean up any resources. MUST be called before the process exists.
-	Close(ctx context.Context)
+	Close(ctx context.Context) error
 }


### PR DESCRIPTION
This commit adds a synchornous background queue for processing e.g. sync
tasks. These shouldn't be blocking in interactive use but still need to
be done before we terminate.

This might also help improve the git implementation later on.

RELEASE_NOTES=n/a

Signed-off-by: Dominik Schulz <dominik.schulz@gauner.org>