### PR TITLE
Fix mixed case keys

### DIFF
--- a/internal/action/insert_test.go
+++ b/internal/action/insert_test.go
@@ -78,7 +78,11 @@ func TestInsert(t *testing.T) {
 		buf.Reset()
 
 		assert.NoError(t, act.show(ctx, gptest.CliCtx(ctx, t), "baz", false))
-		assert.Equal(t, "foobar\nOther: meh\nUser: name\ninvalid key-value\nbody text", buf.String())
+		assert.Equal(t, "foobar\nother: meh\nuser: name\ninvalid key-value\nbody text", buf.String())
+		buf.Reset()
+
+		assert.NoError(t, act.show(ctxutil.WithShowParsing(ctx, false), gptest.CliCtx(ctx, t), "baz", false))
+		assert.Equal(t, "foobar\ninvalid key-value\nOther: meh\nUser: name\nbody text", buf.String())
 		buf.Reset()
 	})
 
@@ -108,7 +112,7 @@ func TestInsert(t *testing.T) {
 		buf.Reset()
 
 		assert.NoError(t, act.show(ctx, gptest.CliCtx(ctx, t), "baz", false))
-		assert.Equal(t, "other: 83\nuser: name\n", buf.String())
+		assert.Equal(t, "other: 83\nuser: name", buf.String())
 		buf.Reset()
 	})
 

--- a/internal/action/show.go
+++ b/internal/action/show.go
@@ -204,7 +204,7 @@ func (s *Action) showGetContent(ctx context.Context, sec gopass.Secret) (string,
 	// everything but the first line
 	if ctxutil.IsShowSafeContent(ctx) && !ctxutil.IsForce(ctx) {
 		var sb strings.Builder
-		for _, k := range sec.Keys() {
+		for i, k := range sec.Keys() {
 			sb.WriteString(k)
 			sb.WriteString(": ")
 			// check if this key should be obstructed
@@ -218,7 +218,10 @@ func (s *Action) showGetContent(ctx context.Context, sec gopass.Secret) (string,
 				}
 				sb.WriteString(strings.Join(v, "\n"+k+": "))
 			}
-			sb.WriteString("\n")
+			// we only add a final new line if the body is non-empty
+			if sec.Body() != "" || i < len(sec.Keys())-1 {
+				sb.WriteString("\n")
+			}
 		}
 
 		sb.WriteString(sec.Body())

--- a/internal/action/show_test.go
+++ b/internal/action/show_test.go
@@ -157,7 +157,7 @@ func TestShowMulti(t *testing.T) {
 		c := gptest.CliCtx(ctx, t, "bar/baz", "bar")
 
 		assert.NoError(t, act.Show(c))
-		assert.Equal(t, "bar: zab\n", buf.String())
+		assert.Equal(t, "bar: zab", buf.String())
 		buf.Reset()
 	})
 
@@ -166,6 +166,18 @@ func TestShowMulti(t *testing.T) {
 		c := gptest.CliCtx(ctx, t, "bar/baz", "nonexisting")
 
 		assert.Error(t, act.Show(c))
+		buf.Reset()
+	})
+
+	t.Run("show keys with mixed case", func(t *testing.T) {
+		ctx = ctxutil.WithShowParsing(ctx, true)
+
+		assert.NoError(t, act.insertStdin(ctx, "baz", []byte("foobar\nOther: meh\nuser: name\nbody text"), false))
+		buf.Reset()
+
+		c := gptest.CliCtx(ctx, t, "baz", "Other")
+		assert.NoError(t, act.Show(c))
+		assert.Equal(t, "meh", buf.String())
 		buf.Reset()
 	})
 }

--- a/pkg/gopass/secrets/kv.go
+++ b/pkg/gopass/secrets/kv.go
@@ -82,15 +82,22 @@ func (k *KV) Bytes() []byte {
 	buf := &bytes.Buffer{}
 	buf.WriteString(k.password)
 	buf.WriteString("\n")
-	for _, key := range k.Keys() {
+	for ik, key := range k.Keys() {
 		sv, ok := k.data[key]
 		if !ok {
 			continue
 		}
-		for _, v := range sv {
+		for iv, v := range sv {
 			_, _ = buf.WriteString(key)
 			_, _ = buf.WriteString(": ")
 			_, _ = buf.WriteString(v)
+			// the last one shouldn't add a newline, it's handled below
+			if iv < len(sv)-1 {
+				_, _ = buf.WriteString("\n")
+			}
+		}
+		// we must only add a final newline if the body is non-empty
+		if k.body != "" || ik < len(k.Keys())-1 {
 			_, _ = buf.WriteString("\n")
 		}
 	}
@@ -202,6 +209,8 @@ func ParseKV(in []byte) (*KV, error) {
 		for i, part := range parts {
 			parts[i] = strings.TrimSpace(part)
 		}
+		// we only store lower case keys for KV
+		parts[0] = strings.ToLower(parts[0])
 		// preserve key only entries
 		if len(parts) < 2 {
 			k.data[parts[0]] = append(k.data[parts[0]], "")

--- a/pkg/gopass/secrets/kv_test.go
+++ b/pkg/gopass/secrets/kv_test.go
@@ -86,12 +86,8 @@ func TestMultiKeyKVMIME(t *testing.T) {
 foo: baz
 foo: bar
 zab: 123`
-	out := `passw0rd
-foo: baz
-foo: bar
-zab: 123
-`
+
 	sec, err := ParseKV([]byte(in))
 	require.NoError(t, err)
-	assert.Equal(t, out, string(sec.Bytes()))
+	assert.Equal(t, in, string(sec.Bytes()))
 }

--- a/pkg/gopass/secrets/secparse/parse_test.go
+++ b/pkg/gopass/secrets/secparse/parse_test.go
@@ -25,9 +25,9 @@ func TestParse(t *testing.T) {
 
 func TestParsedIsSerialized(t *testing.T) {
 	for _, tc := range []string{
-		"foo\n",                   // Plain
-		"foo\nbar\n",              // Plain
-		"foo\nbar: baz\n",         // KV
+		"foo",                     // Plain
+		"foo\nbar",                // Plain
+		"foo\nbar: baz",           // KV
 		"foo\nbar\n---\nzab: 1\n", // YAML
 		// MIME is forcefully converted to KV
 	} {


### PR DESCRIPTION
RELEASE_NOTES=[BUGFIX] fixed mixed case keys for key-value, all keys are lower case now

Fixes #1777 