### PR TITLE
Invalidate cache after generating new GPG key

### DIFF
--- a/internal/backend/crypto/gpg/cli/keyring.go
+++ b/internal/backend/crypto/gpg/cli/keyring.go
@@ -16,7 +16,7 @@ import (
 func (g *GPG) listKeys(ctx context.Context, typ string, search ...string) (gpg.KeyList, error) {
 	args := []string{"--with-colons", "--with-fingerprint", "--fixed-list-mode", "--list-" + typ + "-keys"}
 	args = append(args, search...)
-	if e, found := g.listCache.Get(strings.Join(args, ",")); found {
+	if e, found := g.listCache.Get(strings.Join(args, ",")); found && gpg.UseCache(ctx) {
 		if ev, ok := e.(gpg.KeyList); ok {
 			return ev, nil
 		}

--- a/internal/backend/crypto/gpg/context.go
+++ b/internal/backend/crypto/gpg/context.go
@@ -6,6 +6,7 @@ type contextKey int
 
 const (
 	ctxKeyAlwaysTrust contextKey = iota
+	ctxKeyUseCache
 )
 
 // WithAlwaysTrust will return a context with the flag for always trust set
@@ -21,4 +22,18 @@ func IsAlwaysTrust(ctx context.Context) bool {
 		return false
 	}
 	return bv
+}
+
+// WithUseCache returns a context with the value of NoCache set
+func WithUseCache(ctx context.Context, nc bool) context.Context {
+	return context.WithValue(ctx, ctxKeyUseCache, nc)
+}
+
+// UseCache returns true if this request should ignore the cache
+func UseCache(ctx context.Context) bool {
+	nc, ok := ctx.Value(ctxKeyUseCache).(bool)
+	if !ok {
+		return false
+	}
+	return nc
 }


### PR DESCRIPTION
Fixes #1693

RELEASE_NOTES=[BUGFIX] Invalidate GPG key list after generation

Signed-off-by: Dominik Schulz <dominik.schulz@gauner.org>