### PR TITLE
Output Deprecation warning on StdErr

### DIFF
--- a/main.go
+++ b/main.go
@@ -161,7 +161,7 @@ func setupApp(ctx context.Context, sv semver.Version) (context.Context, *cli.App
 		}
 
 		if c.Args().Present() {
-			out.Red(c.Context, "DEPRECATION WARNING: Use gopass show")
+			out.Error(c.Context, "DEPRECATION WARNING: Use gopass show")
 			return action.Show(c)
 		}
 		return action.REPL(c)


### PR DESCRIPTION
Fixes #1627

RELEASE_NOTES=[BUGFIX] The deprecation warning is now output on stderr

Note that it will still be displayed in red :) 