### PR TITLE
Remove ExportPublicKey from crypto interface

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,7 @@ require (
 	github.com/urfave/cli/v2 v2.2.0
 	github.com/xrash/smetrics v0.0.0-20200730060457-89a2a8a1fb0b // indirect
 	golang.org/x/crypto v0.0.0-20200930160638-afb6bcd081ae
-	golang.org/x/net v0.0.0-20201021035429-f5854403a974 // indirect
+	golang.org/x/net v0.0.0-20201021035429-f5854403a974
 	golang.org/x/sys v0.0.0-20201024232916-9f70ab9862d5
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect

--- a/internal/backend/crypto.go
+++ b/internal/backend/crypto.go
@@ -28,7 +28,6 @@ func (c CryptoBackend) String() string {
 // Keyring is a public/private key manager
 type Keyring interface {
 	ImportPublicKey(ctx context.Context, key []byte) error
-	ExportPublicKey(ctx context.Context, id string) ([]byte, error)
 
 	ListRecipients(ctx context.Context) ([]string, error)
 	ListIdentities(ctx context.Context) ([]string, error)

--- a/internal/backend/crypto/age/unsupported.go
+++ b/internal/backend/crypto/age/unsupported.go
@@ -9,11 +9,6 @@ import (
 	"github.com/gopasspw/gopass/pkg/debug"
 )
 
-// ExportPublicKey is not implemented
-func (a *Age) ExportPublicKey(ctx context.Context, id string) ([]byte, error) {
-	return []byte(id), nil
-}
-
 // FindIdentities it TODO
 func (a *Age) FindIdentities(ctx context.Context, keys ...string) ([]string, error) {
 	nk, err := a.getAllIdentities(ctx)

--- a/internal/store/leaf/crypto.go
+++ b/internal/store/leaf/crypto.go
@@ -98,7 +98,7 @@ func (s *Store) decodePublicKey(ctx context.Context, r string) ([]string, error)
 }
 
 // export an ASCII armored public key
-func (s *Store) exportPublicKey(ctx context.Context, r string) (string, error) {
+func (s *Store) exportPublicKey(ctx context.Context, exp keyExporter, r string) (string, error) {
 	filename := filepath.Join(keyDir, r)
 
 	// do not overwrite existing keys
@@ -106,7 +106,7 @@ func (s *Store) exportPublicKey(ctx context.Context, r string) (string, error) {
 		return "", nil
 	}
 
-	pk, err := s.crypto.ExportPublicKey(ctx, r)
+	pk, err := exp.ExportPublicKey(ctx, r)
 	if err != nil {
 		return "", errors.Wrapf(err, "failed to export public key")
 	}


### PR DESCRIPTION
This change makes exportability checks more idiomatic
and the interface a little less cluttered.

RELEASE_NOTES=n/a

Signed-off-by: Dominik Schulz <dominik.schulz@gauner.org>