### PR TITLE
Add documentation for audit, generate, insert and show flags

### DIFF
--- a/docs/commands/audit.md
+++ b/docs/commands/audit.md
@@ -1,0 +1,19 @@
+# `audit` command
+
+The `audit` command will decrypt all secrets and scan for weak passwords or other common flaws.
+
+## Synopsis
+
+```
+$ gopass aduit
+```
+
+## Password strength backends
+
+Backend | Description
+------- | -----------
+[`zxcvbn`](https://github.com/nbutton23/zxcvbn) | [zxcvbn](https://github.com/dropbox/zxcvbn) password strength checker.
+[`crunchy`](https://github.com/muesli/crunchy) | Crunchy password strength checker
+`name` | Checks if password equals the name of the secret
+
+

--- a/docs/commands/generate.md
+++ b/docs/commands/generate.md
@@ -1,0 +1,49 @@
+# `generate` command
+
+The `generate` command is used to generate a new password and store it into the password store.
+
+Note: If you only want generate a password without storing it in the store, use the `pwgen` command.
+
+## Synopsis
+
+```
+$ gopass generate entry [length]
+$ gopass generate entry key [length]
+```
+
+## Modes of operation
+
+* Generate a new entry with a new password, e.g. a new login. Setting the `Password` field, `gopass generate entry [chars]`
+* Re-generating a new password and setting it in the `Password` field of an existing entry
+* Generate a new password and setting it to a new key of an existing secret, e.g. `gopass generate entry key [chars]
+* Re-generate a new password for an existing key in an existing entry
+
+## Flags
+
+Flag | Aliases | Description
+---- | ------- | -----------
+`--clip` | `-c` | Copy the generated password into the clipboard. Default: Value of `autoclip`
+`--print` | `-p` | Print the generated password to the terminal. Default: false.
+`--force` | `-f` | Force overwriting an existing entry.
+`--edit` | `-e` | Generate a password and open the entry for editing in `$EDITOR`.
+`--generator` | `-g` | Choose of of the available password generators, desribed below. Default: `cryptic`
+`--symbols` | `-s` | Include symbols in the generated password (default: `false`)
+`--strict` | | Ensure each requested character class is actually included. Without this option all requested classes can be included, but not necessarily are. (default: `false`)
+`--sep` | | Word separator for multi-word generators.
+`--lang`| | Language for word-based generators.
+
+## Password Generators
+
+Use `--generator` to select one of the available password generators:
+
+Generator | Description
+--------- | -----------
+`cryptic` | The default generator yields cryptic passwords that should work with most sites. Use `--symbols` and `--strict` if the site has specific requirements. Please note that we auto-detect the correct rules for some sites. The length argument specifies the number of characters.
+`xkcd` | Use an [XKCD#936](https://xkcd.com/936/) style password. Use `--lang` and `--sep` to refine it's behaviour. The length argument specifies the number of words.
+`memorable` | Generate a memorable password. The length argument specifies the minimum lenght of characters. Please note that the password might be longer if not all necessary rules were satisfied by the minimum length solution.
+`external` | Use the external generator from `$GOPASS_EXTERNAL_PWGEN`
+
+## Relevant configuration options
+
+* `autoclip` only applies to `generate`. If set the generated password is automatically copied to the clipboard - unless `--clip` is `false`
+* `safecontent` will suppress printing of the password, unless `-p` is set. The password will not be copied, unless `-c` or the `autoclip` option are set.

--- a/docs/commands/insert.md
+++ b/docs/commands/insert.md
@@ -1,0 +1,30 @@
+# `insert` command
+
+The `insert` command is used to manually set (insert, or change) a password in the store. It applies to either new or existing secrets.
+
+## Synopsis
+
+```
+$ gopass insert entry
+$ gopass insert entry key
+```
+
+## Modes of operations
+
+* Create a new entry with a user-supplied password, e.g. a new site with a user-generated password or one picked from `gopass pwgen`: `gopass insert entry`
+* Change an existing entry to a user-supplied password
+* Create and change any field of a new or existing secret: `gopass insert entry key`
+* Read data from STDIN and insert (or append) to a secret
+
+Insert is simliar in effect to `gopass edit` with the advantage of not displaying any content of the secret when changing a key.
+
+Note: `insert` will not change anything but the `Password` field (using the `insert entry` invocation) or the specified key (using the `insert entry key` invocation).
+
+## Flags
+
+Flag | Aliases | Description
+---- | ------- | -----------
+`--echo` | `-e` | Display the secret while typing (default: `false`)
+`--multiline` | `-m` | Insert using `$EDITOR` (default: `false`). This identical to running `gopass edit entry`. All other flags are ignored.
+`--force` | `-f` | Overwrite any existing value and do not prompt. (default: `false`)
+`--append` | `-a` | Append to any existing data. Only applies if reading from STDIN. (default: `false`)

--- a/docs/commands/show.md
+++ b/docs/commands/show.md
@@ -1,0 +1,44 @@
+# `show` command
+
+This `show` command is the most important and most frequently used command.
+It allows displaying and copying the content of the secrets managed by gopass.
+
+## Synopsis
+
+```
+$ gopass show entry
+$ gopass show entry key
+$ gopass show entry --qr
+$ gopass show entry --password
+```
+
+## Modes of operation
+
+* Show the whole entry: `gopass show entry`
+* Show a specific key of the given entry: `gopass show entry key`
+
+## Flags
+
+Flag | Aliases | Description
+---- | ------- | -----------
+`--clip` | `-c` | Copy the password value into the clipboard and don't show the content.
+`--alsoclip` | `-C` | Copy the password value into the clipboard and show the content.
+`--qr` | | Encode the password field as a QR code and print it. Note: When combining with `-c`/`-C` the unencoded password is copied. Not the QR code.
+`--unsafe` | `-u` | Display unsafe content (e.g. the password) even when the `safecontent` option is set. No-op when `safecontent` is `false`.
+`--password` | `-o` | Display only the password. For use in scripts. Takes precedence over other flags.
+`--revision` | `-r` | Display a specific revision of the entry. Use an exact version identifier from `gopass history` or the special `-N` syntax. Does not work with native (e.g. git) refs.
+
+## Modes of operation
+
+This section describes the expected behaviour of the `show` command with respect to different combinations of flags and config options.
+
+Note: This section desribed the expected behaviour, not necessarily the observed behaviour. If you notice any discrepancies please file a bug and we will try to fix it.
+
+TODO: We need to specify the expecations around new lines.
+
+* When no flag is set the `show` command will display the full content of the secret. If the `safecontent` option is set to `false` any secret fields (currently only `Password`) are replaced with a random number of '*' characters (length: 5-10). Using the `--unsafe` flag will reveal these fields even if `safecontent` is enabled. `--password` takes precedence of `safecontent=true` as well.
+* The `--clip` flag will copy the value of the `Password` field to the clipboard and doesn't display any part of the secret.
+* The `--alsoclip` option will copy the value of the `Password` field but also display the secret content depending on the `safecontent` setting, i.e. obstructing the `Password` field if `safecontent` is `true` or just displaying it if not.
+* The `--qr` flags operates complementary to other flags. It will *additionally* format the value of the `Password` entry as a QR code and display it. Other than that it will honor the other options, e.g. `gopass show --qr` will display the QR code *and* the whole secret content below. One special case is the `-o` flag, this flag doesn't make a lot of sense in combination, so if both `--qr` and `-o` are given only the QR code will be displayed.
+* Since gopass already supports different RCS backends (e.g. git and the custom `ondisk` format) we do not support arbitrary git refs as arguments to the `--revision` flag. Using those might work, but this is explicitly not supported and bug reports will be closed as `wont-fix`. There are two issues with using arbitrary git refs is that (a) this doesn't work with non-git RCS backends and (b) git versions a whole repository, not single files. So the revision `HEAD^`
+  might not have any changes for a given entry. Thus we only support specifc revisions obtained from `gopass history` or our custom syntax `-N` where N is an integer identifying a specific commit before `HEAD` (cf. `HEAD~N`).

--- a/docs/config.md
+++ b/docs/config.md
@@ -50,11 +50,11 @@ This is a list of available options:
 | `askformore`     | `bool`   | If enabled - it will ask to add more data after use of `generate` command.  DEPRECATED in v1.9.3 |
 | `autoclip`       | `bool`   | Always copy the password created by `gopass generate`. Only applies to generate. |
 | `autoimport`     | `bool`   | Import missing keys stored in the pass repository without asking. |
-| `autosync`       | `bool`   | Always do a `git push` after a commit to the store. Makes sure your local changes are always available on your git remote. DEPRECATED in v1.9.3 |
+| `autosync`       | `bool`   | Always do a `git push` after a commit to the store. Makes sure your local changes are always available on your git remote. DEPRECATED in v1.10.0 |
 | `concurrency`    | `int`    | Number of threads to use for batch operations (such as reencrypting).  DEPRECATED in v1.9.3 |
 | `cliptimeout`    | `int`    | How many seconds the secret is stored when using `-c`. |
 | `exportkeys`     | `bool`   | Export public keys of all recipients to the store. |
-| `recipient_hash` | `map`    | Map of recipient ids to their hashes.  DEPRECATED in v1.9.3 |
+| `recipient_hash` | `map`    | Map of recipient ids to their hashes.  DEPRECATED in v1.10.0 |
 | `usesymbols`     | `bool`   | If enabled - it will use symbols when generating passwords.  DEPRECATED in v1.9.3 |
 | `nocolor`        | `bool`   | Do not use color. |
 | `nopager`        | `bool`   | Do not invoke a pager to display long lists. |

--- a/internal/action/commands.go
+++ b/internal/action/commands.go
@@ -805,16 +805,16 @@ func (s *Action) GetCommands() []*cli.Command {
 				&cli.BoolFlag{
 					Name:    "clip",
 					Aliases: []string{"c"},
-					Usage:   "Copy the first line of the secret into the clipboard",
+					Usage:   "Copy the password value into the clipboard",
 				},
 				&cli.BoolFlag{
 					Name:    "alsoclip",
 					Aliases: []string{"C"},
-					Usage:   "Copy the first line of the secret and show everything",
+					Usage:   "Copy the password and show everything",
 				},
 				&cli.BoolFlag{
 					Name:  "qr",
-					Usage: "Print the first line of the secret as QR Code",
+					Usage: "Print the password as a QR Code",
 				},
 				&cli.BoolFlag{
 					Name:    "unsafe",
@@ -824,7 +824,7 @@ func (s *Action) GetCommands() []*cli.Command {
 				&cli.BoolFlag{
 					Name:    "password",
 					Aliases: []string{"o"},
-					Usage:   "Display only the password",
+					Usage:   "Display only the password. Takes precedence over othe flags.",
 				},
 				&cli.StringFlag{
 					Name:  "revision",


### PR DESCRIPTION
RELEASE_NOTES=[DOCUMENTATION] Document audit, generate, insert and show
flags

Signed-off-by: Dominik Schulz <dominik.schulz@gauner.org>