### PR TITLE
Provide more helpful output when config contains extra fields

### DIFF
--- a/tests/tester.go
+++ b/tests/tester.go
@@ -19,10 +19,10 @@ import (
 )
 
 const (
-	gopassConfig = `root:
-  autoclip: false
-  autoimport: true
-  cliptimeout: 45
+	gopassConfig = `autoclip: false
+autoimport: true
+cliptimeout: 45
+exportkeys: false
 `
 	keyID = "BE73F104"
 )
@@ -81,7 +81,7 @@ func newTester(t *testing.T) *tester {
 	// write config
 	require.NoError(t, os.MkdirAll(filepath.Dir(ts.gopassConfig()), 0700))
 	// we need to set the root path to something else than the root directory otherwise the mounts will show as regular entries
-	if err := ioutil.WriteFile(ts.gopassConfig(), []byte(gopassConfig+"\n  path: "+ts.storeDir("root")+"\n"), 0600); err != nil {
+	if err := ioutil.WriteFile(ts.gopassConfig(), []byte(gopassConfig+"\npath: "+ts.storeDir("root")+"\n"), 0600); err != nil {
 		t.Fatalf("Failed to write gopass config to %s: %s", ts.gopassConfig(), err)
 	}
 


### PR DESCRIPTION
RELEASE_NOTES=[ENHANCEMENT] Provide more helpful config parse errors

Fixes #1537

Signed-off-by: Dominik Schulz <dominik.schulz@gauner.org>