### PR TITLE
Rename show flag --force to --unsafe

### DIFF
--- a/internal/action/commands.go
+++ b/internal/action/commands.go
@@ -817,9 +817,9 @@ func (s *Action) GetCommands() []*cli.Command {
 					Usage: "Print the first line of the secret as QR Code",
 				},
 				&cli.BoolFlag{
-					Name:    "force",
-					Aliases: []string{"f"},
-					Usage:   "Display the password even if safecontent is enabled",
+					Name:    "unsafe",
+					Aliases: []string{"u", "force", "f"},
+					Usage:   "Display unsafe content (e.g. the password) even if safecontent is enabled",
 				},
 				&cli.BoolFlag{
 					Name:    "password",

--- a/internal/action/show.go
+++ b/internal/action/show.go
@@ -27,8 +27,8 @@ func showParseArgs(c *cli.Context) context.Context {
 	if c.IsSet("clip") {
 		ctx = WithOnlyClip(ctx, c.Bool("clip"))
 	}
-	if c.IsSet("force") {
-		ctx = ctxutil.WithForce(ctx, c.Bool("force"))
+	if c.IsSet("unsafe") {
+		ctx = ctxutil.WithForce(ctx, c.Bool("unsafe"))
 	}
 	if c.IsSet("qr") {
 		ctx = WithPrintQR(ctx, c.Bool("qr"))

--- a/internal/action/show_test.go
+++ b/internal/action/show_test.go
@@ -84,7 +84,7 @@ func TestShowMulti(t *testing.T) {
 	})
 
 	t.Run("show foo with safecontent enabled, with the force flag", func(t *testing.T) {
-		c := gptest.CliCtxWithFlags(ctx, t, map[string]string{"force": "true"}, "foo")
+		c := gptest.CliCtxWithFlags(ctx, t, map[string]string{"unsafe": "true"}, "foo")
 		assert.NoError(t, act.Show(c))
 		assert.Contains(t, buf.String(), "secret")
 		buf.Reset()
@@ -193,7 +193,7 @@ func TestShowAutoClip(t *testing.T) {
 	// gopass show -f foo
 	// -> ONLY print
 	t.Run("gopass show -f foo", func(t *testing.T) {
-		c := gptest.CliCtxWithFlags(ctx, t, map[string]string{"force": "true"}, "foo")
+		c := gptest.CliCtxWithFlags(ctx, t, map[string]string{"unsafe": "true"}, "foo")
 		assert.NoError(t, act.Show(c))
 		assert.NotContains(t, buf.String(), "WARNING")
 		assert.Contains(t, buf.String(), "secret")
@@ -243,7 +243,7 @@ func TestShowAutoClip(t *testing.T) {
 	t.Run("gopass show -f foo", func(t *testing.T) {
 		// autoclip=false
 		ctx := ctxutil.WithAutoClip(ctx, false)
-		c := gptest.CliCtxWithFlags(ctx, t, map[string]string{"force": "true"}, "foo")
+		c := gptest.CliCtxWithFlags(ctx, t, map[string]string{"unsafe": "true"}, "foo")
 		assert.NoError(t, act.Show(c))
 		assert.NotContains(t, buf.String(), "WARNING")
 		assert.Contains(t, buf.String(), "secret")


### PR DESCRIPTION
Fixes #1505

RELEASE_NOTES=[CLEANUP] Rename --force to --unsafe for show

Signed-off-by: Dominik Schulz <dominik.schulz@gauner.org>