### PR TITLE
Do not require empty new line terminating MIME header

### DIFF
--- a/pkg/gopass/secret/mime.go
+++ b/pkg/gopass/secret/mime.go
@@ -3,11 +3,14 @@ package secret
 import (
 	"bufio"
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"net/textproto"
 	"sort"
 	"strings"
+
+	"github.com/gopasspw/gopass/internal/debug"
 )
 
 const (
@@ -80,7 +83,10 @@ func ParseMIME(buf []byte) (*MIME, error) {
 	tpr := textproto.NewReader(r)
 	m.Header, err = tpr.ReadMIMEHeader()
 	if err != nil {
-		return nil, &PermanentError{Err: err}
+		if !errors.Is(err, io.EOF) {
+			return nil, &PermanentError{Err: err}
+		}
+		debug.Log("Ignoring EOF error when parsing MIME header")
 	}
 	if _, err := io.Copy(m.body, r); err != nil {
 		return nil, &PermanentError{err}


### PR DESCRIPTION
Fixes #1593

RELEASE_NOTES=[BUGFIX] Do not require final new line for MIME

Signed-off-by: Dominik Schulz <dominik.schulz@gauner.org>