### PR TITLE
Fix jsonapi returning 0.0.0 instead of actual version in standalone binary

### DIFF
--- a/cmd/gopass-jsonapi/jsonapi.go
+++ b/cmd/gopass-jsonapi/jsonapi.go
@@ -31,7 +31,13 @@ type jsonapiCLI struct {
 // listen reads a json message on stdin and responds on stdout
 func (s *jsonapiCLI) listen(c *cli.Context) error {
 	ctx := ctxutil.WithGlobalFlags(c)
-	api := jsonapi.API{Store: s.gp, Reader: stdin, Writer: stdout, Version: semver.Version{}}
+
+	version, err := semver.Parse(c.App.Version)
+	if err != nil {
+		version = semver.Version{}
+	}
+
+	api := jsonapi.API{Store: s.gp, Reader: stdin, Writer: stdout, Version: version}
 	if err := api.ReadAndRespond(ctx); err != nil {
 		return api.RespondError(err)
 	}


### PR DESCRIPTION
gopass-jsonapi binary v1.10.0-rc.0 always returns version 0.0.0 via jsonapi command, which makes the gopassbridge version check fail:

![Screenshot 2020-08-11 at 01 01 32](https://user-images.githubusercontent.com/7095678/89840082-ad166400-db6f-11ea-9e02-e5b48196c29f.png)

With this fix, the version is correctly reported when defined during build:
![Screenshot 2020-08-11 at 01 14 53](https://user-images.githubusercontent.com/7095678/89840292-22823480-db70-11ea-89fc-9cbe55cbdbb3.png)

RELEASE_NOTES=n/a

This is also tracked in https://github.com/gopasspw/gopassbridge/issues/165