### PR TITLE
Obstruct unsafe keys in the output

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -444,7 +444,7 @@ To check and reencrypt secrets if recipients are missing, run `gopass fsck`.
 
 ### Debugging
 
-To debug gopass, set the environment variable `GOPASS_DEBUG` to `true`.
+To debug gopass, set the environment variable `GOPASS_DEBUG_LOG` to a output filename.
 
 ### Restricting the characters in generated passwords
 
@@ -473,4 +473,13 @@ This makes it easy to use templates for certain kind of secrets such as database
 ### JSON API
 
 `gopass-jsonapi` enables communication with gopass via JSON messages. This is particularly useful for browser plugins like [gopassbridge](https://github.com/gopasspw/gopassbridge) running gopass as native app. More details can be found in [docs/jsonapi.md](./jsonapi.md).
+
+### Safecontent
+
+Gopass can limit display of certain *unsafe* fields in secrets.
+By default no fields are obstructed, but if the `safecontent`
+config option is set to `true` the `Password` field is obstructed.
+Also the special `Unsafe-Keys` key is evaluated. It expectes
+a comma separated list of keys that will be obstructed when
+printing the secret.
 

--- a/internal/action/show_test.go
+++ b/internal/action/show_test.go
@@ -97,6 +97,34 @@ func TestShowMulti(t *testing.T) {
 		assert.NotContains(t, buf.String(), "123")
 		buf.Reset()
 	})
+
+	t.Run("show entry with unsafe keys", func(t *testing.T) {
+		sec := secret.New()
+		sec.Set("password", "123")
+		sec.Set("bar", "zab")
+		sec.Set("foo", "baz")
+		sec.Set("hello", "world")
+		sec.Set("Unsafe-Keys", "foo, bar")
+		assert.NoError(t, act.Store.Set(ctx, "unsafe/keys", sec))
+		buf.Reset()
+
+		ctx = ctxutil.WithShowSafeContent(ctx, true)
+		c := gptest.CliCtx(ctx, t, "unsafe/keys")
+		assert.NoError(t, act.Show(c))
+		assert.Contains(t, buf.String(), "*****")
+		assert.NotContains(t, buf.String(), "zab")
+		assert.NotContains(t, buf.String(), "baz")
+		buf.Reset()
+	})
+
+	t.Run("show twoliner with safecontent enabled", func(t *testing.T) {
+		ctx = ctxutil.WithShowSafeContent(ctx, true)
+		c := gptest.CliCtx(ctx, t, "bar/baz")
+
+		assert.NoError(t, act.Show(c))
+		assert.Equal(t, "Bar: zab", buf.String())
+		buf.Reset()
+	})
 }
 
 func TestShowAutoClip(t *testing.T) {


### PR DESCRIPTION
This commit introduces a special key called Unsafe-Keys.
Populating this key in any secret with a comma separated
list of unsafe keys will make gopass obstruct these keys
on output if the safecontent option is set.

Fixes #1524
Fixes #408

RELEASE_NOTES=[ENHANCEMENT] Introduce unsafe-keys

Signed-off-by: Dominik Schulz <dominik.schulz@gauner.org>