### PR TITLE
pkg/pinentry: Support OPTION call for pinentry

### DIFF
--- a/pkg/pinentry/pinentry.go
+++ b/pkg/pinentry/pinentry.go
@@ -86,6 +86,19 @@ func (c *Client) Set(key, value string) error {
 	return nil
 }
 
+// Option sets an option, e.g. "default-cancel=Abbruch" or "allow-external-password-cache"
+func (c *Client) Option(value string) error {
+	val := "OPTION " + value + "\n"
+	if _, err := c.in.Write([]byte(val)); err != nil {
+		return err
+	}
+	line, _, _ := c.out.ReadLine()
+	if string(line) != "OK" {
+		return errors.Errorf("error: %s", line)
+	}
+	return nil
+}
+
 // GetPin asks for the pin
 func (c *Client) GetPin() ([]byte, error) {
 	if _, err := c.in.Write([]byte("GETPIN\n")); err != nil {


### PR DESCRIPTION
RELEASE_NOTES=[FEATURE] Pinentry API: support OPTION API call

For example, to allow storing passwords in keychain, the option `allow-external-password-cache` must be set (together with `SETKEYINFO [keyname]`).

Thus, we support the `OPTION` API call, as for example described in http://info2html.sourceforge.net/cgi-bin/info2html-demo/info2html?(pinentry)Protocol .

Background info: I want to support using the keychain in https://github.com/FiloSottile/yubikey-agent (and this package uses your pinentry wrapper :) )