### PR TITLE
Re-use existing .password-store directory if it exists

### DIFF
--- a/internal/config/location.go
+++ b/internal/config/location.go
@@ -63,6 +63,10 @@ func PwStoreDir(mount string) string {
 	if d := os.Getenv("PASSWORD_STORE_DIR"); d != "" {
 		return fsutil.CleanPath(d)
 	}
+	if ld := filepath.Join(appdir.UserHome(), ".password-store"); fsutil.IsDir(ld) {
+		debug.Log("re-using existing legacy dir for root store: %s", ld)
+		return ld
+	}
 	return fsutil.CleanPath(filepath.Join(appdir.UserData(), "stores", "root"))
 }
 

--- a/pkg/appdir/appdir.go
+++ b/pkg/appdir/appdir.go
@@ -2,3 +2,23 @@
 // like config, cache and data dirs. On Linux this uses the XDG specification,
 // on MacOS and Windows the platform defaults.
 package appdir
+
+import (
+	"os"
+
+	"github.com/gopasspw/gopass/internal/debug"
+)
+
+// UserHome returns the users home dir
+func UserHome() string {
+	if hd := os.Getenv("GOPASS_HOMEDIR"); hd != "" {
+		return hd
+	}
+
+	uhd, err := os.UserHomeDir()
+	if err != nil {
+		debug.Log("failed to detect user home dir: %s", err)
+		return ""
+	}
+	return uhd
+}


### PR DESCRIPTION
Fixes #1549

RELEASE_NOTES=[BUGFIX] Re-use existing root store

Signed-off-by: Dominik Schulz <dominik.schulz@gauner.org>