### PR TITLE
Add REPL command lock

### DIFF
--- a/internal/action/repl.go
+++ b/internal/action/repl.go
@@ -150,6 +150,9 @@ READ:
 		switch strings.ToLower(args[0]) {
 		case "quit":
 			break READ
+		case "lock":
+			s.replLock(c.Context)
+			continue
 		case "clear":
 			readline.ClearScreen(stdout)
 			continue
@@ -165,4 +168,12 @@ READ:
 		}
 	}
 	return nil
+}
+
+func (s *Action) replLock(ctx context.Context) {
+	if err := s.Store.Lock(); err != nil {
+		out.Error(ctx, "Failed to lock stores: %s", err)
+		return
+	}
+	out.OK(ctx, "Locked")
 }

--- a/internal/backend/crypto/age/askpass.go
+++ b/internal/backend/crypto/age/askpass.go
@@ -22,6 +22,7 @@ type cacher interface {
 	Get(string) (string, bool)
 	Set(string, string)
 	Remove(string)
+	Purge()
 }
 
 type askPass struct {
@@ -84,4 +85,10 @@ func (a *askPass) Passphrase(key string, reason string) (string, error) {
 
 func (a *askPass) Remove(key string) {
 	a.cache.Remove(key)
+}
+
+// Lock flushes the password cache
+func (a *Age) Lock() {
+	a.askPass.cache.Purge()
+	krCache = nil
 }

--- a/internal/store/leaf/crypto.go
+++ b/internal/store/leaf/crypto.go
@@ -149,3 +149,22 @@ func (s *Store) importPublicKey(ctx context.Context, r string) error {
 	}
 	return fmt.Errorf("public key not found in store")
 }
+
+type locker interface {
+	Lock()
+}
+
+// Lock clears the credential caches of all supported backends
+func (s *Store) Lock() error {
+	f, ok := s.crypto.(locker)
+	if !ok {
+		debug.Log("locking not supported by %T in %q", s.crypto, s.alias)
+	}
+	if f == nil {
+		debug.Log("backend %q invalid", s.alias)
+		return nil
+	}
+	f.Lock()
+	debug.Log("locked backend %T for %q", s.crypto, s.alias)
+	return nil
+}

--- a/internal/store/root/mount.go
+++ b/internal/store/root/mount.go
@@ -127,6 +127,16 @@ func (r *Store) MountPoint(name string) string {
 	return ""
 }
 
+// Lock drops all cached credentials
+func (r *Store) Lock() error {
+	for _, sub := range r.mounts {
+		if err := sub.Lock(); err != nil {
+			return err
+		}
+	}
+	return r.store.Lock()
+}
+
 // getStore returns the Store object at the most-specific mount point for the
 // given key
 // context with sub store options set, sub store reference, truncated path to secret


### PR DESCRIPTION
This allows flushing credential caches, mostly age.
This is useful when using gopass in REPL mode to keep
gopass running but lock the age key material.

RELEASE_NOTES=[ENHANCEMENT] Add REPL cmd lock

Signed-off-by: Dominik Schulz <dominik.schulz@gauner.org>