### PR TITLE
Add getting started docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 # gopass
 
 [![Build Status](https://travis-ci.org/gopasspw/gopass.svg?branch=master)](https://travis-ci.org/gopasspw/gopass)
+[![Packaging status](https://repology.org/badge/tiny-repos/gopass.svg)](https://repology.org/project/gopass/versions)
 [![Go Report Card](https://goreportcard.com/badge/github.com/gopasspw/gopass)](https://goreportcard.com/report/github.com/gopasspw/gopass)
 [![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/gopasspw/gopass/blob/master/LICENSE)
 [![Github All Releases](https://img.shields.io/github/downloads/gopasspw/gopass/total.svg)](https://github.com/gopasspw/gopass/releases)
@@ -64,10 +65,66 @@ WARNING: Please prefer releases, unless you want to contribute to the
 development of gopass. The master branch might not be very well tested and
 can contain breaking changes without further notice.
 
+## Getting Started
+
+Either initialize a new git repository or clone an existing one.
+
+### New password store
+
+```
+$ gopass setup
+
+   __     _    _ _      _ _   ___   ___
+ /'_ '\ /'_'\ ( '_'\  /'_' )/',__)/',__)
+( (_) |( (_) )| (_) )( (_| |\__, \\__, \
+'\__  |'\___/'| ,__/''\__,_)(____/(____/
+( )_) |       | |
+ \___/'       (_)
+
+🌟 Welcome to gopass!
+🌟 Initializing a new password store ...
+🌟 Configuring your password store ...
+🎮 Please select a private key for encrypting secrets:
+[0] gpg - 0xFEEDBEEF - John Doe <john.doe@example.org>
+Please enter the number of a key (0-12, [q]uit) (q to abort) [0]: 0
+❓ Do you want to add a git remote? [y/N/q]: y
+Configuring the git remote ...
+Please enter the git remote for your shared store []: git@gitlab.example.org:john/passwords.git
+✅ Configured
+```
+
+Hint: `gopass setup` will use `gpg` encryption and `git` storage by default.
+
+### Existing password store
+
+```
+$ gopass clone git@gitlab.example.org:john/passwords.git
+
+   __     _    _ _      _ _   ___   ___
+ /'_ '\ /'_'\ ( '_'\  /'_' )/',__)/',__)
+( (_) |( (_) )| (_) )( (_| |\__, \\__, \
+'\__  |'\___/'| ,__/''\__,_)(____/(____/
+( )_) |       | |
+ \___/'       (_)
+
+🌟 Welcome to gopass!
+🌟 Cloning an existing password store from "git@gitlab.example.org:john/passwords.git" ...
+⚠ Cloning git repository "git@gitlab.example.org:john/passwords.git" to "/home/john/.local/share/gopass/stores/root" ...
+⚠ Configuring git repository ...
+🎩 Gathering information for the git repository ...
+🚶 What is your name? [John Doe]: 
+📧 What is your email? [john.doe@example.org]: 
+Your password store is ready to use! Have a look around: `gopass list`
+```
 
 ## Upgrade
 
-To upgrade with Go installed, run:
+To use the self-updater run:
+```bash
+gopass update
+```
+
+or to upgrade with Go installed, run:
 ```bash
 go get -u github.com/gopasspw/gopass
 ```

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -258,7 +258,7 @@ source <(gopass completion bash)
 source /dev/stdin <<<"$(gopass completion bash)"
 ```
 
-### Enable  Z Shell Auto completion
+### Enable Z Shell Auto completion
 
 If you use zsh, `make install` or `make install-completion` should install the completion in the correct location.
 
@@ -334,7 +334,36 @@ The new binary can be downloaded from the latest
 
 For more detailed instructions, please read: [gopass-jsonapi/README](https://github.com/gopasspw/gopass-jsonapi/blob/main/README.md).
 
-### Storing and Syncing your Password Store with Google Drive / Dropbox / etc.
+### Storing and Syncing your with git
+
+This is the recommended way to use `gopass`.
+
+NOTE: We do recommend to use a private Git repository. A public one will keep
+your credentials secure but it will leak metadata.
+
+To use `gopass` with `git` either create a new git repository or clone an existing
+password store.
+
+#### New password store with git
+
+Create a new repository, either locally or on a server, then specify this
+repository during the `gopass setup`.
+
+```bash
+$ gopass setup --crypto gpg --storage gitfs # used by default
+[...]
+# provide an existing, empty git remote, e.g. git@gitlab.example.org:john/passwords.git
+```
+
+#### Existing password store with git
+
+If you have created a password store with `git`, `gopass` can easily clone it.
+
+```bash
+$ gopass clone git@gitlab.example.org:john/passwords.git
+```
+
+### Storing and Syncing your Password Store with Google Drive / Dropbox / Syncthing / etc.
 
 The recommended way to use Gopass is to sync your store with a git repository, preferably a private one, since the name and path of your secrets might reveal information that you'd prefer to keep private.
 However, shall you prefer to, you might also use the `noop` storage backend that is meant to store data on a cloud provider instead of a git server.
@@ -344,7 +373,7 @@ Please be warned that using cloud-based storage may negatively impact the confid
 For example, to use gopass with [Google Drive](https://drive.google.com):
 
 ```bash
-gopass init --rcs noop
+gopass setup --storage fs
 mv .password-store/ "Google Drive/Password-Store"
 gopass config path "~/Google Drive/Password-Store"
 ```

--- a/internal/action/clone.go
+++ b/internal/action/clone.go
@@ -14,7 +14,6 @@ import (
 	"github.com/gopasspw/gopass/pkg/fsutil"
 	"github.com/gopasspw/gopass/pkg/termio"
 
-	"github.com/fatih/color"
 	"github.com/urfave/cli/v2"
 )
 
@@ -36,6 +35,10 @@ func (s *Action) Clone(c *cli.Context) error {
 	if c.Args().Len() > 1 {
 		mount = c.Args().Get(1)
 	}
+
+	out.Printf(ctx, logo)
+	out.Printf(ctx, "🌟 Welcome to gopass!")
+	out.Printf(ctx, "🌟 Cloning an existing password store from %q ...", repo)
 
 	return s.clone(ctx, repo, mount, path)
 }
@@ -69,7 +72,7 @@ func (s *Action) clone(ctx context.Context, repo, mount, path string) error {
 	}
 
 	// clone repo
-	debug.Log("Cloning repo %q to %q", repo, path)
+	out.Noticef(ctx, "Cloning git repository %q to %q ...", repo, path)
 	if _, err := backend.Clone(ctx, storageBackendOrDefault(ctx), repo, path); err != nil {
 		return ExitError(ExitGit, err, "failed to clone repo %q to %q: %s", repo, path, err)
 	}
@@ -86,7 +89,7 @@ func (s *Action) clone(ctx context.Context, repo, mount, path string) error {
 	}
 
 	// try to init git config
-	out.Printf(ctx, "Configuring git repository ...")
+	out.Notice(ctx, "Configuring git repository ...")
 
 	// ask for git config values
 	username, email, err := s.cloneGetGitConfig(ctx, mount)
@@ -128,13 +131,14 @@ func (s *Action) cloneAddMount(ctx context.Context, mount, path string) error {
 }
 
 func (s *Action) cloneGetGitConfig(ctx context.Context, name string) (string, string, error) {
+	out.Printf(ctx, "🎩 Gathering information for the git repository ...")
 	// for convenience, set defaults to user-selected values from available private keys
 	// NB: discarding returned error since this is merely a best-effort look-up for convenience
 	username, email, _ := cui.AskForGitConfigUser(ctx, s.Store.Crypto(ctx, name))
 	if username == "" {
 		username = termio.DetectName(ctx, nil)
 		var err error
-		username, err = termio.AskForString(ctx, color.CyanString("Please enter a user name for password store git config"), username)
+		username, err = termio.AskForString(ctx, "🚶 What is your name?", username)
 		if err != nil {
 			return "", "", ExitError(ExitIO, err, "Failed to read user input: %s", err)
 		}
@@ -142,7 +146,7 @@ func (s *Action) cloneGetGitConfig(ctx context.Context, name string) (string, st
 	if email == "" {
 		email = termio.DetectEmail(ctx, nil)
 		var err error
-		email, err = termio.AskForString(ctx, color.CyanString("Please enter an email address for password store git config"), email)
+		email, err = termio.AskForString(ctx, "📧 What is your email?", email)
 		if err != nil {
 			return "", "", ExitError(ExitIO, err, "Failed to read user input: %s", err)
 		}

--- a/internal/action/errors.go
+++ b/internal/action/errors.go
@@ -56,7 +56,7 @@ const (
 func ExitError(exitCode int, err error, format string, args ...interface{}) error {
 	msg := fmt.Sprintf(format, args...)
 	if err != nil {
-		debug.Log("%s - stacktrace: %+v", err)
+		debug.LogN(1, "%s - stacktrace: %+v", err)
 	}
 	return cli.Exit(msg, exitCode)
 }

--- a/internal/action/init.go
+++ b/internal/action/init.go
@@ -71,7 +71,7 @@ func (s *Action) Init(c *cli.Context) error {
 		return ExitError(ExitUnknown, err, "Failed to initialized store: %s", err)
 	}
 	if inited {
-		out.Errorf(ctx, "❌ Store is already initialized!")
+		out.Errorf(ctx, "Store is already initialized!")
 	}
 
 	if err := s.init(ctx, alias, path, c.Args().Slice()...); err != nil {

--- a/internal/action/setup.go
+++ b/internal/action/setup.go
@@ -44,7 +44,7 @@ func (s *Action) Setup(c *cli.Context) error {
 		return ExitError(ExitUnknown, err, "Failed to initialized store: %s", err)
 	}
 	if inited {
-		out.Errorf(ctx, "⚠ Store is already initialized. Aborting.")
+		out.Errorf(ctx, "Store is already initialized. Aborting.")
 		return nil
 	}
 

--- a/internal/out/print.go
+++ b/internal/out/print.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/gopasspw/gopass/pkg/ctxutil"
+	"github.com/gopasspw/gopass/pkg/debug"
 )
 
 var (
@@ -34,6 +35,7 @@ func Printf(ctx context.Context, format string, args ...interface{}) {
 	if ctxutil.IsHidden(ctx) {
 		return
 	}
+	debug.LogN(1, format, args...)
 	fmt.Fprintf(Stdout, Prefix(ctx)+format+newline(ctx), args...)
 }
 
@@ -47,6 +49,7 @@ func Noticef(ctx context.Context, format string, args ...interface{}) {
 	if ctxutil.IsHidden(ctx) {
 		return
 	}
+	debug.LogN(1, "NOTICE: "+format, args...)
 	fmt.Fprintf(Stdout, Prefix(ctx)+"⚠ "+format+newline(ctx), args...)
 }
 
@@ -60,6 +63,7 @@ func Errorf(ctx context.Context, format string, args ...interface{}) {
 	if ctxutil.IsHidden(ctx) {
 		return
 	}
+	debug.LogN(1, "ERROR: "+format, args...)
 	fmt.Fprint(Stderr, color.RedString(Prefix(ctx)+"❌ "+format+newline(ctx), args...))
 }
 
@@ -73,6 +77,7 @@ func OKf(ctx context.Context, format string, args ...interface{}) {
 	if ctxutil.IsHidden(ctx) {
 		return
 	}
+	debug.LogN(1, "OK: "+format, args...)
 	fmt.Fprintf(Stdout, Prefix(ctx)+"✅ "+format+newline(ctx), args...)
 }
 
@@ -86,5 +91,6 @@ func Warningf(ctx context.Context, format string, args ...interface{}) {
 	if ctxutil.IsHidden(ctx) {
 		return
 	}
+	debug.LogN(1, "WARNING: "+format, args...)
 	fmt.Fprint(Stderr, color.YellowString(Prefix(ctx)+"⚠ "+format+newline(ctx), args...))
 }

--- a/pkg/debug/debug.go
+++ b/pkg/debug/debug.go
@@ -129,8 +129,8 @@ func initDebugTags() {
 	opts.files = parseFilter("GOPASS_DEBUG_FILES", padFile)
 }
 
-func getPosition() (fn, dir, file string, line int) {
-	pc, file, line, ok := runtime.Caller(3)
+func getPosition(offset int) (fn, dir, file string, line int) {
+	pc, file, line, ok := runtime.Caller(3 + offset)
 	if !ok {
 		return "", "", "", 0
 	}
@@ -166,13 +166,20 @@ func checkFilter(filter map[string]bool, key string) bool {
 // Log logs a statement to Stderr (unless filtered) and the
 // debug log file (if enabled).
 func Log(f string, args ...interface{}) {
-	logFn(f, args...)
+	logFn(0, f, args...)
 }
 
-func doNotLog(f string, args ...interface{}) {}
+// LogN logs a statement to Stderr (unless filtered) and the
+// debug log file (if enabled). The offset will be applied to
+// the runtime position.
+func LogN(offset int, f string, args ...interface{}) {
+	logFn(offset, f, args...)
+}
 
-func doLog(f string, args ...interface{}) {
-	fn, dir, file, line := getPosition()
+func doNotLog(offset int, f string, args ...interface{}) {}
+
+func doLog(offset int, f string, args ...interface{}) {
+	fn, dir, file, line := getPosition(offset)
 	if len(f) == 0 || f[len(f)-1] != '\n' {
 		f += "\n"
 	}


### PR DESCRIPTION
This commit adds a getting started section to the readme and improves
the gopass clone UX a little it. It also fixes the call depth for nested
debug.Log invocations (e.g. during ExitError) and adds debug logging
for every out invocation.

RELEASE_NOTES=n/a

Signed-off-by: Dominik Schulz <dominik.schulz@gauner.org>