### PR TITLE
Adding back the global yes flag and bugfix insert

### DIFF
--- a/docs/commands/gopass.md
+++ b/docs/commands/gopass.md
@@ -25,4 +25,5 @@ Flag | Aliases | Description
 ---- | ------- | -----------
 `--clip` | `-c` | Copy the password value into the clipboard and don't show the content.
 `--unsafe` | `-u` | Display unsafe content (e.g. the password) even when the `safecontent` option is set. No-op when `safecontent` is `false`.
+`--yes` |  | Assume yes on all yes/no questions or use the default on all others.
 

--- a/internal/action/insert.go
+++ b/internal/action/insert.go
@@ -126,9 +126,14 @@ func (s *Action) insertSingle(ctx context.Context, name, pw string, kvps map[str
 			}
 		}
 	}
+
 	setMetadata(sec, kvps)
-	sec.Set("password", pw)
-	audit.Single(ctx, pw)
+
+	// we only update the pw if the kvps were not set or if it's non-empty, because otherwise we were updating the kvps
+	if pw != "" || len(kvps) == 0 {
+		sec.Set("password", pw)
+		audit.Single(ctx, pw)
+	}
 
 	if err := s.Store.Set(ctxutil.WithCommitMessage(ctx, "Inserted user supplied password"), name, sec); err != nil {
 		return ExitError(ExitEncrypt, err, "failed to write secret '%s': %s", name, err)

--- a/internal/action/insert_test.go
+++ b/internal/action/insert_test.go
@@ -95,6 +95,13 @@ func TestInsert(t *testing.T) {
 		assert.NoError(t, act.Insert(gptest.CliCtxWithFlags(ctx, t, map[string]string{"multiline": "true"}, "bar", "baz")))
 		buf.Reset()
 	})
+
+	t.Run("insert key:value", func(t *testing.T) {
+		assert.NoError(t, act.Insert(gptest.CliCtxWithFlags(ctx, t, nil, "keyvaltest", "baz:val")))
+		assert.NoError(t, act.show(ctx, gptest.CliCtx(ctx, t), "keyvaltest", false))
+		assert.Equal(t, "Baz: val\n", buf.String())
+		buf.Reset()
+	})
 }
 
 func TestInsertStdin(t *testing.T) {

--- a/main.go
+++ b/main.go
@@ -150,6 +150,10 @@ func setupApp(ctx context.Context, sv semver.Version) (context.Context, *cli.App
 			Aliases: []string{"u", "force", "f"},
 			Usage:   "Display unsafe content (e.g. the password) even if safecontent is enabled",
 		},
+		&cli.BoolFlag{
+			Name:  "yes",
+			Usage: "Assume yes on all yes/no questions or use the default on all others",
+		},
 	}
 	app.Action = func(c *cli.Context) error {
 		if err := action.Initialized(c); err != nil {

--- a/tests/insert_test.go
+++ b/tests/insert_test.go
@@ -26,21 +26,78 @@ func TestInsert(t *testing.T) {
 	t.Run("Regression test for #1573 without actual pipes", func(t *testing.T) {
 		out, err = ts.run("show -f some/secret")
 		assert.NoError(t, err)
-		assert.Equal(t, out, "Password: moar")
+		assert.Equal(t, "Password: moar", out)
 
 		out, err = ts.run("show -f some/newsecret")
 		assert.NoError(t, err)
-		assert.Equal(t, out, "Password: and\n\nmoar")
+		assert.Equal(t, "Password: and\n\nmoar", out)
 
 		_, err := ts.run("config mime false")
 		assert.NoError(t, err)
 
 		out, err = ts.run("show -f some/secret")
 		assert.NoError(t, err)
-		assert.Equal(t, out, "moar")
+		assert.Equal(t, "moar", out)
 
 		out, err = ts.run("show -f some/newsecret")
 		assert.NoError(t, err)
-		assert.Equal(t, out, "and\n\nmoar")
+		assert.Equal(t, "and\n\nmoar", out)
+	})
+
+	t.Run("Regression test for #1595", func(t *testing.T) {
+		_, err = ts.runCmd([]string{ts.Binary, "insert", "some/other"}, []byte("nope"))
+		assert.NoError(t, err)
+
+		out, err = ts.run("insert some/other")
+		assert.Error(t, err)
+		assert.Equal(t, "\nError: not overwriting your current secret\n", out)
+
+		out, err = ts.run("show -o some/other")
+		assert.NoError(t, err)
+		assert.Equal(t, "nope", out)
+
+		out, err = ts.run("--yes insert some/other")
+		assert.NoError(t, err)
+		assert.Equal(t, "Warning: Password is empty or all whitespace", out)
+
+		out, err = ts.run("insert -f some/other")
+		assert.NoError(t, err)
+		assert.Equal(t, "Warning: Password is empty or all whitespace", out)
+
+		out, err = ts.run("show -o some/other")
+		assert.Error(t, err)
+		assert.Equal(t, "\nError: empty secret\n", out)
+
+		_, err = ts.runCmd([]string{ts.Binary, "insert", "-f", "some/other"}, []byte("final"))
+		assert.NoError(t, err)
+
+		out, err = ts.run("show -o some/other")
+		assert.NoError(t, err)
+		assert.Equal(t, "final", out)
+
+		// This is arguably not a good behaviour: it should not overwrite the password when we are only working on a key:value.
+		out, err = ts.run("insert -f some/other test:inline")
+		assert.NoError(t, err)
+		assert.Equal(t, "", out)
+
+		out, err = ts.run("show some/other Test")
+		assert.NoError(t, err)
+		assert.Equal(t, "inline", out)
+
+		out, err = ts.run("insert some/other test:inline2")
+		assert.Error(t, err)
+		assert.Equal(t, "\nError: not overwriting your current secret\n", out)
+
+		out, err = ts.run("show some/other Test")
+		assert.NoError(t, err)
+		assert.Equal(t, "inline", out)
+
+		out, err = ts.run("--yes insert some/other test:inline2")
+		assert.NoError(t, err)
+		assert.Equal(t, "", out)
+
+		out, err = ts.run("show some/other Test")
+		assert.NoError(t, err)
+		assert.Equal(t, "inline2", out)
 	})
 }


### PR DESCRIPTION
Fixes #1595

RELEASE_NOTES=[BUGFIX] Re-adding the global --yes flag
RELEASE_NOTES=[BUGFIX] Insert is not resetting the pw now if a key:value pair is specified inline

This is just adding --yes back since it was mistakenly removed.

It is also correcting the way insert behaves if we use inline key:values:

`gopass insert test key:lol` will no longer overwrite the password with the empty value is none is set. 
Thus `gopass --yes insert -f test newkey:lol oldkey:yay` will not also overwrite the key password whereas previously it would.