### PR TITLE
Fix notifications text on darwin

### DIFF
--- a/internal/notify/notify_darwin.go
+++ b/internal/notify/notify_darwin.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"os"
 	"os/exec"
-	"strings"
 
 	"github.com/gopasspw/gopass/pkg/ctxutil"
 )
@@ -45,7 +44,7 @@ func osaNotification(msg string, subj string) error {
 
 // exec notification program with passed arguments
 func execNotification(executable string, args []string) error {
-	return execCommand(executable, strings.Join(args[:], " ")).Start()
+	return execCommand(executable, args...).Start()
 }
 
 // display notification with terminal-notifier


### PR DESCRIPTION
Hi,

I noticed that copy to clipboard notifications on mac (Catalina 10.15.6) looks almost blank:

<img width="383" alt="Screenshot 2020-09-11 at 21 16 16" src="https://user-images.githubusercontent.com/1165242/92960688-bba9b100-f476-11ea-9a65-982ed15f6f2e.png">

Proposed change fixes this behaviour.

Also, there is a problem with an icon in notifications, because macs don't have `~/.cache` folder by default and the recent change relies on it #1557, but this PR doesn't cover it.