### PR TITLE
Disable gopass update

### DIFF
--- a/internal/action/commands.go
+++ b/internal/action/commands.go
@@ -914,6 +914,7 @@ func (s *Action) GetCommands() []*cli.Command {
 				"This command checks for gopass updates at GitHub and automatically " +
 				"downloads and installs any missing update.",
 			Action: s.Update,
+			Hidden: true,
 			Flags: []cli.Flag{
 				&cli.BoolFlag{
 					Name:  "pre",

--- a/internal/updater/update.go
+++ b/internal/updater/update.go
@@ -168,6 +168,10 @@ func updateCheckHost(u *url.URL) error {
 func updateTo(ctx context.Context, version, url string) error {
 	debug.Log("URL: %s", url)
 	out.Green(ctx, "Update available!")
+	if true {
+		out.Red(ctx, "Gopass Updater is disabled (insecure, see #1676")
+		return nil
+	}
 	ok, err := termio.AskForBool(ctx, fmt.Sprintf("Do you want to update gopass to %s?", version), true)
 	if err != nil {
 		return err


### PR DESCRIPTION
The updater is insecure since it doesn't check signature of downloaded
binaries (which aren't signed at the moment). It shouldn't be used this
way so the quickest fix is to disable it for the time being.

Fixes #1675 

Signed-off-by: Dominik Schulz <dominik.schulz@gauner.org>