### PR TITLE
Relax config checks when loading

### DIFF
--- a/pkg/gopass/api/api.go
+++ b/pkg/gopass/api/api.go
@@ -25,7 +25,7 @@ var _ gopass.Store = &Gopass{}
 // New creates a new secret store
 // WARNING: This will need to change to accommodate for runtime configuration.
 func New(ctx context.Context) (*Gopass, error) {
-	cfg := config.LoadWithFallback()
+	cfg := config.LoadWithFallbackRelaxed()
 	store := root.New(cfg)
 	initialized, err := store.IsInitialized(ctx)
 	if err != nil {


### PR DESCRIPTION
To improve compatability of gopass integrations with gopass itself and
to simplify the upgrade path this PR relaxes config parsing a bit. It
introduces a final attempt where the current config struct is attempted
without the overflow check. Thus it will allow loading configs with
either missing or extra keys. This should allow most forward
compatability cases. However this might lead us to accepts truly invalid
configs.

RELEASE_NOTES=n/a

Signed-off-by: Dominik Schulz <dominik.schulz@gauner.org>