### PR TITLE
Allow removing uninitialized mounts

### DIFF
--- a/internal/store/root/mount.go
+++ b/internal/store/root/mount.go
@@ -86,10 +86,10 @@ func (r *Store) initSub(ctx context.Context, alias, path string, keys []string) 
 // RemoveMount removes and existing mount
 func (r *Store) RemoveMount(ctx context.Context, alias string) error {
 	if _, found := r.mounts[alias]; !found {
-		return errors.Errorf("%s is not mounted", alias)
+		out.Warning(ctx, "%s is not mounted", alias)
 	}
 	if _, found := r.mounts[alias]; !found {
-		out.Print(ctx, "%s is not initialized", alias)
+		out.Warning(ctx, "%s is not initialized", alias)
 	}
 	delete(r.mounts, alias)
 	delete(r.cfg.Mounts, alias)

--- a/internal/store/root/mount_test.go
+++ b/internal/store/root/mount_test.go
@@ -33,5 +33,6 @@ func TestMount(t *testing.T) {
 	assert.Error(t, err)
 	assert.Nil(t, sub)
 
-	assert.Error(t, rs.RemoveMount(ctx, "foo"))
+	// removing mounts should never fail
+	assert.NoError(t, rs.RemoveMount(ctx, "foo"))
 }


### PR DESCRIPTION
Previously we were overly finicky when removing mounts.
If a mount isn't mounted or initialized we shouldn't care.
If it's in the config remove it, if not don't.

Fixes #1746

Signed-off-by: Dominik Schulz <dominik.schulz@gauner.org>