### PR TITLE
Fix ssh command for termux

### DIFF
--- a/internal/backend/storage/gitfs/config.go
+++ b/internal/backend/storage/gitfs/config.go
@@ -25,6 +25,10 @@ func (g *Git) fixConfig(ctx context.Context) error {
 		return fmt.Errorf("failed to set git config for push.default: %w", err)
 	}
 
+	if err := g.ConfigSet(ctx, "pull.rebase", "false"); err != nil {
+		return fmt.Errorf("failed to set git config for pull.rebase: %w", err)
+	}
+
 	// setup for proper diffs
 	if err := g.ConfigSet(ctx, "diff.gpg.binary", "true"); err != nil {
 		out.Errorf(ctx, "Error while initializing git: %s", err)

--- a/internal/backend/storage/gitfs/ssh_others.go
+++ b/internal/backend/storage/gitfs/ssh_others.go
@@ -2,6 +2,8 @@
 
 package gitfs
 
+import "os"
+
 // gitSSHCommand returns a SSH command instructing git to use SSH
 // with persistent connections through a custom socket.
 // See https://linux.die.net/man/5/ssh_config and
@@ -10,5 +12,5 @@ package gitfs
 // Note: Setting GIT_SSH_COMMAND, possibly to an empty string, will take
 // precedence over this setting.
 func gitSSHCommand() string {
-	return "ssh -oControlMaster=auto -oControlPersist=600 -oControlPath=/tmp/.gopass-ssh-${USER}-%r@%h:%p"
+	return "ssh -oControlMaster=auto -oControlPersist=600 -oControlPath=" + os.TempDir() + "/.gopass-ssh-${USER}-%r@%h:%p"
 }


### PR DESCRIPTION
The SSH Command override for presistent connections was broken on termux
where we don't have /tmp. But since $TMPDIR is set os.TempDir should
return a proper location.

RELEASE_NOTES=[BUGFIX] Fix SSH Command override on termux

Signed-off-by: Dominik Schulz <dominik.schulz@gauner.org>