### PR TITLE
Add regexp support to gopass grep

### DIFF
--- a/internal/action/commands.go
+++ b/internal/action/commands.go
@@ -483,6 +483,13 @@ func (s *Action) GetCommands() []*cli.Command {
 			Before: s.Initialized,
 			Action: s.Grep,
 			Hidden: true,
+			Flags: []cli.Flag{
+				&cli.BoolFlag{
+					Name:    "regexp",
+					Aliases: []string{"r"},
+					Usage:   "Interpret pattern as RE2 regular expression",
+				},
+			},
 		},
 		{
 			Name:    "history",

--- a/internal/action/grep_test.go
+++ b/internal/action/grep_test.go
@@ -32,14 +32,27 @@ func TestGrep(t *testing.T) {
 	}()
 
 	c := gptest.CliCtx(ctx, t, "foo")
-	assert.NoError(t, act.Grep(c))
-	buf.Reset()
+	t.Run("empty store", func(t *testing.T) {
+		defer buf.Reset()
+		assert.NoError(t, act.Grep(c))
+	})
 
-	// add some secret
-	sec := secret.New()
-	sec.Set("password", "foobar")
-	sec.WriteString("foobar")
-	assert.NoError(t, act.Store.Set(ctx, "foo", sec))
-	assert.NoError(t, act.Grep(c))
-	buf.Reset()
+	t.Run("add some secret", func(t *testing.T) {
+		defer buf.Reset()
+		sec := secret.New()
+		sec.Set("password", "foobar")
+		sec.WriteString("foobar")
+		assert.NoError(t, act.Store.Set(ctx, "foo", sec))
+	})
+
+	t.Run("should find existing", func(t *testing.T) {
+		defer buf.Reset()
+		assert.NoError(t, act.Grep(c))
+	})
+
+	t.Run("RE2", func(t *testing.T) {
+		defer buf.Reset()
+		c := gptest.CliCtxWithFlags(ctx, t, map[string]string{"regexp": "true"}, "f..bar")
+		assert.NoError(t, act.Grep(c))
+	})
 }


### PR DESCRIPTION
Fixes #1543

RELEASE_NOTES=[ENHANCEMENT] Add regexp support to gopass grep

Signed-off-by: Dominik Schulz <dominik.schulz@gauner.org>