### PR TITLE
Re-introduce gopass -c

### DIFF
--- a/docs/commands/gopass.md
+++ b/docs/commands/gopass.md
@@ -8,6 +8,7 @@ has two different modes.
 ```
 $ gopass
 $ gopass entry
+$ gopass -c entry
 ```
 
 ## Modes of operation
@@ -18,4 +19,10 @@ $ gopass entry
 
 ## Flags
 
-Note: `gopass` intentionally does not support any flags. If you need to use any flag consider using `gopass show` instead.
+Note: DO NOT use in scripts! Use `gopass show` instead.
+
+Flag | Aliases | Description
+---- | ------- | -----------
+`--clip` | `-c` | Copy the password value into the clipboard and don't show the content.
+`--unsafe` | `-u` | Display unsafe content (e.g. the password) even when the `safecontent` option is set. No-op when `safecontent` is `false`.
+

--- a/main.go
+++ b/main.go
@@ -140,6 +140,18 @@ func setupApp(ctx context.Context, sv semver.Version) (context.Context, *cli.App
 		action.Complete(c)
 	}
 
+	app.Flags = []cli.Flag{
+		&cli.BoolFlag{
+			Name:    "clip",
+			Aliases: []string{"c"},
+			Usage:   "Copy the password value into the clipboard",
+		},
+		&cli.BoolFlag{
+			Name:    "unsafe",
+			Aliases: []string{"u", "force", "f"},
+			Usage:   "Display unsafe content (e.g. the password) even if safecontent is enabled",
+		},
+	}
 	app.Action = func(c *cli.Context) error {
 		if err := action.Initialized(c); err != nil {
 			return err


### PR DESCRIPTION
This PR re-introduces the `gopass -c` flag along the `-u` flag to make using the default action more convenient.

RELEASE_NOTES=[ENHANCEMENT] Re-introduce gopass -c

Signed-off-by: Dominik Schulz <dominik.schulz@gauner.org>