### PR TITLE
Handle password cache notification from pinentry

### DIFF
--- a/pkg/pinentry/pinentry.go
+++ b/pkg/pinentry/pinentry.go
@@ -111,6 +111,13 @@ func (c *Client) GetPin() ([]byte, error) {
 	if bytes.HasPrefix(buf, []byte("OK")) {
 		return nil, nil
 	}
+	if bytes.HasPrefix(buf, []byte("S PASSWORD_FROM_CACHE")) {
+		// handle pinentry cache notification
+		buf, _, err = c.out.ReadLine()
+		if err != nil {
+			return nil, err
+		}
+	}
 	if !bytes.HasPrefix(buf, []byte("D ")) {
 		return nil, fmt.Errorf("unexpected response: %s", buf)
 	}


### PR DESCRIPTION
This is required when using e.g. Gnome Keyring to cache credentials.

Reference: https://git.gnupg.org/cgi-bin/gitweb.cgi?p=pinentry.git;a=blob;f=doc/pinentry.texi;h=a4acd8b9f27bf2cdbd50aead2757872978bbe9f6;hb=HEAD#l483