### PR TITLE
Fixed keystroke errors in the command (gopass audit)

### DIFF
--- a/docs/commands/audit.md
+++ b/docs/commands/audit.md
@@ -5,7 +5,7 @@ The `audit` command will decrypt all secrets and scan for weak passwords or othe
 ## Synopsis
 
 ```
-$ gopass aduit
+$ gopass audit
 ```
 
 ## Password strength backends


### PR DESCRIPTION
Hi,

In the documentation of the audit command, I found a typo so I corrected it.

Thanks,

Anthony