### PR TITLE
Remove custom brew

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -60,45 +60,6 @@ release:
   draft: false
   prerelease: auto
 
-brews:
-  - name: gopass
-    tap:
-      owner: gopasspw
-      name: homebrew-gopass
-    caveats:  |
-      Gopass has been installed, have fun!
-      If upgrading from `pass`, everything should work as expected.
-      If installing from scratch, you need to either initialize a new repository now...
-        gopass init
-      ...or clone one from a source:
-        gopass clone git@code.example.com:example/pass.git
-      In order to use the great autocompletion features (they're helpful with gopass),
-      please make sure you have autocompletion for homebrew enabled:
-        https://github.com/bobthecow/git-flow-completion/wiki/Install-Bash-git-completion
-      More information:
-        https://www.gopass.pw/
-        https://github.com/gopasspw/gopass/README.md
-    homepage: "https://www.gopass.pw/"
-    description: "The slightly more awesome Standard Unix Password Manager for Teams."
-    dependencies:
-      - git
-      - gnupg
-      - terminal-notifier
-    install:  |
-      ENV["GOPATH"] = buildpath
-      (buildpath/"src/github.com/gopasspw/gopass").install buildpath.children
-
-      cd "src/github.com/gopasspw/gopass" do
-        ENV["PREFIX"] = prefix
-        system "make", "install"
-      end
-
-      system bin/"gopass completion bash > bash_completion.bash"
-      system bin/"gopass completion zsh > zsh_completion.zsh"
-      bash_completion.install "bash_completion.bash"
-      zsh_completion.install "zsh_completion.zsh"
-    test:  |
-      assert_match version.to_s, shell_output("#{bin}/gopass version")
 nfpms:
   - id: gopass
     vendor: Gopass Authors

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -139,14 +139,15 @@ brew install pinentry-mac
 echo "pinentry-program /usr/local/bin/pinentry-mac" >> ~/.gnupg/gpg-agent.conf
 ```
 
-### Ubuntu & Debian
+### Ubuntu, Debian, Deepin, Devuan, Kali Linux, Pardus, Parrot, Raspbian
 
-**WARNING**: The official Debian repositories contain a package named `gopass` that
-is not related to this project in any way. It's a similar tool with a completely
-independent implementation and feature set. We are aware of this issue but can not
-do anything about it.
+**WARNING**: The official Debian repositories (and derived distributions) contain
+a package named `gopass` that is not related to this project in any way.
+It's a similar tool with a completely independent implementation and feature set.
+We are aware of this issue but can not do anything about it.
 
-When installing on Ubuntu or Debian you can either download the `deb` package and install manually or use our repository.
+When installing on Ubuntu or Debian you can either download the `deb` package
+and [install manually or build from source](#installing-from-source).
 
 #### Manual download
 


### PR DESCRIPTION
Gopass has an official homebrew formula. Remove our custom one.

RELEASE_NOTES=[CLEANUP] Remove the custom formula in favor of the
official one.

Signed-off-by: Dominik Schulz <dominik.schulz@gauner.org>