### PR TITLE
Add release notes helper

### DIFF
--- a/.github/workflows/autorelease.yml
+++ b/.github/workflows/autorelease.yml
@@ -49,7 +49,8 @@ jobs:
         uses: goreleaser/goreleaser-action@v2
         with:
           version: latest
-          args: release --rm-dist
+          args: release --rm-dist --release-notes <(go run helpers/changelog/main.go)
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
           GOPATH: /home/runner/go

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -60,45 +60,45 @@ release:
   draft: false
   prerelease: auto
 
-brews:
-  - name: gopass
-    tap:
-      owner: gopasspw
-      name: homebrew-gopass
-    caveats:  |
-      Gopass has been installed, have fun!
-      If upgrading from `pass`, everything should work as expected.
-      If installing from scratch, you need to either initialize a new repository now...
-        gopass init
-      ...or clone one from a source:
-        gopass clone git@code.example.com:example/pass.git
-      In order to use the great autocompletion features (they're helpful with gopass),
-      please make sure you have autocompletion for homebrew enabled:
-        https://github.com/bobthecow/git-flow-completion/wiki/Install-Bash-git-completion
-      More information:
-        https://www.gopass.pw/
-        https://github.com/gopasspw/gopass/README.md
-    homepage: "https://www.gopass.pw/"
-    description: "The slightly more awesome Standard Unix Password Manager for Teams."
-    dependencies:
-      - git
-      - gnupg
-      - terminal-notifier
-    install:  |
-      ENV["GOPATH"] = buildpath
-      (buildpath/"src/github.com/gopasspw/gopass").install buildpath.children
-
-      cd "src/github.com/gopasspw/gopass" do
-        ENV["PREFIX"] = prefix
-        system "make", "install"
-      end
-
-      system bin/"gopass completion bash > bash_completion.bash"
-      system bin/"gopass completion zsh > zsh_completion.zsh"
-      bash_completion.install "bash_completion.bash"
-      zsh_completion.install "zsh_completion.zsh"
-    test:  |
-      assert_match version.to_s, shell_output("#{bin}/gopass version")
+#brews:
+#  - name: gopass
+#    tap:
+#      owner: gopasspw
+#      name: homebrew-gopass
+#    caveats:  |
+#      Gopass has been installed, have fun!
+#      If upgrading from `pass`, everything should work as expected.
+#      If installing from scratch, you need to either initialize a new repository now...
+#        gopass init
+#      ...or clone one from a source:
+#        gopass clone git@code.example.com:example/pass.git
+#      In order to use the great autocompletion features (they're helpful with gopass),
+#      please make sure you have autocompletion for homebrew enabled:
+#        https://github.com/bobthecow/git-flow-completion/wiki/Install-Bash-git-completion
+#      More information:
+#        https://www.gopass.pw/
+#        https://github.com/gopasspw/gopass/README.md
+#    homepage: "https://www.gopass.pw/"
+#    description: "The slightly more awesome Standard Unix Password Manager for Teams."
+#    dependencies:
+#      - git
+#      - gnupg
+#      - terminal-notifier
+#    install:  |
+#      ENV["GOPATH"] = buildpath
+#      (buildpath/"src/github.com/gopasspw/gopass").install buildpath.children
+#
+#      cd "src/github.com/gopasspw/gopass" do
+#        ENV["PREFIX"] = prefix
+#        system "make", "install"
+#      end
+#
+#      system bin/"gopass completion bash > bash_completion.bash"
+#      system bin/"gopass completion zsh > zsh_completion.zsh"
+#      bash_completion.install "bash_completion.bash"
+#      zsh_completion.install "zsh_completion.zsh"
+#    test:  |
+#      assert_match version.to_s, shell_output("#{bin}/gopass version")
 nfpms:
   - id: gopass
     vendor: Gopass Authors
@@ -133,4 +133,4 @@ signs:
   -
     id: gopass
     artifacts: checksum
-    args: ["-u", "0x2F752B2CA00248FC", "--armor", "--output", "${signature}", "--detach-sign", "${artifact}"]
+    args: ["--batch", "-u", "{{ .Env.GPG_FINGERPRINT }}", "--armor", "--output", "${signature}", "--detach-sign", "${artifact}"]

--- a/helpers/changelog/main.go
+++ b/helpers/changelog/main.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+)
+
+func main() {
+	fh, err := os.Open("CHANGELOG.md")
+	if err != nil {
+		panic(err)
+	}
+	defer fh.Close()
+
+	s := bufio.NewScanner(fh)
+	var in bool
+	for s.Scan() {
+		line := s.Text()
+		if strings.HasPrefix(line, "## ") {
+			if in {
+				break
+			}
+			in = true
+		}
+		fmt.Println(line)
+	}
+}


### PR DESCRIPTION
This adds a small release notes helper that takes the latest releases
notes from CHANGELOG.md and reuses them for the GitHub release notes.

Also this disabled the homebrew section until we figure out how to
make that work with GHA.

Signed-off-by: Dominik Schulz <dominik.schulz@gauner.org>