### PR TITLE
Do not exit on non-empty second pw

### DIFF
--- a/pkg/termio/ask.go
+++ b/pkg/termio/ask.go
@@ -155,7 +155,7 @@ func AskForPassword(ctx context.Context, name string) (string, error) {
 
 	askFn := GetPassPromptFunc(ctx)
 	for i := 0; i < maxTries; i++ {
-		// check for context cancelation
+		// check for context cancellation
 		select {
 		case <-ctx.Done():
 			return "", ErrAborted
@@ -172,7 +172,7 @@ func AskForPassword(ctx context.Context, name string) (string, error) {
 			return "", err
 		}
 
-		if pass == passAgain || pass == "" {
+		if pass == passAgain {
 			return pass, nil
 		}
 


### PR DESCRIPTION
RELEASE_NOTES=[BUGFIX] The empty password must now be confirmed too

Fixes #1718

I simply removed the `|| pass == ""`.

Do we want to have an extra confirmation step in case of empty password or not?