### PR TITLE
Remember when fsck was last run and remind after 90d

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -20,6 +20,7 @@ Some configuration options are only available through setting environment variab
 | `GOPASS_HOMEDIR`        | `string` | Set this to the absolute path of the directory containing the `.config/` tree                                |
 | `GOPASS_FORCE_UPDATE`   | `bool`   | Set to any non-empty value to force an update (if available)                                                 |
 | `GOPASS_NO_NOTIFY`      | `bool`   | Set to any non-empty value to prevent notifications                                                          |
+| `GOPASS_NO_REMINDER`      | `bool`   | Set to any non-empty value to prevent reminders                                                          |
 
 Variables not exclusively used by gopass
 

--- a/internal/action/action.go
+++ b/internal/action/action.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 
 	"github.com/gopasspw/gopass/internal/config"
+	"github.com/gopasspw/gopass/internal/reminder"
 	"github.com/gopasspw/gopass/internal/store/root"
 
 	"github.com/blang/semver/v4"
@@ -22,14 +23,15 @@ type Action struct {
 	Store   *root.Store
 	cfg     *config.Config
 	version semver.Version
+	rem     *reminder.Store
 }
 
 // New returns a new Action wrapper
 func New(cfg *config.Config, sv semver.Version) (*Action, error) {
-	return newAction(cfg, sv)
+	return newAction(cfg, sv, true)
 }
 
-func newAction(cfg *config.Config, sv semver.Version) (*Action, error) {
+func newAction(cfg *config.Config, sv semver.Version, remind bool) (*Action, error) {
 	name := "gopass"
 	if len(os.Args) > 0 {
 		name = filepath.Base(os.Args[0])
@@ -40,6 +42,14 @@ func newAction(cfg *config.Config, sv semver.Version) (*Action, error) {
 		cfg:     cfg,
 		version: sv,
 		Store:   root.New(cfg),
+	}
+
+	if remind {
+		r, err := reminder.New()
+		if err != nil {
+			return nil, err
+		}
+		act.rem = r
 	}
 
 	return act, nil

--- a/internal/action/action_test.go
+++ b/internal/action/action_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gopasspw/gopass/internal/backend"
 	"github.com/gopasspw/gopass/internal/backend/crypto/plain"
 	"github.com/gopasspw/gopass/internal/config"
+	"github.com/gopasspw/gopass/pkg/ctxutil"
 	"github.com/gopasspw/gopass/tests/gptest"
 
 	"github.com/blang/semver/v4"
@@ -26,16 +27,18 @@ func newMock(ctx context.Context, u *gptest.Unit) (*Action, error) {
 
 	ctx = backend.WithCryptoBackend(ctx, backend.Plain)
 	ctx = backend.WithStorageBackend(ctx, backend.GitFS)
-	act, err := newAction(cfg, semver.Version{})
+	act, err := newAction(cfg, semver.Version{}, false)
 	if err != nil {
 		return nil, err
 	}
+
 	fs := flag.NewFlagSet("default", flag.ContinueOnError)
 	c := cli.NewContext(cli.NewApp(), fs, nil)
 	c.Context = ctx
 	if err := act.IsInitialized(c); err != nil {
 		return nil, err
 	}
+
 	return act, nil
 }
 
@@ -44,6 +47,8 @@ func TestAction(t *testing.T) {
 	defer u.Remove()
 
 	ctx := context.Background()
+	ctx = ctxutil.WithInteractive(ctx, false)
+
 	act, err := newMock(ctx, u)
 	require.NoError(t, err)
 	require.NotNil(t, act)

--- a/internal/action/audit.go
+++ b/internal/action/audit.go
@@ -11,16 +11,17 @@ import (
 
 // Audit validates passwords against common flaws
 func (s *Action) Audit(c *cli.Context) error {
-	filter := c.Args().First()
+	s.rem.Reset("audit")
 
+	filter := c.Args().First()
 	ctx := ctxutil.WithGlobalFlags(c)
 
-	out.Printf(ctx, "Auditing passwords for common flaws ...")
-
+	out.Print(ctx, "Auditing passwords for common flaws ...")
 	t, err := s.Store.Tree(ctx)
 	if err != nil {
 		return ExitError(ExitList, err, "failed to get store tree: %s", err)
 	}
+
 	if filter != "" {
 		subtree, err := t.FindFolder(filter)
 		if err != nil {

--- a/internal/action/clone_test.go
+++ b/internal/action/clone_test.go
@@ -101,7 +101,7 @@ func TestCloneBackendIsStoredForMount(t *testing.T) {
 	cfg := config.Load()
 	cfg.Path = u.StoreDir("")
 
-	act, err := newAction(cfg, semver.Version{})
+	act, err := newAction(cfg, semver.Version{}, false)
 	require.NoError(t, err)
 	require.NotNil(t, act)
 

--- a/internal/action/commands_test.go
+++ b/internal/action/commands_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/gopasspw/gopass/pkg/ctxutil"
 	"github.com/gopasspw/gopass/tests/gptest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -36,6 +37,7 @@ func TestCommands(t *testing.T) {
 	defer u.Remove()
 
 	ctx := context.Background()
+	ctx = ctxutil.WithInteractive(ctx, false)
 	act, err := newMock(ctx, u)
 	require.NoError(t, err)
 	require.NotNil(t, act)

--- a/internal/action/completion_test.go
+++ b/internal/action/completion_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/gopasspw/gopass/internal/out"
+	"github.com/gopasspw/gopass/pkg/ctxutil"
 	"github.com/gopasspw/gopass/tests/gptest"
 
 	"github.com/stretchr/testify/assert"
@@ -34,6 +35,7 @@ func TestComplete(t *testing.T) {
 	}()
 
 	ctx := context.Background()
+	ctx = ctxutil.WithInteractive(ctx, false)
 	act, err := newMock(ctx, u)
 	require.NoError(t, err)
 	require.NotNil(t, act)

--- a/internal/action/config_test.go
+++ b/internal/action/config_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/gopasspw/gopass/internal/out"
+	"github.com/gopasspw/gopass/pkg/ctxutil"
 	"github.com/gopasspw/gopass/tests/gptest"
 
 	"github.com/stretchr/testify/assert"
@@ -19,6 +20,7 @@ func TestConfig(t *testing.T) {
 	defer u.Remove()
 
 	ctx := context.Background()
+	ctx = ctxutil.WithInteractive(ctx, false)
 	act, err := newMock(ctx, u)
 	require.NoError(t, err)
 	require.NotNil(t, act)

--- a/internal/action/copy_test.go
+++ b/internal/action/copy_test.go
@@ -20,6 +20,7 @@ func TestCopy(t *testing.T) {
 	defer u.Remove()
 
 	ctx := context.Background()
+	ctx = ctxutil.WithInteractive(ctx, false)
 	ctx = ctxutil.WithAlwaysYes(ctx, true)
 	ctx = ctxutil.WithAutoClip(ctx, false)
 

--- a/internal/action/delete_test.go
+++ b/internal/action/delete_test.go
@@ -21,6 +21,7 @@ func TestDelete(t *testing.T) {
 
 	ctx := context.Background()
 	ctx = ctxutil.WithAlwaysYes(ctx, true)
+	ctx = ctxutil.WithInteractive(ctx, false)
 	act, err := newMock(ctx, u)
 	require.NoError(t, err)
 	require.NotNil(t, act)

--- a/internal/action/fsck.go
+++ b/internal/action/fsck.go
@@ -17,6 +17,8 @@ import (
 
 // Fsck checks the store integrity
 func (s *Action) Fsck(c *cli.Context) error {
+	s.rem.Reset("fsck")
+
 	ctx := ctxutil.WithGlobalFlags(c)
 	if c.IsSet("decrypt") {
 		ctx = leaf.WithFsckDecrypt(ctx, c.Bool("decrypt"))

--- a/internal/action/generate_test.go
+++ b/internal/action/generate_test.go
@@ -32,6 +32,7 @@ func TestGenerate(t *testing.T) {
 	ctx := context.Background()
 	ctx = ctxutil.WithAlwaysYes(ctx, true)
 	ctx = ctxutil.WithAutoClip(ctx, false)
+	ctx = ctxutil.WithInteractive(ctx, false)
 
 	act, err := newMock(ctx, u)
 	require.NoError(t, err)

--- a/internal/action/grep_test.go
+++ b/internal/action/grep_test.go
@@ -21,6 +21,7 @@ func TestGrep(t *testing.T) {
 
 	ctx := context.Background()
 	ctx = ctxutil.WithAlwaysYes(ctx, true)
+	ctx = ctxutil.WithInteractive(ctx, false)
 	act, err := newMock(ctx, u)
 	require.NoError(t, err)
 	require.NotNil(t, act)

--- a/internal/action/history_test.go
+++ b/internal/action/history_test.go
@@ -29,12 +29,14 @@ func TestHistory(t *testing.T) {
 
 	ctx := context.Background()
 	ctx = ctxutil.WithAlwaysYes(ctx, true)
+	ctx = ctxutil.WithInteractive(ctx, false)
+
 	ctx = backend.WithCryptoBackend(ctx, backend.Plain)
 	ctx = backend.WithStorageBackend(ctx, backend.GitFS)
 
 	cfg := config.New()
 	cfg.Path = u.StoreDir("")
-	act, err := newAction(cfg, semver.Version{})
+	act, err := newAction(cfg, semver.Version{}, false)
 	require.NoError(t, err)
 	require.NotNil(t, act)
 

--- a/internal/action/init.go
+++ b/internal/action/init.go
@@ -34,6 +34,7 @@ func (s *Action) IsInitialized(c *cli.Context) error {
 	}
 	if inited {
 		debug.Log("Store is already initialized")
+		s.printReminder(ctx)
 		return nil
 	}
 

--- a/internal/action/list_test.go
+++ b/internal/action/list_test.go
@@ -23,6 +23,7 @@ func TestList(t *testing.T) {
 
 	ctx := context.Background()
 	ctx = ctxutil.WithAlwaysYes(ctx, true)
+	ctx = ctxutil.WithInteractive(ctx, false)
 
 	act, err := newMock(ctx, u)
 	require.NoError(t, err)
@@ -95,6 +96,7 @@ func TestListLimit(t *testing.T) {
 
 	ctx := context.Background()
 	ctx = ctxutil.WithAlwaysYes(ctx, true)
+	ctx = ctxutil.WithInteractive(ctx, false)
 
 	act, err := newMock(ctx, u)
 	require.NoError(t, err)

--- a/internal/action/move_test.go
+++ b/internal/action/move_test.go
@@ -20,6 +20,8 @@ func TestMove(t *testing.T) {
 
 	ctx := context.Background()
 	ctx = ctxutil.WithAlwaysYes(ctx, true)
+	ctx = ctxutil.WithInteractive(ctx, false)
+
 	act, err := newMock(ctx, u)
 	require.NoError(t, err)
 	require.NotNil(t, act)

--- a/internal/action/otp_test.go
+++ b/internal/action/otp_test.go
@@ -23,6 +23,8 @@ func TestOTP(t *testing.T) {
 
 	ctx := context.Background()
 	ctx = ctxutil.WithAlwaysYes(ctx, true)
+	ctx = ctxutil.WithInteractive(ctx, false)
+
 	act, err := newMock(ctx, u)
 	require.NoError(t, err)
 	require.NotNil(t, act)

--- a/internal/action/recipients_test.go
+++ b/internal/action/recipients_test.go
@@ -21,6 +21,8 @@ func TestRecipients(t *testing.T) {
 
 	ctx := context.Background()
 	ctx = ctxutil.WithAlwaysYes(ctx, true)
+	ctx = ctxutil.WithInteractive(ctx, false)
+
 	act, err := newMock(ctx, u)
 	require.NoError(t, err)
 	require.NotNil(t, act)

--- a/internal/action/reminder.go
+++ b/internal/action/reminder.go
@@ -1,0 +1,39 @@
+package action
+
+import (
+	"context"
+	"os"
+
+	"github.com/gopasspw/gopass/internal/out"
+	"github.com/gopasspw/gopass/pkg/ctxutil"
+)
+
+func (s *Action) printReminder(ctx context.Context) {
+	if !ctxutil.IsInteractive(ctx) {
+		return
+	}
+	if !ctxutil.IsTerminal(ctx) {
+		return
+	}
+	if sv := os.Getenv("GOPASS_NO_REMINDER"); sv != "" {
+		return
+	}
+
+	// Note: We only want to print one reminder per day (at most).
+	// So we intentionally return after printing one, leaving the others
+	// for the following days.
+	if s.rem.Overdue("update") {
+		out.Notice(ctx, "You haven't checked for updates in a while. Run 'gopass version' or 'gopass update' to check.")
+		return
+	}
+
+	if s.rem.Overdue("fsck") {
+		out.Notice(ctx, "You haven't run 'gopass fsck' in a while.")
+		return
+	}
+
+	if s.rem.Overdue("audit") {
+		out.Notice(ctx, "You haven't run 'gopass audit' in a while.")
+		return
+	}
+}

--- a/internal/action/show_test.go
+++ b/internal/action/show_test.go
@@ -25,6 +25,8 @@ func TestShowMulti(t *testing.T) {
 	ctx := context.Background()
 	ctx = ctxutil.WithAlwaysYes(ctx, true)
 	ctx = ctxutil.WithTerminal(ctx, false)
+	ctx = ctxutil.WithInteractive(ctx, false)
+
 	act, err := newMock(ctx, u)
 	require.NoError(t, err)
 	require.NotNil(t, act)
@@ -212,6 +214,8 @@ func TestShowAutoClip(t *testing.T) {
 
 	ctx := context.Background()
 	ctx = ctxutil.WithAlwaysYes(ctx, true)
+	ctx = ctxutil.WithInteractive(ctx, false)
+
 	act, err := newMock(ctx, u)
 	require.NoError(t, err)
 	require.NotNil(t, act)
@@ -327,6 +331,8 @@ func TestShowHandleRevision(t *testing.T) {
 	ctx := context.Background()
 	ctx = ctxutil.WithAlwaysYes(ctx, true)
 	ctx = ctxutil.WithTerminal(ctx, false)
+	ctx = ctxutil.WithInteractive(ctx, false)
+
 	act, err := newMock(ctx, u)
 	require.NoError(t, err)
 	require.NotNil(t, act)
@@ -380,6 +386,8 @@ func TestShowPrintQR(t *testing.T) {
 	ctx := context.Background()
 	ctx = ctxutil.WithAlwaysYes(ctx, true)
 	ctx = ctxutil.WithTerminal(ctx, false)
+	ctx = ctxutil.WithInteractive(ctx, false)
+
 	act, err := newMock(ctx, u)
 	require.NoError(t, err)
 	require.NotNil(t, act)

--- a/internal/action/update.go
+++ b/internal/action/update.go
@@ -13,6 +13,8 @@ import (
 
 // Update will start the interactive update assistant
 func (s *Action) Update(c *cli.Context) error {
+	s.rem.Reset("update")
+
 	ctx := ctxutil.WithGlobalFlags(c)
 
 	if s.version.String() == "0.0.0+HEAD" {

--- a/internal/action/version.go
+++ b/internal/action/version.go
@@ -114,6 +114,7 @@ func (s *Action) checkVersion(ctx context.Context, u chan string) {
 		notice += " or via your package manager"
 		u <- color.YellowString(notice)
 	} else {
+		s.rem.Reset("update")
 		debug.Log("gopass is up-to-date (local: %q, GitHub: %q)", s.version, r.Version)
 	}
 	u <- ""

--- a/internal/action/version_test.go
+++ b/internal/action/version_test.go
@@ -24,6 +24,8 @@ func TestVersion(t *testing.T) {
 
 	ctx := context.Background()
 	ctx = ctxutil.WithAlwaysYes(ctx, true)
+	ctx = ctxutil.WithInteractive(ctx, false)
+
 	act, err := newMock(ctx, u)
 	require.NoError(t, err)
 

--- a/internal/backend/storage/gitfs/storage.go
+++ b/internal/backend/storage/gitfs/storage.go
@@ -54,5 +54,9 @@ func (g *Git) Path() string {
 
 // Fsck checks the storage integrity
 func (g *Git) Fsck(ctx context.Context) error {
+	// ensure sane git config
+	if err := g.fixConfig(ctx); err != nil {
+		return fmt.Errorf("failed to fix git config: %w", err)
+	}
 	return g.fs.Fsck(ctx)
 }

--- a/internal/reminder/reminder.go
+++ b/internal/reminder/reminder.go
@@ -1,0 +1,73 @@
+package reminder
+
+import (
+	"time"
+
+	"github.com/gopasspw/gopass/internal/cache"
+	"github.com/gopasspw/gopass/pkg/debug"
+)
+
+// Store stores timestamps on disk
+type Store struct {
+	cache *cache.OnDisk
+}
+
+// New creates a new persistent timestamp store
+func New() (*Store, error) {
+	od, err := cache.NewOnDisk("reminder", 90*24*time.Hour)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Store{
+		cache: od,
+	}, nil
+}
+
+func (s *Store) lastSeen(key string) time.Time {
+	t := time.Time{}
+	if s == nil {
+		return t
+	}
+
+	res, err := s.cache.Get(key)
+	if err != nil {
+		debug.Log("failed to read %q from cache: %s", key, err)
+		return t
+	}
+	if len(res) < 1 {
+		debug.Log("cache result is empty")
+		return t
+	}
+
+	ts, err := time.Parse(time.RFC3339, res[0])
+	if err != nil {
+		debug.Log("failed to parse stored time %q: %s", err)
+		return t
+	}
+
+	return ts
+}
+
+// Reset marks a key as just seen
+func (s *Store) Reset(key string) error {
+	if s == nil {
+		return nil
+	}
+
+	return s.cache.Set(key, []string{time.Now().Format(time.RFC3339)})
+}
+
+// Overdue returns true iff (a) overdue did not return true within 24h AND (b)
+// the key wasn't updated within the last 90 days
+func (s *Store) Overdue(key string) bool {
+	if s == nil {
+		return false
+	}
+
+	if time.Since(s.lastSeen("overdue")) < 24*time.Hour {
+		return false
+	}
+	s.Reset("overdue")
+	return time.Since(s.lastSeen(key)) > 90*24*time.Hour
+}


### PR DESCRIPTION
This adds a reminder when fsck was not run within the last 90d (or
never).

RELEASE_NOTES=[ENHANCEMENT] Remind to run gopass fsck after 90d

Signed-off-by: Dominik Schulz <dominik.schulz@gauner.org>