### PR TITLE
Use persistent SSH connections for git operations

### DIFF
--- a/docs/backends/gitfs.md
+++ b/docs/backends/gitfs.md
@@ -2,3 +2,5 @@
 
 This is the default storage backend. It stores the encrypted data directly in the filesystem. It uses an external git binary to provide history and remote sync operations.
 
+gopass configures git to use persistent ssh connections. If you do not want
+this set `GIT_SSH_COMMAND` to an empty string to override the built-in default.

--- a/internal/backend/storage/gitfs/config.go
+++ b/internal/backend/storage/gitfs/config.go
@@ -29,10 +29,17 @@ func (g *Git) fixConfig(ctx context.Context) error {
 
 	// setup for proper diffs
 	if err := g.ConfigSet(ctx, "diff.gpg.binary", "true"); err != nil {
-		out.Print(ctx, "Error while initializing git: %s", err)
+		out.Error(ctx, "Error while initializing git: %s", err)
 	}
 	if err := g.ConfigSet(ctx, "diff.gpg.textconv", "gpg --no-tty --decrypt"); err != nil {
-		out.Print(ctx, "Error while initializing git: %s", err)
+		out.Error(ctx, "Error while initializing git: %s", err)
+	}
+
+	// setup for persistent SSH connections
+	if sc := gitSSHCommand(); sc != "" {
+		if err := g.ConfigSet(ctx, "core.sshCommand", sc); err != nil {
+			out.Error(ctx, "Error while configuring persistent SSH connections: %s", err)
+		}
 	}
 
 	return nil

--- a/internal/backend/storage/gitfs/ssh_others.go
+++ b/internal/backend/storage/gitfs/ssh_others.go
@@ -1,0 +1,14 @@
+// +build !windows
+
+package gitfs
+
+// gitSSHCommand returns a SSH command instructing git to use SSH
+// with persistent connections through a custom socket.
+// See https://linux.die.net/man/5/ssh_config and
+// https://git-scm.com/docs/git-config#Documentation/git-config.txt-coresshCommand
+//
+// Note: Setting GIT_SSH_COMMAND, possibly to an empty string, will take
+// precedence over this setting.
+func gitSSHCommand() string {
+	return "ssh -oControlMaster=auto -oControlPersist=600 -oControlPath=/tmp/.gopass-ssh-${USER}-%r@%h:%p"
+}

--- a/internal/backend/storage/gitfs/ssh_windows.go
+++ b/internal/backend/storage/gitfs/ssh_windows.go
@@ -1,0 +1,7 @@
+// +build windows
+
+package gitfs
+
+func gitSSHCommand() string {
+	return ""
+}


### PR DESCRIPTION
This will be added to the per-store git config on newly
initialized stores.

RELEASE_NOTES=[ENHANCEMENT] Use persistent SSH connections

Signed-off-by: Dominik Schulz <dominik.schulz@gauner.org>