### PR TITLE
Avoid logging credentials

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -9,6 +9,7 @@ Some configuration options are only available through setting environment variab
 | `CHECKPOINT_DISABLE`    | `bool`   | Set to any non-empty value to disable calling the GitHub API when running `gopass version`.                  |
 | `GOPASS_DEBUG`          | `bool`   | Set to any non-empty value to enable verbose debug output                                                    |
 | `GOPASS_DEBUG_LOG` | `string` | Set to a filename to enable debug logging |
+| `GOPASS_DEBUG_LOG_SECRETS` | `bool` | Set to any non-empty value to enable logging of credentials |
 | `GOPASS_DEBUG_FUNCS` | `string` | Comma separated filter for console debug output (functions) |
 | `GOPASS_DEBUG_FILES` | `string` | Comma separated filter for console debug output (files) |
 | `GOPASS_UMASK`          | `octal`  | Set to any valid umask to mask bits of files created by gopass                                               |

--- a/internal/action/create.go
+++ b/internal/action/create.go
@@ -376,10 +376,12 @@ func (s *Action) createGeneratePassword(ctx context.Context, hostname string) (s
 	if err != nil {
 		return "", err
 	}
+
 	symbols, err := termio.AskForBool(ctx, fmtfn(4, "c", "Include symbols?"), false)
 	if err != nil {
 		return "", err
 	}
+
 	corp, err := termio.AskForBool(ctx, fmtfn(4, "d", "Strict rules?"), false)
 	if err != nil {
 		return "", err
@@ -387,6 +389,7 @@ func (s *Action) createGeneratePassword(ctx context.Context, hostname string) (s
 	if corp {
 		return pwgen.GeneratePasswordWithAllClasses(length)
 	}
+
 	return pwgen.GeneratePassword(length, symbols), nil
 }
 
@@ -396,5 +399,6 @@ func (s *Action) createGeneratePIN(ctx context.Context) (string, error) {
 	if err != nil {
 		return "", err
 	}
+
 	return pwgen.GeneratePasswordCharset(length, "0123456789"), nil
 }

--- a/internal/action/env.go
+++ b/internal/action/env.go
@@ -36,10 +36,12 @@ func (s *Action) Env(c *cli.Context) error {
 		if err != nil {
 			return ExitError(ExitList, err, "failed to list store: %s", err)
 		}
+
 		subtree, err := l.FindFolder(name)
 		if err != nil {
 			return ExitError(ExitNotFound, nil, "Entry %q not found", name)
 		}
+
 		subtree.SetName(name)
 		for _, e := range subtree.List(tree.INF) {
 			en := path.Join(name, e)

--- a/internal/action/find.go
+++ b/internal/action/find.go
@@ -33,6 +33,7 @@ func (s *Action) findCmd(c *cli.Context, cb showFunc, fuzzy bool) error {
 		ctx = WithOnlyClip(ctx, c.Bool("clip"))
 		ctx = WithClip(ctx, c.Bool("clip"))
 	}
+
 	if c.IsSet("unsafe") {
 		ctx = ctxutil.WithForce(ctx, c.Bool("unsafe"))
 	}

--- a/internal/action/fsck.go
+++ b/internal/action/fsck.go
@@ -23,6 +23,7 @@ func (s *Action) Fsck(c *cli.Context) error {
 	if c.IsSet("decrypt") {
 		ctx = leaf.WithFsckDecrypt(ctx, c.Bool("decrypt"))
 	}
+
 	out.Printf(ctx, "Checking store integrity ...")
 	// make sure config is in the right place
 	// we may have loaded it from one of the fallback locations

--- a/internal/action/generate.go
+++ b/internal/action/generate.go
@@ -144,7 +144,7 @@ func (s *Action) generateCopyOrPrint(ctx context.Context, c *cli.Context, name, 
 	out.Printf(
 		ctx,
 		"⚠ The generated password is:\n\n%s\n",
-		password,
+		out.Secret(password),
 	)
 	return nil
 }
@@ -174,15 +174,18 @@ func (s *Action) generatePassword(ctx context.Context, c *cli.Context, length, n
 			}
 			wl = iv
 		}
+
 		question := fmt.Sprintf("How long should the password be? (min: %d, max: %d)", rule.Minlen, rule.Maxlen)
 		iv, err := termio.AskForInt(ctx, question, wl)
 		if err != nil {
 			return "", ExitError(ExitUsage, err, "password length must be a number")
 		}
+
 		pw := pwgen.NewCrypticForDomain(iv, domain).Password()
 		if pw == "" {
 			return "", fmt.Errorf("failed to generate password for %s", domain)
 		}
+
 		return pw, nil
 	}
 
@@ -322,11 +325,13 @@ func (s *Action) generateReplaceExisting(ctx context.Context, name, key, passwor
 	if err != nil {
 		return ctx, ExitError(ExitEncrypt, err, "failed to set key %q of %q: %s", key, name, err)
 	}
+
 	setMetadata(sec, kvps)
 	sec.SetPassword(password)
 	if err := s.Store.Set(ctxutil.WithCommitMessage(ctx, "Generated password for YAML key"), name, sec); err != nil {
 		return ctx, ExitError(ExitEncrypt, err, "failed to set key %q of %q: %s", key, name, err)
 	}
+
 	return ctx, nil
 }
 

--- a/internal/action/insert.go
+++ b/internal/action/insert.go
@@ -95,6 +95,7 @@ func (s *Action) insertStdin(ctx context.Context, name string, content []byte, a
 		if err != nil {
 			return ExitError(ExitDecrypt, err, "failed to decrypt existing secret: %s", err)
 		}
+
 		secW, ok := eSec.(io.Writer)
 		if !ok {
 			return fmt.Errorf("%T is not an io.Writer", eSec)
@@ -102,6 +103,7 @@ func (s *Action) insertStdin(ctx context.Context, name string, content []byte, a
 		if _, err := secW.Write(content); err != nil {
 			return ExitError(ExitEncrypt, err, "failed to write %q: %q", content, err)
 		}
+
 		debug.Log("wrote to secretWriter")
 		sec = eSec
 	} else {
@@ -109,9 +111,11 @@ func (s *Action) insertStdin(ctx context.Context, name string, content []byte, a
 		if n, err := plain.Write(content); err != nil || n < 0 {
 			return ExitError(ExitAborted, err, "failed to write secret from stdin: %s", err)
 		}
+
 		sec = plain
 		debug.Log("Created new plain secret with input")
 	}
+
 	if err := s.Store.Set(ctxutil.WithCommitMessage(ctx, "Read secret from STDIN"), name, sec); err != nil {
 		return ExitError(ExitEncrypt, err, "failed to set %q: %s", name, err)
 	}

--- a/internal/action/show.go
+++ b/internal/action/show.go
@@ -171,8 +171,9 @@ func (s *Action) showHandleOutput(ctx context.Context, name string, sec gopass.S
 		}
 		out.Print(ctx, header)
 	}
+
 	// output the actual secret, newlines are handled by ctx and Print
-	out.Print(ctx, body)
+	out.Print(ctx, out.Secret(body))
 
 	return nil
 }
@@ -242,10 +243,12 @@ func isUnsafeKey(key string, sec gopass.Secret) bool {
 	if strings.ToLower(key) == "password" {
 		return true
 	}
+
 	uks, found := sec.Get("unsafe-keys")
 	if !found || uks == "" {
 		return false
 	}
+
 	for _, uk := range strings.Split(uks, ",") {
 		uk = strings.TrimSpace(uk)
 		if uk == "" {
@@ -255,6 +258,7 @@ func isUnsafeKey(key string, sec gopass.Secret) bool {
 			return true
 		}
 	}
+
 	return false
 }
 
@@ -288,12 +292,15 @@ func (s *Action) showHandleError(ctx context.Context, c *cli.Context, name strin
 		}
 		return ExitError(ExitUnknown, err, "failed to retrieve secret %q: %s", name, err)
 	}
+
 	if newName := s.hasAliasDomain(ctx, name); newName != "" {
 		return s.show(ctx, nil, newName, false)
 	}
+
 	if IsClip(ctx) {
 		_ = notify.Notify(ctx, "gopass - warning", fmt.Sprintf("Entry %q not found. Starting search...", name))
 	}
+
 	out.Warningf(ctx, "Entry %q not found. Starting search...", name)
 	c.Context = ctx
 	if err := s.Find(c); err != nil {

--- a/internal/action/update.go
+++ b/internal/action/update.go
@@ -30,6 +30,7 @@ func (s *Action) Update(c *cli.Context) error {
 	if err := updater.Update(ctx, s.version); err != nil {
 		return ExitError(ExitUnknown, err, "Failed to update gopass: %s", err)
 	}
+
 	out.OKf(ctx, "gopass is up to date")
 	return nil
 }

--- a/internal/out/print.go
+++ b/internal/out/print.go
@@ -18,6 +18,15 @@ var (
 	Stderr io.Writer = os.Stderr
 )
 
+// Secret is a string wrapper for strings containing secrets. These won't be
+// logged as long a GOPASS_DEBUG_LOG_SECRETS is not set
+type Secret string
+
+// SafeStr always return "(elided)"
+func (s Secret) SafeStr() string {
+	return "(elided)"
+}
+
 func newline(ctx context.Context) string {
 	if HasNewline(ctx) {
 		return "\n"
@@ -26,7 +35,7 @@ func newline(ctx context.Context) string {
 }
 
 // Print prints the given string
-func Print(ctx context.Context, arg string) {
+func Print(ctx context.Context, arg interface{}) {
 	Printf(ctx, "%s", arg)
 }
 
@@ -40,7 +49,7 @@ func Printf(ctx context.Context, format string, args ...interface{}) {
 }
 
 // Notice prints the string with an exclamation mark
-func Notice(ctx context.Context, arg string) {
+func Notice(ctx context.Context, arg interface{}) {
 	Noticef(ctx, "%s", arg)
 }
 
@@ -54,7 +63,7 @@ func Noticef(ctx context.Context, format string, args ...interface{}) {
 }
 
 // Error prints the string with a red cross in front
-func Error(ctx context.Context, arg string) {
+func Error(ctx context.Context, arg interface{}) {
 	Errorf(ctx, "%s", arg)
 }
 
@@ -68,7 +77,7 @@ func Errorf(ctx context.Context, format string, args ...interface{}) {
 }
 
 // OK prints the string with a green checkmark in front
-func OK(ctx context.Context, arg string) {
+func OK(ctx context.Context, arg interface{}) {
 	OKf(ctx, "%s", arg)
 }
 
@@ -82,7 +91,7 @@ func OKf(ctx context.Context, format string, args ...interface{}) {
 }
 
 // Warning prints the string with a warning sign in front
-func Warning(ctx context.Context, arg string) {
+func Warning(ctx context.Context, arg interface{}) {
 	Warningf(ctx, "%s", arg)
 }
 

--- a/pkg/gopass/secrets/kv.go
+++ b/pkg/gopass/secrets/kv.go
@@ -236,3 +236,8 @@ func (k *KV) Write(buf []byte) (int, error) {
 func (k *KV) FromMime() bool {
 	return k.fromMime
 }
+
+// SafeStr always returnes "(elided)"
+func (k *KV) SafeStr() string {
+	return "(elided)"
+}

--- a/pkg/gopass/secrets/plain.go
+++ b/pkg/gopass/secrets/plain.go
@@ -126,3 +126,8 @@ func (p *Plain) Write(buf []byte) (int, error) {
 func (p *Plain) WriteString(in string) {
 	p.Write([]byte(in))
 }
+
+// SafeStr always returnes "(elided)"
+func (p *Plain) SafeStr() string {
+	return "(elided)"
+}

--- a/pkg/gopass/secrets/secparse/parse.go
+++ b/pkg/gopass/secrets/secparse/parse.go
@@ -1,6 +1,7 @@
 package secparse
 
 import (
+	"github.com/gopasspw/gopass/internal/out"
 	"github.com/gopasspw/gopass/pkg/debug"
 	"github.com/gopasspw/gopass/pkg/gopass"
 	"github.com/gopasspw/gopass/pkg/gopass/secrets"
@@ -16,7 +17,8 @@ func Parse(in []byte) (gopass.Secret, error) {
 		debug.Log("parsed as MIME: %+v", s)
 		return s, nil
 	}
-	debug.Log("failed to parse as MIME: %s", err)
+	debug.Log("failed to parse as MIME: %s", out.Secret(err.Error()))
+
 	if _, ok := err.(*secrets.PermanentError); ok {
 		return secrets.ParsePlain(in), err
 	}
@@ -25,14 +27,16 @@ func Parse(in []byte) (gopass.Secret, error) {
 		debug.Log("parsed as YAML: %+v", s)
 		return s, nil
 	}
-	debug.Log("failed to parse as YAML: %s\n%s", err, string(in))
+	debug.Log("failed to parse as YAML: %s\n%s", err, out.Secret(string(in)))
+
 	s, err = secrets.ParseKV(in)
 	if err == nil {
 		debug.Log("parsed as KV: %+v", s)
 		return s, nil
 	}
 	debug.Log("failed to parse as KV: %s", err)
+
 	s = secrets.ParsePlain(in)
-	debug.Log("parsed as plain: %s", string(s.Bytes()))
+	debug.Log("parsed as plain: %s", out.Secret(s.Bytes()))
 	return s, nil
 }

--- a/pkg/gopass/secrets/yaml.go
+++ b/pkg/gopass/secrets/yaml.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/caspr-io/yamlpath"
+	"github.com/gopasspw/gopass/internal/out"
 	"github.com/gopasspw/gopass/pkg/debug"
 	"github.com/gopasspw/gopass/pkg/gopass"
 	yaml "gopkg.in/yaml.v3"
@@ -91,7 +92,7 @@ func ParseYAML(in []byte) (*YAML, error) {
 	y := &YAML{
 		data: make(map[string]interface{}, 10),
 	}
-	debug.Log("Parsing %s", string(in))
+	debug.Log("Parsing %s", out.Secret(in))
 	r := bufio.NewReader(bytes.NewReader(in))
 	line, err := r.ReadString('\n')
 	if err != nil {
@@ -183,4 +184,9 @@ func (y *YAML) Bytes() []byte {
 func (y *YAML) Write(buf []byte) (int, error) {
 	y.body += string(buf)
 	return len(buf), nil
+}
+
+// SafeStr always returnes "(elided)"
+func (y *YAML) SafeStr() string {
+	return "(elided)"
 }


### PR DESCRIPTION
This commit adds filtering to avoid logging credentials in the debug
logs. If logging of credentials, e.g. for debugging secret parsers,
is required GOPASS_DEBUG_LOG_SECRETS can be set to an non empty
string to enable logging of secrets.

Fixes #1883

RELEASE_NOTES=[BUGFIX] Avoid logging credentials

Signed-off-by: Dominik Schulz <dominik.schulz@gauner.org>