### PR TITLE
Honor --password flag

### DIFF
--- a/internal/action/show.go
+++ b/internal/action/show.go
@@ -164,7 +164,7 @@ func (s *Action) showHandleOutput(ctx context.Context, name string, sec gopass.S
 	}
 
 	ctx = out.WithNewline(ctx, ctxutil.IsTerminal(ctx))
-	if ctxutil.IsTerminal(ctx) {
+	if ctxutil.IsTerminal(ctx) && !IsPasswordOnly(ctx) {
 		header := fmt.Sprintf("Secret: %s\n", name)
 		if HasKey(ctx) {
 			header += fmt.Sprintf("Key: %s\n", GetKey(ctx))


### PR DESCRIPTION
Do not print the output header when --password/-o is given.

RELEASE_NOTES=[BUGFIX] Fix -o

Fixes #1821

Signed-off-by: Dominik Schulz <dominik.schulz@gauner.org>