### PR TITLE
Adding Mime warning to fsck

### DIFF
--- a/internal/secrets/kv.go
+++ b/internal/secrets/kv.go
@@ -26,6 +26,7 @@ type KV struct {
 	password string
 	data     map[string]string
 	body     string
+	fromMime bool
 }
 
 // Bytes serializes
@@ -148,7 +149,13 @@ func ParseKV(in []byte) (*KV, error) {
 	return k, nil
 }
 
+// Write appends the buffer to the secret's body
 func (k *KV) Write(buf []byte) (int, error) {
 	k.body += string(buf)
 	return len(buf), nil
+}
+
+// FromMime returns which whether this secret was converted from a Mime secret of not
+func (k *KV) FromMime() bool {
+	return k.fromMime
 }

--- a/internal/secrets/mime.go
+++ b/internal/secrets/mime.go
@@ -46,6 +46,7 @@ func ParseLegacyMIME(buf []byte) (*KV, error) {
 		password: pw,
 		data:     make(map[string]string, len(hdr)),
 		body:     body.String(),
+		fromMime: true,
 	}
 
 	for k := range hdr {

--- a/internal/secrets/yaml.go
+++ b/internal/secrets/yaml.go
@@ -160,6 +160,7 @@ func (y *YAML) Bytes() []byte {
 	return buf.Bytes()
 }
 
+// Write appends the buffer to the secret's body
 func (y *YAML) Write(buf []byte) (int, error) {
 	y.body += string(buf)
 	return len(buf), nil


### PR DESCRIPTION
RELEASE_NOTES=[ENHANCEMENT] fsck now detects leftover Mime secrets
RELEASE_NOTES=[BUGFIX] fsck won't correct recipients without --decrypt
