### PR TITLE
Add suffix f to formating out methods

### DIFF
--- a/internal/action/aliases.go
+++ b/internal/action/aliases.go
@@ -12,7 +12,7 @@ import (
 
 // AliasesPrint prints all cofigured aliases
 func (s *Action) AliasesPrint(c *cli.Context) error {
-	out.Print(c.Context, "Configured aliases:")
+	out.Printf(c.Context, "Configured aliases:")
 	aliases := pwrules.AllAliases()
 	keys := make([]string, 0, len(aliases))
 	for k := range aliases {
@@ -20,7 +20,7 @@ func (s *Action) AliasesPrint(c *cli.Context) error {
 	}
 	sort.Strings(keys)
 	for _, k := range keys {
-		out.Print(c.Context, "- %s -> %s", k, strings.Join(aliases[k], ", "))
+		out.Printf(c.Context, "- %s -> %s", k, strings.Join(aliases[k], ", "))
 	}
 	return nil
 }
@@ -39,7 +39,7 @@ func (s *Action) AliasesAdd(c *cli.Context) error {
 		return err
 	}
 
-	out.Print(ctx, "Added alias '%s' to domain '%s'", alias, domain)
+	out.Printf(ctx, "Added alias %q to domain %q", alias, domain)
 	return nil
 }
 
@@ -57,7 +57,7 @@ func (s *Action) AliasesRemove(c *cli.Context) error {
 		return err
 	}
 
-	out.Print(ctx, "Remove alias '%s' from domain '%s'", alias, domain)
+	out.Printf(ctx, "Remove alias %q from domain %q", alias, domain)
 	return nil
 }
 
@@ -74,6 +74,6 @@ func (s *Action) AliasesDelete(c *cli.Context) error {
 		return err
 	}
 
-	out.Print(ctx, "Remove aliases for domain '%s'", domain)
+	out.Printf(ctx, "Remove aliases for domain %q", domain)
 	return nil
 }

--- a/internal/action/audit.go
+++ b/internal/action/audit.go
@@ -15,7 +15,7 @@ func (s *Action) Audit(c *cli.Context) error {
 
 	ctx := ctxutil.WithGlobalFlags(c)
 
-	out.Print(ctx, "Auditing passwords for common flaws ...")
+	out.Printf(ctx, "Auditing passwords for common flaws ...")
 
 	t, err := s.Store.Tree(ctx)
 	if err != nil {
@@ -31,7 +31,7 @@ func (s *Action) Audit(c *cli.Context) error {
 	list := t.List(tree.INF)
 
 	if len(list) < 1 {
-		out.Print(ctx, "No secrets found")
+		out.Printf(ctx, "No secrets found")
 		return nil
 	}
 

--- a/internal/action/binary.go
+++ b/internal/action/binary.go
@@ -216,7 +216,7 @@ func (s *Action) binaryValidate(ctx context.Context, buf []byte, name string) er
 	fileSum := fmt.Sprintf("%x", h.Sum(nil))
 	h.Reset()
 
-	debug.Log("in: %s - '%s'", fileSum, string(buf))
+	debug.Log("in: %s - %q", fileSum, string(buf))
 
 	var err error
 	buf, err = s.binaryGet(ctx, name)
@@ -226,7 +226,7 @@ func (s *Action) binaryValidate(ctx context.Context, buf []byte, name string) er
 	_, _ = h.Write(buf)
 	storeSum := fmt.Sprintf("%x", h.Sum(nil))
 
-	debug.Log("store: %s - '%s'", storeSum, string(buf))
+	debug.Log("store: %s - %q", storeSum, string(buf))
 
 	if fileSum != storeSum {
 		return fmt.Errorf("hashsum mismatch (file: %s, store: %s)", fileSum, storeSum)
@@ -266,7 +266,7 @@ func (s *Action) Sum(c *cli.Context) error {
 
 	h := sha256.New()
 	_, _ = h.Write(buf)
-	out.Print(ctx, "%x", h.Sum(nil))
+	out.Printf(ctx, "%x", h.Sum(nil))
 
 	return nil
 }

--- a/internal/action/clone.go
+++ b/internal/action/clone.go
@@ -69,13 +69,13 @@ func (s *Action) clone(ctx context.Context, repo, mount, path string) error {
 	}
 
 	// clone repo
-	debug.Log("Cloning repo '%s' to '%s'", repo, path)
+	debug.Log("Cloning repo %q to %q", repo, path)
 	if _, err := backend.Clone(ctx, storageBackendOrDefault(ctx), repo, path); err != nil {
-		return ExitError(ExitGit, err, "failed to clone repo '%s' to '%s': %s", repo, path, err)
+		return ExitError(ExitGit, err, "failed to clone repo %q to %q: %s", repo, path, err)
 	}
 
 	// add mount
-	debug.Log("Mounting cloned repo '%s' at '%s'", path, mount)
+	debug.Log("Mounting cloned repo %q at %q", path, mount)
 	if err := s.cloneAddMount(ctx, mount, path); err != nil {
 		return err
 	}
@@ -86,7 +86,7 @@ func (s *Action) clone(ctx context.Context, repo, mount, path string) error {
 	}
 
 	// try to init git config
-	out.Print(ctx, "Configuring git repository ...")
+	out.Printf(ctx, "Configuring git repository ...")
 
 	// ask for git config values
 	username, email, err := s.cloneGetGitConfig(ctx, mount)
@@ -97,13 +97,13 @@ func (s *Action) clone(ctx context.Context, repo, mount, path string) error {
 	// initialize git config
 	if err := s.Store.RCSInitConfig(ctx, mount, username, email); err != nil {
 		debug.Log("Stacktrace: %+v\n", err)
-		out.Error(ctx, "Failed to configure git: %s", err)
+		out.Errorf(ctx, "Failed to configure git: %s", err)
 	}
 
 	if mount != "" {
 		mount = " " + mount
 	}
-	out.Print(ctx, "Your password store is ready to use! Have a look around: `%s list%s`\n", s.Name, mount)
+	out.Printf(ctx, "Your password store is ready to use! Have a look around: `%s list%s`\n", s.Name, mount)
 
 	return nil
 }
@@ -123,7 +123,7 @@ func (s *Action) cloneAddMount(ctx context.Context, mount, path string) error {
 	if err := s.Store.AddMount(ctx, mount, path); err != nil {
 		return ExitError(ExitMount, err, "Failed to add mount: %s", err)
 	}
-	out.Print(ctx, "Mounted password store %s at mount point `%s` ...", path, mount)
+	out.Printf(ctx, "Mounted password store %s at mount point `%s` ...", path, mount)
 	return nil
 }
 

--- a/internal/action/completion.go
+++ b/internal/action/completion.go
@@ -32,7 +32,7 @@ func (s *Action) Complete(c *cli.Context) {
 	ctx := ctxutil.WithGlobalFlags(c)
 	_, err := s.Store.IsInitialized(ctx) // important to make sure the structs are not nil
 	if err != nil {
-		out.Error(ctx, "Store not initialized: %s", err)
+		out.Errorf(ctx, "Store not initialized: %s", err)
 		return
 	}
 	list, err := s.Store.List(ctx, tree.INF)

--- a/internal/action/config.go
+++ b/internal/action/config.go
@@ -37,11 +37,11 @@ func (s *Action) Config(c *cli.Context) error {
 func (s *Action) printConfigValues(ctx context.Context, needles ...string) {
 	m := s.cfg.ConfigMap()
 	for _, k := range filterMap(m, needles) {
-		out.Print(ctx, "%s: %s", k, m[k])
+		out.Printf(ctx, "%s: %s", k, m[k])
 	}
 	for alias, path := range s.cfg.Mounts {
 		if len(needles) < 1 {
-			out.Print(ctx, "mount '%s' => '%s'", alias, path)
+			out.Printf(ctx, "mount %q => %q", alias, path)
 		}
 	}
 }

--- a/internal/action/copy.go
+++ b/internal/action/copy.go
@@ -37,7 +37,7 @@ func (s *Action) copy(ctx context.Context, from, to string, force bool) error {
 	}
 
 	if err := s.Store.Copy(ctx, from, to); err != nil {
-		return ExitError(ExitIO, err, "failed to copy from '%s' to '%s'", from, to)
+		return ExitError(ExitIO, err, "failed to copy from %q to %q", from, to)
 	}
 
 	return nil

--- a/internal/action/create/create.go
+++ b/internal/action/create/create.go
@@ -93,7 +93,7 @@ func (s *creator) createWebsite(ctx context.Context, c *cli.Context) error {
 		err      error
 		genPw    bool
 	)
-	out.Print(ctx, "=> Creating Website login")
+	out.Printf(ctx, "=> Creating Website login")
 	urlStr, err = termio.AskForString(ctx, fmtfn(2, "1", "URL"), urlStr)
 	if err != nil {
 		return err
@@ -101,7 +101,7 @@ func (s *creator) createWebsite(ctx context.Context, c *cli.Context) error {
 	// the hostname is used as part of the name
 	hostname := extractHostname(urlStr)
 	if hostname == "" {
-		return action.ExitError(action.ExitUnknown, err, "Can not parse URL '%s'. Please use 'gopass edit' to manually create the secret", urlStr)
+		return action.ExitError(action.ExitUnknown, err, "Can not parse URL %q. Please use 'gopass edit' to manually create the secret", urlStr)
 	}
 
 	username, err = termio.AskForString(ctx, fmtfn(2, "2", "Login"), username)
@@ -154,7 +154,7 @@ func (s *creator) createWebsite(ctx context.Context, c *cli.Context) error {
 		sec.Set("password-change-url", u)
 	}
 	if err := s.store.Set(ctxutil.WithCommitMessage(ctx, "Created new entry"), name, sec); err != nil {
-		return action.ExitError(action.ExitEncrypt, err, "failed to set '%s': %s", name, err)
+		return action.ExitError(action.ExitEncrypt, err, "failed to set %q: %s", name, err)
 	}
 
 	return s.createPrintOrCopy(ctx, c, name, password, genPw)
@@ -192,7 +192,7 @@ func (s *creator) createPIN(ctx context.Context, c *cli.Context) error {
 		err         error
 		genPw       bool
 	)
-	out.Print(ctx, "=> Creating numerical PIN ...")
+	out.Printf(ctx, "=> Creating numerical PIN ...")
 	authority, err = termio.AskForString(ctx, fmtfn(2, "1", "Authority"), authority)
 	if err != nil {
 		return err
@@ -245,7 +245,7 @@ func (s *creator) createPIN(ctx context.Context, c *cli.Context) error {
 	sec.Set("application", application)
 	sec.Set("comment", comment)
 	if err := s.store.Set(ctxutil.WithCommitMessage(ctx, "Created new entry"), name, sec); err != nil {
-		return action.ExitError(action.ExitEncrypt, err, "failed to set '%s': %s", name, err)
+		return action.ExitError(action.ExitEncrypt, err, "failed to set %q: %s", name, err)
 	}
 
 	return s.createPrintOrCopy(ctx, c, name, password, genPw)
@@ -260,7 +260,7 @@ func (s *creator) createGeneric(ctx context.Context, c *cli.Context) error {
 		err       error
 		genPw     bool
 	)
-	out.Print(ctx, "=> Creating generic secret ...")
+	out.Printf(ctx, "=> Creating generic secret ...")
 	shortname, err = termio.AskForString(ctx, fmtfn(2, "1", "Name"), shortname)
 	if err != nil {
 		return err
@@ -302,7 +302,7 @@ func (s *creator) createGeneric(ctx context.Context, c *cli.Context) error {
 	}
 	sec := secrets.New()
 	sec.SetPassword(password)
-	out.Print(ctx, fmtfn(2, "3", "Enter zero or more key value pairs for this secret:"))
+	out.Printf(ctx, fmtfn(2, "3", "Enter zero or more key value pairs for this secret:"))
 	for {
 		key, err := termio.AskForString(ctx, fmtfn(4, "a", "Name (enter to quit)"), "")
 		if err != nil {
@@ -318,7 +318,7 @@ func (s *creator) createGeneric(ctx context.Context, c *cli.Context) error {
 		sec.Set(key, val)
 	}
 	if err := s.store.Set(ctxutil.WithCommitMessage(ctx, "Created new entry"), name, sec); err != nil {
-		return action.ExitError(action.ExitEncrypt, err, "failed to set '%s': %s", name, err)
+		return action.ExitError(action.ExitEncrypt, err, "failed to set %q: %s", name, err)
 	}
 
 	return s.createPrintOrCopy(ctx, c, name, password, genPw)
@@ -327,7 +327,7 @@ func (s *creator) createGeneric(ctx context.Context, c *cli.Context) error {
 // createGeneratePasssword will walk through the password generation steps
 func (s *creator) createGeneratePassword(ctx context.Context, hostname string) (string, error) {
 	if _, found := pwrules.LookupRule(hostname); found {
-		out.Print(ctx, "Using password rules for %s ...", hostname)
+		out.Printf(ctx, "Using password rules for %s ...", hostname)
 		length, err := termio.AskForInt(ctx, fmtfn(4, "b", "How long?"), defaultLength)
 		if err != nil {
 			return "", err

--- a/internal/action/delete.go
+++ b/internal/action/delete.go
@@ -23,7 +23,7 @@ func (s *Action) Delete(c *cli.Context) error {
 	}
 
 	if !recursive && s.Store.IsDir(ctx, name) && !s.Store.Exists(ctx, name) {
-		return ExitError(ExitUsage, nil, "Cannot remove '%s': Is a directory. Use 'gopass rm -r %s' to delete", name, name)
+		return ExitError(ExitUsage, nil, "Cannot remove %q: Is a directory. Use 'gopass rm -r %s' to delete", name, name)
 	}
 
 	// specifying a key is optional
@@ -42,7 +42,7 @@ func (s *Action) Delete(c *cli.Context) error {
 	if recursive {
 		debug.Log("pruning %q", name)
 		if err := s.Store.Prune(ctx, name); err != nil {
-			return ExitError(ExitUnknown, err, "failed to prune '%s': %s", name, err)
+			return ExitError(ExitUnknown, err, "failed to prune %q: %s", name, err)
 		}
 		debug.Log("pruned %q", name)
 		return nil
@@ -56,7 +56,7 @@ func (s *Action) Delete(c *cli.Context) error {
 
 	debug.Log("removing entry %q", name)
 	if err := s.Store.Delete(ctx, name); err != nil {
-		return ExitError(ExitIO, err, "Can not delete '%s': %s", name, err)
+		return ExitError(ExitIO, err, "Can not delete %q: %s", name, err)
 	}
 	return nil
 }
@@ -65,11 +65,11 @@ func (s *Action) Delete(c *cli.Context) error {
 func (s *Action) deleteKeyFromYAML(ctx context.Context, name, key string) error {
 	sec, err := s.Store.Get(ctx, name)
 	if err != nil {
-		return ExitError(ExitIO, err, "Can not delete key '%s' from '%s': %s", key, name, err)
+		return ExitError(ExitIO, err, "Can not delete key %q from %q: %s", key, name, err)
 	}
 	sec.Del(key)
 	if err := s.Store.Set(ctxutil.WithCommitMessage(ctx, "Updated Key"), name, sec); err != nil {
-		return ExitError(ExitIO, err, "Can not delete key '%s' from '%s': %s", key, name, err)
+		return ExitError(ExitIO, err, "Can not delete key %q from %q: %s", key, name, err)
 	}
 	return nil
 }

--- a/internal/action/edit.go
+++ b/internal/action/edit.go
@@ -30,7 +30,7 @@ func (s *Action) Edit(c *cli.Context) error {
 func (s *Action) edit(ctx context.Context, c *cli.Context, name string) error {
 	ed := editor.Path(c)
 	if err := editor.Check(ctx, ed); err != nil {
-		out.Warning(ctx, "Failed to check editor config: %s", err)
+		out.Warningf(ctx, "Failed to check editor config: %s", err)
 	}
 
 	// get existing content or generate new one from a template
@@ -97,7 +97,7 @@ func (s *Action) editGetContent(ctx context.Context, name string, create bool) (
 	}
 
 	if !create {
-		out.Warning(ctx, "Entry %s not found. Creating new secret ...", name)
+		out.Warningf(ctx, "Entry %s not found. Creating new secret ...", name)
 	}
 
 	// load template if it exists

--- a/internal/action/env.go
+++ b/internal/action/env.go
@@ -38,7 +38,7 @@ func (s *Action) Env(c *cli.Context) error {
 		}
 		subtree, err := l.FindFolder(name)
 		if err != nil {
-			return ExitError(ExitNotFound, nil, "Entry '%s' not found", name)
+			return ExitError(ExitNotFound, nil, "Entry %q not found", name)
 		}
 		subtree.SetName(name)
 		for _, e := range subtree.List(tree.INF) {

--- a/internal/action/find.go
+++ b/internal/action/find.go
@@ -62,10 +62,10 @@ func (s *Action) find(ctx context.Context, c *cli.Context, needle string, cb sho
 	// if we have an exact match print it
 	if len(choices) == 1 {
 		if cb == nil {
-			out.Print(ctx, choices[0])
+			out.Printf(ctx, choices[0])
 			return nil
 		}
-		out.OK(ctx, "Found exact match in '%s'", choices[0])
+		out.OKf(ctx, "Found exact match in %q", choices[0])
 		return cb(ctx, c, choices[0], false)
 	}
 
@@ -85,7 +85,7 @@ func (s *Action) find(ctx context.Context, c *cli.Context, needle string, cb sho
 	// gopass find/search was invoked directly (for scripts)
 	if !ctxutil.IsTerminal(ctx) || (c != nil && c.Command.Name == "find") {
 		for _, value := range choices {
-			out.Print(ctx, value)
+			out.Printf(ctx, value)
 		}
 		return nil
 	}

--- a/internal/action/find_test.go
+++ b/internal/action/find_test.go
@@ -54,7 +54,7 @@ func TestFind(t *testing.T) {
 	// find fo
 	c = gptest.CliCtxWithFlags(ctx, t, nil, "fo")
 	assert.NoError(t, act.Find(c))
-	assert.Contains(t, strings.TrimSpace(buf.String()), "Found exact match in 'foo'\nsecret")
+	assert.Contains(t, strings.TrimSpace(buf.String()), "Found exact match in \"foo\"\nsecret")
 	buf.Reset()
 
 	// find fo (no fuzzy search)
@@ -73,14 +73,14 @@ func TestFind(t *testing.T) {
 	c = gptest.CliCtxWithFlags(ctx, t, map[string]string{"clip": "true"}, "fo")
 	assert.NoError(t, act.Find(c))
 	out := strings.TrimSpace(buf.String())
-	assert.Contains(t, out, "Found exact match in 'foo'")
+	assert.Contains(t, out, "Found exact match in \"foo\"")
 	buf.Reset()
 
 	// safecontent case with force flag set
 	c = gptest.CliCtxWithFlags(ctx, t, map[string]string{"unsafe": "true"}, "fo")
 	assert.NoError(t, act.Find(c))
 	out = strings.TrimSpace(buf.String())
-	assert.Contains(t, out, "Found exact match in 'foo'\nsecret")
+	assert.Contains(t, out, "Found exact match in \"foo\"\nsecret")
 	buf.Reset()
 
 	// stopping with the safecontent tests

--- a/internal/action/fsck.go
+++ b/internal/action/fsck.go
@@ -21,7 +21,7 @@ func (s *Action) Fsck(c *cli.Context) error {
 	if c.IsSet("decrypt") {
 		ctx = leaf.WithFsckDecrypt(ctx, c.Bool("decrypt"))
 	}
-	out.Print(ctx, "Checking store integrity ...")
+	out.Printf(ctx, "Checking store integrity ...")
 	// make sure config is in the right place
 	// we may have loaded it from one of the fallback locations
 	if err := s.cfg.Save(); err != nil {
@@ -32,7 +32,7 @@ func (s *Action) Fsck(c *cli.Context) error {
 	oldCfg := filepath.Join(config.Homedir(), ".gopass.yml")
 	if fsutil.IsFile(oldCfg) {
 		if err := os.Remove(oldCfg); err != nil {
-			out.Error(ctx, "Failed to remove old gopass config %s: %s", oldCfg, err)
+			out.Errorf(ctx, "Failed to remove old gopass config %s: %s", oldCfg, err)
 		}
 	}
 

--- a/internal/action/grep.go
+++ b/internal/action/grep.go
@@ -35,7 +35,7 @@ func (s *Action) Grep(c *cli.Context) error {
 	if c.Bool("regexp") {
 		re, err := regexp.Compile(needle)
 		if err != nil {
-			return ExitError(ExitUsage, err, "failed to compile regexp '%s': %s", needle, err)
+			return ExitError(ExitUsage, err, "failed to compile regexp %q: %s", needle, err)
 		}
 		matchFn = re.MatchString
 	}
@@ -45,18 +45,18 @@ func (s *Action) Grep(c *cli.Context) error {
 	for _, v := range haystack {
 		sec, err := s.Store.Get(ctx, v)
 		if err != nil {
-			out.Error(ctx, "failed to decrypt %s: %v", v, err)
+			out.Errorf(ctx, "failed to decrypt %s: %v", v, err)
 			continue
 		}
 
 		if matchFn(string(sec.Bytes())) {
-			out.Print(ctx, "%s matches", color.BlueString(v))
+			out.Printf(ctx, "%s matches", color.BlueString(v))
 		}
 	}
 
 	if errors > 0 {
-		out.Warning(ctx, "%d secrets failed to decrypt", errors)
+		out.Warningf(ctx, "%d secrets failed to decrypt", errors)
 	}
-	out.Print(ctx, "\nScanned %d secrets. %d matches, %d errors", len(haystack), matches, errors)
+	out.Printf(ctx, "\nScanned %d secrets. %d matches, %d errors", len(haystack), matches, errors)
 	return nil
 }

--- a/internal/action/history.go
+++ b/internal/action/history.go
@@ -34,13 +34,13 @@ func (s *Action) History(c *cli.Context) error {
 		if showPassword {
 			_, sec, err := s.Store.GetRevision(ctx, name, rev.Hash)
 			if err != nil {
-				debug.Log("Failed to get revision '%s' of '%s': %s", rev.Hash, name, err)
+				debug.Log("Failed to get revision %q of %q: %s", rev.Hash, name, err)
 			}
 			if err == nil {
 				pw = " - " + sec.Password()
 			}
 		}
-		out.Print(ctx, "%s - %s <%s> - %s - %s%s\n", rev.Hash, rev.AuthorName, rev.AuthorEmail, rev.Date.Format(time.RFC3339), rev.Subject, pw)
+		out.Printf(ctx, "%s - %s <%s> - %s - %s%s\n", rev.Hash, rev.AuthorName, rev.AuthorEmail, rev.Date.Format(time.RFC3339), rev.Subject, pw)
 	}
 	return nil
 }

--- a/internal/action/init.go
+++ b/internal/action/init.go
@@ -42,10 +42,10 @@ func (s *Action) IsInitialized(c *cli.Context) error {
 		return ExitError(ExitNotInitialized, nil, "password-store is not initialized. Try '%s init'", s.Name)
 	}
 
-	out.Print(ctx, logo)
-	out.Print(ctx, "🌟 Welcome to gopass!")
-	out.Notice(ctx, "No existing configuration found.")
-	out.Print(ctx, "☝ Please run 'gopass setup'")
+	out.Printf(ctx, logo)
+	out.Printf(ctx, "🌟 Welcome to gopass!")
+	out.Noticef(ctx, "No existing configuration found.")
+	out.Printf(ctx, "☝ Please run 'gopass setup'")
 
 	return ExitError(ExitNotInitialized, err, "not initialized")
 }
@@ -57,7 +57,7 @@ func (s *Action) Init(c *cli.Context) error {
 	alias := c.String("store")
 
 	ctx = initParseContext(ctx, c)
-	out.Print(ctx, "🍭 Initializing a new password store ...")
+	out.Printf(ctx, "🍭 Initializing a new password store ...")
 
 	if name := termio.DetectName(c.Context, c); name != "" {
 		ctx = ctxutil.WithUsername(ctx, name)
@@ -70,7 +70,7 @@ func (s *Action) Init(c *cli.Context) error {
 		return ExitError(ExitUnknown, err, "Failed to initialized store: %s", err)
 	}
 	if inited {
-		out.Error(ctx, "❌ Store is already initialized!")
+		out.Errorf(ctx, "❌ Store is already initialized!")
 	}
 
 	if err := s.init(ctx, alias, path, c.Args().Slice()...); err != nil {
@@ -111,7 +111,7 @@ func (s *Action) init(ctx context.Context, alias, path string, keys ...string) e
 	debug.Log("action.init(%s, %s, %+v)", alias, path, keys)
 
 	debug.Log("Checking private keys ...")
-	out.Print(ctx, "🔑 Searching for usable private Keys ...")
+	out.Printf(ctx, "🔑 Searching for usable private Keys ...")
 	crypto := s.getCryptoFor(ctx, alias)
 	// private key selection doesn't matter for plain. save one question.
 	if crypto.Name() == "plain" {
@@ -142,7 +142,7 @@ func (s *Action) init(ctx context.Context, alias, path string, keys ...string) e
 		debug.Log("Initializing RCS (%s) ...", bn)
 		if err := s.rcsInit(ctx, alias, ctxutil.GetUsername(ctx), ctxutil.GetEmail(ctx)); err != nil {
 			debug.Log("Stacktrace: %+v\n", err)
-			out.Error(ctx, "❌ Failed to init Version Control (%s): %s", bn, err)
+			out.Errorf(ctx, "❌ Failed to init Version Control (%s): %s", bn, err)
 		}
 	} else {
 		debug.Log("not initializing RCS backend ...")
@@ -154,7 +154,7 @@ func (s *Action) init(ctx context.Context, alias, path string, keys ...string) e
 		return ExitError(ExitConfig, err, "failed to write config: %s", err)
 	}
 
-	out.Print(ctx, "🏁 Password store %s initialized for:", path)
+	out.Printf(ctx, "🏁 Password store %s initialized for:", path)
 	s.printRecipients(ctx, alias)
 
 	return nil
@@ -167,7 +167,7 @@ func (s *Action) printRecipients(ctx context.Context, alias string) {
 		if kl, err := crypto.FindRecipients(ctx, recipient); err == nil && len(kl) > 0 {
 			r = crypto.FormatKey(ctx, kl[0], "")
 		}
-		out.Print(ctx, "📩 "+r)
+		out.Printf(ctx, "📩 "+r)
 	}
 }
 

--- a/internal/action/insert.go
+++ b/internal/action/insert.go
@@ -113,7 +113,7 @@ func (s *Action) insertStdin(ctx context.Context, name string, content []byte, a
 		debug.Log("Created new plain secret with input")
 	}
 	if err := s.Store.Set(ctxutil.WithCommitMessage(ctx, "Read secret from STDIN"), name, sec); err != nil {
-		return ExitError(ExitEncrypt, err, "failed to set '%s': %s", name, err)
+		return ExitError(ExitEncrypt, err, "failed to set %q: %s", name, err)
 	}
 	return nil
 }
@@ -147,7 +147,7 @@ func (s *Action) insertSingle(ctx context.Context, name, pw string, kvps map[str
 	}
 
 	if err := s.Store.Set(ctxutil.WithCommitMessage(ctx, "Inserted user supplied password"), name, sec); err != nil {
-		return ExitError(ExitEncrypt, err, "failed to write secret '%s': %s", name, err)
+		return ExitError(ExitEncrypt, err, "failed to write secret %q: %s", name, err)
 	}
 	return nil
 }
@@ -166,7 +166,7 @@ func (s *Action) insertYAML(ctx context.Context, name, key string, content []byt
 		var err error
 		sec, err = s.Store.Get(ctx, name)
 		if err != nil {
-			return ExitError(ExitEncrypt, err, "failed to set key '%s' of '%s': %s", key, name, err)
+			return ExitError(ExitEncrypt, err, "failed to set key %q of %q: %s", key, name, err)
 		}
 	} else {
 		sec = secrets.New()
@@ -176,7 +176,7 @@ func (s *Action) insertYAML(ctx context.Context, name, key string, content []byt
 		return ExitError(ExitUsage, err, "failed set key %q of %q: %q", key, name, err)
 	}
 	if err := s.Store.Set(ctxutil.WithCommitMessage(ctx, "Inserted YAML value from STDIN"), name, sec); err != nil {
-		return ExitError(ExitEncrypt, err, "failed to set key '%s' of '%s': %s", key, name, err)
+		return ExitError(ExitEncrypt, err, "failed to set key %q of %q: %s", key, name, err)
 	}
 	return nil
 }
@@ -199,10 +199,10 @@ func (s *Action) insertMultiline(ctx context.Context, c *cli.Context, name strin
 	sec := &secrets.Plain{}
 	n, err := sec.Write(content)
 	if err != nil || n < 0 {
-		out.Error(ctx, "WARNING: Invalid secret: %s of len %d", err, n)
+		out.Errorf(ctx, "WARNING: Invalid secret: %s of len %d", err, n)
 	}
 	if err := s.Store.Set(ctxutil.WithCommitMessage(ctx, fmt.Sprintf("Inserted user supplied password with %s", ed)), name, sec); err != nil {
-		return ExitError(ExitEncrypt, err, "failed to store secret '%s': %s", name, err)
+		return ExitError(ExitEncrypt, err, "failed to store secret %q: %s", name, err)
 	}
 	return nil
 }

--- a/internal/action/list.go
+++ b/internal/action/list.go
@@ -71,7 +71,7 @@ func (s *Action) listFiltered(ctx context.Context, l *tree.Root, limit int, flat
 		// We restrict ourselves to the filter
 		l, err = l.FindFolder(filter)
 		if err != nil {
-			return ExitError(ExitNotFound, nil, "Entry '%s' not found", filter)
+			return ExitError(ExitNotFound, nil, "Entry %q not found", filter)
 		}
 		l.SetName(filter + sep)
 	}

--- a/internal/action/mount.go
+++ b/internal/action/mount.go
@@ -26,14 +26,14 @@ func (s *Action) MountRemove(c *cli.Context) error {
 	}
 
 	if err := s.Store.RemoveMount(ctx, c.Args().Get(0)); err != nil {
-		out.Error(ctx, "Failed to remove mount: %s", err)
+		out.Errorf(ctx, "Failed to remove mount: %s", err)
 	}
 
 	if err := s.cfg.Save(); err != nil {
 		return ExitError(ExitConfig, err, "failed to write config: %s", err)
 	}
 
-	out.Print(ctx, "Password Store %s umounted", c.Args().Get(0))
+	out.Printf(ctx, "Password Store %s umounted", c.Args().Get(0))
 	return nil
 }
 
@@ -41,7 +41,7 @@ func (s *Action) MountRemove(c *cli.Context) error {
 func (s *Action) MountsPrint(c *cli.Context) error {
 	ctx := ctxutil.WithGlobalFlags(c)
 	if len(s.Store.Mounts()) < 1 {
-		out.Print(ctx, "No mounts")
+		out.Printf(ctx, "No mounts")
 		return nil
 	}
 
@@ -52,7 +52,7 @@ func (s *Action) MountsPrint(c *cli.Context) error {
 	for _, alias := range mps {
 		path := mounts[alias]
 		if err := root.AddMount(alias, path); err != nil {
-			out.Error(ctx, "Failed to add mount to tree: %s", err)
+			out.Errorf(ctx, "Failed to add mount to tree: %s", err)
 		}
 	}
 	debug.Log("MountsPrint - %+v - %+v", mounts, mps)
@@ -83,19 +83,19 @@ func (s *Action) MountAdd(c *cli.Context) error {
 	}
 
 	if s.Store.Exists(ctx, alias) {
-		out.Warning(ctx, "shadowing %s entry", alias)
+		out.Warningf(ctx, "shadowing %s entry", alias)
 	}
 
 	if err := s.Store.AddMount(ctx, alias, localPath); err != nil {
 		switch e := errors.Unwrap(err).(type) {
 		case root.AlreadyMountedError:
-			out.Print(ctx, "Store is already mounted")
+			out.Printf(ctx, "Store is already mounted")
 			return nil
 		case root.NotInitializedError:
-			out.Print(ctx, "Mount %s is not yet initialized. Please use 'gopass init --store %s' instead", e.Alias(), e.Alias())
+			out.Printf(ctx, "Mount %s is not yet initialized. Please use 'gopass init --store %s' instead", e.Alias(), e.Alias())
 			return e
 		default:
-			return ExitError(ExitMount, err, "failed to add mount '%s' to '%s': %s", alias, localPath, err)
+			return ExitError(ExitMount, err, "failed to add mount %q to %q: %s", alias, localPath, err)
 		}
 	}
 
@@ -103,6 +103,6 @@ func (s *Action) MountAdd(c *cli.Context) error {
 		return ExitError(ExitConfig, err, "failed to save config: %s", err)
 	}
 
-	out.Print(ctx, "Mounted %s as %s", alias, localPath)
+	out.Printf(ctx, "Mounted %s as %s", alias, localPath)
 	return nil
 }

--- a/internal/action/otp.go
+++ b/internal/action/otp.go
@@ -58,9 +58,9 @@ func (s *Action) otp(ctx context.Context, name, qrf string, clip, pw, recurse bo
 	}
 
 	if pw {
-		out.Print(ctx, "%s", token)
+		out.Printf(ctx, "%s", token)
 	} else {
-		out.Print(ctx, "%s lasts %ds \t|%s%s|", token, secondsLeft, strings.Repeat("-", otpPeriod-secondsLeft), strings.Repeat("=", secondsLeft))
+		out.Printf(ctx, "%s lasts %ds \t|%s%s|", token, secondsLeft, strings.Repeat("-", otpPeriod-secondsLeft), strings.Repeat("=", secondsLeft))
 	}
 
 	if clip {
@@ -78,9 +78,9 @@ func (s *Action) otp(ctx context.Context, name, qrf string, clip, pw, recurse bo
 
 func (s *Action) otpHandleError(ctx context.Context, name, qrf string, clip, pw, recurse bool, err error) error {
 	if err != store.ErrNotFound || !recurse || !ctxutil.IsTerminal(ctx) {
-		return ExitError(ExitUnknown, err, "failed to retrieve secret '%s': %s", name, err)
+		return ExitError(ExitUnknown, err, "failed to retrieve secret %q: %s", name, err)
 	}
-	out.Print(ctx, "Entry '%s' not found. Starting search...", name)
+	out.Printf(ctx, "Entry %q not found. Starting search...", name)
 	cb := func(ctx context.Context, c *cli.Context, name string, recurse bool) error {
 		return s.otp(ctx, name, qrf, clip, pw, false)
 	}

--- a/internal/action/rcs.go
+++ b/internal/action/rcs.go
@@ -46,12 +46,12 @@ func (s *Action) rcsInit(ctx context.Context, store, un, ue string) error {
 			return nil
 		}
 		if gtv := os.Getenv("GPG_TTY"); gtv == "" {
-			out.Print(ctx, "Git initialization failed. You may want to try to 'export GPG_TTY=$(tty)' and start over.")
+			out.Printf(ctx, "Git initialization failed. You may want to try to 'export GPG_TTY=$(tty)' and start over.")
 		}
 		return fmt.Errorf("failed to run git init: %w", err)
 	}
 
-	out.Print(ctx, "Initialized git repository (%s) for %s / %s...", bn, un, ue)
+	out.Printf(ctx, "Initialized git repository (%s) for %s / %s...", bn, un, ue)
 	return nil
 }
 
@@ -72,7 +72,7 @@ func (s *Action) getUserData(ctx context.Context, store, name, email string) (st
 		var err error
 		name, err = termio.AskForString(ctx, color.CyanString("Please enter a user name for password store git config"), userName)
 		if err != nil {
-			out.Error(ctx, "Failed to ask for user input: %s", err)
+			out.Errorf(ctx, "Failed to ask for user input: %s", err)
 		}
 	}
 	if email == "" {
@@ -82,7 +82,7 @@ func (s *Action) getUserData(ctx context.Context, store, name, email string) (st
 		var err error
 		email, err = termio.AskForString(ctx, color.CyanString("Please enter an email address for password store git config"), userEmail)
 		if err != nil {
-			out.Error(ctx, "Failed to ask for user input: %s", err)
+			out.Errorf(ctx, "Failed to ask for user input: %s", err)
 		}
 	}
 
@@ -136,12 +136,12 @@ func (s *Action) RCSPush(c *cli.Context) error {
 
 	if err := s.Store.RCSPush(ctx, store, origin, branch); err != nil {
 		if errors.Is(err, si.ErrGitNoRemote) {
-			out.Notice(ctx, "No Git remote. Not pushing")
+			out.Noticef(ctx, "No Git remote. Not pushing")
 			return nil
 		}
 		return ExitError(ExitGit, err, "Failed to push to remote")
 	}
-	out.OK(ctx, "Pushed to git remote")
+	out.OKf(ctx, "Pushed to git remote")
 	return nil
 }
 

--- a/internal/action/recipients.go
+++ b/internal/action/recipients.go
@@ -37,7 +37,7 @@ credentials.
 // RecipientsPrint prints all recipients per store
 func (s *Action) RecipientsPrint(c *cli.Context) error {
 	ctx := ctxutil.WithGlobalFlags(c)
-	out.Print(ctx, "Hint: run 'gopass sync' to import any missing public keys")
+	out.Printf(ctx, "Hint: run 'gopass sync' to import any missing public keys")
 
 	t, err := s.Store.RecipientsTree(ctx, true)
 	if err != nil {
@@ -94,17 +94,17 @@ func (s *Action) RecipientsAdd(c *cli.Context) error {
 	for _, r := range recipients {
 		keys, err := crypto.FindRecipients(ctx, r)
 		if err != nil {
-			out.Print(ctx, "WARNING: Failed to list public key '%s': %s", r, err)
+			out.Printf(ctx, "WARNING: Failed to list public key %q: %s", r, err)
 			if !force {
 				continue
 			}
 			keys = []string{r}
 		}
 		if len(keys) < 1 && !force && crypto.Name() == "gpgcli" {
-			out.Print(ctx, "Warning: No matching valid key found. If the key is in your keyring you may need to validate it.")
-			out.Print(ctx, "If this is your key: gpg --edit-key %s; trust (set to ultimate); quit", r)
-			out.Print(ctx, "If this is not your key: gpg --edit-key %s; lsign; trust; save; quit", r)
-			out.Print(ctx, "You may need to run 'gpg --update-trustdb' afterwards")
+			out.Printf(ctx, "Warning: No matching valid key found. If the key is in your keyring you may need to validate it.")
+			out.Printf(ctx, "If this is your key: gpg --edit-key %s; trust (set to ultimate); quit", r)
+			out.Printf(ctx, "If this is not your key: gpg --edit-key %s; lsign; trust; save; quit", r)
+			out.Printf(ctx, "You may need to run 'gpg --update-trustdb' afterwards")
 			continue
 		}
 
@@ -113,12 +113,12 @@ func (s *Action) RecipientsAdd(c *cli.Context) error {
 			recp = crypto.Fingerprint(ctx, keys[0])
 		}
 
-		if !termio.AskForConfirmation(ctx, fmt.Sprintf("Do you want to add '%s' as a recipient to the store '%s'?", crypto.FormatKey(ctx, recp, ""), store)) {
+		if !termio.AskForConfirmation(ctx, fmt.Sprintf("Do you want to add %q as a recipient to the store %q?", crypto.FormatKey(ctx, recp, ""), store)) {
 			continue
 		}
 
 		if err := s.Store.AddRecipient(ctx, store, recp); err != nil {
-			return ExitError(ExitRecipients, err, "failed to add recipient '%s': %s", r, err)
+			return ExitError(ExitRecipients, err, "failed to add recipient %q: %s", r, err)
 		}
 		added++
 	}
@@ -126,8 +126,8 @@ func (s *Action) RecipientsAdd(c *cli.Context) error {
 		return ExitError(ExitUnknown, nil, "no key added")
 	}
 
-	out.Print(ctx, "\nAdded %d recipients", added)
-	out.Print(ctx, "You need to run 'gopass sync' to push these changes")
+	out.Printf(ctx, "\nAdded %d recipients", added)
+	out.Printf(ctx, "You need to run 'gopass sync' to push these changes")
 	return nil
 }
 
@@ -167,18 +167,18 @@ func (s *Action) RecipientsRemove(c *cli.Context) error {
 
 		keys, err := crypto.FindRecipients(ctx, r)
 		if err != nil {
-			out.Print(ctx, "WARNING: Failed to list public key '%s': %s", r, err)
-			out.Print(ctx, "Hint: You can use `--force` to remove unknown keys.")
+			out.Printf(ctx, "WARNING: Failed to list public key %q: %s", r, err)
+			out.Printf(ctx, "Hint: You can use `--force` to remove unknown keys.")
 			if !force {
 				continue
 			}
 			keys = []string{r}
 		}
 		if len(keys) < 1 && !force {
-			out.Print(ctx, "Warning: No matching valid key found. If the key is in your keyring you may need to validate it.")
-			out.Print(ctx, "If this is your key: gpg --edit-key %s; trust (set to ultimate); quit", r)
-			out.Print(ctx, "If this is not your key: gpg --edit-key %s; lsign; trust; save; quit", r)
-			out.Print(ctx, "You may need to run 'gpg --update-trustdb' afterwards")
+			out.Printf(ctx, "Warning: No matching valid key found. If the key is in your keyring you may need to validate it.")
+			out.Printf(ctx, "If this is your key: gpg --edit-key %s; trust (set to ultimate); quit", r)
+			out.Printf(ctx, "If this is not your key: gpg --edit-key %s; lsign; trust; save; quit", r)
+			out.Printf(ctx, "You may need to run 'gpg --update-trustdb' afterwards")
 			continue
 		}
 
@@ -188,7 +188,7 @@ func (s *Action) RecipientsRemove(c *cli.Context) error {
 		}
 
 		if err := s.Store.RemoveRecipient(ctx, store, recp); err != nil {
-			return ExitError(ExitRecipients, err, "failed to remove recipient '%s': %s", recp, err)
+			return ExitError(ExitRecipients, err, "failed to remove recipient %q: %s", recp, err)
 		}
 		fmt.Fprintf(stdout, removalWarning, r)
 		removed++
@@ -197,8 +197,8 @@ func (s *Action) RecipientsRemove(c *cli.Context) error {
 		return ExitError(ExitUnknown, nil, "no key removed")
 	}
 
-	out.Print(ctx, "\nRemoved %d recipients", removed)
-	out.Print(ctx, "You need to run 'gopass sync' to push these changes")
+	out.Printf(ctx, "\nRemoved %d recipients", removed)
+	out.Printf(ctx, "You need to run 'gopass sync' to push these changes")
 	return nil
 }
 

--- a/internal/action/repl.go
+++ b/internal/action/repl.go
@@ -112,12 +112,12 @@ func (s *Action) REPL(c *cli.Context) error {
 		if err == nil {
 			return
 		}
-		out.Error(c.Context, "%s", err)
+		out.Errorf(c.Context, "%s", err)
 	}
 
-	out.Print(c.Context, logo)
-	out.Print(c.Context, "🌟 Welcome to gopass!")
-	out.Print(c.Context, "⚠ This is the built-in shell. Type 'help' for a list of commands.")
+	out.Printf(c.Context, logo)
+	out.Printf(c.Context, "🌟 Welcome to gopass!")
+	out.Printf(c.Context, "⚠ This is the built-in shell. Type 'help' for a list of commands.")
 
 	rl, err := readline.New("gopass> ")
 	if err != nil {
@@ -141,7 +141,7 @@ READ:
 		}
 		args, err := shellquote.Split(line)
 		if err != nil {
-			out.Print(c.Context, "Error: %s", err)
+			out.Printf(c.Context, "Error: %s", err)
 			continue
 		}
 		if len(args) < 1 {
@@ -172,8 +172,8 @@ READ:
 
 func (s *Action) replLock(ctx context.Context) {
 	if err := s.Store.Lock(); err != nil {
-		out.Error(ctx, "Failed to lock stores: %s", err)
+		out.Errorf(ctx, "Failed to lock stores: %s", err)
 		return
 	}
-	out.OK(ctx, "Locked")
+	out.OKf(ctx, "Locked")
 }

--- a/internal/action/show_test.go
+++ b/internal/action/show_test.go
@@ -67,7 +67,7 @@ func TestShowMulti(t *testing.T) {
 	})
 
 	t.Run("show twoliner with safecontent enabled", func(t *testing.T) {
-		ctx = ctxutil.WithShowSafeContent(ctx, true)
+		ctx := ctxutil.WithShowSafeContent(ctx, true)
 		c := gptest.CliCtx(ctx, t, "bar/baz")
 
 		assert.NoError(t, act.Show(c))
@@ -78,6 +78,8 @@ func TestShowMulti(t *testing.T) {
 	})
 
 	t.Run("show foo with safecontent enabled, should error out", func(t *testing.T) {
+		ctx := ctxutil.WithShowSafeContent(ctx, true)
+
 		c := gptest.CliCtx(ctx, t, "foo")
 		assert.NoError(t, act.Show(c))
 		assert.NotContains(t, buf.String(), "secret")
@@ -92,7 +94,7 @@ func TestShowMulti(t *testing.T) {
 	})
 
 	t.Run("show twoliner with safecontent enabled, but with the clip flag, which should copy just the secret", func(t *testing.T) {
-		ctx = ctxutil.WithShowSafeContent(ctx, true)
+		ctx := ctxutil.WithShowSafeContent(ctx, true)
 		c := gptest.CliCtxWithFlags(ctx, t, map[string]string{"clip": "true"}, "bar/baz")
 
 		assert.NoError(t, act.Show(c))
@@ -110,7 +112,7 @@ func TestShowMulti(t *testing.T) {
 		assert.NoError(t, act.Store.Set(ctx, "unsafe/keys", sec))
 		buf.Reset()
 
-		ctx = ctxutil.WithShowSafeContent(ctx, true)
+		ctx := ctxutil.WithShowSafeContent(ctx, true)
 		c := gptest.CliCtx(ctx, t, "unsafe/keys")
 		assert.NoError(t, act.Show(c))
 		assert.Contains(t, buf.String(), "*****")
@@ -120,7 +122,7 @@ func TestShowMulti(t *testing.T) {
 	})
 
 	t.Run("show twoliner with safecontent enabled", func(t *testing.T) {
-		ctx = ctxutil.WithShowSafeContent(ctx, true)
+		ctx := ctxutil.WithShowSafeContent(ctx, true)
 		c := gptest.CliCtx(ctx, t, "bar/baz")
 
 		assert.NoError(t, act.Show(c))
@@ -131,7 +133,7 @@ func TestShowMulti(t *testing.T) {
 	})
 
 	t.Run("show twoliner with parsing disabled and safecontent enabled", func(t *testing.T) {
-		ctx = ctxutil.WithShowSafeContent(ctx, true)
+		ctx := ctxutil.WithShowSafeContent(ctx, true)
 		ctx = ctxutil.WithShowParsing(ctx, false)
 		c := gptest.CliCtx(ctx, t, "bar/baz")
 
@@ -144,7 +146,7 @@ func TestShowMulti(t *testing.T) {
 	})
 
 	t.Run("show key with parsing enabled", func(t *testing.T) {
-		ctx = ctxutil.WithShowParsing(ctx, true)
+		ctx := ctxutil.WithShowParsing(ctx, true)
 		c := gptest.CliCtx(ctx, t, "bar/baz", "bar")
 
 		assert.NoError(t, act.Show(c))
@@ -153,16 +155,16 @@ func TestShowMulti(t *testing.T) {
 	})
 
 	t.Run("show key with parsing disabled", func(t *testing.T) {
-		ctx = ctxutil.WithShowParsing(ctx, false)
+		ctx := ctxutil.WithShowParsing(ctx, false)
 		c := gptest.CliCtx(ctx, t, "bar/baz", "bar")
 
 		assert.NoError(t, act.Show(c))
-		assert.Equal(t, "bar: zab", buf.String())
+		assert.Equal(t, "123\nbar: zab", buf.String())
 		buf.Reset()
 	})
 
 	t.Run("show nonexisting key with parsing enabled", func(t *testing.T) {
-		ctx = ctxutil.WithShowParsing(ctx, true)
+		ctx := ctxutil.WithShowParsing(ctx, true)
 		c := gptest.CliCtx(ctx, t, "bar/baz", "nonexisting")
 
 		assert.Error(t, act.Show(c))
@@ -170,7 +172,7 @@ func TestShowMulti(t *testing.T) {
 	})
 
 	t.Run("show keys with mixed case", func(t *testing.T) {
-		ctx = ctxutil.WithShowParsing(ctx, true)
+		ctx := ctxutil.WithShowParsing(ctx, true)
 
 		assert.NoError(t, act.insertStdin(ctx, "baz", []byte("foobar\nOther: meh\nuser: name\nbody text"), false))
 		buf.Reset()
@@ -178,6 +180,21 @@ func TestShowMulti(t *testing.T) {
 		c := gptest.CliCtx(ctx, t, "baz", "Other")
 		assert.NoError(t, act.Show(c))
 		assert.Equal(t, "meh", buf.String())
+		buf.Reset()
+	})
+
+	t.Run("show value with format strings", func(t *testing.T) {
+		ctx := ctxutil.WithShowParsing(ctx, true)
+
+		pw := "some-chars-are-odd-%s-%p-%q"
+
+		assert.NoError(t, act.insertStdin(ctx, "printf", []byte(pw), false))
+		buf.Reset()
+
+		c := gptest.CliCtx(ctx, t, "printf")
+		assert.NoError(t, act.Show(c))
+		assert.Equal(t, pw, buf.String())
+		assert.NotContains(t, buf.String(), "MISSING")
 		buf.Reset()
 	})
 }

--- a/internal/action/templates.go
+++ b/internal/action/templates.go
@@ -103,7 +103,7 @@ func (s *Action) TemplateRemove(c *cli.Context) error {
 	}
 
 	if !s.Store.HasTemplate(ctx, name) {
-		return ExitError(ExitNotFound, nil, "template '%s' not found", name)
+		return ExitError(ExitNotFound, nil, "template %q not found", name)
 	}
 
 	return s.Store.RemoveTemplate(ctx, name)
@@ -137,18 +137,18 @@ func (s *Action) renderTemplate(ctx context.Context, name string, content []byte
 
 	tmplStr := strings.TrimSpace(string(tmpl))
 	if tmplStr == "" {
-		debug.Log("Skipping empty template '%s', for %s", tName, name)
+		debug.Log("Skipping empty template %q, for %s", tName, name)
 		return content, false
 	}
 
 	// load template if it exists
 	nc, err := tpl.Execute(ctx, string(tmpl), name, content, s.Store)
 	if err != nil {
-		fmt.Fprintf(stdout, "failed to execute template '%s': %s\n", tName, err)
+		fmt.Fprintf(stdout, "failed to execute template %q: %s\n", tName, err)
 		return content, false
 	}
 
-	out.Print(ctx, "Note: Using template %s", tName)
+	out.Printf(ctx, "Note: Using template %s", tName)
 
 	return nc, true
 }

--- a/internal/action/update.go
+++ b/internal/action/update.go
@@ -16,7 +16,7 @@ func (s *Action) Update(c *cli.Context) error {
 	ctx := ctxutil.WithGlobalFlags(c)
 
 	if s.version.String() == "0.0.0+HEAD" {
-		out.Error(ctx, "Can not check version against HEAD")
+		out.Errorf(ctx, "Can not check version against HEAD")
 		return nil
 	}
 
@@ -24,10 +24,10 @@ func (s *Action) Update(c *cli.Context) error {
 		return fmt.Errorf("gopass update is not supported on windows (#1722)")
 	}
 
-	out.Print(ctx, "⚒ Checking for available updates ...")
+	out.Printf(ctx, "⚒ Checking for available updates ...")
 	if err := updater.Update(ctx, s.version); err != nil {
 		return ExitError(ExitUnknown, err, "Failed to update gopass: %s", err)
 	}
-	out.OK(ctx, "gopass is up to date")
+	out.OKf(ctx, "gopass is up to date")
 	return nil
 }

--- a/internal/action/version.go
+++ b/internal/action/version.go
@@ -54,7 +54,7 @@ func (s *Action) Version(c *cli.Context) error {
 			fmt.Fprintln(stdout, vi)
 		}
 	case <-time.After(2 * time.Second):
-		out.Error(ctx, "Version check timed out")
+		out.Errorf(ctx, "Version check timed out")
 	case <-ctx.Done():
 		return ExitError(ExitAborted, nil, "user aborted")
 	}

--- a/internal/action/version_test.go
+++ b/internal/action/version_test.go
@@ -36,7 +36,7 @@ func TestVersion(t *testing.T) {
 	}()
 
 	cli.VersionPrinter = func(*cli.Context) {
-		out.Print(ctx, "gopass version 0.0.0-test")
+		out.Printf(ctx, "gopass version 0.0.0-test")
 	}
 
 	t.Run("print fixed version", func(t *testing.T) {

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -43,7 +43,7 @@ type validator func(string, gopass.Secret) error
 
 // Batch runs a password strength audit on multiple secrets
 func Batch(ctx context.Context, secrets []string, secStore secretGetter) error {
-	out.Print(ctx, "Checking %d secrets. This may take some time ...\n", len(secrets))
+	out.Printf(ctx, "Checking %d secrets. This may take some time ...\n", len(secrets))
 
 	// Secrets that still need auditing.
 	pending := make(chan string, 100)
@@ -223,7 +223,7 @@ func printAuditResults(m map[string][]string, format string, color func(format s
 func Single(ctx context.Context, password string) {
 	validator := crunchy.NewValidator()
 	if err := validator.Check(password); err != nil {
-		out.Print(ctx, fmt.Sprintf("Warning: %s", err))
+		out.Printf(ctx, fmt.Sprintf("Warning: %s", err))
 	}
 }
 
@@ -233,19 +233,19 @@ func auditPrintResults(ctx context.Context, duplicates, messages, errors map[str
 		if len(secrets) > 1 {
 			foundDuplicates = true
 
-			out.Print(ctx, "Detected a shared secret for:")
+			out.Printf(ctx, "Detected a shared secret for:")
 			for _, secret := range secrets {
-				out.Print(ctx, "\t- %s", secret)
+				out.Printf(ctx, "\t- %s", secret)
 			}
 		}
 	}
 	if !foundDuplicates {
-		out.Print(ctx, "No shared secrets found.")
+		out.Printf(ctx, "No shared secrets found.")
 	}
 
 	foundWeakPasswords := printAuditResults(messages, "%s:\n", color.CyanString)
 	if !foundWeakPasswords {
-		out.Print(ctx, "No weak secrets detected.")
+		out.Printf(ctx, "No weak secrets detected.")
 	}
 	foundErrors := printAuditResults(errors, "%s:\n", color.RedString)
 

--- a/internal/backend/crypto/age/age.go
+++ b/internal/backend/crypto/age/age.go
@@ -89,7 +89,7 @@ func (a *Age) parseRecipients(ctx context.Context, recipients []string) ([]age.R
 		if strings.HasPrefix(r, "age1") {
 			id, err := age.ParseX25519Recipient(r)
 			if err != nil {
-				debug.Log("Failed to parse recipient '%s' as X25519: %s", r, err)
+				debug.Log("Failed to parse recipient %q as X25519: %s", r, err)
 				continue
 			}
 			out = append(out, id)
@@ -98,7 +98,7 @@ func (a *Age) parseRecipients(ctx context.Context, recipients []string) ([]age.R
 		if strings.HasPrefix(r, "ssh-") {
 			id, err := agessh.ParseRecipient(r)
 			if err != nil {
-				debug.Log("Failed to parse recipient '%s' as SSH: %s", r, err)
+				debug.Log("Failed to parse recipient %q as SSH: %s", r, err)
 				continue
 			}
 			out = append(out, id)
@@ -112,7 +112,7 @@ func (a *Age) parseRecipients(ctx context.Context, recipients []string) ([]age.R
 			for _, pk := range pks {
 				id, err := agessh.ParseRecipient(r)
 				if err != nil {
-					debug.Log("Failed to parse GitHub recipient '%s': '%s': %s", r, pk, err)
+					debug.Log("Failed to parse GitHub recipient %q: %q: %s", r, pk, err)
 					continue
 				}
 				out = append(out, id)
@@ -197,7 +197,7 @@ func (a *Age) getNativeIdentities(ctx context.Context) (map[string]age.Identity,
 	for _, k := range kr {
 		id, err := age.ParseX25519Identity(k.Identity)
 		if err != nil {
-			debug.Log("Failed to parse identity '%s': %s", k, err)
+			debug.Log("Failed to parse identity %q: %s", k, err)
 			continue
 		}
 		ids[id.Recipient().String()] = id

--- a/internal/backend/crypto/age/askpass.go
+++ b/internal/backend/crypto/age/askpass.go
@@ -63,7 +63,7 @@ func (a *askPass) Passphrase(key string, reason string, repeat bool) (string, er
 	debug.Log("Value for %s not found in cache", key)
 
 	// TODO we shouldn't print here like this ...
-	out.Print(context.TODO(), "🔑 Please enter your passphrase to unlock the age keyring")
+	out.Printf(context.TODO(), "🔑 Please enter your passphrase to unlock the age keyring")
 	pi, err := a.pinentry()
 	if err != nil {
 		return "", fmt.Errorf("pinentry Error: %s", err)

--- a/internal/backend/crypto/gpg/cli/binary_windows.go
+++ b/internal/backend/crypto/gpg/cli/binary_windows.go
@@ -21,13 +21,13 @@ func detectBinary(bin string) (string, error) {
 	}
 	bv := make(byVersion, 0, len(bins))
 	for _, b := range bins {
-		debug.Log("Looking for '%s' ...", b)
+		debug.Log("Looking for %q ...", b)
 		if p, err := exec.LookPath(b); err == nil {
 			gb := gpgBin{
 				path: p,
 				ver:  version(context.TODO(), p),
 			}
-			debug.Log("Found '%s' at '%s' (%s)", b, p, gb.ver.String())
+			debug.Log("Found %q at %q (%s)", b, p, gb.ver.String())
 			bv = append(bv, gb)
 		}
 	}
@@ -35,7 +35,7 @@ func detectBinary(bin string) (string, error) {
 		return "", errors.New("no gpg binary found")
 	}
 	binary := bv[0].path
-	debug.Log("using '%s'", binary)
+	debug.Log("using %q", binary)
 	return binary, nil
 }
 

--- a/internal/backend/crypto/gpg/cli/gpg.go
+++ b/internal/backend/crypto/gpg/cli/gpg.go
@@ -114,7 +114,7 @@ func (g *GPG) RecipientIDs(ctx context.Context, buf []byte) ([]string, error) {
 
 	if g.throwKids {
 		// TODO shouldn't log here
-		out.Warning(ctx, "gpg option throw-keyids is set. some features might not work.")
+		out.Warningf(ctx, "gpg option throw-keyids is set. some features might not work.")
 	}
 	return recp, nil
 }
@@ -134,7 +134,7 @@ func (g *GPG) Encrypt(ctx context.Context, plaintext []byte, recipients []string
 		if err != nil {
 			debug.Log("Failed to check key %s. Adding anyway. %s", err)
 		} else if len(kl.UseableKeys(gpg.IsAlwaysTrust(ctx))) < 1 {
-			out.Print(ctx, "Not using expired key %s for encryption", r)
+			out.Printf(ctx, "Not using expired key %s for encryption", r)
 			continue
 		}
 		args = append(args, "--recipient", r)

--- a/internal/backend/crypto/gpg/cli/keyring.go
+++ b/internal/backend/crypto/gpg/cli/keyring.go
@@ -128,7 +128,7 @@ func (g *GPG) FormatKey(ctx context.Context, id, tpl string) string {
 
 	buf := &bytes.Buffer{}
 	if err := tmpl.Execute(buf, g.findKey(ctx, id).Identity()); err != nil {
-		debug.Log("Failed to render template '%s': %s", tpl, err)
+		debug.Log("Failed to render template %q: %s", tpl, err)
 		return ""
 	}
 

--- a/internal/backend/storage/fs/fsck.go
+++ b/internal/backend/storage/fs/fsck.go
@@ -61,12 +61,12 @@ func (s *Store) fsckCheckFile(ctx context.Context, filename string) error {
 		return nil
 	}
 
-	out.Print(ctx, "Permissions too wide: %s (%s)", filename, fi.Mode().String())
+	out.Printf(ctx, "Permissions too wide: %s (%s)", filename, fi.Mode().String())
 
 	np := uint32(fi.Mode().Perm() & 0600)
-	out.Print(ctx, "  Fixing permissions from %s to %s", fi.Mode().Perm().String(), os.FileMode(np).Perm().String())
+	out.Printf(ctx, "  Fixing permissions from %s to %s", fi.Mode().Perm().String(), os.FileMode(np).Perm().String())
 	if err := syscall.Chmod(filename, np); err != nil {
-		out.Error(ctx, "  Failed to set permissions for %s to rw-------: %s", filename, err)
+		out.Errorf(ctx, "  Failed to set permissions for %s to rw-------: %s", filename, err)
 	}
 	return nil
 }
@@ -80,12 +80,12 @@ func (s *Store) fsckCheckDir(ctx context.Context, dirname string) error {
 	// check if any group or other perms are set,
 	// i.e. check for perms other than rwx------
 	if fi.Mode().Perm()&077 != 0 {
-		out.Print(ctx, "Permissions too wide %s on dir %s", fi.Mode().Perm().String(), dirname)
+		out.Printf(ctx, "Permissions too wide %s on dir %s", fi.Mode().Perm().String(), dirname)
 
 		np := uint32(fi.Mode().Perm() & 0700)
-		out.Print(ctx, "  Fixing permissions from %s to %s", fi.Mode().Perm().String(), os.FileMode(np).Perm().String())
+		out.Printf(ctx, "  Fixing permissions from %s to %s", fi.Mode().Perm().String(), os.FileMode(np).Perm().String())
 		if err := syscall.Chmod(dirname, np); err != nil {
-			out.Error(ctx, "  Failed to set permissions for %s to rwx------: %s", dirname, err)
+			out.Errorf(ctx, "  Failed to set permissions for %s to rwx------: %s", dirname, err)
 		}
 	}
 
@@ -95,7 +95,7 @@ func (s *Store) fsckCheckDir(ctx context.Context, dirname string) error {
 		return err
 	}
 	if isEmpty {
-		out.Error(ctx, "Folder %s is empty. Removing", dirname)
+		out.Errorf(ctx, "Folder %s is empty. Removing", dirname)
 		return os.Remove(dirname)
 	}
 	return nil

--- a/internal/backend/storage/gitfs/config.go
+++ b/internal/backend/storage/gitfs/config.go
@@ -28,16 +28,16 @@ func (g *Git) fixConfig(ctx context.Context) error {
 
 	// setup for proper diffs
 	if err := g.ConfigSet(ctx, "diff.gpg.binary", "true"); err != nil {
-		out.Error(ctx, "Error while initializing git: %s", err)
+		out.Errorf(ctx, "Error while initializing git: %s", err)
 	}
 	if err := g.ConfigSet(ctx, "diff.gpg.textconv", "gpg --no-tty --decrypt"); err != nil {
-		out.Error(ctx, "Error while initializing git: %s", err)
+		out.Errorf(ctx, "Error while initializing git: %s", err)
 	}
 
 	// setup for persistent SSH connections
 	if sc := gitSSHCommand(); sc != "" {
 		if err := g.ConfigSet(ctx, "core.sshCommand", sc); err != nil {
-			out.Error(ctx, "Error while configuring persistent SSH connections: %s", err)
+			out.Errorf(ctx, "Error while configuring persistent SSH connections: %s", err)
 		}
 	}
 
@@ -52,14 +52,14 @@ func (g *Git) InitConfig(ctx context.Context, userName, userEmail string) error 
 			return fmt.Errorf("failed to set git config user.name: %w", err)
 		}
 	} else {
-		out.Print(ctx, "Git Username not set")
+		out.Printf(ctx, "Git Username not set")
 	}
 	if userEmail != "" && strings.Contains(userEmail, "@") {
 		if err := g.ConfigSet(ctx, "user.email", userEmail); err != nil {
 			return fmt.Errorf("failed to set git config user.email: %w", err)
 		}
 	} else {
-		out.Print(ctx, "Git Email not set")
+		out.Printf(ctx, "Git Email not set")
 	}
 
 	// ensure sane git config
@@ -71,10 +71,10 @@ func (g *Git) InitConfig(ctx context.Context, userName, userEmail string) error 
 		return fmt.Errorf("failed to initialize git: %w", err)
 	}
 	if err := g.Add(ctx, g.fs.Path()+"/.gitattributes"); err != nil {
-		out.Warning(ctx, "Failed to add .gitattributes to git")
+		out.Warningf(ctx, "Failed to add .gitattributes to git")
 	}
 	if err := g.Commit(ctx, "Configure git repository for gpg file diff."); err != nil {
-		out.Warning(ctx, "Failed to commit .gitattributes to git")
+		out.Warningf(ctx, "Failed to commit .gitattributes to git")
 	}
 
 	return nil

--- a/internal/backend/storage/gitfs/git.go
+++ b/internal/backend/storage/gitfs/git.go
@@ -79,7 +79,7 @@ func Init(ctx context.Context, path, userName, userEmail string) (*Git, error) {
 		if err := g.Cmd(ctx, "Init", "init"); err != nil {
 			return nil, fmt.Errorf("failed to initialize git: %s", err)
 		}
-		out.Print(ctx, "git initialized at %s", g.fs.Path())
+		out.Printf(ctx, "git initialized at %s", g.fs.Path())
 	}
 
 	if !ctxutil.IsGitInit(ctx) {
@@ -90,7 +90,7 @@ func Init(ctx context.Context, path, userName, userEmail string) (*Git, error) {
 	if err := g.InitConfig(ctx, userName, userEmail); err != nil {
 		return g, fmt.Errorf("failed to configure git: %s", err)
 	}
-	out.Print(ctx, "git configured at %s", g.fs.Path())
+	out.Printf(ctx, "git configured at %s", g.fs.Path())
 
 	// add current content of the store
 	if err := g.Add(ctx, g.fs.Path()); err != nil {
@@ -133,7 +133,7 @@ func (g *Git) captureCmd(ctx context.Context, name string, args ...string) ([]by
 func (g *Git) Cmd(ctx context.Context, name string, args ...string) error {
 	stdout, stderr, err := g.captureCmd(ctx, name, args...)
 	if err != nil {
-		debug.Log("CMD: %s %+v\nError: %s\nOutput:\n  Stdout: '%s'\n  Stderr: '%s'", name, args, err, string(stdout), string(stderr))
+		debug.Log("CMD: %s %+v\nError: %s\nOutput:\n  Stdout: %q\n  Stderr: %q", name, args, err, string(stdout), string(stderr))
 		return fmt.Errorf("%s: %s", err, strings.TrimSpace(string(stderr)))
 	}
 
@@ -163,7 +163,7 @@ func (g *Git) Version(ctx context.Context) semver.Version {
 
 	sv, err := semver.ParseTolerant(svStr)
 	if err != nil {
-		debug.Log("Failed to parse '%s' as semver: %s", svStr, err)
+		debug.Log("Failed to parse %q as semver: %s", svStr, err)
 		return v
 	}
 	return sv
@@ -266,7 +266,7 @@ func (g *Git) PushPull(ctx context.Context, op, remote, branch string) error {
 		if op == "pull" {
 			return err
 		}
-		out.Warning(ctx, "Failed to pull before git push: %s", err)
+		out.Warningf(ctx, "Failed to pull before git push: %s", err)
 	}
 	if op == "pull" {
 		return nil

--- a/internal/editor/edit_others_test.go
+++ b/internal/editor/edit_others_test.go
@@ -28,7 +28,7 @@ func TestEditor(t *testing.T) {
 	out, err := Invoke(ctx, touch, []byte(want))
 	require.NoError(t, err)
 	if string(out) != want {
-		t.Errorf("'%s' != '%s'", string(out), want)
+		t.Errorf("%q != %q", string(out), want)
 	}
 }
 

--- a/internal/editor/edit_windows_test.go
+++ b/internal/editor/edit_windows_test.go
@@ -26,7 +26,7 @@ func TestEditor(t *testing.T) {
 	out, err := Invoke(ctx, touch, []byte(want))
 	require.NoError(t, err)
 	if string(out) != want {
-		t.Errorf("'%s' != '%s'", string(out), want)
+		t.Errorf("%q != %q", string(out), want)
 	}
 }
 

--- a/internal/editor/editor.go
+++ b/internal/editor/editor.go
@@ -58,7 +58,7 @@ func Check(ctx context.Context, editor string) error {
 		return nil
 	}
 	debug.Log("%s did not match %s", string(buf), vimOptsRe)
-	out.Warning(ctx, "Vim might leak credentials. Check your setup.\nhttps://github.com/gopasspw/gopass/blob/master/docs/setup.md#securing-your-editor")
+	out.Warningf(ctx, "Vim might leak credentials. Check your setup.\nhttps://github.com/gopasspw/gopass/blob/master/docs/setup.md#securing-your-editor")
 	return nil
 }
 

--- a/internal/out/print.go
+++ b/internal/out/print.go
@@ -24,40 +24,65 @@ func newline(ctx context.Context) string {
 	return ""
 }
 
-// Print formats and prints the given string
-func Print(ctx context.Context, format string, args ...interface{}) {
+// Print prints the given string
+func Print(ctx context.Context, arg string) {
+	Printf(ctx, "%s", arg)
+}
+
+// Printf formats and prints the given string
+func Printf(ctx context.Context, format string, args ...interface{}) {
 	if ctxutil.IsHidden(ctx) {
 		return
 	}
 	fmt.Fprintf(Stdout, Prefix(ctx)+format+newline(ctx), args...)
 }
 
-// Notice prints the string with an exclamation mark in front
-func Notice(ctx context.Context, format string, args ...interface{}) {
+// Notice prints the string with an exclamation mark
+func Notice(ctx context.Context, arg string) {
+	Noticef(ctx, "%s", arg)
+}
+
+// Noticef prints the string with an exclamation mark in front
+func Noticef(ctx context.Context, format string, args ...interface{}) {
 	if ctxutil.IsHidden(ctx) {
 		return
 	}
 	fmt.Fprintf(Stdout, Prefix(ctx)+"⚠ "+format+newline(ctx), args...)
 }
 
-// Error prints the string in red to stderr
-func Error(ctx context.Context, format string, args ...interface{}) {
+// Error prints the string with a red cross in front
+func Error(ctx context.Context, arg string) {
+	Errorf(ctx, "%s", arg)
+}
+
+// Errorf prints the string in red to stderr
+func Errorf(ctx context.Context, format string, args ...interface{}) {
 	if ctxutil.IsHidden(ctx) {
 		return
 	}
 	fmt.Fprint(Stderr, color.RedString(Prefix(ctx)+"❌ "+format+newline(ctx), args...))
 }
 
-// OK prints the string in with an OK checkmark in front
-func OK(ctx context.Context, format string, args ...interface{}) {
+// OK prints the string with a green checkmark in front
+func OK(ctx context.Context, arg string) {
+	OKf(ctx, "%s", arg)
+}
+
+// OKf prints the string in with an OK checkmark in front
+func OKf(ctx context.Context, format string, args ...interface{}) {
 	if ctxutil.IsHidden(ctx) {
 		return
 	}
 	fmt.Fprintf(Stdout, Prefix(ctx)+"✅ "+format+newline(ctx), args...)
 }
 
-// Warning prints the string in yellow to stderr and prepends "Warning: "
-func Warning(ctx context.Context, format string, args ...interface{}) {
+// Warning prints the string with a warning sign in front
+func Warning(ctx context.Context, arg string) {
+	Warningf(ctx, "%s", arg)
+}
+
+// Warningf prints the string in yellow to stderr and prepends a warning sign
+func Warningf(ctx context.Context, format string, args ...interface{}) {
 	if ctxutil.IsHidden(ctx) {
 		return
 	}

--- a/internal/out/print_test.go
+++ b/internal/out/print_test.go
@@ -18,15 +18,15 @@ func TestPrint(t *testing.T) {
 		Stdout = os.Stdout
 	}()
 
-	Print(ctx, "%s = %d", "foo", 42)
+	Printf(ctx, "%s = %d", "foo", 42)
 	assert.Equal(t, "foo = 42\n", buf.String())
 	buf.Reset()
 
-	Print(ctxutil.WithHidden(ctx, true), "%s = %d", "foo", 42)
+	Printf(ctxutil.WithHidden(ctx, true), "%s = %d", "foo", 42)
 	assert.Equal(t, "", buf.String())
 	buf.Reset()
 
-	Print(WithNewline(ctx, false), "%s = %d", "foo", 42)
+	Printf(WithNewline(ctx, false), "%s = %d", "foo", 42)
 	assert.Equal(t, "foo = 42", buf.String())
 	buf.Reset()
 }

--- a/internal/store/leaf/convert.go
+++ b/internal/store/leaf/convert.go
@@ -65,7 +65,7 @@ func (s *Store) Convert(ctx context.Context, cryptoBe backend.CryptoBackend, sto
 		return err
 	}
 
-	out.Print(ctx, "Converting store ...")
+	out.Printf(ctx, "Converting store ...")
 	bar := termio.NewProgressBar(int64(len(entries)), ctxutil.IsHidden(ctx))
 	if !ctxutil.IsTerminal(ctx) || ctxutil.IsHidden(ctx) {
 		bar = nil

--- a/internal/store/leaf/crypto.go
+++ b/internal/store/leaf/crypto.go
@@ -46,7 +46,7 @@ func (s *Store) ImportMissingPublicKeys(ctx context.Context) error {
 		// gpg does on encryption
 		kl, err := s.crypto.FindRecipients(ctx, r)
 		if err != nil {
-			out.Error(ctx, "[%s] Failed to get public key for %s: %s", s.alias, r, err)
+			out.Errorf(ctx, "[%s] Failed to get public key for %s: %s", s.alias, r, err)
 		}
 		if len(kl) > 0 {
 			debug.Log("[%s] Keyring contains %d public keys for %s", s.alias, len(kl), r)
@@ -56,7 +56,7 @@ func (s *Store) ImportMissingPublicKeys(ctx context.Context) error {
 		// get info about this public key
 		names, err := s.decodePublicKey(ctx, r)
 		if err != nil {
-			out.Error(ctx, "[%s] Failed to decode public key %s: %s", s.alias, r, err)
+			out.Errorf(ctx, "[%s] Failed to decode public key %s: %s", s.alias, r, err)
 			continue
 		}
 
@@ -72,10 +72,10 @@ func (s *Store) ImportMissingPublicKeys(ctx context.Context) error {
 
 		// try to load this recipient
 		if err := s.importPublicKey(ctx, r); err != nil {
-			out.Error(ctx, "[%s] Failed to import public key for %s: %s", s.alias, r, err)
+			out.Errorf(ctx, "[%s] Failed to import public key for %s: %s", s.alias, r, err)
 			continue
 		}
-		out.Print(ctx, "[%s] Imported public key for %s into Keyring", s.alias, r)
+		out.Printf(ctx, "[%s] Imported public key for %s into Keyring", s.alias, r)
 	}
 	return nil
 }

--- a/internal/store/leaf/init.go
+++ b/internal/store/leaf/init.go
@@ -32,11 +32,11 @@ You can add secondary stores with gopass init --path <path to secondary store> -
 		}
 		kl, err := s.crypto.FindRecipients(ctx, id)
 		if err != nil {
-			out.Error(ctx, "Failed to fetch public key for '%s': %s", id, err)
+			out.Errorf(ctx, "Failed to fetch public key for %q: %s", id, err)
 			continue
 		}
 		if len(kl) < 1 {
-			out.Error(ctx, "No useable keys for '%s'", id)
+			out.Errorf(ctx, "No useable keys for %q", id)
 			continue
 		}
 		recipients = append(recipients, kl[0])

--- a/internal/store/leaf/rcs.go
+++ b/internal/store/leaf/rcs.go
@@ -55,6 +55,6 @@ func (s *Store) GitStatus(ctx context.Context, _ string) error {
 	if err != nil {
 		return err
 	}
-	out.Print(ctx, string(buf))
+	out.Printf(ctx, string(buf))
 	return nil
 }

--- a/internal/store/leaf/read.go
+++ b/internal/store/leaf/read.go
@@ -25,7 +25,7 @@ func (s *Store) Get(ctx context.Context, name string) (gopass.Secret, error) {
 
 	content, err := s.crypto.Decrypt(ctx, ciphertext)
 	if err != nil {
-		out.Error(ctx, "Decryption failed: %s\n%s", err, string(content))
+		out.Errorf(ctx, "Decryption failed: %s\n%s", err, string(content))
 		return nil, store.ErrDecrypt
 	}
 	var sec gopass.Secret

--- a/internal/store/leaf/recipients.go
+++ b/internal/store/leaf/recipients.go
@@ -26,7 +26,7 @@ const (
 func (s *Store) Recipients(ctx context.Context) []string {
 	rs, err := s.GetRecipients(ctx, "")
 	if err != nil {
-		out.Error(ctx, "failed to read recipient list: %s", err)
+		out.Errorf(ctx, "failed to read recipient list: %s", err)
 	}
 	return rs
 }
@@ -76,7 +76,7 @@ func (s *Store) AddRecipient(ctx context.Context, id string) error {
 		return fmt.Errorf("failed to save recipients: %w", err)
 	}
 
-	out.Print(ctx, "Reencrypting existing secrets. This may take some time ...")
+	out.Printf(ctx, "Reencrypting existing secrets. This may take some time ...")
 	return s.reencrypt(ctxutil.WithCommitMessage(ctx, "Added Recipient "+id))
 }
 
@@ -100,7 +100,7 @@ func (s *Store) SetRecipients(ctx context.Context, rs []string) error {
 func (s *Store) RemoveRecipient(ctx context.Context, id string) error {
 	keys, err := s.crypto.FindRecipients(ctx, id)
 	if err != nil {
-		out.Print(ctx, "Warning: Failed to get GPG Key Info for %s: %s", id, err)
+		out.Printf(ctx, "Warning: Failed to get GPG Key Info for %s: %s", id, err)
 	}
 
 	rs, err := s.GetRecipients(ctx, "")
@@ -208,7 +208,7 @@ func (s *Store) ExportMissingPublicKeys(ctx context.Context, rs []string) (bool,
 		path, err := s.exportPublicKey(ctx, exp, r)
 		if err != nil {
 			failed = true
-			out.Error(ctx, "failed to export public key for '%s': %s", r, err)
+			out.Errorf(ctx, "failed to export public key for %q: %s", r, err)
 			continue
 		}
 		if path == "" {
@@ -221,12 +221,12 @@ func (s *Store) ExportMissingPublicKeys(ctx context.Context, rs []string) (bool,
 				continue
 			}
 			failed = true
-			out.Error(ctx, "failed to add public key for '%s' to git: %s", r, err)
+			out.Errorf(ctx, "failed to add public key for %q to git: %s", r, err)
 			continue
 		}
 		if err := s.storage.Commit(ctx, fmt.Sprintf("Exported Public Keys %s", r)); err != nil && err != store.ErrGitNothingToCommit {
 			failed = true
-			out.Error(ctx, "Failed to git commit: %s", err)
+			out.Errorf(ctx, "Failed to git commit: %s", err)
 			continue
 		}
 	}
@@ -263,7 +263,7 @@ func (s *Store) saveRecipients(ctx context.Context, rs []string, msg string) err
 	// save all recipients public keys to the repo
 	if ctxutil.IsExportKeys(ctx) {
 		if _, err := s.ExportMissingPublicKeys(ctx, rs); err != nil {
-			out.Error(ctx, "Failed to export missing public keys: %s", err)
+			out.Errorf(ctx, "Failed to export missing public keys: %s", err)
 		}
 	}
 

--- a/internal/store/leaf/reencrypt.go
+++ b/internal/store/leaf/reencrypt.go
@@ -34,7 +34,7 @@ func (s *Store) reencrypt(ctx context.Context) error {
 		jobs := make(chan string)
 		// We use a logger to write without race condition on stdout
 		logger := log.New(os.Stdout, "", 0)
-		out.Print(ctx, "Starting reencrypt")
+		out.Printf(ctx, "Starting reencrypt")
 		// We spawn as many workers as we have set in the concurrency setting
 		// GetConcurrency will return 1 if the concurrency setting is not set
 		// or if it set to a value below 1.

--- a/internal/store/leaf/templates.go
+++ b/internal/store/leaf/templates.go
@@ -34,7 +34,7 @@ func (s *Store) LookupTemplate(ctx context.Context, name string) (string, []byte
 		tpl := filepath.Join(name, TemplateFile)
 		if s.storage.Exists(ctx, tpl) {
 			if content, err := s.storage.Get(ctx, tpl); err == nil {
-				debug.Log("Found template '%s' for '%s'", tpl, oName)
+				debug.Log("Found template %q for %q", tpl, oName)
 				return tpl, content, true
 			}
 		}
@@ -73,7 +73,7 @@ func (s *Store) TemplateTree(ctx context.Context) *tree.Root {
 	root := tree.New("gopass")
 	for _, t := range s.ListTemplates(ctx, "") {
 		if err := root.AddFile(t, "gopass/template"); err != nil {
-			out.Error(ctx, "Failed to add template: %s", err)
+			out.Errorf(ctx, "Failed to add template: %s", err)
 		}
 	}
 

--- a/internal/store/leaf/write.go
+++ b/internal/store/leaf/write.go
@@ -84,7 +84,7 @@ func (s *Store) gitCommitAndPush(ctx context.Context, name string) error {
 		if errors.Is(err, store.ErrGitNotInit) {
 			msg := "Warning: git is not initialized for this.storage. Ignoring auto-push option\n" +
 				"Run: gopass git init"
-			out.Error(ctx, msg)
+			out.Errorf(ctx, msg)
 			return nil
 		}
 		if errors.Is(err, store.ErrGitNoRemote) {

--- a/internal/store/root/fsck.go
+++ b/internal/store/root/fsck.go
@@ -23,12 +23,12 @@ func (s *Store) Fsck(ctx context.Context, path string) error {
 		path = strings.TrimPrefix(path, alias+"/")
 		debug.Log("Checking %s", alias)
 		if err := sub.Fsck(ctx, path); err != nil {
-			out.Error(ctx, "fsck failed on sub store %s: %s", alias, err)
+			out.Errorf(ctx, "fsck failed on sub store %s: %s", alias, err)
 			result = multierror.Append(result, err)
 		}
 	}
 	if err := s.store.Fsck(ctx, path); err != nil {
-		out.Error(ctx, "fsck failed on root store: %s", err)
+		out.Errorf(ctx, "fsck failed on root store: %s", err)
 		result = multierror.Append(result, err)
 	}
 

--- a/internal/store/root/init.go
+++ b/internal/store/root/init.go
@@ -75,7 +75,7 @@ func (r *Store) initialize(ctx context.Context) error {
 	for alias, path := range r.cfg.Mounts {
 		path := fsutil.CleanPath(path)
 		if err := r.addMount(ctx, alias, path); err != nil {
-			out.Error(ctx, "Failed to initialize mount %s (%s). Ignoring: %s", alias, path, err)
+			out.Errorf(ctx, "Failed to initialize mount %s (%s). Ignoring: %s", alias, path, err)
 			continue
 		}
 		debug.Log("Sub-Store mounted at %s from %s", alias, path)

--- a/internal/store/root/list.go
+++ b/internal/store/root/list.go
@@ -37,7 +37,7 @@ func (r *Store) Tree(ctx context.Context) (*tree.Root, error) {
 				ct = "text/plain"
 			}
 			if err := root.AddFile(f, ct); err != nil {
-				out.Error(ctx, "Failed to add file %s to tree: %s", f, err)
+				out.Errorf(ctx, "Failed to add file %s to tree: %s", f, err)
 				continue
 			}
 		}
@@ -45,7 +45,7 @@ func (r *Store) Tree(ctx context.Context) (*tree.Root, error) {
 	addTplFunc := func(in ...string) {
 		for _, f := range in {
 			if err := root.AddTemplate(f); err != nil {
-				out.Error(ctx, "Failed to add template %s to tree: %s", f, err)
+				out.Errorf(ctx, "Failed to add template %s to tree: %s", f, err)
 				continue
 			}
 		}

--- a/internal/store/root/mount.go
+++ b/internal/store/root/mount.go
@@ -75,7 +75,7 @@ func (r *Store) initSub(ctx context.Context, alias, path string, keys []string) 
 	if err := s.Init(ctx, path, keys...); err != nil {
 		return s, fmt.Errorf("failed to initialize store %q at %q: %w", alias, path, err)
 	}
-	out.Print(ctx, "Password store %s initialized for:", path)
+	out.Printf(ctx, "Password store %s initialized for:", path)
 	for _, r := range s.Recipients(ctx) {
 		color.Yellow(r)
 	}
@@ -86,10 +86,10 @@ func (r *Store) initSub(ctx context.Context, alias, path string, keys []string) 
 // RemoveMount removes and existing mount
 func (r *Store) RemoveMount(ctx context.Context, alias string) error {
 	if _, found := r.mounts[alias]; !found {
-		out.Warning(ctx, "%s is not mounted", alias)
+		out.Warningf(ctx, "%s is not mounted", alias)
 	}
 	if _, found := r.mounts[alias]; !found {
-		out.Warning(ctx, "%s is not initialized", alias)
+		out.Warningf(ctx, "%s is not initialized", alias)
 	}
 	delete(r.mounts, alias)
 	delete(r.cfg.Mounts, alias)

--- a/internal/store/root/rcs.go
+++ b/internal/store/root/rcs.go
@@ -63,6 +63,6 @@ func (r *Store) GetRevision(ctx context.Context, name, revision string) (context
 // RCSStatus show the git status
 func (r *Store) RCSStatus(ctx context.Context, name string) error {
 	store, name := r.getStore(name)
-	out.Print(ctx, "Store: %s", store.Path())
+	out.Printf(ctx, "Store: %s", store.Path())
 	return store.GitStatus(ctx, name)
 }

--- a/internal/store/root/recipients.go
+++ b/internal/store/root/recipients.go
@@ -57,7 +57,7 @@ func (r *Store) addRecipient(ctx context.Context, prefix string, root *tree.Root
 func (r *Store) ImportMissingPublicKeys(ctx context.Context) error {
 	for alias, sub := range r.mounts {
 		if err := sub.ImportMissingPublicKeys(ctx); err != nil {
-			out.Error(ctx, "[%s] Failed to import missing public keys: %s", alias, err)
+			out.Errorf(ctx, "[%s] Failed to import missing public keys: %s", alias, err)
 		}
 	}
 
@@ -69,7 +69,7 @@ func (r *Store) ImportMissingPublicKeys(ctx context.Context) error {
 func (r *Store) SaveRecipients(ctx context.Context) error {
 	for alias, sub := range r.mounts {
 		if err := sub.SaveRecipients(ctx); err != nil {
-			out.Error(ctx, "[%s] Failed to save recipients: %s", alias, err)
+			out.Errorf(ctx, "[%s] Failed to save recipients: %s", alias, err)
 		}
 	}
 

--- a/internal/store/root/templates.go
+++ b/internal/store/root/templates.go
@@ -28,7 +28,7 @@ func (r *Store) TemplateTree(ctx context.Context) (*tree.Root, error) {
 	for _, t := range r.store.ListTemplates(ctx, "") {
 		debug.Log("[<root>] Adding template %s", t)
 		if err := root.AddFile(t, "gopass/template"); err != nil {
-			out.Error(ctx, "Failed to add file to tree: %s", err)
+			out.Errorf(ctx, "Failed to add file to tree: %s", err)
 		}
 	}
 
@@ -45,7 +45,7 @@ func (r *Store) TemplateTree(ctx context.Context) (*tree.Root, error) {
 		for _, t := range substore.ListTemplates(ctx, alias) {
 			debug.Log("[%s] Adding template %s", alias, t)
 			if err := root.AddFile(t, "gopass/template"); err != nil {
-				out.Error(ctx, "Failed to add file to tree: %s", err)
+				out.Errorf(ctx, "Failed to add file to tree: %s", err)
 			}
 		}
 	}

--- a/internal/updater/update.go
+++ b/internal/updater/update.go
@@ -22,7 +22,7 @@ var (
 // Update will start th interactive update assistant
 func Update(ctx context.Context, currentVersion semver.Version) error {
 	if err := IsUpdateable(ctx); err != nil {
-		out.Error(ctx, "Your gopass binary is externally managed. Can not update: %q", err)
+		out.Errorf(ctx, "Your gopass binary is externally managed. Can not update: %q", err)
 		return err
 	}
 
@@ -39,7 +39,7 @@ func Update(ctx context.Context, currentVersion semver.Version) error {
 	debug.Log("Current: %s - Latest: %s", currentVersion.String(), rel.Version.String())
 	// binary is newer or equal to the latest release -> nothing to do
 	if currentVersion.GTE(rel.Version) {
-		out.Print(ctx, "gopass is up to date (%s)", currentVersion.String())
+		out.Printf(ctx, "gopass is up to date (%s)", currentVersion.String())
 		if gfu := os.Getenv("GOPASS_FORCE_UPDATE"); gfu == "" {
 			return nil
 		}

--- a/main.go
+++ b/main.go
@@ -116,7 +116,7 @@ func setupApp(ctx context.Context, sv semver.Version) (context.Context, *cli.App
 	// initialize action handlers
 	action, err := ap.New(cfg, sv)
 	if err != nil {
-		out.Error(ctx, "No gpg binary found: %s", err)
+		out.Errorf(ctx, "No gpg binary found: %s", err)
 		os.Exit(ap.ExitGPG)
 	}
 

--- a/pkg/clipboard/clipboard.go
+++ b/pkg/clipboard/clipboard.go
@@ -22,7 +22,7 @@ var (
 // clearing of the clipboard
 func CopyTo(ctx context.Context, name string, content []byte) error {
 	if clipboard.Unsupported {
-		out.Print(ctx, "%s", ErrNotSupported)
+		out.Printf(ctx, "%s", ErrNotSupported)
 		_ = notify.Notify(ctx, "gopass - clipboard", fmt.Sprintf("%s", ErrNotSupported))
 		return nil
 	}
@@ -37,7 +37,7 @@ func CopyTo(ctx context.Context, name string, content []byte) error {
 		return fmt.Errorf("failed to clear clipboard: %w", err)
 	}
 
-	out.Print(ctx, "✔ Copied %s to clipboard. Will clear in %d seconds.", color.YellowString(name), ctxutil.GetClipTimeout(ctx))
+	out.Printf(ctx, "✔ Copied %s to clipboard. Will clear in %d seconds.", color.YellowString(name), ctxutil.GetClipTimeout(ctx))
 	_ = notify.Notify(ctx, "gopass - clipboard", fmt.Sprintf("✔ Copied %s to clipboard. Will clear in %d seconds.", name, ctxutil.GetClipTimeout(ctx)))
 	return nil
 }

--- a/pkg/fsutil/fsutil_test.go
+++ b/pkg/fsutil/fsutil_test.go
@@ -20,7 +20,7 @@ func TestCleanFilename(t *testing.T) {
 		out := CleanFilename(k)
 		t.Logf("%s -> %s / %s", k, v, out)
 		if out != v {
-			t.Errorf("'%s' != '%s'", out, v)
+			t.Errorf("%q != %q", out, v)
 		}
 	}
 }

--- a/pkg/hibp/dump/scanner.go
+++ b/pkg/hibp/dump/scanner.go
@@ -141,7 +141,7 @@ func (s *Scanner) scanSortedFile(ctx context.Context, fn string, in []string, re
 	var rdr io.Reader
 	fh, err := os.Open(fn)
 	if err != nil {
-		out.Error(ctx, "Failed to open file %s: %s", fn, err)
+		out.Errorf(ctx, "Failed to open file %s: %s", fn, err)
 		return
 	}
 	defer func() {
@@ -152,7 +152,7 @@ func (s *Scanner) scanSortedFile(ctx context.Context, fn string, in []string, re
 	if strings.HasSuffix(fn, ".gz") {
 		gzr, err := gzip.NewReader(fh)
 		if err != nil {
-			out.Error(ctx, "Failed to open the file %s: %s", fn, err)
+			out.Errorf(ctx, "Failed to open the file %s: %s", fn, err)
 			return
 		}
 		defer func() {
@@ -207,7 +207,7 @@ func (s *Scanner) scanUnsortedFile(ctx context.Context, fn string, in []string, 
 	var rdr io.Reader
 	fh, err := os.Open(fn)
 	if err != nil {
-		out.Error(ctx, "Failed to open file %s: %s", fn, err)
+		out.Errorf(ctx, "Failed to open file %s: %s", fn, err)
 		return
 	}
 	defer func() {
@@ -218,7 +218,7 @@ func (s *Scanner) scanUnsortedFile(ctx context.Context, fn string, in []string, 
 	if strings.HasSuffix(fn, ".gz") {
 		gzr, err := gzip.NewReader(fh)
 		if err != nil {
-			out.Error(ctx, "Failed to open the file %s: %s", fn, err)
+			out.Errorf(ctx, "Failed to open the file %s: %s", fn, err)
 			return
 		}
 		defer func() {

--- a/pkg/pwgen/cryptic.go
+++ b/pkg/pwgen/cryptic.go
@@ -52,7 +52,7 @@ func NewCrypticForDomain(length int, domain string) *Cryptic {
 	}
 	for _, req := range r.Required {
 		chars := charsFromRule(req)
-		debug.Log("Adding validator for %s: Requires '%s' -> '%s'", domain, req, chars)
+		debug.Log("Adding validator for %s: Requires %q -> %q", domain, req, chars)
 		if chars == "" {
 			continue
 		}

--- a/pkg/termio/ask.go
+++ b/pkg/termio/ask.go
@@ -137,7 +137,7 @@ func AskForKeyImport(ctx context.Context, key string, names []string) bool {
 		return false
 	}
 
-	ok, err := AskForBool(ctx, fmt.Sprintf("Do you want to import the public key '%s' (Names: %+v) into your keyring?", key, names), false)
+	ok, err := AskForBool(ctx, fmt.Sprintf("Do you want to import the public key %q (Names: %+v) into your keyring?", key, names), false)
 	if err != nil {
 		return false
 	}
@@ -174,7 +174,7 @@ func AskForPassword(ctx context.Context, name string) (string, error) {
 			return pass, nil
 		}
 
-		out.Error(ctx, "Error: the entered password do not match")
+		out.Errorf(ctx, "Error: the entered password do not match")
 	}
 	return "", fmt.Errorf("no valid user input")
 }

--- a/pkg/termio/promptpass_others.go
+++ b/pkg/termio/promptpass_others.go
@@ -28,7 +28,7 @@ func promptPass(ctx context.Context, prompt string) (string, error) {
 	}
 	defer func() {
 		if err := term.Restore(fd, oldState); err != nil {
-			out.Error(ctx, "Failed to restore terminal: %s", err)
+			out.Errorf(ctx, "Failed to restore terminal: %s", err)
 		}
 	}()
 
@@ -38,7 +38,7 @@ func promptPass(ctx context.Context, prompt string) (string, error) {
 	go func() {
 		<-sigch
 		if err := term.Restore(fd, oldState); err != nil {
-			out.Error(ctx, "Failed to restore terminal: %s", err)
+			out.Errorf(ctx, "Failed to restore terminal: %s", err)
 		}
 		os.Exit(1)
 	}()

--- a/tests/config_test.go
+++ b/tests/config_test.go
@@ -80,8 +80,8 @@ parsing: true
 path: `
 	wanted += ts.storeDir("root") + "\n"
 	wanted += `safecontent: false
-mount 'mnt/m1' => '`
-	wanted += ts.storeDir("m1") + "'\n"
+mount "mnt/m1" => "`
+	wanted += ts.storeDir("m1") + "\"\n"
 
 	out, err := ts.run("config")
 	assert.NoError(t, err)

--- a/tests/delete_test.go
+++ b/tests/delete_test.go
@@ -19,7 +19,7 @@ func TestDelete(t *testing.T) {
 
 	out, err = ts.run("delete foobarbaz")
 	assert.Error(t, err)
-	assert.Equal(t, "\nError: Can not delete 'foobarbaz': entry is not in the password store\n", out)
+	assert.Contains(t, out, "entry is not in the password store", out)
 
 	ts.initSecrets("")
 
@@ -31,6 +31,6 @@ func TestDelete(t *testing.T) {
 
 		out, err = ts.run("delete -f " + secret)
 		assert.Error(t, err)
-		assert.Equal(t, "\nError: Can not delete '"+secret+"': entry is not in the password store\n", out)
+		assert.Contains(t, out, "entry is not in the password store\n", out)
 	}
 }

--- a/tests/gptest/unit.go
+++ b/tests/gptest/unit.go
@@ -112,7 +112,7 @@ func (u Unit) InitStore(name string) error {
 		if err := os.MkdirAll(filepath.Dir(fn), 0700); err != nil {
 			return err
 		}
-		if err := ioutil.WriteFile(fn, []byte("secret\nsecond\nhird"), 0600); err != nil {
+		if err := ioutil.WriteFile(fn, []byte("secret\nsecond\nthird"), 0600); err != nil {
 			return err
 		}
 	}

--- a/tests/mount_test.go
+++ b/tests/mount_test.go
@@ -28,7 +28,7 @@ func TestSingleMount(t *testing.T) {
 
 	out, err = ts.run("show mnt/m1/secret")
 	assert.Error(t, err)
-	assert.Equal(t, "\nError: failed to retrieve secret 'mnt/m1/secret': entry is not in the password store\n", out)
+	assert.Contains(t, out, "entry is not in the password store")
 
 	ts.initSecrets("mnt/m1/")
 
@@ -85,7 +85,7 @@ func TestMountShadowing(t *testing.T) {
 	// check that the mount is not containing our shadowed secret
 	out, err = ts.run("show -f mnt/m1/secret")
 	assert.Error(t, err)
-	assert.Equal(t, "\nError: failed to retrieve secret 'mnt/m1/secret': entry is not in the password store\n", out)
+	assert.Contains(t, out, "entry is not in the password store")
 
 	// insert some secret at the place that is shadowed by the mount
 	_, err = ts.runCmd([]string{ts.Binary, "insert", "mnt/m1/secret"}, []byte("food"))

--- a/tests/show_test.go
+++ b/tests/show_test.go
@@ -29,7 +29,7 @@ func TestShow(t *testing.T) {
 	t.Run("test show with non-existing secret", func(t *testing.T) {
 		out, err := ts.run("show foo")
 		assert.Error(t, err)
-		assert.Equal(t, "\nError: failed to retrieve secret 'foo': entry is not in the password store\n", out)
+		assert.Contains(t, out, "entry is not in the password store", out)
 	})
 
 	ts.initSecrets("")

--- a/tests/yaml_test.go
+++ b/tests/yaml_test.go
@@ -21,7 +21,7 @@ func TestYAMLAndSecret(t *testing.T) {
 	t.Run("default action (show) from initialized store", func(t *testing.T) {
 		out, err := ts.run("foo/bar baz")
 		assert.Error(t, err)
-		assert.Contains(t, out, "Error: failed to retrieve secret 'foo/bar': entry is not in the password store")
+		assert.Contains(t, out, "entry is not in the password store")
 	})
 
 	t.Run("insert key", func(t *testing.T) {
@@ -73,7 +73,7 @@ url: http://www.test.com/`
 	t.Run("show non-existing secret", func(t *testing.T) {
 		out, err := ts.run("foo/bar")
 		assert.Error(t, err)
-		assert.Contains(t, out, "Error: failed to retrieve secret 'foo/bar': entry is not in the password store")
+		assert.Contains(t, out, "entry is not in the password store")
 	})
 
 	t.Run("insert new secret", func(t *testing.T) {


### PR DESCRIPTION
This commit renames the existing out methods that expect
a format string to include the common f suffix and introduces
new out methods without this suffix that don't accept a
format string or variadic arguments.

Note: Everything outside of `internal/out/` is based on a
search and replace operation and doesn't need much
attention.

Fixes #1793

RELEASE_NOTES=n/a

Signed-off-by: Dominik Schulz <dominik.schulz@gauner.org>