### PR TITLE
Use BSD install compatible install -d

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -254,6 +254,7 @@ man:
 	@go run helpers/man/main.go > gopass.1
 
 install-man: man
-	@install -D -m 0644 gopass.1 $(DESTDIR)$(PREFIX)/share/man/man1/gopass.1
+	@install -d -m 0755 $(DESTDIR)$(PREFIX)/share/man/man1
+	@install -m 0644 gopass.1 $(DESTDIR)$(PREFIX)/share/man/man1/gopass.1
 
 .PHONY: clean build completion install sysinfo crosscompile test codequality release goreleaser debsign man


### PR DESCRIPTION
Use BSD install compatible install -d instead of GNU install -D to
create directories.

See https://github.com/Homebrew/homebrew-core/pull/73572#issuecomment-803413195

Manually tested on MacOS.

RELEASE_NOTES=[BUGFIX] Fix make install on BSD

Signed-off-by: Dominik Schulz <dominik.schulz@gauner.org>