### PR TITLE
Ensure 8-byte alignment of progressbar counters

### DIFF
--- a/pkg/termio/progress.go
+++ b/pkg/termio/progress.go
@@ -22,9 +22,12 @@ var (
 
 // ProgressBar is a gopass progress bar
 type ProgressBar struct {
-	hidden  bool
+	// keep both int64 fields at the top to ensure correct
+	// 8-byte alignment on 32 bit systems. See https://golang.org/pkg/sync/atomic/#pkg-note-BUG
+	// and https://github.com/golang/go/issues/36606
 	total   int64
 	current int64
+	hidden  bool
 	mutex   chan struct{}
 	lastUpd time.Time
 }


### PR DESCRIPTION
Fixes #1854

RELEASE_NOTES=[BUGFIX] Fix progress bar on 32 bit archs

Signed-off-by: Dominik Schulz <dominik.schulz@gauner.org>