### PR TITLE
Correct missing padding to TOTP entry.

### DIFF
--- a/internal/otp/otp.go
+++ b/internal/otp/otp.go
@@ -35,7 +35,7 @@ func Calculate(name string, sec gopass.Secret) (twofactor.OTP, string, error) {
 		return twofactor.FromURL(secKey)
 	}
 
-	otp, err := twofactor.NewGoogleTOTP(secKey)
+	otp, err := twofactor.NewGoogleTOTP(twofactor.Pad(secKey))
 	return otp, label, err
 }
 

--- a/internal/otp/otp_test.go
+++ b/internal/otp/otp_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 const pw string = "password"
-const totpSecret string = "GJWTGMTNN5YWW2TNPJXWG2DHMIFA===="
+const totpSecret string = "GJWTGMTNN5YWW2TNPJXWG2DHMIFA"
 const totpURL string = "otpauth://totp/example-otp.com?secret=2m32moqkjmzochgb&issuer=authenticator&digits=6"
 
 func TestCalculate(t *testing.T) {


### PR DESCRIPTION
Fixes https://github.com/gopasspw/gopass/issues/1473

RELEASE_NOTES=[BUGFIX] Correct missing padding to TOTP entry

This is some attempt to correct the missing padding for TOTP entry.
One example of those TOTP are the ones from Amazon that are sometime
52bytes in length.