### PR TITLE
Fixed Table Formating for Clone Command Documentation

### DIFF
--- a/docs/commands/clone.md
+++ b/docs/commands/clone.md
@@ -12,7 +12,7 @@ $ gopass clone git@example.com/store.git sub/store
 
 ## Flags
 
-Flag | Aliases | Description
----- | ------- | -----------
+Flag | Aliases | Description
+---- | ------- | -----------
 `--path` | | The path to clone the repo to.
-`--crypto` | | Override the crypto backend to use if the auto-detection fails.
+`--crypto` | | Override the crypto backend to use if the auto-detection fails.


### PR DESCRIPTION

## Changes
Fixes the formatting for clone command.md to display table in documentation.

## Issue Screenshot(s)
![Screenshot from 2021-06-12 00-08-48](https://user-images.githubusercontent.com/5054653/121768287-65a39000-cb12-11eb-8057-1f34f14bdc01.png)
