### PR TITLE
Handling 2 regressions from #1391

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -41,25 +41,25 @@ All configuration options are also available for reading and writing through the
 * To display all values: `gopass config`
 * To display a single value: `gopass config autosync`
 * To update a single value: `gopass config autosync false`
-* As many other sub-commands this command accepts a `--store` flag to operate on a given sub-store.
+* As many other sub-commands this command accepts a `--store` flag to operate on a given sub-store, provided the sub-store is a remote one. Support for different local configurations per mount was dropped in v1.9.3.
 
 This is a list of available options:
 
 | **Option**       | **Type** | Description |
 | ---------------- | -------- | ----------- |
-| `askformore`     | `bool`   | If enabled - it will ask to add more data after use of `generate` command. |
+| `askformore`     | `bool`   | If enabled - it will ask to add more data after use of `generate` command.  DEPRECATED in v1.9.3 |
 | `autoclip`       | `bool`   | Always copy the password created by `pass generate`. |
 | `autoimport`     | `bool`   | Import missing keys stored in the pass repository without asking. |
-| `autosync`       | `bool`   | Always do a `git push` after a commit to the store. Makes sure your local changes are always available on your git remote. |
-| `concurrency`    | `int`    | Number of threads to use for batch operations (such as reencrypting). |
+| `autosync`       | `bool`   | Always do a `git push` after a commit to the store. Makes sure your local changes are always available on your git remote. DEPRECATED in v1.9.3 |
+| `concurrency`    | `int`    | Number of threads to use for batch operations (such as reencrypting).  DEPRECATED in v1.9.3 |
 | `cliptimeout`    | `int`    | How many seconds the secret is stored when using `-c`. |
-| `noconfirm`      | `bool`   | Do not confirm recipient list when encrypting. |
-| `path`           | `string` | Path to the root store. |
+| `confirm`      | `bool`   | Confirm recipient list when encrypting. |
 | `editrecipients` | `bool`   | Modify recipients when creating and editing passwords. |
 | `exportkeys`     | `bool`   | Export public keys of all recipients to the store. |
-| `recipient_hash` | `map`    | Map of recipient ids to their hashes. |
-| `safecontent`    | `bool`   | Only output _safe content_ (i.e. everything but the first line of a secret) to the terminal. Use _copy_ (`-c`) to retrieve the password in the clipboard. |
-| `usesymbols`     | `bool`   | If enabled - it will use symbols when generating passwords. |
-| `notifications`  | `bool`   | Enable desktop notifications. |
+| `recipient_hash` | `map`    | Map of recipient ids to their hashes.  DEPRECATED in v1.9.3 |
+| `usesymbols`     | `bool`   | If enabled - it will use symbols when generating passwords.  DEPRECATED in v1.9.3 |
 | `nocolor`        | `bool`   | Do not use color. |
 | `nopager`        | `bool`   | Do not invoke a pager to display long lists. |
+| `notifications`  | `bool`   | Enable desktop notifications. |
+| `path`           | `string` | Path to the root store. |
+| `safecontent`    | `bool`   | Only output _safe content_ (i.e. everything but the first line of a secret) to the terminal. Use _copy_ (`-c`) to retrieve the password in the clipboard, or _force_ (`-f`) to still print it. |

--- a/internal/action/commands.go
+++ b/internal/action/commands.go
@@ -99,7 +99,7 @@ func (s *Action) GetCommands() []*cli.Command {
 			Flags: []cli.Flag{
 				&cli.StringFlag{
 					Name:  "store",
-					Usage: "Set value to substore config",
+					Usage: "Set value to remote substore config",
 				},
 			},
 		},

--- a/internal/action/config_test.go
+++ b/internal/action/config_test.go
@@ -69,7 +69,7 @@ func TestConfig(t *testing.T) {
 	t.Run("print single config value", func(t *testing.T) {
 		defer buf.Reset()
 
-		act.printConfigValues(ctx, "", "nopager")
+		act.printConfigValues(ctx, "nopager")
 
 		want := "nopager: true"
 		assert.Equal(t, want, strings.TrimSpace(buf.String()), "action.printConfigValues")
@@ -78,7 +78,7 @@ func TestConfig(t *testing.T) {
 	t.Run("print all config values", func(t *testing.T) {
 		defer buf.Reset()
 
-		act.printConfigValues(ctx, "")
+		act.printConfigValues(ctx)
 		want := `root store config:
   autoclip: true
   autoimport: true

--- a/tests/mount_test.go
+++ b/tests/mount_test.go
@@ -96,6 +96,9 @@ func TestMountShadowing(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "food", out)
 
+	// add more secrets
+	ts.initSecrets("mnt/m1/")
+
 	// check that the mount is listed
 	list := `
 gopass
@@ -111,16 +114,40 @@ gopass
         ├── fixed
         │   ├── secret
         │   └── twoliner
-        └── foo
-            └── bar
+        ├── foo
+        │   └── bar
+        └── secret
 `
 	list = fmt.Sprintf(list, ts.storeDir("m1"))
 
 	out, err = ts.run("list")
 	assert.NoError(t, err)
-
-	t.Skip("this test is currently failing because the list is shadowing the mount")
 	assert.Equal(t, strings.TrimSpace(list), out)
+
+	// check that unmounting works:
+	_, err = ts.run("mounts rm mnt/m1")
+	assert.NoError(t, err)
+
+	list = `
+gopass
+├── baz
+├── fixed
+│   ├── secret
+│   └── twoliner
+├── foo
+│   └── bar
+└── mnt
+    └── m1
+        └── secret
+`
+
+	out, err = ts.run("list")
+	assert.NoError(t, err)
+	assert.Equal(t, strings.TrimSpace(list), out)
+
+	out, err = ts.run("show -f mnt/m1/secret")
+	assert.NoError(t, err)
+	assert.Equal(t, "moar", out)
 }
 
 func TestMultiMount(t *testing.T) {

--- a/tests/mount_test.go
+++ b/tests/mount_test.go
@@ -16,6 +16,53 @@ func TestSingleMount(t *testing.T) {
 	ts.initStore()
 	ts.initSecrets("")
 
+	out, err := ts.run("init --store mnt/m1 --path " + ts.storeDir("m1") + " --storage=fs " + keyID)
+	t.Logf("Output: %s", out)
+	require.NoError(t, err)
+
+	out, err = ts.run("mounts")
+	assert.NoError(t, err)
+	want := "gopass (" + ts.storeDir("root") + ")\n"
+	want += "└── mnt\n    └── m1 (" + ts.storeDir("m1") + ")"
+	assert.Equal(t, strings.TrimSpace(want), out)
+
+	out, err = ts.run("show mnt/m1/secret")
+	assert.Error(t, err)
+	assert.Equal(t, "\nError: failed to retrieve secret 'mnt/m1/secret': Entry is not in the password store\n", out)
+
+	ts.initSecrets("mnt/m1/")
+
+	list := `
+gopass
+├── baz
+├── fixed
+│   ├── secret
+│   └── twoliner
+├── foo
+│   └── bar
+└── mnt
+    └── m1 (%s)
+        ├── baz
+        ├── fixed
+        │   ├── secret
+        │   └── twoliner
+        └── foo
+            └── bar
+`
+	list = fmt.Sprintf(list, ts.storeDir("m1"))
+
+	out, err = ts.run("list")
+	assert.NoError(t, err)
+	assert.Equal(t, strings.TrimSpace(list), out)
+}
+
+func TestMountShadowing(t *testing.T) {
+	ts := newTester(t)
+	defer ts.teardown()
+
+	ts.initStore()
+	ts.initSecrets("")
+
 	// insert some secret at a place that will be shadowed by a mount
 	_, err := ts.runCmd([]string{ts.Binary, "insert", "mnt/m1/secret"}, []byte("moar"))
 	require.NoError(t, err)
@@ -28,32 +75,51 @@ func TestSingleMount(t *testing.T) {
 	t.Logf("Output: %s", out)
 	require.NoError(t, err)
 
-	out, err = ts.run("show mnt/m1/secret")
+	// check the mount is there
+	out, err = ts.run("mounts")
+	assert.NoError(t, err)
+	want := "gopass (" + ts.storeDir("root") + ")\n"
+	want += "└── mnt\n    └── m1 (" + ts.storeDir("m1") + ")"
+	assert.Equal(t, strings.TrimSpace(want), out)
+
+	// check that the mount is not containing our shadowed secret
+	out, err = ts.run("show -f mnt/m1/secret")
 	assert.Error(t, err)
 	assert.Equal(t, "\nError: failed to retrieve secret 'mnt/m1/secret': Entry is not in the password store\n", out)
 
-	ts.initSecrets("mnt/m1/")
+	// insert some secret at the place that is shadowed by the mount
+	_, err = ts.runCmd([]string{ts.Binary, "insert", "mnt/m1/secret"}, []byte("food"))
+	require.NoError(t, err)
 
-	list := `gopass
+	// check that the mount is containing our new secret shadowing the old one
+	out, err = ts.run("show -f mnt/m1/secret")
+	assert.NoError(t, err)
+	assert.Equal(t, "food", out)
+
+	// check that the mount is listed
+	list := `
+gopass
+├── baz
 ├── fixed
 │   ├── secret
 │   └── twoliner
 ├── foo
 │   └── bar
-├── mnt
+└── mnt
+    └── m1 (%s)
+        ├── baz
+        ├── fixed
+        │   ├── secret
+        │   └── twoliner
+        └── foo
+            └── bar
 `
-	list += "│   └── m1 (" + ts.storeDir("m1") + ")\n"
-	list += `│       ├── fixed
-│       │   ├── secret
-│       │   └── twoliner
-│       ├── foo
-│       │   └── bar
-│       └── baz
-└── baz`
+	list = fmt.Sprintf(list, ts.storeDir("m1"))
 
 	out, err = ts.run("list")
 	assert.NoError(t, err)
-	t.Skip("integration test seems broken, but not manual tests")
+
+	t.Skip("this test is currently failing because the list is shadowing the mount")
 	assert.Equal(t, strings.TrimSpace(list), out)
 }
 

--- a/tests/tester.go
+++ b/tests/tester.go
@@ -81,6 +81,7 @@ func newTester(t *testing.T) *tester {
 
 	// write config
 	require.NoError(t, os.MkdirAll(filepath.Dir(ts.gopassConfig()), 0700))
+	// we need to set the root path to something else than the root directory otherwise the mounts will show as regular entries
 	if err := ioutil.WriteFile(ts.gopassConfig(), []byte(gopassConfig+"\n  path: "+ts.storeDir("root")+"\n"), 0600); err != nil {
 		t.Fatalf("Failed to write gopass config to %s: %s", ts.gopassConfig(), err)
 	}


### PR DESCRIPTION
Fixes #1458
This fixes a panic caused by a `nil` dereference since the store variable is usually "" because it is the _ root_ store.
Notice that `getOnDiskStorage` is really meant to work on substores, not on the root one, hence the panic.

Also notice that #1391 removed capacity to set per-mount config options for non-remote stores, see #1459. 
This is doing the small refactoring of the code mentioned in that issue in commit `85abbcc`.
Fixes #1459 

This PR is also adding some more integration tests to catch an issue like #1458 and a regression like #1459.

This is also adding a test to detect the wrong behaviour mentioned in #1460.
