### PR TITLE
Delete empty parent directories on gopass rm -r

### DIFF
--- a/internal/action/delete.go
+++ b/internal/action/delete.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/gopasspw/gopass/pkg/ctxutil"
+	"github.com/gopasspw/gopass/pkg/debug"
 	"github.com/gopasspw/gopass/pkg/termio"
 
 	"github.com/urfave/cli/v2"
@@ -39,17 +40,21 @@ func (s *Action) Delete(c *cli.Context) error {
 	}
 
 	if recursive {
+		debug.Log("pruning %q", name)
 		if err := s.Store.Prune(ctx, name); err != nil {
 			return ExitError(ExitUnknown, err, "failed to prune '%s': %s", name, err)
 		}
+		debug.Log("pruned %q", name)
 		return nil
 	}
 
 	// deletes a single key from a YAML doc
 	if key != "" {
+		debug.Log("removing key %q from %q", key, name)
 		return s.deleteKeyFromYAML(ctx, name, key)
 	}
 
+	debug.Log("removing entry %q", name)
 	if err := s.Store.Delete(ctx, name); err != nil {
 		return ExitError(ExitIO, err, "Can not delete '%s': %s", name, err)
 	}

--- a/internal/backend/storage/fs/store.go
+++ b/internal/backend/storage/fs/store.go
@@ -88,6 +88,7 @@ func (s *Store) removeEmptyParentDirectories(path string) error {
 		return nil
 	}
 
+	debug.Log("removing empty parent dir: %q", parent)
 	err := os.Remove(parent)
 	switch {
 	case err == nil:
@@ -162,7 +163,12 @@ func (s *Store) IsDir(ctx context.Context, name string) bool {
 func (s *Store) Prune(ctx context.Context, prefix string) error {
 	path := filepath.Join(s.path, filepath.Clean(prefix))
 	debug.Log("Purning %s from %s", prefix, path)
-	return os.RemoveAll(path)
+
+	if err := os.RemoveAll(path); err != nil {
+		return err
+	}
+
+	return s.removeEmptyParentDirectories(path)
 }
 
 // Name returns the name of this backend

--- a/internal/store/leaf/move.go
+++ b/internal/store/leaf/move.go
@@ -76,6 +76,8 @@ func (s *Store) delete(ctx context.Context, name string, recurse bool) error {
 		}
 	}
 	if err := s.deleteSingle(ctx, path); err != nil {
+		// might fail if we deleted the root of a tree which isn't a secret
+		// itself
 		if !recurse {
 			return err
 		}
@@ -115,6 +117,7 @@ func (s *Store) deleteRecurse(ctx context.Context, name, path string) error {
 
 	debug.Log("Pruning %s", name)
 	if err := s.storage.Prune(ctx, name); err != nil {
+		debug.Log("storage.Prune(%v) failed", name)
 		return err
 	}
 
@@ -124,6 +127,7 @@ func (s *Store) deleteRecurse(ctx context.Context, name, path string) error {
 		}
 		return errors.Wrapf(err, "failed to add '%s' to git", path)
 	}
+	debug.Log("pruned")
 	return nil
 }
 

--- a/internal/store/leaf/move_test.go
+++ b/internal/store/leaf/move_test.go
@@ -280,8 +280,7 @@ func TestPrune(t *testing.T) {
 					assert.Error(t, err)
 
 					// delete empty folder
-					assert.NoError(t, s.Prune(ctx, "foo/"))
-					assert.Error(t, s.Prune(ctx, "foo/"))
+					assert.Error(t, s.Prune(ctx, "foo/"), "delete non-existing entry")
 				}
 			},
 		},


### PR DESCRIPTION
This adds house keeping around empty parent directories. They would
have been left over in some cases. This adds more proetections to avoid
that, i.e. removing empty parents on rm -r (not only rm) as well as
fsck checks.

Fixes #1723

Signed-off-by: Dominik Schulz <dominik.schulz@gauner.org>