### PR TITLE
Fix some regressions

### DIFF
--- a/internal/action/clone.go
+++ b/internal/action/clone.go
@@ -40,6 +40,8 @@ func (s *Action) Clone(c *cli.Context) error {
 	return s.clone(ctx, repo, mount, path)
 }
 
+// storageBackendOrDefault will return a storage backend that can be clone,
+// i.e. specifically backend.FS can't be cloned.
 func storageBackendOrDefault(ctx context.Context) backend.StorageBackend {
 	if be := backend.GetStorageBackend(ctx); be != backend.FS {
 		return be

--- a/internal/action/commands.go
+++ b/internal/action/commands.go
@@ -398,10 +398,6 @@ func (s *Action) GetCommands() []*cli.Command {
 							Aliases: []string{"useremail"},
 							Usage:   "Git Author Email",
 						},
-						&cli.StringFlag{
-							Name:  "rcs",
-							Usage: "Select sync backend (git, gitcli, noop)",
-						},
 					},
 				},
 				{
@@ -525,18 +521,13 @@ func (s *Action) GetCommands() []*cli.Command {
 				},
 				&cli.StringFlag{
 					Name:  "crypto",
-					Usage: "Select crypto backend (gpgcli, plain, xc)",
+					Usage: "Select crypto backend (gpgcli, age, xc, plain)",
 					Value: "gpgcli",
 				},
 				&cli.StringFlag{
-					Name:  "rcs",
-					Usage: "Select sync backend (git, gitcli, noop)",
-					Value: "gitcli",
-				},
-				&cli.StringFlag{
 					Name:  "storage",
-					Usage: "Select storage backend (fs, inmen, ondisk)",
-					Value: "fs",
+					Usage: "Select storage backend (gitfs, fs, ondisk)",
+					Value: "gitfs",
 				},
 			},
 		},
@@ -644,13 +635,6 @@ func (s *Action) GetCommands() []*cli.Command {
 						"at any path in an existing root store.",
 					Before: s.Initialized,
 					Action: s.MountAdd,
-					Flags: []cli.Flag{
-						&cli.StringFlag{
-							Name:    "init",
-							Aliases: []string{"i"},
-							Usage:   "Init the store with the given recipient key",
-						},
-					},
 				},
 				{
 					Name:    "remove",

--- a/internal/action/init.go
+++ b/internal/action/init.go
@@ -57,6 +57,9 @@ func (s *Action) Init(c *cli.Context) error {
 	alias := c.String("store")
 
 	ctx = initParseContext(ctx, c)
+	ctx = out.WithPrefix(ctx, "[init] ")
+	out.Cyan(ctx, "Initializing a new password store ...")
+
 	if name := termio.DetectName(c.Context, c); name != "" {
 		ctx = ctxutil.WithUsername(ctx, name)
 	}
@@ -93,9 +96,6 @@ func initParseContext(ctx context.Context, c *cli.Context) context.Context {
 		debug.Log("Using default storage backend (GitFS)")
 		ctx = backend.WithStorageBackend(ctx, backend.GitFS)
 	}
-
-	ctx = out.WithPrefix(ctx, "[init] ")
-	out.Cyan(ctx, "Initializing a new password store ...")
 
 	return ctx
 }
@@ -182,6 +182,9 @@ func (s *Action) InitOnboarding(c *cli.Context) error {
 	create := c.Bool("create")
 
 	ctx = initParseContext(ctx, c)
+	ctx = out.WithPrefix(ctx, "[init] ")
+	out.Cyan(ctx, "Initializing a new password store ...")
+
 	if name := termio.DetectName(c.Context, c); name != "" {
 		ctx = ctxutil.WithUsername(ctx, name)
 	}

--- a/internal/action/mount.go
+++ b/internal/action/mount.go
@@ -81,25 +81,18 @@ func (s *Action) MountAdd(c *cli.Context) error {
 		localPath = config.PwStoreDir(alias)
 	}
 
-	keys := make([]string, 0, 1)
-	if k := c.String("init"); k != "" {
-		keys = append(keys, k)
-	}
-
 	if s.Store.Exists(ctx, alias) {
 		out.Yellow(ctx, "WARNING: shadowing %s entry", alias)
 	}
 
-	if err := s.Store.AddMount(ctx, alias, localPath, keys...); err != nil {
+	if err := s.Store.AddMount(ctx, alias, localPath); err != nil {
 		switch e := errors.Cause(err).(type) {
 		case root.AlreadyMountedError:
 			out.Print(ctx, "Store is already mounted")
 			return nil
 		case root.NotInitializedError:
-			out.Print(ctx, "Mount %s is not yet initialized. Initializing ...", e.Alias())
-			if err := s.init(ctx, e.Alias(), e.Path()); err != nil {
-				return ExitError(ExitUnknown, err, "failed to add mount '%s': failed to initialize store: %s", e.Alias(), err)
-			}
+			out.Print(ctx, "Mount %s is not yet initialized. Please use 'gopass init --store %s' instead", e.Alias(), e.Alias())
+			return e
 		default:
 			return ExitError(ExitMount, err, "failed to add mount '%s' to '%s': %s", alias, localPath, err)
 		}

--- a/internal/action/rcs.go
+++ b/internal/action/rcs.go
@@ -36,7 +36,9 @@ func (s *Action) RCSInit(c *cli.Context) error {
 }
 
 func (s *Action) rcsInit(ctx context.Context, store, un, ue string) error {
-	// TODO this is a hack
+	// TODO this is a hack, we just skip rcsInit is the backend is FS, which
+	// doesn't support this. The check should rather ask the backend if it
+	// can be initialized for RCS.
 	if backend.GetStorageBackend(ctx) == backend.FS {
 		return nil
 	}

--- a/internal/store/root/init.go
+++ b/internal/store/root/init.go
@@ -29,7 +29,7 @@ func (r *Store) Init(ctx context.Context, alias, path string, ids ...string) err
 		ctx = backend.WithCryptoBackend(ctx, backend.GPGCLI)
 	}
 	if !backend.HasStorageBackend(ctx) {
-		ctx = backend.WithStorageBackend(ctx, backend.FS)
+		ctx = backend.WithStorageBackend(ctx, backend.GitFS)
 	}
 	sub, err := leaf.New(ctx, alias, path)
 	if err != nil {

--- a/internal/store/root/mount.go
+++ b/internal/store/root/mount.go
@@ -66,8 +66,10 @@ func (r *Store) initSub(ctx context.Context, alias, path string, keys []string) 
 
 	debug.Log("[%s] Mount %s is not initialized", alias, path)
 	if len(keys) < 1 {
+		debug.Log("[%s] No keys available", alias)
 		return s, NotInitializedError{alias, path}
 	}
+	debug.Log("[%s] Trying to initialize at %s for %+v", alias, path, keys)
 	if err := s.Init(ctx, path, keys...); err != nil {
 		return s, errors.Wrapf(err, "failed to initialize store '%s' at '%s'", alias, path)
 	}

--- a/internal/tree/root.go
+++ b/internal/tree/root.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/fatih/color"
+	"github.com/gopasspw/gopass/internal/debug"
 )
 
 const (
@@ -71,7 +72,10 @@ func (r *Root) insert(path string, template bool, mountPath string) error {
 				n.Path = mountPath
 			}
 		}
-		node, _ := t.Insert(n)
+		node, err := t.Insert(n)
+		if err != nil {
+			debug.Log("failed to insert: %s", err)
+		}
 		// do we need to extend an existing subtree?
 		if i < len(p)-1 && node.Subtree == nil {
 			node.Subtree = NewTree()

--- a/internal/tree/root_test.go
+++ b/internal/tree/root_test.go
@@ -48,3 +48,31 @@ func TestRoot(t *testing.T) {
     └── bar
 `, f.Format(-1))
 }
+
+func TestMountShadow(t *testing.T) {
+	color.NoColor = true
+
+	r := New("gopass")
+	r.AddTemplate("foo")
+	r.AddFile("foo/bar/baz", "")
+	r.AddFile("foo/bar/zab", "")
+	r.AddMount("foo", "/tmp/m1")
+	r.AddFile("foo/zab", "")
+	r.AddFile("foo/baz", "")
+	t.Logf("%+#v", r)
+	assert.Equal(t, `gopass
+└── foo (/tmp/m1)
+    ├── baz
+    └── zab
+`, r.Format(-1))
+
+	assert.Equal(t, []string{
+		"foo/baz",
+		"foo/zab",
+	}, r.List(-1))
+	assert.Equal(t, []string{
+		"foo",
+	}, r.ListFolders(-1))
+	_, err := r.FindFolder("mnt/m1")
+	assert.Error(t, err)
+}

--- a/internal/tree/tree.go
+++ b/internal/tree/tree.go
@@ -44,6 +44,10 @@ func (t *Tree) Equals(other *Tree) bool {
 func (t *Tree) Insert(node *Node) (*Node, error) {
 	pos, found := t.find(node.Name)
 	if found != nil {
+		if node.Mount {
+			t.Nodes[pos] = node
+			return node, nil
+		}
 		return t.Nodes[pos], fmt.Errorf("node %q already preset", node.Name)
 	}
 

--- a/tests/mount_test.go
+++ b/tests/mount_test.go
@@ -1,6 +1,7 @@
 package tests
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -23,7 +24,7 @@ func TestSingleMount(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "moar", out)
 
-	out, err = ts.run("init --store mnt/m1 --path " + ts.storeDir("m1") + " --rcs=noop " + keyID)
+	out, err = ts.run("init --store mnt/m1 --path " + ts.storeDir("m1") + " --storage=fs " + keyID)
 	t.Logf("Output: %s", out)
 	require.NoError(t, err)
 
@@ -64,65 +65,67 @@ func TestMultiMount(t *testing.T) {
 	ts.initSecrets("")
 
 	// mount m1
-	out, err := ts.run("init --store mnt/m1 --path " + ts.storeDir("m1") + " --rcs=noop " + keyID)
+	out, err := ts.run("init --store mnt/m1 --path " + ts.storeDir("m1") + " --storage=fs " + keyID)
 	t.Logf("Output: %s", out)
 	require.NoError(t, err)
 
 	ts.initSecrets("mnt/m1/")
 
-	list := `gopass
+	list := `
+gopass
+├── baz
 ├── fixed
 │   ├── secret
 │   └── twoliner
 ├── foo
 │   └── bar
-├── mnt
+└── mnt
+    └── m1 (%s)
+        ├── baz
+        ├── fixed
+        │   ├── secret
+        │   └── twoliner
+        └── foo
+            └── bar
 `
-	list += "│   └── m1 (" + ts.storeDir("m1") + ")\n"
-	list += `│       ├── fixed
-│       │   ├── secret
-│       │   └── twoliner
-│       ├── foo
-│       │   └── bar
-│       └── baz
-└── baz`
+	list = fmt.Sprintf(list, ts.storeDir("m1"))
 
 	out, err = ts.run("list")
 	assert.NoError(t, err)
-	t.Skip("integration test seems broken, but not manual tests")
 	assert.Equal(t, strings.TrimSpace(list), out)
 
 	// mount m2
-	out, err = ts.run("init --store mnt/m2 --path " + ts.storeDir("m2") + " --rcs=noop " + keyID)
+	out, err = ts.run("init --store mnt/m2 --path " + ts.storeDir("m2") + " --storage=fs " + keyID)
 	t.Logf("Output: %s", out)
 	require.NoError(t, err)
 
 	ts.initSecrets("mnt/m2/")
 
-	list = `gopass
+	list = `
+gopass
+├── baz
 ├── fixed
 │   ├── secret
 │   └── twoliner
 ├── foo
 │   └── bar
-├── mnt
+└── mnt
+    ├── m1 (%s)
+    │   ├── baz
+    │   ├── fixed
+    │   │   ├── secret
+    │   │   └── twoliner
+    │   └── foo
+    │       └── bar
+    └── m2 (%s)
+        ├── baz
+        ├── fixed
+        │   ├── secret
+        │   └── twoliner
+        └── foo
+            └── bar
 `
-	list += "│   ├── m1 (" + ts.storeDir("m1") + ")\n"
-	list += `│   │   ├── fixed
-│   │   │   ├── secret
-│   │   │   └── twoliner
-│   │   ├── foo
-│   │   │   └── bar
-│   │   └── baz
-`
-	list += "│   └── m2 (" + ts.storeDir("m2") + ")\n"
-	list += `│       ├── fixed
-│       │   ├── secret
-│       │   └── twoliner
-│       ├── foo
-│       │   └── bar
-│       └── baz
-└── baz`
+	list = fmt.Sprintf(list, ts.storeDir("m1"), ts.storeDir("m2"))
 
 	out, err = ts.run("list")
 	assert.NoError(t, err)

--- a/tests/tester.go
+++ b/tests/tester.go
@@ -81,7 +81,7 @@ func newTester(t *testing.T) *tester {
 
 	// write config
 	require.NoError(t, os.MkdirAll(filepath.Dir(ts.gopassConfig()), 0700))
-	if err := ioutil.WriteFile(ts.gopassConfig(), []byte(gopassConfig+"\n  path: "+ts.storeDir("")+"\n"), 0600); err != nil {
+	if err := ioutil.WriteFile(ts.gopassConfig(), []byte(gopassConfig+"\n  path: "+ts.storeDir("root")+"\n"), 0600); err != nil {
 		t.Fatalf("Failed to write gopass config to %s: %s", ts.gopassConfig(), err)
 	}
 


### PR DESCRIPTION
Fixes #1460
Fixes #1462

This commit fixes broken shadowing in the new tree implementation
as well as removing the broken init flag to mounts add.

RELELASE_NOTES=[BUGFIX] Fix tree shadowing.

Signed-off-by: Dominik Schulz <dominik.schulz@gauner.org>