### PR TITLE
Upgrade to Go 1.16

### DIFF
--- a/.github/workflows/autorelease.yml
+++ b/.github/workflows/autorelease.yml
@@ -22,7 +22,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.15
+          go-version: 1.16
       -
         name: Import GPG signing key
         id: import_gpg

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.x
+        go-version: 1.16
 
     - name: Ubuntu Dependencies
       run: sudo apt-get install --yes git gnupg2
@@ -63,7 +63,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.x
+        go-version: 1.16
 
     - run: git config --global user.name nobody
     - run: git config --global user.email foo.bar@example.org
@@ -81,7 +81,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.x
+        go-version: 1.16
 
     - name: MacOS Dependencies
       run: brew install git gnupg

--- a/go.sum
+++ b/go.sum
@@ -1,10 +1,8 @@
 filippo.io/age v1.0.0-beta7 h1:RZiSK+N3KL2UwT82xiCavjYw8jJHzWMEUYePAukTpk0=
 filippo.io/age v1.0.0-beta7/go.mod h1:chAuTrTb0FTTmKtvs6fQTGhYTvH9AigjN1uEUsvLdZ0=
-filippo.io/edwards25519 v1.0.0-alpha.2 h1:EWbZLqGEPSIj2W69gx04KtNVkyPIfe3uj0DhDQJonbQ=
 filippo.io/edwards25519 v1.0.0-alpha.2/go.mod h1:X+pm78QAUPtFLi1z9PYIlS/bdDnvbCOGKtZ+ACWEf7o=
 filippo.io/edwards25519 v1.0.0-beta.3 h1:WQxB0FH5NzrhciInJ30bgL3soLng3AbdI651yQuVlCs=
 filippo.io/edwards25519 v1.0.0-beta.3/go.mod h1:X+pm78QAUPtFLi1z9PYIlS/bdDnvbCOGKtZ+ACWEf7o=
-github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/atotto/clipboard v0.1.2 h1:YZCtFu5Ie8qX2VmVTBnrqLSiU9XOWwqNRmdT3gIQzbY=
 github.com/atotto/clipboard v0.1.2/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
@@ -20,7 +18,6 @@ github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e h1:fY5BOSpyZCqRo5O
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1 h1:q763qf9huN11kDQavWsoZXJNW3xEE4JJyHa5Q25/sd8=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
-github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d h1:U+s90UTSYgptZMwQh2aRr3LuazLJIa+Pg3Kc1ylSYVY=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.0 h1:EoUDS0afbrsXAZ9YQ9jdu/mZ2sXgT1/2yyNng4PGlyM=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
@@ -34,7 +31,6 @@ github.com/godbus/dbus v0.0.0-20190623212516-8a1682060722 h1:NNKZiuNXd6lpZRyoFM/
 github.com/godbus/dbus v0.0.0-20190623212516-8a1682060722/go.mod h1:bBOAhwG1umN6/6ZUMtDFBMQR8jRg9O75tm9K00oMsK4=
 github.com/gokyle/twofactor v1.0.1 h1:uRhvx0S4Hb82RPIDALnf7QxbmPL49LyyaCkJDpWx+Ek=
 github.com/gokyle/twofactor v1.0.1/go.mod h1:4gxzH1eaE/F3Pct/sCDNOylP0ClofUO5j4XZN9tKtLE=
-github.com/google/go-cmp v0.3.0 h1:crn/baboCvb5fXaQ0IJ1SGTsTVrWpDsCWC8EGETZijY=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.5.4 h1:L8R9j+yAqZuZjsqh/z+F1NCffTKKLShY6zXTItVIZ8M=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
@@ -42,7 +38,6 @@ github.com/google/go-github v17.0.0+incompatible h1:N0LgJ1j65A7kfXrZnUDaYCs/Sf4r
 github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
 github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
-github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
@@ -56,7 +51,6 @@ github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNU
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
-github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
@@ -81,7 +75,6 @@ github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0RK8m9o+Q=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
@@ -89,7 +82,6 @@ github.com/schollz/closestmatch v0.0.0-20190308193919-1fbe626be92e h1:HFUDYOpUVZ
 github.com/schollz/closestmatch v0.0.0-20190308193919-1fbe626be92e/go.mod h1:RtP1ddjLong6gTkbtmuhtR2uUrrJOpYzYRvbcPAid+g=
 github.com/sergi/go-diff v1.1.0 h1:we8PVUC3FE2uYfodKH/nBHMSetSfHDR6scGdBi+erh0=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
-github.com/shurcooL/sanitized_anchor_name v1.0.0 h1:PdmoCO6wvbs+7yrJyMORt4/BmY5IYyJwS/kOiWx8mHo=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e h1:MRM5ITcdelLK2j1vwZ3Je0FKVCfqOLp5zO6trqMLYs0=
 github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e/go.mod h1:XV66xRDqSt+GTGFMVlhk3ULuV0y9ZmzeVGR4mloJI3M=
@@ -101,7 +93,6 @@ github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5Cc
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/urfave/cli/v2 v2.3.0 h1:qph92Y649prgesehzOrQjdWyxFOp/QVM+6imKHad91M=
 github.com/urfave/cli/v2 v2.3.0/go.mod h1:LJmUH05zAU44vOAcrfzZQKsZbVcdbOG8rtL3/XcUArI=
-github.com/xrash/smetrics v0.0.0-20170218160415-a3153f7040e9 h1:w8V9v0qVympSF6GjdjIyeqR7+EVhAF9CBQmkmW7Zw0w=
 github.com/xrash/smetrics v0.0.0-20170218160415-a3153f7040e9/go.mod h1:N3UwUGtsrSj3ccvlPHLoLsHnpR27oXr4ZE984MbSER8=
 github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 h1:bAn7/zixMGCfxrRTfdpNzjtPYqr8smhKouy9mxVdGPU=
 github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673/go.mod h1:N3UwUGtsrSj3ccvlPHLoLsHnpR27oXr4ZE984MbSER8=
@@ -110,7 +101,6 @@ golang.org/x/crypto v0.0.0-20200323165209-0ec3e9974c59/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad h1:DN0cp81fZ3njFcrLCytUHRSUkqBjfTo4Tx9RJTWs0EY=
 golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
-golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3 h1:0GoQqolDA55aaLxZyTzK/Y2ePZzZTUrRacwib7cNsYQ=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20210119194325-5f4716e94777 h1:003p0dJM77cxMSyCPFphvZf/Y5/NXf5fzg6ufd1/Oew=
 golang.org/x/net v0.0.0-20210119194325-5f4716e94777/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
@@ -124,17 +114,13 @@ golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210217090653-ed5674b6da4a h1:m4knbKtdWq+rPB3TE+ApaRzkETZngkKdhYjvTnnRq4s=
 golang.org/x/sys v0.0.0-20210217090653-ed5674b6da4a/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
-golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 h1:v+OssWQX+hTHEmOBgwxdZxK4zHq3yOs8F9J7mk0PY8E=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20201210144234-2321bbc49cbf h1:MZ2shdL+ZM/XzY3ZGOnh4Nlpnxz5GSOhOmtHo3iPU6M=
 golang.org/x/term v0.0.0-20201210144234-2321bbc49cbf/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
-golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
-golang.org/x/tools v0.0.0-20190624222133-a101b041ded4 h1:1mMox4TgefDwqluYCv677yNXwlfTkija4owZve/jr78=
 golang.org/x/tools v0.0.0-20190624222133-a101b041ded4/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
-golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
@@ -142,7 +128,6 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f h1:BLraFXnmrev5lT+xlilqcH8XK9/i0At2xKjWk4p6zsU=
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.3/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/helpers/release/main.go
+++ b/helpers/release/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"regexp"
@@ -274,7 +273,7 @@ func writeChangelog(prev, next semver.Version) error {
 }
 
 func writeVersion(v semver.Version) error {
-	return ioutil.WriteFile("VERSION", []byte(v.String()+"\n"), 0644)
+	return os.WriteFile("VERSION", []byte(v.String()+"\n"), 0644)
 }
 
 type tplPayload struct {
@@ -309,7 +308,7 @@ func isGitClean() bool {
 }
 
 func versionFile() (semver.Version, error) {
-	buf, err := ioutil.ReadFile("VERSION")
+	buf, err := os.ReadFile("VERSION")
 	if err != nil {
 		return semver.Version{}, err
 	}

--- a/internal/action/action_test.go
+++ b/internal/action/action_test.go
@@ -3,7 +3,6 @@ package action
 import (
 	"context"
 	"flag"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -66,7 +65,7 @@ func TestAction(t *testing.T) {
 }
 
 func TestNew(t *testing.T) {
-	td, err := ioutil.TempDir("", "gopass-")
+	td, err := os.MkdirTemp("", "gopass-")
 	require.NoError(t, err)
 	defer func() {
 		_ = os.RemoveAll(td)
@@ -83,7 +82,7 @@ func TestNew(t *testing.T) {
 	t.Run("init an existing plain store", func(t *testing.T) {
 		cfg.Path = filepath.Join(td, "store")
 		assert.NoError(t, os.MkdirAll(cfg.Path, 0700))
-		assert.NoError(t, ioutil.WriteFile(filepath.Join(cfg.Path, plain.IDFile), []byte("foobar"), 0600))
+		assert.NoError(t, os.WriteFile(filepath.Join(cfg.Path, plain.IDFile), []byte("foobar"), 0600))
 		_, err = New(cfg, sv)
 		assert.NoError(t, err)
 	})

--- a/internal/action/binary.go
+++ b/internal/action/binary.go
@@ -7,7 +7,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -157,7 +156,7 @@ func (s *Action) binaryCopyFromFileToStore(ctx context.Context, from, to string,
 	// and a relative one for the secret
 
 	// copy from FS to store
-	buf, err := ioutil.ReadFile(from)
+	buf, err := os.ReadFile(from)
 	if err != nil {
 		return fmt.Errorf("failed to read file from %q: %w", from, err)
 	}
@@ -191,7 +190,7 @@ func (s *Action) binaryCopyFromStoreToFile(ctx context.Context, from, to string,
 	if err != nil {
 		return fmt.Errorf("failed to read data from %q: %w", from, err)
 	}
-	if err := ioutil.WriteFile(to, buf, 0600); err != nil {
+	if err := os.WriteFile(to, buf, 0600); err != nil {
 		return fmt.Errorf("failed to write data to %q: %w", to, err)
 	}
 

--- a/internal/action/binary_test.go
+++ b/internal/action/binary_test.go
@@ -3,7 +3,6 @@ package action
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -88,7 +87,7 @@ func TestBinaryCat(t *testing.T) {
 	})
 
 	t.Run("compare output", func(t *testing.T) {
-		buf, err := ioutil.ReadFile(stdinfile)
+		buf, err := os.ReadFile(stdinfile)
 		require.NoError(t, err)
 		sec, err := act.binaryGet(ctx, "baz")
 		require.NoError(t, err)
@@ -118,7 +117,7 @@ func TestBinaryCopy(t *testing.T) {
 		defer buf.Reset()
 
 		infile := filepath.Join(u.Dir, "input.txt")
-		assert.NoError(t, ioutil.WriteFile(infile, []byte("0xDEADBEEF\n"), 0644))
+		assert.NoError(t, os.WriteFile(infile, []byte("0xDEADBEEF\n"), 0644))
 		assert.NoError(t, act.binaryCopy(ctx, gptest.CliCtx(ctx, t), infile, "txt", true))
 	})
 
@@ -198,5 +197,5 @@ func writeBinfile(t *testing.T, fn string) {
 	n, err := rand.Read(buf)
 	assert.NoError(t, err)
 	assert.Equal(t, size, n)
-	assert.NoError(t, ioutil.WriteFile(fn, buf, 0644))
+	assert.NoError(t, os.WriteFile(fn, buf, 0644))
 }

--- a/internal/action/clone_test.go
+++ b/internal/action/clone_test.go
@@ -3,7 +3,6 @@ package action
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -30,7 +29,7 @@ func aGitRepo(ctx context.Context, u *gptest.Unit, t *testing.T, name string) st
 	assert.Error(t, err)
 
 	idf := filepath.Join(gd, ".gpg-id")
-	assert.NoError(t, ioutil.WriteFile(idf, []byte("0xDEADBEEF"), 0600))
+	assert.NoError(t, os.WriteFile(idf, []byte("0xDEADBEEF"), 0600))
 
 	gr, err := git.Init(ctx, gd, "Nobody", "foo.bar@example.org")
 	assert.NoError(t, err)

--- a/internal/action/setup.go
+++ b/internal/action/setup.go
@@ -3,7 +3,7 @@ package action
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/fatih/color"
 	"github.com/gopasspw/gopass/internal/backend"
@@ -172,7 +172,7 @@ func (s *Action) initExportPublicKey(ctx context.Context, crypto backend.Crypto,
 	if err != nil {
 		return fmt.Errorf("failed to export public key: %w", err)
 	}
-	if err := ioutil.WriteFile(fn, pk, 06444); err != nil {
+	if err := os.WriteFile(fn, pk, 06444); err != nil {
 		out.Errorf(ctx, "❌ Failed to export public key %q: %q", fn, err)
 		return err
 	}

--- a/internal/backend/crypto/age/decrypt.go
+++ b/internal/backend/crypto/age/decrypt.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 
 	"filippo.io/age"
 	"github.com/gopasspw/gopass/pkg/ctxutil"
@@ -42,7 +42,7 @@ func (a *Age) decrypt(ciphertext []byte, ids ...age.Identity) ([]byte, error) {
 }
 
 func (a *Age) decryptFile(ctx context.Context, filename string) ([]byte, error) {
-	ciphertext, err := ioutil.ReadFile(filename)
+	ciphertext, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/backend/crypto/age/encrypt.go
+++ b/internal/backend/crypto/age/encrypt.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"filippo.io/age"
 	"github.com/gopasspw/gopass/pkg/ctxutil"
@@ -78,5 +78,5 @@ func (a *Age) encryptFile(ctx context.Context, filename string, plaintext []byte
 		return err
 	}
 
-	return ioutil.WriteFile(filename, buf, 0600)
+	return os.WriteFile(filename, buf, 0600)
 }

--- a/internal/backend/crypto/age/ssh.go
+++ b/internal/backend/crypto/age/ssh.go
@@ -2,7 +2,6 @@ package age
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -26,7 +25,7 @@ func (a *Age) getSSHIdentities(ctx context.Context) (map[string]age.Identity, er
 		return nil, err
 	}
 	sshDir := filepath.Join(uhd, ".ssh")
-	files, err := ioutil.ReadDir(sshDir)
+	files, err := os.ReadDir(sshDir)
 	if err != nil {
 		return nil, err
 	}
@@ -54,11 +53,11 @@ func (a *Age) parseSSHIdentity(ctx context.Context, pubFn string) (string, age.I
 	if err != nil {
 		return "", nil, err
 	}
-	pubBuf, err := ioutil.ReadFile(pubFn)
+	pubBuf, err := os.ReadFile(pubFn)
 	if err != nil {
 		return "", nil, err
 	}
-	privBuf, err := ioutil.ReadFile(privFn)
+	privBuf, err := os.ReadFile(privFn)
 	if err != nil {
 		return "", nil, err
 	}

--- a/internal/backend/crypto/plain/backend_test.go
+++ b/internal/backend/crypto/plain/backend_test.go
@@ -2,7 +2,6 @@ package plain
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -14,7 +13,7 @@ import (
 )
 
 func TestPlain(t *testing.T) {
-	td, err := ioutil.TempDir("", "gopass-")
+	td, err := os.MkdirTemp("", "gopass-")
 	require.NoError(t, err)
 	defer func() {
 		_ = os.RemoveAll(td)

--- a/internal/backend/crypto_test.go
+++ b/internal/backend/crypto_test.go
@@ -2,7 +2,6 @@ package backend
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -14,7 +13,7 @@ import (
 func TestDetectCrypto(t *testing.T) {
 	ctx := context.Background()
 
-	td, err := ioutil.TempDir("", "gopass-")
+	td, err := os.MkdirTemp("", "gopass-")
 	require.NoError(t, err)
 	defer func() {
 		_ = os.RemoveAll(td)
@@ -40,7 +39,7 @@ func TestDetectCrypto(t *testing.T) {
 		fsDir := filepath.Join(td, "fs")
 		os.RemoveAll(fsDir)
 		assert.NoError(t, os.MkdirAll(fsDir, 0700))
-		assert.NoError(t, ioutil.WriteFile(filepath.Join(fsDir, tc.file), []byte("foo"), 0600))
+		assert.NoError(t, os.WriteFile(filepath.Join(fsDir, tc.file), []byte("foo"), 0600))
 
 		r, err := DetectStorage(ctx, fsDir)
 		assert.NoError(t, err)

--- a/internal/backend/crypto_xc_test.go
+++ b/internal/backend/crypto_xc_test.go
@@ -4,7 +4,6 @@ package backend
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -16,7 +15,7 @@ import (
 func TestDetectCryptoXC(t *testing.T) {
 	ctx := context.Background()
 
-	td, err := ioutil.TempDir("", "gopass-")
+	td, err := os.MkdirTemp("", "gopass-")
 	require.NoError(t, err)
 	defer func() {
 		_ = os.RemoveAll(td)
@@ -34,7 +33,7 @@ func TestDetectCryptoXC(t *testing.T) {
 		fsDir := filepath.Join(td, "fs")
 		os.RemoveAll(fsDir)
 		assert.NoError(t, os.MkdirAll(fsDir, 0700))
-		assert.NoError(t, ioutil.WriteFile(filepath.Join(fsDir, tc.file), []byte("foo"), 0600))
+		assert.NoError(t, os.WriteFile(filepath.Join(fsDir, tc.file), []byte("foo"), 0600))
 
 		r, err := DetectStorage(ctx, fsDir)
 		assert.NoError(t, err)

--- a/internal/backend/rcs_test.go
+++ b/internal/backend/rcs_test.go
@@ -3,7 +3,6 @@ package backend
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -17,7 +16,7 @@ import (
 func TestClone(t *testing.T) {
 	ctx := context.Background()
 
-	td, err := ioutil.TempDir("", "gopass-")
+	td, err := os.MkdirTemp("", "gopass-")
 	require.NoError(t, err)
 	defer func() {
 		_ = os.RemoveAll(td)
@@ -40,7 +39,7 @@ func TestClone(t *testing.T) {
 func TestInitRCS(t *testing.T) {
 	ctx := context.Background()
 
-	td, err := ioutil.TempDir("", "gopass-")
+	td, err := os.MkdirTemp("", "gopass-")
 	require.NoError(t, err)
 	defer func() {
 		_ = os.RemoveAll(td)

--- a/internal/backend/storage/fs/fsck.go
+++ b/internal/backend/storage/fs/fsck.go
@@ -2,7 +2,6 @@ package fs
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -139,7 +138,7 @@ func (s *Store) fsckCheckEmptyDirs() error {
 }
 
 func fsckRemoveEmptyDir(fp string) error {
-	ls, err := ioutil.ReadDir(fp)
+	ls, err := os.ReadDir(fp)
 	if err != nil {
 		return err
 	}

--- a/internal/backend/storage/fs/fsck_test.go
+++ b/internal/backend/storage/fs/fsck_test.go
@@ -2,7 +2,6 @@ package fs
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -29,7 +28,7 @@ func TestFsck(t *testing.T) {
 		filepath.Join(path, "foo", "zen"),
 	} {
 		assert.NoError(t, os.MkdirAll(filepath.Dir(fn), 0777))
-		assert.NoError(t, ioutil.WriteFile(fn, []byte(fn), 0663))
+		assert.NoError(t, os.WriteFile(fn, []byte(fn), 0663))
 	}
 
 	assert.NoError(t, s.Fsck(ctx))

--- a/internal/backend/storage/fs/store.go
+++ b/internal/backend/storage/fs/store.go
@@ -5,7 +5,6 @@ package fs
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -40,7 +39,7 @@ func (s *Store) Get(ctx context.Context, name string) ([]byte, error) {
 	}
 	path := filepath.Join(s.path, filepath.Clean(name))
 	debug.Log("Reading %s from %s", name, path)
-	return ioutil.ReadFile(path)
+	return os.ReadFile(path)
 }
 
 // Set writes the given content
@@ -56,7 +55,7 @@ func (s *Store) Set(ctx context.Context, name string, value []byte) error {
 		}
 	}
 	debug.Log("Writing %s to %s", name, filepath.Join(s.path, name))
-	return ioutil.WriteFile(filepath.Join(s.path, name), value, 0644)
+	return os.WriteFile(filepath.Join(s.path, name), value, 0644)
 }
 
 // Delete removes the named entity

--- a/internal/backend/storage/fs/store_test.go
+++ b/internal/backend/storage/fs/store_test.go
@@ -2,7 +2,6 @@ package fs
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -208,7 +207,7 @@ func TestDelete(t *testing.T) {
 
 func newTempDir(t *testing.T) (string, func()) {
 	t.Helper()
-	td, err := ioutil.TempDir("", "gopass-")
+	td, err := os.MkdirTemp("", "gopass-")
 	if err != nil {
 		t.Error(err)
 	}

--- a/internal/backend/storage/gitfs/config.go
+++ b/internal/backend/storage/gitfs/config.go
@@ -3,7 +3,6 @@ package gitfs
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -67,7 +66,7 @@ func (g *Git) InitConfig(ctx context.Context, userName, userEmail string) error 
 		return fmt.Errorf("failed to fix git config: %w", err)
 	}
 
-	if err := ioutil.WriteFile(filepath.Join(g.fs.Path(), ".gitattributes"), []byte("*.gpg diff=gpg\n"), fileMode); err != nil {
+	if err := os.WriteFile(filepath.Join(g.fs.Path(), ".gitattributes"), []byte("*.gpg diff=gpg\n"), fileMode); err != nil {
 		return fmt.Errorf("failed to initialize git: %w", err)
 	}
 	if err := g.Add(ctx, g.fs.Path()+"/.gitattributes"); err != nil {

--- a/internal/backend/storage/gitfs/config_test.go
+++ b/internal/backend/storage/gitfs/config_test.go
@@ -3,7 +3,6 @@ package gitfs
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -16,7 +15,7 @@ import (
 )
 
 func TestGitConfig(t *testing.T) {
-	td, err := ioutil.TempDir("", "gopass-")
+	td, err := os.MkdirTemp("", "gopass-")
 	require.NoError(t, err)
 	defer func() {
 		_ = os.RemoveAll(td)

--- a/internal/backend/storage/gitfs/git_test.go
+++ b/internal/backend/storage/gitfs/git_test.go
@@ -3,7 +3,6 @@ package gitfs
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -16,7 +15,7 @@ import (
 )
 
 func TestGit(t *testing.T) {
-	td, err := ioutil.TempDir("", "gopass-")
+	td, err := os.MkdirTemp("", "gopass-")
 	require.NoError(t, err)
 	defer func() {
 		_ = os.RemoveAll(td)
@@ -46,7 +45,7 @@ func TestGit(t *testing.T) {
 
 		assert.True(t, git.IsInitialized())
 		tf := filepath.Join(gitdir, "some-file")
-		require.NoError(t, ioutil.WriteFile(tf, []byte("foobar"), 0644))
+		require.NoError(t, os.WriteFile(tf, []byte("foobar"), 0644))
 		assert.NoError(t, git.Add(ctx, "some-file"))
 		assert.True(t, git.HasStagedChanges(ctx))
 		assert.NoError(t, git.Commit(ctx, "added some-file"))
@@ -73,7 +72,7 @@ func TestGit(t *testing.T) {
 		assert.Equal(t, "git", git.Name())
 
 		tf := filepath.Join(gitdir2, "some-other-file")
-		require.NoError(t, ioutil.WriteFile(tf, []byte("foobar"), 0644))
+		require.NoError(t, os.WriteFile(tf, []byte("foobar"), 0644))
 		assert.NoError(t, git.Add(ctx, "some-other-file"))
 		assert.NoError(t, git.Commit(ctx, "added some-other-file"))
 

--- a/internal/backend/storage_test.go
+++ b/internal/backend/storage_test.go
@@ -2,7 +2,6 @@ package backend
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -20,7 +19,7 @@ func TestDetectStorage(t *testing.T) {
 	uv := gptest.UnsetVars("GOPASS_HOMEDIR")
 	defer uv()
 
-	td, err := ioutil.TempDir("", "gopass-")
+	td, err := os.MkdirTemp("", "gopass-")
 	require.NoError(t, err)
 	defer func() {
 		_ = os.RemoveAll(td)

--- a/internal/cache/disk.go
+++ b/internal/cache/disk.go
@@ -2,7 +2,6 @@ package cache
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -45,7 +44,7 @@ func (o *OnDisk) Get(key string) ([]string, error) {
 	if time.Now().After(fi.ModTime().Add(o.ttl)) {
 		return nil, fmt.Errorf("expired")
 	}
-	buf, err := ioutil.ReadFile(fn)
+	buf, err := os.ReadFile(fn)
 	if err != nil {
 		return nil, err
 	}
@@ -55,5 +54,5 @@ func (o *OnDisk) Get(key string) ([]string, error) {
 // Set adds an entry to the cache.
 func (o *OnDisk) Set(key string, value []string) error {
 	key = fsutil.CleanFilename(key)
-	return ioutil.WriteFile(filepath.Join(o.dir, key), []byte(strings.Join(value, "\n")), 0644)
+	return os.WriteFile(filepath.Join(o.dir, key), []byte(strings.Join(value, "\n")), 0644)
 }

--- a/internal/cache/disk_test.go
+++ b/internal/cache/disk_test.go
@@ -1,7 +1,6 @@
 package cache
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 	"time"
@@ -11,7 +10,7 @@ import (
 )
 
 func TestOnDisk(t *testing.T) {
-	td, err := ioutil.TempDir("", "gopass-")
+	td, err := os.MkdirTemp("", "gopass-")
 	require.NoError(t, err)
 
 	defer func() {

--- a/internal/config/io.go
+++ b/internal/config/io.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -67,7 +66,7 @@ func load(cf string, relaxed bool) (*Config, error) {
 	if _, err := os.Stat(cf); err != nil {
 		return nil, ErrConfigNotFound
 	}
-	buf, err := ioutil.ReadFile(cf)
+	buf, err := os.ReadFile(cf)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error reading config from %s: %s\n", cf, err)
 		return nil, ErrConfigNotFound
@@ -189,7 +188,7 @@ func (c *Config) Save() error {
 			return fmt.Errorf("failed to create dir %q: %w", cfgDir, err)
 		}
 	}
-	if err := ioutil.WriteFile(cfgLoc, buf, 0600); err != nil {
+	if err := os.WriteFile(cfgLoc, buf, 0600); err != nil {
 		return fmt.Errorf("failed to write config file to %q: %w", cfgLoc, err)
 	}
 	debug.Log("Saved config to %s: %+v\n", cfgLoc, c)

--- a/internal/config/io_test.go
+++ b/internal/config/io_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -387,7 +386,7 @@ func TestLoad(t *testing.T) {
 	assert.NoError(t, os.Setenv("GOPASS_CONFIG", gcfg))
 	assert.NoError(t, os.Setenv("GOPASS_HOMEDIR", td))
 
-	require.NoError(t, ioutil.WriteFile(gcfg, []byte(testConfig), 0600))
+	require.NoError(t, os.WriteFile(gcfg, []byte(testConfig), 0600))
 
 	cfg := Load()
 	assert.True(t, cfg.SafeContent)
@@ -411,7 +410,7 @@ func TestLoadError(t *testing.T) {
 	cfg, err := load(gcfg, false)
 	assert.Error(t, err)
 
-	td, err := ioutil.TempDir("", "gopass-")
+	td, err := os.MkdirTemp("", "gopass-")
 	require.NoError(t, err)
 	defer func() {
 		os.RemoveAll(td)
@@ -426,7 +425,7 @@ func TestDecodeError(t *testing.T) {
 	assert.NoError(t, os.Setenv("GOPASS_CONFIG", gcfg))
 
 	_ = os.Remove(gcfg)
-	require.NoError(t, ioutil.WriteFile(gcfg, []byte(testConfig+"\nfoobar: zab\n"), 0600))
+	require.NoError(t, os.WriteFile(gcfg, []byte(testConfig+"\nfoobar: zab\n"), 0600))
 
 	capture(t, func() error {
 		_, err := load(gcfg, false)

--- a/internal/editor/editor.go
+++ b/internal/editor/editor.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -49,7 +48,7 @@ func Check(ctx context.Context, editor string) error {
 	if !fsutil.IsFile(vrc) {
 		return nil
 	}
-	buf, err := ioutil.ReadFile(vrc)
+	buf, err := os.ReadFile(vrc)
 	if err != nil {
 		return err
 	}
@@ -108,7 +107,7 @@ func Invoke(ctx context.Context, editor string, content []byte) ([]byte, error) 
 		return []byte{}, fmt.Errorf("failed to run %s with %s file: %w", editor, tmpfile.Name(), err)
 	}
 
-	nContent, err := ioutil.ReadFile(tmpfile.Name())
+	nContent, err := os.ReadFile(tmpfile.Name())
 	if err != nil {
 		return []byte{}, fmt.Errorf("failed to read from tmpfile: %w", err)
 	}

--- a/internal/store/leaf/crypto_test.go
+++ b/internal/store/leaf/crypto_test.go
@@ -3,7 +3,6 @@ package leaf
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -16,7 +15,7 @@ import (
 func TestGPG(t *testing.T) {
 	ctx := context.Background()
 
-	tempdir, err := ioutil.TempDir("", "gopass-")
+	tempdir, err := os.MkdirTemp("", "gopass-")
 	require.NoError(t, err)
 	defer func() {
 		_ = os.RemoveAll(tempdir)

--- a/internal/store/leaf/fsck_test.go
+++ b/internal/store/leaf/fsck_test.go
@@ -3,7 +3,6 @@ package leaf
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -28,7 +27,7 @@ func TestFsck(t *testing.T) {
 	}()
 
 	// common setup
-	tempdir, err := ioutil.TempDir("", "gopass-")
+	tempdir, err := os.MkdirTemp("", "gopass-")
 	require.NoError(t, err)
 
 	s := &Store{

--- a/internal/store/leaf/init_test.go
+++ b/internal/store/leaf/init_test.go
@@ -2,7 +2,6 @@ package leaf
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -13,7 +12,7 @@ import (
 func TestInit(t *testing.T) {
 	ctx := context.Background()
 
-	tempdir, err := ioutil.TempDir("", "gopass-")
+	tempdir, err := os.MkdirTemp("", "gopass-")
 	require.NoError(t, err)
 	defer func() {
 		_ = os.RemoveAll(tempdir)

--- a/internal/store/leaf/list_test.go
+++ b/internal/store/leaf/list_test.go
@@ -3,7 +3,6 @@ package leaf
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -76,7 +75,7 @@ func TestList(t *testing.T) {
 		},
 	} {
 		// common setup
-		tempdir, err := ioutil.TempDir("", "gopass-")
+		tempdir, err := os.MkdirTemp("", "gopass-")
 		require.NoError(t, err)
 
 		s := &Store{

--- a/internal/store/leaf/move_test.go
+++ b/internal/store/leaf/move_test.go
@@ -3,7 +3,6 @@ package leaf
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -71,7 +70,7 @@ func TestCopy(t *testing.T) {
 		},
 	} {
 		// common setup
-		tempdir, err := ioutil.TempDir("", "gopass-")
+		tempdir, err := os.MkdirTemp("", "gopass-")
 		require.NoError(t, err)
 
 		s := &Store{
@@ -146,7 +145,7 @@ func TestMove(t *testing.T) {
 		},
 	} {
 		// common setup
-		tempdir, err := ioutil.TempDir("", "gopass-")
+		tempdir, err := os.MkdirTemp("", "gopass-")
 		require.NoError(t, err)
 
 		s := &Store{
@@ -205,7 +204,7 @@ func TestDelete(t *testing.T) {
 		},
 	} {
 		// common setup
-		tempdir, err := ioutil.TempDir("", "gopass-")
+		tempdir, err := os.MkdirTemp("", "gopass-")
 		require.NoError(t, err)
 
 		s := &Store{
@@ -286,7 +285,7 @@ func TestPrune(t *testing.T) {
 		},
 	} {
 		// common setup
-		tempdir, err := ioutil.TempDir("", "gopass-")
+		tempdir, err := os.MkdirTemp("", "gopass-")
 		require.NoError(t, err)
 
 		s := &Store{

--- a/internal/store/leaf/rcs_test.go
+++ b/internal/store/leaf/rcs_test.go
@@ -2,7 +2,6 @@ package leaf
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -17,7 +16,7 @@ import (
 func TestGit(t *testing.T) {
 	ctx := context.Background()
 
-	tempdir, err := ioutil.TempDir("", "gopass-")
+	tempdir, err := os.MkdirTemp("", "gopass-")
 	require.NoError(t, err)
 	defer func() {
 		_ = os.RemoveAll(tempdir)
@@ -47,7 +46,7 @@ func TestGit(t *testing.T) {
 func TestGitRevisions(t *testing.T) {
 	ctx := context.Background()
 
-	tempdir, err := ioutil.TempDir("", "gopass-")
+	tempdir, err := os.MkdirTemp("", "gopass-")
 	require.NoError(t, err)
 	defer func() {
 		_ = os.RemoveAll(tempdir)

--- a/internal/store/leaf/recipients_test.go
+++ b/internal/store/leaf/recipients_test.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"bytes"
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -24,7 +23,7 @@ import (
 func TestGetRecipientsDefault(t *testing.T) {
 	ctx := context.Background()
 
-	tempdir, err := ioutil.TempDir("", "gopass-")
+	tempdir, err := os.MkdirTemp("", "gopass-")
 	require.NoError(t, err)
 	defer func() {
 		_ = os.RemoveAll(tempdir)
@@ -55,7 +54,7 @@ func TestGetRecipientsDefault(t *testing.T) {
 func TestGetRecipientsSubID(t *testing.T) {
 	ctx := context.Background()
 
-	tempdir, err := ioutil.TempDir("", "gopass-")
+	tempdir, err := os.MkdirTemp("", "gopass-")
 	require.NoError(t, err)
 	defer func() {
 		_ = os.RemoveAll(tempdir)
@@ -81,7 +80,7 @@ func TestGetRecipientsSubID(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, genRecs, recs)
 
-	err = ioutil.WriteFile(filepath.Join(tempdir, "foo", "bar", s.crypto.IDFile()), []byte("john.doe\n"), 0600)
+	err = os.WriteFile(filepath.Join(tempdir, "foo", "bar", s.crypto.IDFile()), []byte("john.doe\n"), 0600)
 	require.NoError(t, err)
 
 	recs, err = s.GetRecipients(ctx, "foo/bar/baz")
@@ -93,7 +92,7 @@ func TestSaveRecipients(t *testing.T) {
 	ctx := context.Background()
 	ctx = ctxutil.WithExportKeys(ctx, true)
 
-	tempdir, err := ioutil.TempDir("", "gopass-")
+	tempdir, err := os.MkdirTemp("", "gopass-")
 	require.NoError(t, err)
 	defer func() {
 		_ = os.RemoveAll(tempdir)
@@ -146,7 +145,7 @@ func TestAddRecipient(t *testing.T) {
 	ctx := context.Background()
 	ctx = ctxutil.WithHidden(ctx, true)
 
-	tempdir, err := ioutil.TempDir("", "gopass-")
+	tempdir, err := os.MkdirTemp("", "gopass-")
 	require.NoError(t, err)
 	defer func() {
 		_ = os.RemoveAll(tempdir)
@@ -185,7 +184,7 @@ func TestRemoveRecipient(t *testing.T) {
 	ctx := context.Background()
 	ctx = ctxutil.WithHidden(ctx, true)
 
-	tempdir, err := ioutil.TempDir("", "gopass-")
+	tempdir, err := os.MkdirTemp("", "gopass-")
 	require.NoError(t, err)
 	defer func() {
 		_ = os.RemoveAll(tempdir)
@@ -217,7 +216,7 @@ func TestRemoveRecipient(t *testing.T) {
 func TestListRecipients(t *testing.T) {
 	ctx := context.Background()
 
-	tempdir, err := ioutil.TempDir("", "gopass-")
+	tempdir, err := os.MkdirTemp("", "gopass-")
 	require.NoError(t, err)
 	defer func() {
 		_ = os.RemoveAll(tempdir)

--- a/internal/store/leaf/store_test.go
+++ b/internal/store/leaf/store_test.go
@@ -2,7 +2,6 @@ package leaf
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -80,16 +79,16 @@ func createStore(dir string, recipients, entries []string) ([]string, []string, 
 		if err := os.MkdirAll(filepath.Dir(filename), 0700); err != nil {
 			return recipients, entries, err
 		}
-		if err := ioutil.WriteFile(filename, []byte{}, 0644); err != nil {
+		if err := os.WriteFile(filename, []byte{}, 0644); err != nil {
 			return recipients, entries, err
 		}
 	}
-	err := ioutil.WriteFile(filepath.Join(dir, plain.IDFile), []byte(strings.Join(recipients, "\n")), 0600)
+	err := os.WriteFile(filepath.Join(dir, plain.IDFile), []byte(strings.Join(recipients, "\n")), 0600)
 	return recipients, entries, err
 }
 
 func TestStore(t *testing.T) {
-	tempdir, err := ioutil.TempDir("", "gopass-")
+	tempdir, err := os.MkdirTemp("", "gopass-")
 	require.NoError(t, err)
 	defer func() {
 		_ = os.RemoveAll(tempdir)
@@ -106,7 +105,7 @@ func TestStore(t *testing.T) {
 func TestIdFile(t *testing.T) {
 	ctx := context.Background()
 
-	tempdir, err := ioutil.TempDir("", "gopass-")
+	tempdir, err := os.MkdirTemp("", "gopass-")
 	require.NoError(t, err)
 	defer func() {
 		_ = os.RemoveAll(tempdir)
@@ -124,7 +123,7 @@ func TestIdFile(t *testing.T) {
 	sec.Set("foo", "bar")
 	sec.WriteString("bar")
 	require.NoError(t, s.Set(ctx, secName, sec))
-	require.NoError(t, ioutil.WriteFile(filepath.Join(tempdir, "sub", "a", plain.IDFile), []byte("foobar"), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(tempdir, "sub", "a", plain.IDFile), []byte("foobar"), 0600))
 	assert.Equal(t, filepath.Join("a", plain.IDFile), s.idFile(ctx, secName))
 	assert.True(t, s.Exists(ctx, secName))
 
@@ -134,14 +133,14 @@ func TestIdFile(t *testing.T) {
 		secName += "/a"
 	}
 	require.NoError(t, s.Set(ctx, secName, sec))
-	require.NoError(t, ioutil.WriteFile(filepath.Join(tempdir, "sub", "a", ".gpg-id"), []byte("foobar"), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(tempdir, "sub", "a", ".gpg-id"), []byte("foobar"), 0600))
 	assert.Equal(t, plain.IDFile, s.idFile(ctx, secName))
 }
 
 func TestNew(t *testing.T) {
 	ctx := context.Background()
 
-	tempdir, err := ioutil.TempDir("", "gopass-")
+	tempdir, err := os.MkdirTemp("", "gopass-")
 	require.NoError(t, err)
 	defer func() {
 		_ = os.RemoveAll(tempdir)

--- a/internal/store/leaf/templates_test.go
+++ b/internal/store/leaf/templates_test.go
@@ -2,7 +2,6 @@ package leaf
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -16,7 +15,7 @@ import (
 func TestTemplates(t *testing.T) {
 	ctx := context.Background()
 
-	tempdir, err := ioutil.TempDir("", "gopass-")
+	tempdir, err := os.MkdirTemp("", "gopass-")
 	require.NoError(t, err)
 	defer func() {
 		_ = os.RemoveAll(tempdir)

--- a/internal/store/leaf/write_test.go
+++ b/internal/store/leaf/write_test.go
@@ -2,7 +2,6 @@ package leaf
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"runtime"
 	"testing"
@@ -15,7 +14,7 @@ import (
 func TestSet(t *testing.T) {
 	ctx := context.Background()
 
-	tempdir, err := ioutil.TempDir("", "gopass-")
+	tempdir, err := os.MkdirTemp("", "gopass-")
 	require.NoError(t, err)
 	defer func() {
 		_ = os.RemoveAll(tempdir)

--- a/internal/updater/update_test.go
+++ b/internal/updater/update_test.go
@@ -5,7 +5,6 @@ package updater
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -21,7 +20,7 @@ func TestIsUpdateable(t *testing.T) {
 		executable = oldExec
 	}()
 
-	td, err := ioutil.TempDir("", "gopass-")
+	td, err := os.MkdirTemp("", "gopass-")
 	require.NoError(t, err)
 	defer func() {
 		_ = os.RemoveAll(td)
@@ -84,7 +83,7 @@ func TestIsUpdateable(t *testing.T) {
 		{
 			name: "no write access to file",
 			pre: func() error {
-				return ioutil.WriteFile(filepath.Join(td, "gopass"), []byte("foobar"), 0555)
+				return os.WriteFile(filepath.Join(td, "gopass"), []byte("foobar"), 0555)
 			},
 			exec: func(context.Context) (string, error) {
 				return filepath.Join(td, "gopass"), nil

--- a/pkg/clipboard/clipboard_others.go
+++ b/pkg/clipboard/clipboard_others.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"crypto/sha256"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"strconv"
@@ -40,7 +39,7 @@ func clear(ctx context.Context, content []byte, timeout int) error {
 
 func walkFn(pid int, killFn func(int)) {
 	// read the commandline for this process
-	cmdline, err := ioutil.ReadFile(fmt.Sprintf("/proc/%d/cmdline", pid))
+	cmdline, err := os.ReadFile(fmt.Sprintf("/proc/%d/cmdline", pid))
 	if err != nil {
 		return
 	}

--- a/pkg/fsutil/fsutil_test.go
+++ b/pkg/fsutil/fsutil_test.go
@@ -2,7 +2,6 @@ package fsutil
 
 import (
 	"crypto/rand"
-	"io/ioutil"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -26,7 +25,7 @@ func TestCleanFilename(t *testing.T) {
 }
 
 func TestCleanPath(t *testing.T) {
-	tempdir, err := ioutil.TempDir("", "gopass-")
+	tempdir, err := os.MkdirTemp("", "gopass-")
 	require.NoError(t, err)
 	defer func() {
 		_ = os.RemoveAll(tempdir)
@@ -59,34 +58,34 @@ func TestCleanPath(t *testing.T) {
 }
 
 func TestIsDir(t *testing.T) {
-	tempdir, err := ioutil.TempDir("", "gopass-")
+	tempdir, err := os.MkdirTemp("", "gopass-")
 	require.NoError(t, err)
 	defer func() {
 		_ = os.RemoveAll(tempdir)
 	}()
 
 	fn := filepath.Join(tempdir, "foo")
-	assert.NoError(t, ioutil.WriteFile(fn, []byte("bar"), 0644))
+	assert.NoError(t, os.WriteFile(fn, []byte("bar"), 0644))
 	assert.Equal(t, true, IsDir(tempdir))
 	assert.Equal(t, false, IsDir(fn))
 	assert.Equal(t, false, IsDir(filepath.Join(tempdir, "non-existing")))
 }
 
 func TestIsFile(t *testing.T) {
-	tempdir, err := ioutil.TempDir("", "gopass-")
+	tempdir, err := os.MkdirTemp("", "gopass-")
 	require.NoError(t, err)
 	defer func() {
 		_ = os.RemoveAll(tempdir)
 	}()
 
 	fn := filepath.Join(tempdir, "foo")
-	assert.NoError(t, ioutil.WriteFile(fn, []byte("bar"), 0644))
+	assert.NoError(t, os.WriteFile(fn, []byte("bar"), 0644))
 	assert.Equal(t, false, IsFile(tempdir))
 	assert.Equal(t, true, IsFile(fn))
 }
 
 func TestShred(t *testing.T) {
-	tempdir, err := ioutil.TempDir("", "gopass-")
+	tempdir, err := os.MkdirTemp("", "gopass-")
 	require.NoError(t, err)
 	defer func() {
 		_ = os.RemoveAll(tempdir)
@@ -121,7 +120,7 @@ func TestShred(t *testing.T) {
 }
 
 func TestIsEmptyDir(t *testing.T) {
-	tempdir, err := ioutil.TempDir("", "gopass-")
+	tempdir, err := os.MkdirTemp("", "gopass-")
 	require.NoError(t, err)
 	defer func() {
 		_ = os.RemoveAll(tempdir)
@@ -135,7 +134,7 @@ func TestIsEmptyDir(t *testing.T) {
 	assert.Equal(t, true, isEmpty)
 
 	fn = filepath.Join(fn, ".config.yml")
-	require.NoError(t, ioutil.WriteFile(fn, []byte("foo"), 0644))
+	require.NoError(t, os.WriteFile(fn, []byte("foo"), 0644))
 
 	isEmpty, err = IsEmptyDir(tempdir)
 	require.NoError(t, err)

--- a/pkg/hibp/api/client.go
+++ b/pkg/hibp/api/client.go
@@ -3,7 +3,7 @@ package api
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -43,7 +43,7 @@ func Lookup(shaSum string) (uint64, error) {
 			return nil
 		}
 
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return err
 		}

--- a/pkg/hibp/dump/scanner_test.go
+++ b/pkg/hibp/dump/scanner_test.go
@@ -4,7 +4,6 @@ import (
 	"compress/gzip"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -50,7 +49,7 @@ func Example() {
 }
 
 func TestScanner(t *testing.T) {
-	td, err := ioutil.TempDir("", "gopass-")
+	td, err := os.MkdirTemp("", "gopass-")
 	require.NoError(t, err)
 
 	defer func() {
@@ -65,7 +64,7 @@ func TestScanner(t *testing.T) {
 
 	// setup file and env (sorted)
 	fn := filepath.Join(td, "dump.txt")
-	assert.NoError(t, ioutil.WriteFile(fn, []byte(testHibpSampleSorted), 0644))
+	assert.NoError(t, os.WriteFile(fn, []byte(testHibpSampleSorted), 0644))
 
 	scanner, err := New(fn)
 	assert.NoError(t, err)
@@ -73,7 +72,7 @@ func TestScanner(t *testing.T) {
 
 	// setup file and env (unsorted)
 	fn = filepath.Join(td, "dump.txt")
-	assert.NoError(t, ioutil.WriteFile(fn, []byte(testHibpSampleUnsorted), 0644))
+	assert.NoError(t, os.WriteFile(fn, []byte(testHibpSampleUnsorted), 0644))
 
 	scanner, err = New(fn)
 	assert.NoError(t, err)

--- a/pkg/otp/otp.go
+++ b/pkg/otp/otp.go
@@ -2,7 +2,7 @@ package otp
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/gokyle/twofactor"
@@ -62,7 +62,7 @@ func WriteQRFile(otp twofactor.OTP, label, file string) error {
 		return fmt.Errorf("failed to write qr file: %w", err)
 	}
 
-	if err := ioutil.WriteFile(file, qr, 0600); err != nil {
+	if err := os.WriteFile(file, qr, 0600); err != nil {
 		return fmt.Errorf("failed to write QR code: %w", err)
 	}
 	return nil

--- a/pkg/otp/otp_test.go
+++ b/pkg/otp/otp_test.go
@@ -2,7 +2,6 @@ package otp
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -36,7 +35,7 @@ func TestCalculate(t *testing.T) {
 }
 
 func TestWrite(t *testing.T) {
-	td, err := ioutil.TempDir("", "gopass-")
+	td, err := os.MkdirTemp("", "gopass-")
 	assert.NoError(t, err)
 	defer func() {
 		os.RemoveAll(td)

--- a/pkg/tempfile/file.go
+++ b/pkg/tempfile/file.go
@@ -1,11 +1,10 @@
-// Package tempfile is a wrapper around ioutil.TempDir, providing an OO pattern
+// Package tempfile is a wrapper around os.MkdirTemp, providing an OO pattern
 // as well as secure placement on a temporary ramdisk.
 package tempfile
 
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 )
@@ -22,7 +21,7 @@ type File struct {
 
 // New returns a new tempfile wrapper
 func New(ctx context.Context, prefix string) (*File, error) {
-	td, err := ioutil.TempDir(tempdirBase(), globalPrefix+prefix)
+	td, err := os.MkdirTemp(tempdirBase(), globalPrefix+prefix)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/tempfile/file_test.go
+++ b/pkg/tempfile/file_test.go
@@ -3,7 +3,6 @@ package tempfile
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -31,7 +30,7 @@ func Example() {
 	if err := tempfile.Close(); err != nil {
 		panic(err)
 	}
-	out, err := ioutil.ReadFile(tempfile.Name())
+	out, err := os.ReadFile(tempfile.Name())
 	if err != nil {
 		panic(err)
 	}
@@ -40,7 +39,7 @@ func Example() {
 }
 
 func TestTempdirBase(t *testing.T) {
-	tempdir, err := ioutil.TempDir(tempdirBase(), "gopass-")
+	tempdir, err := os.MkdirTemp(tempdirBase(), "gopass-")
 	assert.NoError(t, err)
 	defer func() {
 		_ = os.RemoveAll(tempdir)

--- a/tests/binary_test.go
+++ b/tests/binary_test.go
@@ -1,7 +1,6 @@
 package tests
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -29,7 +28,7 @@ func TestBinaryCopy(t *testing.T) {
 
 	fn := filepath.Join(ts.tempDir, "copy")
 	dat := []byte("foobar")
-	require.NoError(t, ioutil.WriteFile(fn, dat, 0644))
+	require.NoError(t, os.WriteFile(fn, dat, 0644))
 
 	t.Run("copy file to store", func(t *testing.T) {
 		_, err := ts.run("fscopy " + fn + " foo/bar")
@@ -41,7 +40,7 @@ func TestBinaryCopy(t *testing.T) {
 		_, err := ts.run("fscopy foo/bar " + fn)
 		assert.NoError(t, err)
 
-		buf, err := ioutil.ReadFile(fn)
+		buf, err := os.ReadFile(fn)
 		require.NoError(t, err)
 
 		assert.Equal(t, buf, dat)
@@ -72,7 +71,7 @@ func TestBinaryMove(t *testing.T) {
 
 	fn := filepath.Join(ts.tempDir, "move")
 	dat := []byte("foobar")
-	require.NoError(t, ioutil.WriteFile(fn, dat, 0644))
+	require.NoError(t, os.WriteFile(fn, dat, 0644))
 
 	t.Run("move fs to store", func(t *testing.T) {
 		_, err := ts.run("fsmove " + fn + " foo/bar")
@@ -84,7 +83,7 @@ func TestBinaryMove(t *testing.T) {
 		_, err := ts.run("fsmove foo/bar " + fn)
 		assert.NoError(t, err)
 
-		buf, err := ioutil.ReadFile(fn)
+		buf, err := os.ReadFile(fn)
 		require.NoError(t, err)
 
 		assert.Equal(t, buf, dat)
@@ -116,7 +115,7 @@ func TestBinaryShasum(t *testing.T) {
 	t.Run("populate store", func(t *testing.T) {
 		fn := filepath.Join(ts.tempDir, "shasum")
 		dat := []byte("foobar")
-		require.NoError(t, ioutil.WriteFile(fn, dat, 0644))
+		require.NoError(t, os.WriteFile(fn, dat, 0644))
 
 		_, err := ts.run("fsmove " + fn + " foo/bar")
 		assert.NoError(t, err)

--- a/tests/gptest/unit.go
+++ b/tests/gptest/unit.go
@@ -1,7 +1,6 @@
 package gptest
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -47,7 +46,7 @@ func (u Unit) GPGHome() string {
 // NewUnitTester creates a new unit test helper
 func NewUnitTester(t *testing.T) *Unit {
 	aclip.Unsupported = true
-	td, err := ioutil.TempDir("", "gopass-")
+	td, err := os.MkdirTemp("", "gopass-")
 	assert.NoError(t, err)
 
 	u := &Unit{
@@ -76,7 +75,7 @@ func NewUnitTester(t *testing.T) *Unit {
 }
 
 func (u Unit) initConfig() error {
-	return ioutil.WriteFile(
+	return os.WriteFile(
 		u.GPConfig(),
 		[]byte(gopassConfig+"\npath: "+u.StoreDir("")+"\n"),
 		0600,
@@ -103,7 +102,7 @@ func (u Unit) InitStore(name string) error {
 	}
 	fn := filepath.Join(dir, ".plain-id") // plain.IDFile
 	_ = os.Remove(fn)
-	if err := ioutil.WriteFile(fn, u.recipients(), 0600); err != nil {
+	if err := os.WriteFile(fn, u.recipients(), 0600); err != nil {
 		return err
 	}
 	for _, p := range AllPathsToSlash(u.Entries) {
@@ -112,7 +111,7 @@ func (u Unit) InitStore(name string) error {
 		if err := os.MkdirAll(filepath.Dir(fn), 0700); err != nil {
 			return err
 		}
-		if err := ioutil.WriteFile(fn, []byte("secret\nsecond\nthird"), 0600); err != nil {
+		if err := os.WriteFile(fn, []byte("secret\nsecond\nthird"), 0600); err != nil {
 			return err
 		}
 	}

--- a/tests/tester.go
+++ b/tests/tester.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -64,7 +63,7 @@ func newTester(t *testing.T) *tester {
 		Binary:    gopassBin,
 	}
 	// create tempDir
-	td, err := ioutil.TempDir("", "gopass-")
+	td, err := os.MkdirTemp("", "gopass-")
 	require.NoError(t, err)
 
 	t.Logf("Tempdir: %s", td)
@@ -82,7 +81,7 @@ func newTester(t *testing.T) *tester {
 	// write config
 	require.NoError(t, os.MkdirAll(filepath.Dir(ts.gopassConfig()), 0700))
 	// we need to set the root path to something else than the root directory otherwise the mounts will show as regular entries
-	if err := ioutil.WriteFile(ts.gopassConfig(), []byte(gopassConfig+"\npath: "+ts.storeDir("root")+"\n"), 0600); err != nil {
+	if err := os.WriteFile(ts.gopassConfig(), []byte(gopassConfig+"\npath: "+ts.storeDir("root")+"\n"), 0600); err != nil {
 		t.Fatalf("Failed to write gopass config to %s: %s", ts.gopassConfig(), err)
 	}
 
@@ -94,13 +93,13 @@ func newTester(t *testing.T) *tester {
 		filepath.Join(ts.sourceDir, "can", "gnupg", "trustdb.gpg"): filepath.Join(ts.gpgDir(), "trustdb.gpg"),
 	}
 	for from, to := range files {
-		buf, err := ioutil.ReadFile(from)
+		buf, err := os.ReadFile(from)
 		require.NoError(t, err, "Failed to read file %s", from)
 
 		err = os.MkdirAll(filepath.Dir(to), 0700)
 		require.NoError(t, err, "Failed to create dir for %s", to)
 
-		err = ioutil.WriteFile(to, buf, 0600)
+		err = os.WriteFile(to, buf, 0600)
 		require.NoError(t, err, "Failed to write file %s", to)
 	}
 


### PR DESCRIPTION
Remove usage of io/ioutil: https://golang.org/doc/go1.16?s=03#ioutil

RELEASE_NOTES=[ENHANCEMENT] Use Go 1.16

Signed-off-by: Dominik Schulz <dominik.schulz@gauner.org>