### PR TITLE
Fix travis runs caused by outdated gocyclo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -192,7 +192,7 @@ codequality:
 
 	@echo -n "     CYCLO     "
 	@which gocyclo > /dev/null; if [ $$? -ne 0 ]; then \
-		$(GO) get -u github.com/fzipp/gocyclo; \
+		$(GO) get -u github.com/fzipp/gocyclo/cmd/gocyclo; \
 	fi
 	@$(foreach gofile, $(GOFILES_NOVENDOR),\
 			gocyclo -over 22 $(gofile) || exit 1;)


### PR DESCRIPTION
Fixes #1636

It seems that https://github.com/fzipp/gocyclo suddenly stopped being inactive and they've moved things into packages.
This PR makes us use the right path for gocyclo in Travis on Linux.