### PR TITLE
Do not fail if reminder can not be initialized

### DIFF
--- a/internal/action/action.go
+++ b/internal/action/action.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gopasspw/gopass/internal/config"
 	"github.com/gopasspw/gopass/internal/reminder"
 	"github.com/gopasspw/gopass/internal/store/root"
+	"github.com/gopasspw/gopass/pkg/debug"
 
 	"github.com/blang/semver/v4"
 )
@@ -47,9 +48,12 @@ func newAction(cfg *config.Config, sv semver.Version, remind bool) (*Action, err
 	if remind {
 		r, err := reminder.New()
 		if err != nil {
-			return nil, err
+			debug.Log("failed to init reminder: %s", err)
+		} else {
+			// only populate the reminder variable on success, the implementation
+			// can handle being called on a nil pointer
+			act.rem = r
 		}
-		act.rem = r
 	}
 
 	return act, nil

--- a/internal/reminder/reminder.go
+++ b/internal/reminder/reminder.go
@@ -1,6 +1,7 @@
 package reminder
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/gopasspw/gopass/internal/cache"
@@ -16,7 +17,7 @@ type Store struct {
 func New() (*Store, error) {
 	od, err := cache.NewOnDisk("reminder", 90*24*time.Hour)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to init reminder cache: %w", err)
 	}
 
 	return &Store{

--- a/main.go
+++ b/main.go
@@ -115,8 +115,8 @@ func setupApp(ctx context.Context, sv semver.Version) (context.Context, *cli.App
 	// initialize action handlers
 	action, err := ap.New(cfg, sv)
 	if err != nil {
-		out.Errorf(ctx, "No gpg binary found: %s", err)
-		os.Exit(ap.ExitGPG)
+		out.Errorf(ctx, "failed to initialize gopass: %s", err)
+		os.Exit(ap.ExitUnknown)
 	}
 
 	// set some action callbacks


### PR DESCRIPTION
Manually verified that this fixes the reported issue with:

```
export XDG_CACHE_HOME=/tmp/cache
mkdir /tmp/cache
chmod 000 /tmp/cache
./gopass
```

Fixes #1832

RELEASE_NOTES=[BUGFIX] Do not fail if reminder is unavailable

Signed-off-by: Dominik Schulz <dominik.schulz@gauner.org>