### PR TITLE
Correcting newlines handling

### DIFF
--- a/internal/action/completion.go
+++ b/internal/action/completion.go
@@ -2,10 +2,11 @@ package action
 
 import (
 	"fmt"
-	"github.com/gopasspw/gopass/internal/tree"
 	"regexp"
 	"runtime"
 	"strings"
+
+	"github.com/gopasspw/gopass/internal/tree"
 
 	fishcomp "github.com/gopasspw/gopass/internal/completion/fish"
 	zshcomp "github.com/gopasspw/gopass/internal/completion/zsh"

--- a/internal/action/copy_test.go
+++ b/internal/action/copy_test.go
@@ -68,6 +68,6 @@ func TestCopy(t *testing.T) {
 	buf.Reset()
 
 	assert.NoError(t, act.show(ctx, c, "zab/bam/zab", false))
-	assert.Equal(t, "\nbarfoo\n", buf.String())
+	assert.Equal(t, "Password: barfoo\n", buf.String())
 	buf.Reset()
 }

--- a/internal/action/env.go
+++ b/internal/action/env.go
@@ -2,11 +2,12 @@ package action
 
 import (
 	"fmt"
-	"github.com/gopasspw/gopass/internal/tree"
 	"os"
 	"os/exec"
 	"path"
 	"strings"
+
+	"github.com/gopasspw/gopass/internal/tree"
 
 	"github.com/gopasspw/gopass/internal/debug"
 	"github.com/gopasspw/gopass/pkg/ctxutil"

--- a/internal/action/find.go
+++ b/internal/action/find.go
@@ -3,9 +3,10 @@ package action
 import (
 	"context"
 	"fmt"
-	"github.com/gopasspw/gopass/internal/tree"
 	"sort"
 	"strings"
+
+	"github.com/gopasspw/gopass/internal/tree"
 
 	"github.com/gopasspw/gopass/internal/cui"
 	"github.com/gopasspw/gopass/internal/debug"

--- a/internal/action/fsck.go
+++ b/internal/action/fsck.go
@@ -1,9 +1,10 @@
 package action
 
 import (
-	"github.com/gopasspw/gopass/internal/tree"
 	"os"
 	"path/filepath"
+
+	"github.com/gopasspw/gopass/internal/tree"
 
 	"github.com/gopasspw/gopass/internal/config"
 	"github.com/gopasspw/gopass/internal/out"

--- a/internal/action/generate.go
+++ b/internal/action/generate.go
@@ -3,12 +3,13 @@ package action
 import (
 	"context"
 	"fmt"
-	"github.com/gopasspw/gopass/internal/tree"
 	"path"
 	"regexp"
 	"sort"
 	"strconv"
 	"strings"
+
+	"github.com/gopasspw/gopass/internal/tree"
 
 	"github.com/gopasspw/gopass/internal/clipboard"
 	"github.com/gopasspw/gopass/internal/debug"

--- a/internal/action/grep.go
+++ b/internal/action/grep.go
@@ -1,9 +1,10 @@
 package action
 
 import (
-	"github.com/gopasspw/gopass/internal/tree"
 	"regexp"
 	"strings"
+
+	"github.com/gopasspw/gopass/internal/tree"
 
 	"github.com/gopasspw/gopass/internal/out"
 	"github.com/gopasspw/gopass/pkg/ctxutil"

--- a/internal/action/recipients.go
+++ b/internal/action/recipients.go
@@ -3,6 +3,7 @@ package action
 import (
 	"context"
 	"fmt"
+
 	"github.com/gopasspw/gopass/internal/tree"
 
 	"github.com/gopasspw/gopass/internal/cui"

--- a/internal/action/repl.go
+++ b/internal/action/repl.go
@@ -3,8 +3,9 @@ package action
 import (
 	"context"
 	"fmt"
-	"github.com/gopasspw/gopass/internal/tree"
 	"strings"
+
+	"github.com/gopasspw/gopass/internal/tree"
 
 	"github.com/chzyer/readline"
 	"github.com/gopasspw/gopass/internal/debug"

--- a/internal/action/show_test.go
+++ b/internal/action/show_test.go
@@ -303,30 +303,6 @@ func TestShowHandleError(t *testing.T) {
 	buf.Reset()
 }
 
-func TestShowHandleYAMLError(t *testing.T) {
-	u := gptest.NewUnitTester(t)
-	defer u.Remove()
-
-	ctx := context.Background()
-	ctx = ctxutil.WithAlwaysYes(ctx, true)
-	ctx = ctxutil.WithTerminal(ctx, false)
-	act, err := newMock(ctx, u)
-	require.NoError(t, err)
-	require.NotNil(t, act)
-
-	color.NoColor = true
-	buf := &bytes.Buffer{}
-	out.Stdout = buf
-	stdout = buf
-	defer func() {
-		stdout = os.Stdout
-		out.Stdout = os.Stdout
-	}()
-
-	assert.Error(t, act.showHandleYAMLError("foo", "bar", fmt.Errorf("test")))
-	buf.Reset()
-}
-
 func TestShowPrintQR(t *testing.T) {
 	u := gptest.NewUnitTester(t)
 	defer u.Remove()

--- a/internal/action/sync.go
+++ b/internal/action/sync.go
@@ -3,6 +3,7 @@ package action
 import (
 	"context"
 	"fmt"
+
 	"github.com/gopasspw/gopass/internal/tree"
 
 	"github.com/gopasspw/gopass/internal/debug"

--- a/internal/action/templates.go
+++ b/internal/action/templates.go
@@ -4,8 +4,9 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/gopasspw/gopass/internal/tree"
 	"strings"
+
+	"github.com/gopasspw/gopass/internal/tree"
 
 	"github.com/gopasspw/gopass/internal/debug"
 	"github.com/gopasspw/gopass/internal/editor"

--- a/internal/secrets/kv_test.go
+++ b/internal/secrets/kv_test.go
@@ -73,7 +73,22 @@ zab: 123`
 Foo: bar
 Password: passw0rd
 Zab: 123
+`
+	sec, err := ParseKV([]byte(in))
+	require.NoError(t, err)
+	msec := sec.MIME()
+	assert.Equal(t, out, string(msec.Bytes()))
+}
 
+func TestMultiKeyKVMIME(t *testing.T) {
+	in := `passw0rd
+foo: baz
+foo: bar
+zab: 123`
+	out := `GOPASS-SECRET-1.0
+Foo: bar
+Password: passw0rd
+Zab: 123
 `
 	sec, err := ParseKV([]byte(in))
 	require.NoError(t, err)

--- a/internal/secrets/plain.go
+++ b/internal/secrets/plain.go
@@ -71,7 +71,10 @@ func (p *Plain) Set(key, value string) {
 	if err != nil {
 		debug.Log("failed to discard password line: %s", err)
 	}
-	io.Copy(buf, br)
+	_, err = io.Copy(buf, br)
+	if err != nil {
+		debug.Log("failed to copy buffer: %s", err)
+	}
 	p.Body = buf.Bytes()
 }
 

--- a/internal/store/root/list_test.go
+++ b/internal/store/root/list_test.go
@@ -2,8 +2,9 @@ package root
 
 import (
 	"context"
-	"github.com/gopasspw/gopass/internal/tree"
 	"testing"
+
+	"github.com/gopasspw/gopass/internal/tree"
 
 	"github.com/fatih/color"
 	"github.com/gopasspw/gopass/internal/gptest"

--- a/internal/store/root/move_test.go
+++ b/internal/store/root/move_test.go
@@ -2,8 +2,9 @@ package root
 
 import (
 	"context"
-	"github.com/gopasspw/gopass/internal/tree"
 	"testing"
+
+	"github.com/gopasspw/gopass/internal/tree"
 
 	"github.com/gopasspw/gopass/internal/gptest"
 	"github.com/gopasspw/gopass/internal/out"

--- a/internal/store/root/store_test.go
+++ b/internal/store/root/store_test.go
@@ -2,10 +2,11 @@ package root
 
 import (
 	"context"
-	"github.com/gopasspw/gopass/internal/tree"
 	"path"
 	"sort"
 	"testing"
+
+	"github.com/gopasspw/gopass/internal/tree"
 
 	"github.com/gopasspw/gopass/internal/backend"
 	"github.com/gopasspw/gopass/internal/config"

--- a/pkg/gopass/api/api.go
+++ b/pkg/gopass/api/api.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"fmt"
+
 	"github.com/gopasspw/gopass/internal/tree"
 
 	_ "github.com/gopasspw/gopass/internal/backend/crypto"  // load crypto backends

--- a/pkg/gopass/secret/mime_test.go
+++ b/pkg/gopass/secret/mime_test.go
@@ -42,8 +42,16 @@ func TestNewline(t *testing.T) {
 	assert.Equal(t, "bar", sec.Get("Foo"))
 
 	assert.Equal(t, in, string(sec.Bytes()))
-	assert.Equal(t, in, string(sec.Bytes()))
-	assert.Equal(t, in, string(sec.Bytes()))
+}
+
+func TestNoNewline(t *testing.T) {
+	in := "GOPASS-SECRET-1.0\nFoo: bar"
+	sec, err := ParseMIME([]byte(in))
+	require.NoError(t, err)
+	assert.Equal(t, "", sec.GetBody())
+	assert.Equal(t, "bar", sec.Get("Foo"))
+
+	assert.Equal(t, in+"\n", string(sec.Bytes()))
 }
 
 func TestEquals(t *testing.T) {

--- a/tests/insert_test.go
+++ b/tests/insert_test.go
@@ -19,4 +19,28 @@ func TestInsert(t *testing.T) {
 
 	_, err = ts.runCmd([]string{ts.Binary, "insert", "some/secret"}, []byte("moar"))
 	assert.NoError(t, err)
+
+	_, err = ts.runCmd([]string{ts.Binary, "insert", "some/newsecret"}, []byte("and\nmoar"))
+	assert.NoError(t, err)
+
+	t.Run("Regression test for #1573 without actual pipes", func(t *testing.T) {
+		out, err = ts.run("show -f some/secret")
+		assert.NoError(t, err)
+		assert.Equal(t, out, "Password: moar")
+
+		out, err = ts.run("show -f some/newsecret")
+		assert.NoError(t, err)
+		assert.Equal(t, out, "Password: and\n\nmoar")
+
+		_, err := ts.run("config mime false")
+		assert.NoError(t, err)
+
+		out, err = ts.run("show -f some/secret")
+		assert.NoError(t, err)
+		assert.Equal(t, out, "moar")
+
+		out, err = ts.run("show -f some/newsecret")
+		assert.NoError(t, err)
+		assert.Equal(t, out, "and\n\nmoar")
+	})
 }

--- a/tests/mount_test.go
+++ b/tests/mount_test.go
@@ -69,7 +69,7 @@ func TestMountShadowing(t *testing.T) {
 
 	out, err := ts.run("show -f mnt/m1/secret")
 	assert.NoError(t, err)
-	assert.Equal(t, "moar", out)
+	assert.Equal(t, "Password: moar", out)
 
 	out, err = ts.run("init --store mnt/m1 --path " + ts.storeDir("m1") + " --storage=fs " + keyID)
 	t.Logf("Output: %s", out)
@@ -94,7 +94,7 @@ func TestMountShadowing(t *testing.T) {
 	// check that the mount is containing our new secret shadowing the old one
 	out, err = ts.run("show -f mnt/m1/secret")
 	assert.NoError(t, err)
-	assert.Equal(t, "food", out)
+	assert.Equal(t, "Password: food", out)
 
 	// add more secrets
 	ts.initSecrets("mnt/m1/")
@@ -145,7 +145,7 @@ gopass
 	assert.NoError(t, err)
 	assert.Equal(t, strings.TrimSpace(list), out)
 
-	out, err = ts.run("show -f mnt/m1/secret")
+	out, err = ts.run("show -o mnt/m1/secret")
 	assert.NoError(t, err)
 	assert.Equal(t, "moar", out)
 }

--- a/tests/show_test.go
+++ b/tests/show_test.go
@@ -34,18 +34,30 @@ func TestShow(t *testing.T) {
 
 	ts.initSecrets("")
 
-	t.Run("show foo", func(t *testing.T) {
+	t.Run("show folder foo", func(t *testing.T) {
 		_, err = ts.run("show foo")
 		assert.NoError(t, err)
-		_, err = ts.run("show -f foo")
+		_, err = ts.run("show -u foo")
 		assert.NoError(t, err)
-		_, err = ts.run("show foo -force")
+		_, err = ts.run("show foo -unsafe")
 		assert.NoError(t, err)
 	})
 
-	t.Run("show fixed/secret", func(t *testing.T) {
-		_, err = ts.run("show fixed/secret")
+	t.Run("show w/o safecontent", func(t *testing.T) {
+		_, err = ts.run("config safecontent false")
 		assert.NoError(t, err)
+
+		out, err := ts.run("show fixed/secret")
+		assert.NoError(t, err)
+		assert.Equal(t, "Password: moar", out)
+
+		out, err = ts.run("show fixed/twoliner")
+		assert.NoError(t, err)
+		assert.Equal(t, "Password: and\n\nmore stuff", out)
+
+		out, err = ts.run("show --qr fixed/secret")
+		assert.NoError(t, err)
+		assert.Equal(t, goldenQr, out)
 	})
 
 	t.Run("show w/o autoclip", func(t *testing.T) {
@@ -55,40 +67,130 @@ func TestShow(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	t.Run("force showing full secret", func(t *testing.T) {
-		out, err := ts.run("show -f fixed/secret")
+	t.Run("show with safecontent", func(t *testing.T) {
+		_, err = ts.run("config safecontent true")
 		assert.NoError(t, err)
-		assert.Equal(t, "Password: moar", out)
+		_, err = ts.run("config mime true")
+		assert.NoError(t, err)
+
+		out, err := ts.run("show fixed/secret")
+		assert.NoError(t, err)
+		assert.Contains(t, out, "Password: ***")
+
+		out, err = ts.run("show fixed/twoliner password")
+		assert.NoError(t, err)
+		assert.Equal(t, "and", out)
+
+		out, err = ts.run("show fixed/twoliner")
+		assert.NoError(t, err)
+		assert.Contains(t, out, "more stuff")
+		assert.NotContains(t, out, "and")
 	})
 
-	out, err := ts.run("show -o fixed/secret")
-	assert.NoError(t, err)
-	assert.Equal(t, "moar", out)
+	t.Run("force showing full secret", func(t *testing.T) {
+		_, err = ts.run("config safecontent true")
+		assert.NoError(t, err)
+		_, err = ts.run("config mime true")
+		assert.NoError(t, err)
 
-	out, err = ts.run("show fixed/twoliner")
-	assert.NoError(t, err)
-	assert.Contains(t, out, "more stuff")
+		out, err := ts.run("show -u fixed/secret")
+		assert.NoError(t, err)
+		assert.Equal(t, "Password: moar", out)
 
-	out, err = ts.run("show -f fixed/twoliner")
-	assert.NoError(t, err)
-	assert.Equal(t, "and\nmore stuff", out)
+		out, err = ts.run("show -o fixed/secret")
+		assert.NoError(t, err)
+		assert.Equal(t, "moar", out)
 
-	out, err = ts.run("show -c fixed/twoliner")
-	assert.Error(t, err)
-	assert.NotContains(t, out, "safe content to display")
+		out, err = ts.run("show -u fixed/twoliner")
+		assert.NoError(t, err)
+		assert.Equal(t, "Password: and\n\nmore stuff", out)
 
-	_, err = ts.run("config safecontent false")
-	assert.NoError(t, err)
+		out, err = ts.run("show -o fixed/twoliner")
+		assert.NoError(t, err)
+		assert.Equal(t, "and", out)
 
-	out, err = ts.run("show fixed/twoliner")
-	assert.NoError(t, err)
-	assert.Equal(t, "and\nmore stuff", out)
+		out, err = ts.run("show -c fixed/twoliner")
+		assert.NoError(t, err)
+		assert.NotContains(t, out, "***")
+		assert.NotContains(t, out, "and")
 
-	out, err = ts.run("show -o fixed/secret")
-	assert.NoError(t, err)
-	assert.Equal(t, "moar", out)
+		out, err = ts.run("show -C fixed/twoliner")
+		assert.NoError(t, err)
+		assert.Contains(t, out, "***")
+		assert.NotContains(t, out, "and")
+	})
 
-	out, err = ts.run("show --qr fixed/secret")
-	assert.NoError(t, err)
-	assert.Equal(t, goldenQr, out)
+	// what if we disable the new secret type after having been using it?
+	t.Run("after disabling mime", func(t *testing.T) {
+		_, err = ts.run("config mime false")
+		assert.NoError(t, err)
+		_, err = ts.run("config safecontent true")
+		assert.NoError(t, err)
+
+		// No flags
+		out, err := ts.run("show fixed/secret")
+		assert.NoError(t, err)
+		assert.Contains(t, out, "***")
+		assert.NotContains(t, out, "Warning: safecontent=true")
+
+		out, err = ts.run("show fixed/twoliner password")
+		assert.NoError(t, err)
+		assert.Equal(t, out, "and")
+
+		out, err = ts.run("show fixed/twoliner")
+		assert.NoError(t, err)
+		assert.Contains(t, out, "more stuff")
+		assert.NotContains(t, out, "and")
+
+		// with flags now
+		out, err = ts.run("show -o fixed/secret")
+		assert.NoError(t, err)
+		assert.Equal(t, "moar", out)
+
+		out, err = ts.run("show -u fixed/secret")
+		assert.NoError(t, err)
+		assert.Equal(t, "moar", out)
+
+		out, err = ts.run("show -o fixed/twoliner")
+		assert.NoError(t, err)
+		assert.Equal(t, "and", out)
+
+		out, err = ts.run("show -u fixed/twoliner")
+		assert.NoError(t, err)
+		assert.Equal(t, "and\n\nmore stuff", out)
+	})
+
+	t.Run("Regression test for #1574 and #1575", func(t *testing.T) {
+		_, err = ts.run("config safecontent true")
+		assert.NoError(t, err)
+		_, err = ts.run("config mime false")
+		assert.NoError(t, err)
+
+		_, err := ts.run("generate fo2 5")
+		assert.NoError(t, err)
+
+		out, err := ts.run("show fo2")
+		assert.Error(t, err)
+		assert.Contains(t, out, "Warning: safecontent=true")
+
+		out, err = ts.run("show -u fo2")
+		assert.NoError(t, err)
+		assert.Equal(t, out, "aaaaa")
+
+		_, err = ts.run("config mime true")
+		assert.NoError(t, err)
+
+		_, err = ts.run("generate fo6 5")
+		assert.NoError(t, err)
+
+		out, err = ts.run("show fo6")
+		assert.NoError(t, err)
+		assert.Contains(t, out, "Password: ***")
+		assert.NotContains(t, out, "\n\n")
+
+		out, err = ts.run("show -u fo6")
+		assert.NoError(t, err)
+		assert.Equal(t, out, "Password: aaaaa")
+		assert.NotContains(t, out, "\n\n")
+	})
 }


### PR DESCRIPTION
Fixes #788
Fixes #1575
Fixes #1574
Fixes #1573
Fixes #1570
Fixes #1592

This is trying to correct the way we display and write newlines.
Newlines are appended by the MIME type after the header but won't be displayed by show now unless the MIME body is non-empty.

Notice the `mime` setting is significantly changing the way secrets are handled, written and displayed, also how the newlines are treated.
I've tried to add tests to take this into account.

I've also added unit tests and integration tests accordingly to try and detect such regressions in the future.

This is changing the behaviour of insert to make it compatible with the new MIME format by parsing its stdin input with the secret parser before writing it.

This is also refactoring the code a bit, removing dead code such as the YAML special handling.