### PR TITLE
Link to doc on vim potential leak

### DIFF
--- a/internal/editor/editor.go
+++ b/internal/editor/editor.go
@@ -58,7 +58,7 @@ func Check(ctx context.Context, editor string) error {
 		return nil
 	}
 	debug.Log("%s did not match %s", string(buf), vimOptsRe)
-	out.Yellow(ctx, "Warning: Vim might leak credentials. Check your setup.")
+	out.Yellow(ctx, "Warning: Vim might leak credentials. Check your setup.\nhttps://github.com/gopasspw/gopass/blob/master/docs/setup.md#securing-your-editor")
 	return nil
 }
 


### PR DESCRIPTION
I just got the warning, but I had to do quite a search to find what the actual issue was, and the fix for this.

This PR simply adds a link to the doc after the warning message.