### PR TITLE
Do not allow saving a malformed native secret

### DIFF
--- a/pkg/gopass/secret/mime.go
+++ b/pkg/gopass/secret/mime.go
@@ -15,6 +15,15 @@ const (
 	Ident = "GOPASS-SECRET-1.0"
 )
 
+// PermanentError signal that parsing should not attempt other formats.
+type PermanentError struct {
+	Err error
+}
+
+func (p *PermanentError) Error() string {
+	return p.Err.Error()
+}
+
 // MIME is a gopass MIME secret
 type MIME struct {
 	Header textproto.MIMEHeader
@@ -64,10 +73,10 @@ func ParseMIME(buf []byte) (*MIME, error) {
 	tpr := textproto.NewReader(r)
 	m.Header, err = tpr.ReadMIMEHeader()
 	if err != nil {
-		return nil, err
+		return nil, &PermanentError{Err: err}
 	}
 	if _, err := io.Copy(m.body, r); err != nil {
-		return nil, err
+		return nil, &PermanentError{err}
 	}
 	return m, nil
 }

--- a/pkg/gopass/secret/secparse/parse.go
+++ b/pkg/gopass/secret/secparse/parse.go
@@ -18,6 +18,9 @@ func Parse(in []byte) (gopass.Secret, error) {
 		return s, nil
 	}
 	debug.Log("failed to parse as MIME: %s", err)
+	if _, ok := err.(*secret.PermanentError); ok {
+		return secrets.ParsePlain(in), err
+	}
 	s, err = secrets.ParseYAML(in)
 	if err == nil {
 		debug.Log("parsed as YAML: %+v", s)


### PR DESCRIPTION
Fixes #1484

RELEASE_NOTES=[BUGFIX] Do not allow malformed secrets

Signed-off-by: Dominik Schulz <dominik.schulz@gauner.org>