### PR TITLE
Add proper diff numbers on sync

### DIFF
--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -1,0 +1,31 @@
+package diff
+
+// List returnes the number of items added to and removed from the first to
+// the second list
+func List(l, r []string) (int, int) {
+	ml := listToMap(l)
+	mr := listToMap(r)
+
+	var removed int
+	for k := range ml {
+		if _, found := mr[k]; !found {
+			removed++
+		}
+	}
+	var added int
+	for k := range mr {
+		if _, found := ml[k]; !found {
+			added++
+		}
+	}
+
+	return added, removed
+}
+
+func listToMap(l []string) map[string]struct{} {
+	m := make(map[string]struct{}, len(l))
+	for _, e := range l {
+		m[e] = struct{}{}
+	}
+	return m
+}

--- a/internal/diff/diff_test.go
+++ b/internal/diff/diff_test.go
@@ -1,0 +1,37 @@
+package diff
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestList(t *testing.T) {
+	for _, tc := range []struct {
+		old     []string
+		new     []string
+		added   int
+		removed int
+	}{
+		{
+			old:   []string{"foo", "bar"},
+			new:   []string{"foo", "bar", "baz"},
+			added: 1,
+		},
+		{
+			old:     []string{"foo", "bar", "baz"},
+			new:     []string{"foo", "bar"},
+			removed: 1,
+		},
+		{
+			old:     []string{"foo", "baz"},
+			new:     []string{"foo", "bar"},
+			added:   1,
+			removed: 1,
+		},
+	} {
+		a, r := List(tc.old, tc.new)
+		assert.Equal(t, tc.added, a)
+		assert.Equal(t, tc.removed, r)
+	}
+}


### PR DESCRIPTION
This commit adds a small diff helper that computes the number
of added and removed (but not changed) entries during a sync
operation.

RELEASE_NOTES=[ENHANCEMENT] Add proper diff numbers on sync

Signed-off-by: Dominik Schulz <dominik.schulz@gauner.org>