### PR TITLE
Use gpgconf(1) to locate the gpg binary

### DIFF
--- a/internal/backend/crypto/gpg/cli/binary_others.go
+++ b/internal/backend/crypto/gpg/cli/binary_others.go
@@ -4,11 +4,25 @@ package cli
 
 import (
 	"os/exec"
+
+	"github.com/gopasspw/gopass/pkg/debug"
+	"github.com/gopasspw/gopass/pkg/pinentry/gpgconf"
 )
 
 func detectBinary(name string) (string, error) {
-	if name == "" {
-		name = "gpg"
+	// user supplied binaries take precedence
+	if name != "" {
+		return exec.LookPath(name)
 	}
-	return exec.LookPath(name)
+	// try to get the proper binary from gpgconf(1)
+	p, err := gpgconf.Path("gpg")
+	if err != nil || p == "" {
+		debug.Log("gpgconf failed, falling back to path lookup: %q", err)
+		// otherwise fall back to the default and try
+		// to look up "gpg"
+		return exec.LookPath("gpg")
+	}
+
+	debug.Log("gpgconf returned %q for gpg", p)
+	return p, nil
 }

--- a/pkg/pinentry/gpgconf/gpgconf.go
+++ b/pkg/pinentry/gpgconf/gpgconf.go
@@ -1,0 +1,39 @@
+package gpgconf
+
+import (
+	"bufio"
+	"bytes"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/gopasspw/gopass/pkg/debug"
+)
+
+// Path returns the path to a GPG component
+func Path(key string) (string, error) {
+	buf := &bytes.Buffer{}
+	cmd := exec.Command("gpgconf")
+	cmd.Stdout = buf
+	cmd.Stderr = os.Stderr
+
+	debug.Log("%s %+v", cmd.Path, cmd.Args)
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+
+	key = strings.TrimSpace(strings.ToLower(key))
+	sc := bufio.NewScanner(buf)
+	for sc.Scan() {
+		p := strings.Split(strings.TrimSpace(sc.Text()), ":")
+		if len(p) < 3 {
+			continue
+		}
+		if key == p[0] {
+			return p[2], nil
+		}
+	}
+
+	debug.Log("key %q not found", key)
+	return "", nil
+}

--- a/pkg/pinentry/pinentry_darwin.go
+++ b/pkg/pinentry/pinentry_darwin.go
@@ -2,7 +2,12 @@
 
 package pinentry
 
+import "github.com/gopasspw/gopass/pkg/pinentry/gpgconf"
+
 // GetBinary always returns pinentry-mac
 func GetBinary() string {
+	if p, err := gpgconf.Path("pinentry"); err == nil && p != "" {
+		return p
+	}
 	return "pinentry-mac"
 }

--- a/pkg/pinentry/pinentry_others.go
+++ b/pkg/pinentry/pinentry_others.go
@@ -2,7 +2,12 @@
 
 package pinentry
 
+import "github.com/gopasspw/gopass/pkg/pinentry/gpgconf"
+
 // GetBinary returns the binary name
 func GetBinary() string {
+	if p, err := gpgconf.Path("pinentry"); err == nil && p != "" {
+		return p
+	}
 	return "pinentry"
 }

--- a/pkg/pinentry/pinentry_windows.go
+++ b/pkg/pinentry/pinentry_windows.go
@@ -2,7 +2,12 @@
 
 package pinentry
 
+import "github.com/gopasspw/gopass/pkg/pinentry/gpgconf"
+
 // GetBinary always returns pinentry.exe
 func GetBinary() string {
+	if p, err := gpgconf.Path("pinentry"); err == nil && p != "" {
+		return p
+	}
 	return "pinentry.exe"
 }


### PR DESCRIPTION
Attempt to use gpgconf(1) for locating the path to the GPG binary.

Fixes #1757

RELEASE_NOTES=[ENHANCEMENT] Use gpgconf to the the gpg binary

Signed-off-by: Dominik Schulz <dominik.schulz@gauner.org>