### PR TITLE
Remove show --sync flag

### DIFF
--- a/internal/action/commands.go
+++ b/internal/action/commands.go
@@ -826,11 +826,6 @@ func (s *Action) GetCommands() []*cli.Command {
 					Aliases: []string{"o"},
 					Usage:   "Display only the password",
 				},
-				&cli.BoolFlag{
-					Name:    "sync",
-					Aliases: []string{"s"},
-					Usage:   "Sync before attempting to display the secret",
-				},
 				&cli.StringFlag{
 					Name:  "revision",
 					Usage: "Show a past revision",

--- a/internal/action/show.go
+++ b/internal/action/show.go
@@ -56,12 +56,6 @@ func (s *Action) Show(c *cli.Context) error {
 		ctx = WithKey(ctx, key)
 	}
 
-	if c.Bool("sync") {
-		if err := s.sync(out.WithHidden(ctx, true), s.Store.MountPoint(name)); err != nil {
-			out.Error(ctx, "Failed to sync %s: %s", name, err)
-		}
-	}
-
 	if err := s.show(ctx, c, name, true); err != nil {
 		return ExitError(ExitDecrypt, err, "%s", err)
 	}


### PR DESCRIPTION
Fixes #1504

RELEASE_NOTES=[CLEANUP] Remove the --sync flag to gopass show

Signed-off-by: Dominik Schulz <dominik.schulz@gauner.org>