### PR TITLE
Avoid age keyring being recreated when a wrong passphrase is entered

### DIFF
--- a/internal/backend/crypto/age/age.go
+++ b/internal/backend/crypto/age/age.go
@@ -2,7 +2,9 @@ package age
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -169,7 +171,13 @@ func (a *Age) getNativeIdentities(ctx context.Context) (map[string]age.Identity,
 		return krCache, nil
 	}
 	kr, err := a.loadKeyring(ctx)
-	if len(kr) < 1 || err != nil {
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		debug.Log("failed to load native identities: %+v", err)
+		return nil, err
+	}
+	debug.Log("keyring: %+v", kr)
+	if len(kr) < 1 {
+		debug.Log("generating new age keypair")
 		id, err := a.genKey(ctx)
 		if err != nil {
 			return nil, err

--- a/internal/backend/crypto/age/decrypt.go
+++ b/internal/backend/crypto/age/decrypt.go
@@ -41,7 +41,7 @@ func (a *Age) decrypt(ciphertext []byte, ids ...age.Identity) ([]byte, error) {
 }
 
 func (a *Age) decryptFile(ctx context.Context, filename string) ([]byte, error) {
-	pw, err := ctxutil.GetPasswordCallback(ctx)("index") // TODO should pass filename?
+	pw, err := ctxutil.GetPasswordCallback(ctx)(filename)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/backend/crypto/age/encrypt.go
+++ b/internal/backend/crypto/age/encrypt.go
@@ -64,7 +64,7 @@ func (a *Age) encrypt(plaintext []byte, recp ...age.Recipient) ([]byte, error) {
 }
 
 func (a *Age) encryptFile(ctx context.Context, filename string, plaintext []byte) error {
-	pw, err := ctxutil.GetPasswordCallback(ctx)("index") // TODO should pass filename?
+	pw, err := ctxutil.GetPasswordCallback(ctx)(filename)
 	if err != nil {
 		return err
 	}

--- a/internal/backend/crypto/age/keyring.go
+++ b/internal/backend/crypto/age/keyring.go
@@ -80,7 +80,7 @@ func (a *Age) loadKeyring(ctx context.Context) (Keyring, error) {
 			return []byte(pw), err
 		})
 	}
-	kr := make(Keyring, 1)
+	kr := make(Keyring, 0)
 	buf, err := a.decryptFile(ctx, a.keyring)
 	if err != nil {
 		debug.Log("can't decrypt keyring at %s: %s", a.keyring, err)


### PR DESCRIPTION
While this is arguably secure the useability is terrible and of course
this is a bug. Before this fix we would threat every kind of error (including
one from a wrong passphrase) the same and just blindly generate
a new identity, overwriting the keyring. This wouldn't be able to decrypt
the previously encrypted secrets anymore.

Please note that the whole age backend must be still considered a proof-of-concept.
The concept of a keyring doesn't match age very well and if possible I'd like to
remove this pseudo keyring again in the future.

Fixes #1678

Signed-off-by: Dominik Schulz <dominik.schulz@gauner.org>