### PR TITLE
Fix env command crash

### DIFF
--- a/internal/action/env.go
+++ b/internal/action/env.go
@@ -20,6 +20,10 @@ func (s *Action) Env(c *cli.Context) error {
 	name := c.Args().First()
 	args := c.Args().Tail()
 
+	if len(args) == 0 {
+		return ExitError(ExitUsage, nil, "Missing subcommand to execute")
+	}
+
 	if !s.Store.Exists(ctx, name) && !s.Store.IsDir(ctx, name) {
 		return ExitError(ExitNotFound, nil, "Secret %s not found", name)
 	}

--- a/internal/action/env.go
+++ b/internal/action/env.go
@@ -12,7 +12,9 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-// Env implements an env subcommand the populates the env of an subprocess with a set of secrets
+// Env implements the env subcommand. It populates the environment of a subprocess with
+// a set of environment variables corresponding to the secret subtree specified on the
+// command line.
 func (s *Action) Env(c *cli.Context) error {
 	ctx := ctxutil.WithGlobalFlags(c)
 	name := c.Args().First()

--- a/internal/action/env_test.go
+++ b/internal/action/env_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestEnv(t *testing.T) {
+func TestEnvLeafHappyPath(t *testing.T) {
 	u := gptest.NewUnitTester(t)
 	defer u.Remove()
 
@@ -34,6 +34,12 @@ func TestEnv(t *testing.T) {
 		stdout = os.Stdout
 	}()
 
+	// Command-line would be: "gopass env foo env", where "foo" is an existing
+	// secret with value "secret". We expect to see the key/value in the output
+	// of the /usr/bin/env utility in the form "FOO=secret".
+	//
+	// TODO(@dominikschulz): consider populating foo with a long, random password to
+	// absolutely ensure that the correct secret is displayed.
 	assert.NoError(t, act.Env(gptest.CliCtx(ctx, t, "foo", "env")))
-	assert.Contains(t, buf.String(), "secret")
+	assert.Contains(t, buf.String(), "FOO=secret\n")
 }

--- a/internal/action/env_test.go
+++ b/internal/action/env_test.go
@@ -59,3 +59,19 @@ func TestEnvSecretNotFound(t *testing.T) {
 	assert.EqualError(t, act.Env(gptest.CliCtx(ctx, t, "non-existing", "true")),
 		"Secret non-existing not found")
 }
+
+func TestEnvProgramNotFound(t *testing.T) {
+	u := gptest.NewUnitTester(t)
+	defer u.Remove()
+
+	ctx := context.Background()
+	ctx = ctxutil.WithAlwaysYes(ctx, true)
+	ctx = ctxutil.WithTerminal(ctx, false)
+	act, err := newMock(ctx, u)
+	require.NoError(t, err)
+	require.NotNil(t, act)
+
+	// Command-line would be: "gopass env foo non-existing".
+	assert.EqualError(t, act.Env(gptest.CliCtx(ctx, t, "foo", "non-existing")),
+		"exec: \"non-existing\": executable file not found in $PATH")
+}

--- a/internal/action/env_test.go
+++ b/internal/action/env_test.go
@@ -43,3 +43,19 @@ func TestEnvLeafHappyPath(t *testing.T) {
 	assert.NoError(t, act.Env(gptest.CliCtx(ctx, t, "foo", "env")))
 	assert.Contains(t, buf.String(), "FOO=secret\n")
 }
+
+func TestEnvSecretNotFound(t *testing.T) {
+	u := gptest.NewUnitTester(t)
+	defer u.Remove()
+
+	ctx := context.Background()
+	ctx = ctxutil.WithAlwaysYes(ctx, true)
+	ctx = ctxutil.WithTerminal(ctx, false)
+	act, err := newMock(ctx, u)
+	require.NoError(t, err)
+	require.NotNil(t, act)
+
+	// Command-line would be: "gopass env non-existing true".
+	assert.EqualError(t, act.Env(gptest.CliCtx(ctx, t, "non-existing", "true")),
+		"Secret non-existing not found")
+}

--- a/internal/action/env_test.go
+++ b/internal/action/env_test.go
@@ -75,3 +75,20 @@ func TestEnvProgramNotFound(t *testing.T) {
 	assert.EqualError(t, act.Env(gptest.CliCtx(ctx, t, "foo", "non-existing")),
 		"exec: \"non-existing\": executable file not found in $PATH")
 }
+
+// Crash regression
+func TestEnvProgramNotSpecified(t *testing.T) {
+	u := gptest.NewUnitTester(t)
+	defer u.Remove()
+
+	ctx := context.Background()
+	ctx = ctxutil.WithAlwaysYes(ctx, true)
+	ctx = ctxutil.WithTerminal(ctx, false)
+	act, err := newMock(ctx, u)
+	require.NoError(t, err)
+	require.NotNil(t, act)
+
+	// Command-line would be: "gopass env foo".
+	assert.EqualError(t, act.Env(gptest.CliCtx(ctx, t, "foo")),
+		"Missing subcommand to execute")
+}


### PR DESCRIPTION
`env` command: do not crash if called without a command to execute

Fixes: #1474.

Best reviewed commit-per-commit.

As explained in the comments with the fix, I am not sure that is the correct place.

* env command: tests: make the test more stringent
* env command: tests: add test for secret not found
* env command: tests: add test for program not found
* FIX env command: do not crash if called without a command to execute
