### PR TITLE
Add -f flag to gopass create

### DIFF
--- a/internal/action/commands.go
+++ b/internal/action/commands.go
@@ -199,6 +199,11 @@ func (s *Action) GetCommands() []*cli.Command {
 					Aliases: []string{"s"},
 					Usage:   "Which store to use",
 				},
+				&cli.BoolFlag{
+					Name:    "force",
+					Aliases: []string{"f"},
+					Usage:   "Force path selection",
+				},
 			},
 		},
 		{

--- a/internal/action/setup.go
+++ b/internal/action/setup.go
@@ -134,7 +134,7 @@ func (s *Action) initGenerateIdentity(ctx context.Context, crypto backend.Crypto
 		return fmt.Errorf("failed to list private keys: %w", err)
 	}
 	if len(kl) > 1 {
-		out.Noticef(ctx, "More than one private key detected. Make sure to use the correct one!")
+		out.Notice(ctx, "More than one private key detected. Make sure to use the correct one!")
 		return nil
 	}
 	if len(kl) < 1 {
@@ -145,7 +145,7 @@ func (s *Action) initGenerateIdentity(ctx context.Context, crypto backend.Crypto
 	if err := s.initExportPublicKey(ctx, crypto, kl[0]); err != nil {
 		return err
 	}
-	out.OKf(ctx, "Key pair validated")
+	out.OK(ctx, "Key pair validated")
 	return nil
 }
 
@@ -239,7 +239,7 @@ func (s *Action) initLocal(ctx context.Context) error {
 		return fmt.Errorf("failed to save config: %w", err)
 	}
 
-	out.OKf(ctx, "Configured")
+	out.OK(ctx, "Configured")
 	return nil
 }
 

--- a/internal/cui/cui.go
+++ b/internal/cui/cui.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/fatih/color"
 	"github.com/gopasspw/gopass/pkg/ctxutil"
 	"github.com/gopasspw/gopass/pkg/termio"
 )
@@ -17,7 +18,8 @@ func GetSelection(ctx context.Context, prompt string, choices []string) (string,
 	}
 
 	for i, c := range choices {
-		fmt.Printf("[%  d] %s\n", i, c)
+		fmt.Print(color.GreenString("[%  d]", i))
+		fmt.Printf(" %s\n", c)
 	}
 	fmt.Println()
 	var i int


### PR DESCRIPTION
This new flag allows overriding the default secret name
computation with a custom secret name passed as the first
argument.

Fixes #1811

RELEASE_NOTES=[ENHANCEMENT] Add -f flag to create

Signed-off-by: Dominik Schulz <dominik.schulz@gauner.org>