### PR TITLE
fixed MacTootls GPGSuite path problem in jsonapi-wrapper

### DIFF
--- a/cmd/gopass-jsonapi/internal/jsonapi/manifest/wrapper.go
+++ b/cmd/gopass-jsonapi/internal/jsonapi/manifest/wrapper.go
@@ -20,6 +20,7 @@ else
 fi
 
 export PATH="$PATH:/usr/local/bin" # required on MacOS/brew
+export PATH="$PATH:/usr/local/MacGPG2/bin" # required on MacOS/GPGTools GPGSuite
 export GPG_TTY="$(tty)"
 
 {{ .Gopass }} listen

--- a/cmd/gopass-jsonapi/internal/jsonapi/manifest/wrapper_test.go
+++ b/cmd/gopass-jsonapi/internal/jsonapi/manifest/wrapper_test.go
@@ -18,6 +18,7 @@ else
 fi
 
 export PATH="$PATH:/usr/local/bin" # required on MacOS/brew
+export PATH="$PATH:/usr/local/MacGPG2/bin" # required on MacOS/GPGTools GPGSuite
 export GPG_TTY="$(tty)"
 
 gopass-jsonapi listen


### PR DESCRIPTION
macos-users not using homebrews gpg, but the MacTools GPGSuite won't be
able to use the gopassbridge-browser-plugin as the gopass-jsonapi cannot locate the gpg-binary.
this fix adds the MacTools GPGSuite bin folder to the PATH. more
specific description of the issue can be found under https://github.com/gopasspw/gopassbridge/issues/151

gopassbridge-firefox-plugin fails with `Native application tried to send message of XXX bytes, which exceeds the limit of 1048576 bytes`. after some investigation i found out that `gopass-jsonapi listen` responds with

```
Failed to initialize gopass API: failed to initialized stores: 
failed to initialize the root store at '/Users/stefan/.password-store': 
failed to init crypto backend: no gpg binary found: no gpg binary found: 
failed to init crypto backend: no gpg binary found: no gpg binary found: 
failed to initialize the root store at '/Users/stefan/.password-store': 
failed to init crypto backend: no gpg binary found: no gpg binary found: 
failed to init crypto backend: no gpg binary found: no gpg binary found
``` 

on the `{"type":"getVersion"}` nativeMessage from the firefox-plugin.