### PR TITLE
Add gopass ln

### DIFF
--- a/docs/commands/link.md
+++ b/docs/commands/link.md
@@ -1,0 +1,28 @@
+# `link` command
+
+The `link` (or `ln`) command is used to create a symlink from one secret in a
+store to a target in the same store.
+
+Note: Symlinks across different stores / mounts are currently not supported!
+
+Note: `audit` and `list` do not recognize symlinks, yet. They will treat
+symlinks as regular (different) entries.
+
+## Synopsis
+
+```
+$ gopass ln foo/bar bar/baz
+$ gopass show foo/bar
+$ gopass show bar/baz
+```
+
+## Modes of operations
+
+* Create a symlink from an existing secret to a new name, the target must not exist, yet
+
+Note: Use `gopass rm` to remove a symlink.
+
+## Flags
+
+None.
+

--- a/internal/action/audit.go
+++ b/internal/action/audit.go
@@ -5,6 +5,7 @@ import (
 	"github.com/gopasspw/gopass/internal/out"
 	"github.com/gopasspw/gopass/internal/tree"
 	"github.com/gopasspw/gopass/pkg/ctxutil"
+	"github.com/gopasspw/gopass/pkg/debug"
 
 	"github.com/urfave/cli/v2"
 )
@@ -27,6 +28,7 @@ func (s *Action) Audit(c *cli.Context) error {
 		if err != nil {
 			return ExitError(ExitUnknown, err, "failed to find subtree: %s", err)
 		}
+		debug.Log("subtree for %q: %+v", filter, subtree)
 		t = subtree
 	}
 	list := t.List(tree.INF)

--- a/internal/action/commands.go
+++ b/internal/action/commands.go
@@ -607,6 +607,18 @@ func (s *Action) GetCommands() []*cli.Command {
 			},
 		},
 		{
+			Name:  "link",
+			Usage: "Create a symlink",
+			Description: "" +
+				"This command creates a symlink from one entry in a mounted store to another entry." +
+				"Important: Does not cross mounts!",
+			Aliases:      []string{"ln", "symlink"},
+			Hidden:       true,
+			Before:       s.IsInitialized,
+			Action:       s.Link,
+			BashComplete: s.Complete,
+		},
+		{
 			Name:  "list",
 			Usage: "List existing secrets",
 			Description: "" +

--- a/internal/action/link.go
+++ b/internal/action/link.go
@@ -1,0 +1,20 @@
+package action
+
+import (
+	"github.com/gopasspw/gopass/pkg/ctxutil"
+	"github.com/urfave/cli/v2"
+)
+
+// Link creates a symlink
+func (s *Action) Link(c *cli.Context) error {
+	ctx := ctxutil.WithGlobalFlags(c)
+
+	from := c.Args().Get(0)
+	to := c.Args().Get(1)
+
+	if from == "" || to == "" {
+		return ExitError(ExitUsage, nil, "Usage: link <from> <to>")
+	}
+
+	return s.Store.Link(ctx, from, to)
+}

--- a/internal/action/list.go
+++ b/internal/action/list.go
@@ -83,10 +83,9 @@ func (s *Action) listFiltered(ctx context.Context, l *tree.Root, limit int, flat
 		}
 		for _, e := range listOver(limit) {
 			if stripPrefix {
-				fmt.Fprintln(stdout, e)
-				continue
+				e = strings.TrimPrefix(e, filter+sep)
 			}
-			fmt.Fprintln(stdout, filter+sep+e)
+			fmt.Fprintln(stdout, e)
 		}
 		return nil
 	}

--- a/internal/backend/storage.go
+++ b/internal/backend/storage.go
@@ -39,6 +39,7 @@ type Storage interface {
 	List(ctx context.Context, prefix string) ([]string, error)
 	IsDir(ctx context.Context, name string) bool
 	Prune(ctx context.Context, prefix string) error
+	Link(ctx context.Context, from, to string) error
 
 	Name() string
 	Path() string

--- a/internal/backend/storage/fs/link.go
+++ b/internal/backend/storage/fs/link.go
@@ -1,0 +1,73 @@
+package fs
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/gopasspw/gopass/pkg/debug"
+)
+
+// addRel adds the required number of relative elements to go from dst back to
+// src
+func addRel(src, dst string) string {
+	for i := 0; i < strings.Count(dst, "/"); i++ {
+		src = "../" + src
+	}
+	return src
+}
+
+// longestCommonPrefix finds the longest common prefix directory
+func longestCommonPrefix(l, r string) string {
+	var prefix string
+	for i := 0; i < len(l) && i < len(r); i++ {
+		if l[i] != r[i] {
+			prefix = l[:i]
+			break
+		}
+	}
+	if !strings.Contains(prefix, "/") {
+		return prefix
+	}
+	return prefix[:strings.LastIndex(prefix, "/")]
+}
+
+// Link creates a symlink
+func (s *Store) Link(ctx context.Context, from, to string) error {
+	if runtime.GOOS == "windows" {
+		from = filepath.FromSlash(from)
+		to = filepath.FromSlash(to)
+	}
+	fromPath := filepath.Join(s.path, from)
+	toPath := filepath.Join(s.path, to)
+	prefix := longestCommonPrefix(fromPath, toPath)
+
+	fromRel := strings.TrimPrefix(fromPath, prefix+string(filepath.Separator))
+	toRel := strings.TrimPrefix(toPath, prefix+string(filepath.Separator))
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("can not get current working directory: %w", err)
+	}
+	defer func() {
+		os.Chdir(cwd)
+	}()
+
+	toDir := filepath.Dir(toPath)
+	if err := os.MkdirAll(toDir, 0700); err != nil {
+		return fmt.Errorf("failed to create destination dir %q: %w", toDir, err)
+	}
+
+	if err := os.Chdir(toDir); err != nil {
+		return fmt.Errorf("can no change to link dir %q: %w", toDir, err)
+	}
+
+	linkDst := addRel(fromRel, toRel)
+
+	debug.Log("path: %q\n\tfromPath:\t%q\n\ttoPath:\t\t%q\n\tprefix:\t\t%q\n\tfromRel:\t%q\n\ttoRel:\t\t%q\n\ttoDir:\t\t%q\n\tlinkDst:\t%q",
+		s.path, fromPath, toPath, prefix, fromRel, toRel, toDir, linkDst)
+	return os.Symlink(linkDst, filepath.Base(toRel))
+}

--- a/internal/backend/storage/fs/link_test.go
+++ b/internal/backend/storage/fs/link_test.go
@@ -1,0 +1,40 @@
+package fs
+
+import (
+	"testing"
+
+	"gotest.tools/assert"
+)
+
+func TestLongestCommonPrefix(t *testing.T) {
+	for _, tc := range []struct {
+		Src    string
+		Dst    string
+		Prefix string
+	}{
+		{
+			Src:    "foo/bar/baz/zab.txt",
+			Dst:    "foo/baz/foo.txt",
+			Prefix: "foo",
+		},
+	} {
+		prefix := longestCommonPrefix(tc.Src, tc.Dst)
+		assert.Equal(t, tc.Prefix, prefix)
+	}
+}
+
+func TestAddRel(t *testing.T) {
+	for _, tc := range []struct {
+		Src string
+		Dst string
+		Out string
+	}{
+		{
+			Src: "bar/baz.txt",
+			Dst: "baz/foo.txt",
+			Out: "../bar/baz.txt",
+		},
+	} {
+		assert.Equal(t, tc.Out, addRel(tc.Src, tc.Dst))
+	}
+}

--- a/internal/backend/storage/gitfs/storage.go
+++ b/internal/backend/storage/gitfs/storage.go
@@ -60,3 +60,8 @@ func (g *Git) Fsck(ctx context.Context) error {
 	}
 	return g.fs.Fsck(ctx)
 }
+
+// Link creates a symlink
+func (g *Git) Link(ctx context.Context, from, to string) error {
+	return g.fs.Link(ctx, from, to)
+}

--- a/internal/store/leaf/link.go
+++ b/internal/store/leaf/link.go
@@ -1,0 +1,40 @@
+package leaf
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/gopasspw/gopass/internal/queue"
+	"github.com/gopasspw/gopass/internal/store"
+	"github.com/gopasspw/gopass/pkg/debug"
+)
+
+// Link creates a symlink
+func (s *Store) Link(ctx context.Context, from, to string) error {
+	if !s.Exists(ctx, from) {
+		return fmt.Errorf("source %q does not exists", from)
+	}
+	if s.Exists(ctx, to) {
+		return fmt.Errorf("destination %q already exists", to)
+	}
+
+	if err := s.storage.Link(ctx, s.passfile(from), s.passfile(to)); err != nil {
+		return fmt.Errorf("failed to create symlink from %q to %q: %w", from, to, err)
+	}
+	debug.Log("created symlink from %q to %q", from, to)
+
+	if err := s.storage.Add(ctx, s.passfile(to)); err != nil {
+		if errors.Is(err, store.ErrGitNotInit) {
+			return nil
+		}
+		return fmt.Errorf("failed to add %q to git: %w", to, err)
+	}
+
+	// try to enqueue this task, if the queue is not available
+	// it will return the task and we will execute it inline
+	t := queue.GetQueue(ctx).Add(func(ctx context.Context) error {
+		return s.gitCommitAndPush(ctx, to)
+	})
+	return t(ctx)
+}

--- a/internal/store/leaf/link_test.go
+++ b/internal/store/leaf/link_test.go
@@ -1,0 +1,36 @@
+package leaf
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/gopasspw/gopass/pkg/gopass/secrets"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLink(t *testing.T) {
+	ctx := context.Background()
+
+	tempdir, err := os.MkdirTemp("", "gopass-")
+	require.NoError(t, err)
+	defer func() {
+		_ = os.RemoveAll(tempdir)
+	}()
+	t.Logf(tempdir)
+
+	s, err := createSubStore(tempdir)
+	require.NoError(t, err)
+
+	sec := &secrets.Plain{}
+	sec.SetPassword("foo")
+	sec.WriteString("bar")
+	require.NoError(t, s.Set(ctx, "zab/zab", sec))
+
+	assert.NoError(t, s.Link(ctx, "zab/zab", "foo/123"))
+
+	p, err := s.Get(ctx, "foo/123")
+	require.NoError(t, err)
+	assert.Equal(t, "foo", p.Password())
+}

--- a/internal/store/mockstore/inmem/store.go
+++ b/internal/store/mockstore/inmem/store.go
@@ -202,3 +202,8 @@ func (m *InMem) Status(context.Context) ([]byte, error) {
 func (m *InMem) Compact(context.Context) error {
 	return nil
 }
+
+// Link is not implemented
+func (m *InMem) Link(context.Context, string, string) error {
+	return nil
+}

--- a/internal/store/mockstore/store.go
+++ b/internal/store/mockstore/store.go
@@ -225,3 +225,8 @@ func (m *MockStore) Valid() bool {
 func (m *MockStore) MountPoints() []string {
 	return nil
 }
+
+// Link does nothing
+func (m *MockStore) Link(context.Context, string, string) error {
+	return nil
+}

--- a/internal/store/root/link.go
+++ b/internal/store/root/link.go
@@ -1,0 +1,18 @@
+package root
+
+import (
+	"context"
+	"fmt"
+)
+
+// Link creates a symlink
+func (r *Store) Link(ctx context.Context, from, to string) error {
+	subFrom, fName := r.getStore(from)
+	subTo, tName := r.getStore(to)
+
+	if !subFrom.Equals(subTo) {
+		return fmt.Errorf("sylinks across stores are not supported")
+	}
+
+	return subFrom.Link(ctx, fName, tName)
+}

--- a/internal/tree/root.go
+++ b/internal/tree/root.go
@@ -3,6 +3,7 @@ package tree
 import (
 	"bytes"
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	"github.com/fatih/color"
@@ -28,6 +29,7 @@ var (
 type Root struct {
 	Name    string
 	Subtree *Tree
+	Prefix  string
 }
 
 // New creates a new tree
@@ -105,7 +107,7 @@ func (r *Root) Format(maxDepth int) string {
 func (r *Root) List(maxDepth int) []string {
 	out := make([]string, 0, r.Len())
 	for _, t := range r.Subtree.Nodes {
-		out = append(out, t.list("", maxDepth, 0, true)...)
+		out = append(out, t.list(r.Prefix, maxDepth, 0, true)...)
 	}
 	return out
 }
@@ -114,7 +116,7 @@ func (r *Root) List(maxDepth int) []string {
 func (r *Root) ListFolders(maxDepth int) []string {
 	out := make([]string, 0, r.Len())
 	for _, t := range r.Subtree.Nodes {
-		out = append(out, t.list("", maxDepth, 0, false)...)
+		out = append(out, t.list(r.Prefix, maxDepth, 0, false)...)
 	}
 	return out
 }
@@ -126,16 +128,19 @@ func (r *Root) String() string {
 
 // FindFolder returns the subtree rooted at path
 func (r *Root) FindFolder(path string) (*Root, error) {
+	path = strings.TrimSuffix(path, "/")
 	t := r.Subtree
 	p := strings.Split(path, "/")
+	prefix := ""
 	for _, e := range p {
 		_, node := t.find(e)
 		if node == nil || node.Type == "file" || node.Subtree == nil {
 			return nil, fmt.Errorf("not found")
 		}
 		t = node.Subtree
+		prefix = filepath.Join(prefix, e)
 	}
-	return &Root{Name: r.Name, Subtree: t}, nil
+	return &Root{Name: r.Name, Subtree: t, Prefix: prefix}, nil
 }
 
 // SetName changes the name of this tree

--- a/main_test.go
+++ b/main_test.go
@@ -75,6 +75,7 @@ var commandsWithError = map[string]struct{}{
 	".history":           {},
 	".init":              {},
 	".insert":            {},
+	".link":              {},
 	".mounts.add":        {},
 	".mounts.remove":     {},
 	".move":              {},
@@ -121,7 +122,7 @@ func TestGetCommands(t *testing.T) {
 	c.Context = ctx
 
 	commands := getCommands(act, app)
-	assert.Equal(t, 36, len(commands))
+	assert.Equal(t, 37, len(commands))
 
 	prefix := ""
 	testCommands(t, c, commands, prefix)


### PR DESCRIPTION
This commit adds a new subcommand to support symlinks within the same
mount. The command is intentionally still hidden since the support
isn't fully fleshed out, yet. Neither audit nor list know of links
and cross mount symlinks aren't supported either (and maybe never will).

RELEASE_NOTES=[ENHANCEMENT] Add gopass ln

Fixes #1820

Signed-off-by: Dominik Schulz <dominik.schulz@gauner.org>