### PR TITLE
Redirect changelog helper output

### DIFF
--- a/.github/workflows/autorelease.yml
+++ b/.github/workflows/autorelease.yml
@@ -46,7 +46,8 @@ jobs:
           env
       -
         name: Generate release-notes
-        run: go run helpers/changelog/main.go
+        run: |
+          go run helpers/changelog/main.go >../RELEASE_NOTES
       -
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2

--- a/helpers/changelog/main.go
+++ b/helpers/changelog/main.go
@@ -14,12 +14,6 @@ func main() {
 	}
 	defer fh.Close()
 
-	fw, err := os.Create("../RELEASE_NOTES")
-	if err != nil {
-		panic(err)
-	}
-	defer fw.Close()
-
 	s := bufio.NewScanner(fh)
 	var in bool
 	for s.Scan() {
@@ -31,9 +25,6 @@ func main() {
 			in = true
 		}
 
-		_, err := fmt.Fprintln(fw, line)
-		if err != nil {
-			panic(err)
-		}
+		fmt.Println(line)
 	}
 }


### PR DESCRIPTION
The command being run is [executed using the OS shell](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstepsrun), so this redirect should work.

RELEASE_NOTES=n/a

Signed-off-by: Dominik Schulz <dominik.schulz@gauner.org>