### PR TITLE
Install manpage when using `make install`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ $(GOPASS_OUTPUT): $(GOFILES_BUILD)
 	@$(GO) build -o $@ $(BUILDFLAGS)
 	@printf '%s\n' '$(OK)'
 
-install: all install-completion
+install: all install-completion install-man
 	@echo -n ">> INSTALL, version = $(GOPASS_VERSION)"
 	@install -m 0755 -d $(DESTDIR)$(BINDIR)
 	@install -m 0755 $(GOPASS_OUTPUT) $(DESTDIR)$(BINDIR)/gopass
@@ -251,5 +251,8 @@ upgrade: gen fmt
 
 man:
 	@go run helpers/man/main.go > gopass.1
+
+install-man: man
+	@install -D -m 0644 gopass.1 $(DESTDIR)$(PREFIX)/share/man/man1/gopass.1
 
 .PHONY: clean build completion install sysinfo crosscompile test codequality release goreleaser debsign man


### PR DESCRIPTION
Add an `install-man` make target to install the manpage, and include it in the `install` target.

RELEASE_NOTES=[ENHANCEMENT] Install manpage when using `make install`

Signed-off-by: Silke Hofstra <silke@slxh.eu>