### PR TITLE
Add fish completion for `otp` subcommand

### DIFF
--- a/fish.completion
+++ b/fish.completion
@@ -234,6 +234,7 @@ complete -c $PROG -f -n '__fish_gopass_uses_command mounts remove -l version -d 
 complete -c $PROG -f -n '__fish_gopass_needs_command' -a move -d 'Command: Move secrets from one location to another'
 complete -c $PROG -f -n '__fish_gopass_uses_command move' -a "(__fish_gopass_print_entries)"
 complete -c $PROG -f -n '__fish_gopass_needs_command' -a otp -d 'Command: Generate time- or hmac-based tokens'
+complete -c $PROG -f -n '__fish_gopass_uses_command otp' -a "(__fish_gopass_print_entries)"
 complete -c $PROG -f -n '__fish_gopass_needs_command' -a pwgen -d 'Command: Generate passwords'
 complete -c $PROG -f -n '__fish_gopass_needs_command' -a recipients -d 'Command: Edit recipient permissions'
 complete -c $PROG -f -n '__fish_gopass_uses_command recipients' -a add -d 'Subcommand: Add any number of Recipients to any store'

--- a/internal/completion/fish/template.go
+++ b/internal/completion/fish/template.go
@@ -45,7 +45,7 @@ complete -c $PROG -f -s c -l clip -r -a "(__fish_{{ $prog }}_print_entries)"
 {{ range .Commands }}
 complete -c $PROG -f -n '__fish_{{ $prog }}_needs_command' -a {{ .Name }} -d 'Command: {{ .Usage }}'
 {{- $cmd := .Name -}}
-{{- if or (eq $cmd "copy") (eq $cmd "cp") (eq $cmd "move") (eq $cmd "mv") (eq $cmd "delete") (eq $cmd "remove") (eq $cmd "rm") (eq $cmd "show") (eq $cmd "set") (eq $cmd "edit") }}
+{{- if or (eq $cmd "copy") (eq $cmd "cp") (eq $cmd "move") (eq $cmd "mv") (eq $cmd "delete") (eq $cmd "remove") (eq $cmd "rm") (eq $cmd "show") (eq $cmd "set") (eq $cmd "edit") (eq $cmd "otp") }}
 complete -c $PROG -f -n '__fish_{{ $prog }}_uses_command {{ $cmd }}' -a "(__fish_{{ $prog }}_print_entries)"{{ end -}}
 {{- if or (eq $cmd "insert") (eq $cmd "generate") (eq $cmd "list") (eq $cmd "ls") }}
 complete -c $PROG -f -n '__fish_{{ $prog }}_uses_command {{ $cmd }}' -a "(__fish_{{ $prog }}_print_dir)"{{ end -}}


### PR DESCRIPTION
Fill in entries on `gopass otp <TAB>` in fish shell, just like `gopass show <TAB>`.


Funny testing this on Arch. Fish checks and loads `/usr/share/fish/vendor_completions.d/gopass.fish` which cleared my local mods. Took a while to figure out why i had to double source this file. Alas, once this is merged it'll make it's way into the Arch vendor files.