### PR TITLE
Update fixed path in Pre182 legacy-config

### DIFF
--- a/internal/config/legacy.go
+++ b/internal/config/legacy.go
@@ -118,7 +118,7 @@ func (c *Pre182) Config() *Config {
 		Mounts:        make(map[string]string, len(c.Mounts)),
 	}
 	if p, err := pathFromURL(c.Root.Path); err == nil {
-		c.Path = p
+		cfg.Path = p
 	}
 	for k, v := range c.Mounts {
 		p, err := pathFromURL(v.Path)

--- a/internal/config/legacy.go
+++ b/internal/config/legacy.go
@@ -67,7 +67,7 @@ func (c *Pre193) Config() *Config {
 	return cfg
 }
 
-// Pre182 is the current config struct
+// Pre182 is the gopass config structure before version 1.8.2
 type Pre182 struct {
 	Path    string                        `yaml:"-"`
 	Root    *Pre182StoreConfig            `yaml:"root"`
@@ -103,7 +103,7 @@ func (c *Pre182) CheckOverflow() error {
 	return checkOverflow(c.XXX)
 }
 
-// Config converts the Pre140 config to the current config struct
+// Config converts the Pre182 config to the current config struct
 func (c *Pre182) Config() *Config {
 	cfg := &Config{
 		AutoClip:      c.Root.AutoClip,


### PR DESCRIPTION
Hello everyone,
this PR should fix #1561. The issue was just a typo that caused the change to be written to the input-object instead of the output-object.
Let me know if this works for you and thanks for maintaining gopass!