### PR TITLE
Use 32 byte salt by default

### DIFF
--- a/internal/tpl/funcs.go
+++ b/internal/tpl/funcs.go
@@ -5,8 +5,10 @@ import (
 	"crypto/md5"
 	"crypto/sha1"
 	"fmt"
+	"strconv"
 	"text/template"
 
+	"github.com/gopasspw/gopass/internal/debug"
 	"github.com/jsimonetti/pwscheme/md5crypt"
 	"github.com/jsimonetti/pwscheme/ssha"
 	"github.com/jsimonetti/pwscheme/ssha256"
@@ -39,27 +41,52 @@ func sha1sum() func(...string) (string, error) {
 	}
 }
 
+// saltLen tries to parse the given string into a numeric salt length.
+// NOTE: This is on of the rare cases where I think named returns
+// are useful.
+func saltLen(s []string) (saltLen int) {
+	defer func() {
+		debug.Log("using saltLen %d", saltLen)
+	}()
+
+	// default should be 32bit
+	saltLen = 32
+
+	if len(s) < 2 {
+		return
+	}
+
+	i, err := strconv.Atoi(s[0])
+	if err == nil && i > 0 {
+		saltLen = i
+	}
+	if err != nil {
+		debug.Log("failed to parse saltLen %+v: %q", s, err)
+	}
+	return
+}
+
 func md5cryptFunc() func(...string) (string, error) {
 	return func(s ...string) (string, error) {
-		return md5crypt.Generate(s[0], 4)
+		return md5crypt.Generate(s[0], uint8(saltLen(s)))
 	}
 }
 
 func sshaFunc() func(...string) (string, error) {
 	return func(s ...string) (string, error) {
-		return ssha.Generate(s[0], 4)
+		return ssha.Generate(s[0], uint8(saltLen(s)))
 	}
 }
 
 func ssha256Func() func(...string) (string, error) {
 	return func(s ...string) (string, error) {
-		return ssha256.Generate(s[0], 4)
+		return ssha256.Generate(s[0], uint8(saltLen(s)))
 	}
 }
 
 func ssha512Func() func(...string) (string, error) {
 	return func(s ...string) (string, error) {
-		return ssha512.Generate(s[0], 4)
+		return ssha512.Generate(s[0], uint8(saltLen(s)))
 	}
 }
 


### PR DESCRIPTION
This changes the salted hash funcs for the template feature to
use 32 salts by default and accept a parameter to choose the
desired salt length.

Fixes #1688

Signed-off-by: Dominik Schulz <dominik.schulz@gauner.org>