### PR TITLE
Fix nil error panic

### DIFF
--- a/internal/cui/cui.go
+++ b/internal/cui/cui.go
@@ -2,6 +2,7 @@ package cui
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/gopasspw/gopass/internal/termio"
@@ -25,10 +26,12 @@ func GetSelection(ctx context.Context, prompt string, choices []string) (string,
 		if err == nil && i < len(choices) {
 			break
 		}
-		if err == termio.ErrAborted {
+		if errors.Is(err, termio.ErrAborted) {
 			return "aborted", 0
 		}
-		fmt.Println(err.Error())
+		if err != nil {
+			fmt.Println(err.Error())
+		}
 	}
 	fmt.Println(i)
 	return "default", i


### PR DESCRIPTION
Fixes panic on incorrect number

```text
❯ gopass new
[ 0] Website Login
[ 1] PIN Code (numerical)
[ 2] Generic

Please select the type of secret you would like to create [0]: 123
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x5557dc575be5]

goroutine 1 [running]:
github.com/gopasspw/gopass/internal/cui.GetSelection(0x5557dd1e6ae0, 0xc000afa390, 0x5557dcb335c8, 0x39, 0xc000afae10, 0x3, 0x3, 0x3, 0x5557dd10fe00, 0x5557dd151160)
	github.com/gopasspw/gopass/internal/cui/cui.go:31 +0x245
github.com/gopasspw/gopass/internal/action/create.Create(0xc000098880, 0x5557dd1e38a0, 0xc00000e140, 0x0, 0x0)
	github.com/gopasspw/gopass/internal/action/create/create.go:53 +0x233
github.com/gopasspw/gopass/internal/action/create.GetCommands.func1(0xc000098880, 0x0, 0x0)
	github.com/gopasspw/gopass/internal/action/create/commands.go:22 +0x3f
github.com/urfave/cli/v2.(*Command).Run(0xc00038a240, 0xc000098600, 0x0, 0x0)
	github.com/urfave/cli/v2@v2.2.0/command.go:164 +0x4ed
github.com/urfave/cli/v2.(*App).RunContext(0xc000102d80, 0x5557dd1e6ae0, 0xc000afa390, 0xc00000e080, 0x2, 0x2, 0x0, 0x0)
	github.com/urfave/cli/v2@v2.2.0/app.go:306 +0x830
main.main()
	github.com/gopasspw/gopass/main.go:95 +0x474
```