### PR TITLE
Do not recurse when deleting a key

### DIFF
--- a/internal/action/delete.go
+++ b/internal/action/delete.go
@@ -29,6 +29,10 @@ func (s *Action) Delete(c *cli.Context) error {
 	// specifying a key is optional
 	key := c.Args().Get(1)
 
+	if recursive && key != "" {
+		return ExitError(ExitUsage, nil, "Can not use -r with a key. Invoke delete either with a key or with -r")
+	}
+
 	if !force { // don't check if it's force anyway
 		recStr := ""
 		if recursive {
@@ -39,7 +43,7 @@ func (s *Action) Delete(c *cli.Context) error {
 		}
 	}
 
-	if recursive {
+	if recursive && key == "" {
 		debug.Log("pruning %q", name)
 		if err := s.Store.Prune(ctx, name); err != nil {
 			return ExitError(ExitUnknown, err, "failed to prune %q: %s", name, err)

--- a/internal/action/delete_test.go
+++ b/internal/action/delete_test.go
@@ -60,4 +60,9 @@ func TestDelete(t *testing.T) {
 	c = gptest.CliCtxWithFlags(ctx, t, map[string]string{"recursive": "true"}, "foo")
 	assert.NoError(t, act.Delete(c))
 	buf.Reset()
+
+	// reject recursive flag when a key is given
+	c = gptest.CliCtxWithFlags(ctx, t, map[string]string{"recursive": "true"}, "foo", "bar")
+	assert.Error(t, act.Delete(c))
+	buf.Reset()
 }


### PR DESCRIPTION
Fixes #1906

RELEASE_NOTES=[BUGFIX] Do not recurse with a key

Signed-off-by: Dominik Schulz <dominik.schulz@gauner.org>