### PR TITLE
Do not search when editing a new secret

### DIFF
--- a/docs/commands/edit.md
+++ b/docs/commands/edit.md
@@ -28,4 +28,4 @@ $ EDITOR=/bin/nano gopass edit entry
 Flag | Aliases | Description
 ---- | ------- | -----------
 `--editor` | `-e` | Specify the path to an editor. Must accept the filename as it's first argument.
-`--create` | `-c` | Create a new secret. Note: This is a no-op. You can create a new secret with `edit` with or without `-c`.
+`--create` | `-c` | Create a new secret. You can create a new secret with `edit` with or without `-c`, but `-c` will skip searching for existing matches.

--- a/internal/action/edit.go
+++ b/internal/action/edit.go
@@ -71,7 +71,7 @@ func (s *Action) editUpdate(ctx context.Context, name string, content, nContent 
 }
 
 func (s *Action) editGetContent(ctx context.Context, name string, create bool) (string, []byte, bool, error) {
-	if !s.Store.Exists(ctx, name) {
+	if !s.Store.Exists(ctx, name) && !create {
 		newName := ""
 		// capture only the name of the selected secret
 		cb := func(ctx context.Context, c *cli.Context, name string, recurse bool) error {


### PR DESCRIPTION
When -c is given to edit skip searching for existing ones.

Fixes #1682

Signed-off-by: Dominik Schulz <dominik.schulz@gauner.org>