### PR TITLE
Do not duplicate K/V password key

### DIFF
--- a/internal/action/edit.go
+++ b/internal/action/edit.go
@@ -101,7 +101,13 @@ func (s *Action) editGetContent(ctx context.Context, name string, create bool) (
 			return nil
 		}
 		if err := s.find(ctxutil.WithFuzzySearch(ctx, false), nil, name, cb); err == nil {
-			name = newName
+			cont, err := termio.AskForBool(ctx, fmt.Sprintf("No secret at '%s'. Found possible match in '%s'. Edit existing entry?", name, newName), true)
+			if err != nil {
+				return "", nil, false, err
+			}
+			if cont {
+				name = newName
+			}
 		}
 	}
 

--- a/internal/secrets/kv.go
+++ b/internal/secrets/kv.go
@@ -60,7 +60,9 @@ func (k *KV) Keys() []string {
 	for key := range k.data {
 		keys = append(keys, key)
 	}
-	keys = append(keys, "password")
+	if _, found := k.data["password"]; !found {
+		keys = append(keys, "password")
+	}
 	sort.Strings(keys)
 	return keys
 }

--- a/internal/secrets/kv_test.go
+++ b/internal/secrets/kv_test.go
@@ -13,6 +13,7 @@ func TestKV(t *testing.T) {
 Test / test.com
 username: myuser@test.com
 url: http://www.test.com/
+password: bar
 `
 	s, err := ParseKV([]byte(mlValue))
 	require.NoError(t, err)
@@ -23,12 +24,17 @@ url: http://www.test.com/
 	t.Logf("Secret:\n%+v\n%s\n", s, string(s.Bytes()))
 
 	mlOut := `somepasswd
+password: bar
 url: http://www.test.com/
 username: myuser@test.com
 Test / test.com
 `
 	t.Run("read back the secret", func(t *testing.T) {
 		assert.Equal(t, mlOut, string(s.Bytes()))
+	})
+
+	t.Run("no_duplicate_keys", func(t *testing.T) {
+		assert.Equal(t, []string{"password", "url", "username"}, s.Keys())
 	})
 
 	t.Run("read some keys", func(t *testing.T) {

--- a/internal/secrets/yaml.go
+++ b/internal/secrets/yaml.go
@@ -31,7 +31,9 @@ func (y *YAML) Keys() []string {
 	for key := range y.data {
 		keys = append(keys, key)
 	}
-	keys = append(keys, "password")
+	if _, found := y.data["password"]; !found {
+		keys = append(keys, "password")
+	}
 	sort.Strings(keys)
 	return keys
 }

--- a/internal/secrets/yaml_test.go
+++ b/internal/secrets/yaml_test.go
@@ -169,6 +169,22 @@ url: http://www.test.com/`
 	assert.Equal(t, "myuser@test.com", s.Get("username"))
 }
 
+func TestYAMLBodyWithPW(t *testing.T) {
+	t.Logf("YAML Body with Password (#1607)")
+	mlValue := `password
+---
+username: myuser@test.com
+password: somepasswd
+url: http://www.test.com/`
+	s, err := ParseYAML([]byte(mlValue))
+	require.NoError(t, err)
+	assert.NotNil(t, s)
+
+	t.Logf("Secret: \n%+v\n%s", s, string(s.Bytes()))
+
+	// read back key
+	assert.Equal(t, []string{"password", "url", "username"}, s.Keys())
+}
 func TestYAMLValues(t *testing.T) {
 	s := &YAML{
 		data: map[string]interface{}{


### PR DESCRIPTION
RELEASE_NOTES=[BUGFIX] Do not duplicate key password in K/V secrets
RELEASE_NOTES=[ENHANCEMENT] Prompt for edit search result

Fixes #1607

Signed-off-by: Dominik Schulz <dominik.schulz@gauner.org>