### PR TITLE
Patch pw prompt on Windows

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/kr/text v0.2.0 // indirect
 	github.com/martinhoefling/goxkcdpwgen v0.0.0-20190331205820-7dc3d102eca3
 	github.com/mattn/go-colorable v0.1.7
+	github.com/mattn/go-isatty v0.0.12
 	github.com/minio/minio-go/v6 v6.0.57
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/go-ps v1.0.0

--- a/internal/cui/recipients.go
+++ b/internal/cui/recipients.go
@@ -28,7 +28,7 @@ const (
 	maxTries = 42
 )
 
-// AskForPrivateKey promts the user to select from a list of private keys
+// AskForPrivateKey prompts the user to select from a list of private keys
 func AskForPrivateKey(ctx context.Context, crypto backend.Crypto, prompt string) (string, error) {
 	if !ctxutil.IsInteractive(ctx) {
 		return "", errors.New("can not select private key without terminal")

--- a/internal/termio/ask.go
+++ b/internal/termio/ask.go
@@ -28,7 +28,7 @@ const (
 )
 
 // AskForString asks for a string once, using the default if the
-// anser is empty. Errors are only returned on I/O errors
+// answer is empty. Errors are only returned on I/O errors
 func AskForString(ctx context.Context, text, def string) (string, error) {
 	if ctxutil.IsAlwaysYes(ctx) || !ctxutil.IsInteractive(ctx) {
 		return def, nil

--- a/internal/termio/promptpass_windows.go
+++ b/internal/termio/promptpass_windows.go
@@ -4,9 +4,11 @@ package termio
 
 import (
 	"context"
+	"fmt"
+	"os"
 
 	"github.com/gopasspw/gopass/pkg/ctxutil"
-	"github.com/pkg/errors"
+	"golang.org/x/crypto/ssh/terminal"
 )
 
 // promptPass will prompt user's for a password by terminal.
@@ -15,5 +17,8 @@ func promptPass(ctx context.Context, prompt string) (string, error) {
 		return AskForString(ctx, prompt, "")
 	}
 
-	return "", errors.New("not a terminal")
+	fmt.Fprintf(Stdout, "%s: ", prompt)
+	passBytes, err := terminal.ReadPassword(int(os.Stdin.Fd()))
+	fmt.Fprintln(Stdout, "")
+	return string(passBytes), err
 }

--- a/main.go
+++ b/main.go
@@ -22,11 +22,11 @@ import (
 	"github.com/gopasspw/gopass/pkg/ctxutil"
 	"github.com/gopasspw/gopass/pkg/gopass/secret"
 	"github.com/gopasspw/gopass/pkg/protect"
-	"golang.org/x/crypto/ssh/terminal"
 
 	"github.com/blang/semver"
 	"github.com/fatih/color"
 	colorable "github.com/mattn/go-colorable"
+	"github.com/mattn/go-isatty"
 	"github.com/urfave/cli/v2"
 
 	ap "github.com/gopasspw/gopass/internal/action"
@@ -295,7 +295,7 @@ func initContext(ctx context.Context, cfg *config.Config) context.Context {
 	}
 
 	// only emit color codes when stdout is a terminal
-	if !terminal.IsTerminal(int(os.Stdout.Fd())) {
+	if !isatty.IsTerminal(os.Stdout.Fd()) {
 		color.NoColor = true
 		ctx = ctxutil.WithColor(ctx, false)
 		ctx = ctxutil.WithTerminal(ctx, false)


### PR DESCRIPTION
Fixes #1333

RELEASE_NOTES=[BUGFIX] Password insert prompt now works on Windows but stil not in Git Bash. Only CMD and Powershell.

It should work in Cygwin too.