### PR TITLE
Allow --strict to be chained with --symbols

### DIFF
--- a/internal/action/create.go
+++ b/internal/action/create.go
@@ -396,7 +396,7 @@ func (s *Action) createGeneratePassword(ctx context.Context, hostname string) (s
 		return "", err
 	}
 	if corp {
-		return pwgen.GeneratePasswordWithAllClasses(length)
+		return pwgen.GeneratePasswordWithAllClasses(length, symbols)
 	}
 
 	return pwgen.GeneratePassword(length, symbols), nil

--- a/internal/action/generate.go
+++ b/internal/action/generate.go
@@ -224,7 +224,7 @@ func (s *Action) generatePassword(ctx context.Context, c *cli.Context, length, n
 		return pwgen.GenerateExternal(pwlen)
 	default:
 		if c.Bool("strict") {
-			return pwgen.GeneratePasswordWithAllClasses(pwlen)
+			return pwgen.GeneratePasswordWithAllClasses(pwlen, symbols)
 		}
 		return pwgen.GeneratePassword(pwlen, symbols), nil
 	}

--- a/pkg/pwgen/cryptic.go
+++ b/pkg/pwgen/cryptic.go
@@ -21,12 +21,16 @@ type Cryptic struct {
 }
 
 // NewCryptic creates a new generator with sane defaults.
-func NewCryptic(length int) *Cryptic {
+func NewCryptic(length int, symbols bool) *Cryptic {
 	if length < 1 {
 		length = 16
 	}
+	chars := Digits + Upper + Lower
+	if symbols {
+		chars += Syms
+	}
 	return &Cryptic{
-		Chars:    Digits + Upper + Lower,
+		Chars:    chars,
 		Length:   length,
 		MaxTries: 64,
 	}
@@ -35,7 +39,7 @@ func NewCryptic(length int) *Cryptic {
 // NewCrypticForDomain tries to look up password rules for the given domain
 // or uses the default generator.
 func NewCrypticForDomain(length int, domain string) *Cryptic {
-	c := NewCryptic(length)
+	c := NewCryptic(length, true)
 	r, found := pwrules.LookupRule(domain)
 	debug.Log("found rules for %s: %t", domain, found)
 	if !found {
@@ -116,8 +120,8 @@ func uniqueChars(in string) string {
 
 // NewCrypticWithAllClasses returns a password generator that generates passwords
 // containing all available character classes
-func NewCrypticWithAllClasses(length int) *Cryptic {
-	c := NewCryptic(length)
+func NewCrypticWithAllClasses(length int, symbols bool) *Cryptic {
+	c := NewCryptic(length, symbols)
 	c.Validators = append(c.Validators, func(pw string) error {
 		if containsAllClasses(pw, c.Chars) {
 			return nil
@@ -129,8 +133,8 @@ func NewCrypticWithAllClasses(length int) *Cryptic {
 
 // NewCrypticWithCrunchy returns a password generators that only returns a
 // password if it's successfully validated with crunchy.
-func NewCrypticWithCrunchy(length int) *Cryptic {
-	c := NewCryptic(length)
+func NewCrypticWithCrunchy(length int, symbols bool) *Cryptic {
+	c := NewCryptic(length, symbols)
 	c.MaxTries = 3
 	validator := crunchy.NewValidator()
 	c.Validators = append(c.Validators, validator.Check)

--- a/pkg/pwgen/pwgen.go
+++ b/pkg/pwgen/pwgen.go
@@ -41,7 +41,7 @@ func GeneratePassword(length int, symbols bool) string {
 // GeneratePasswordCharset generates a random password from a given
 // set of characters
 func GeneratePasswordCharset(length int, chars string) string {
-	c := NewCryptic(length)
+	c := NewCryptic(length, false)
 	c.Chars = chars
 	return c.Password()
 }
@@ -50,8 +50,8 @@ func GeneratePasswordCharset(length int, chars string) string {
 // contains all character classes instead of only enabling them.
 // This is especially useful for broken (corporate) password policies
 // that mandate the use of certain character classes for no good reason
-func GeneratePasswordWithAllClasses(length int) (string, error) {
-	c := NewCrypticWithAllClasses(length)
+func GeneratePasswordWithAllClasses(length int, symbols bool) (string, error) {
+	c := NewCrypticWithAllClasses(length, symbols)
 	if pw := c.Password(); pw != "" {
 		return pw, nil
 	}
@@ -61,7 +61,7 @@ func GeneratePasswordWithAllClasses(length int) (string, error) {
 // GeneratePasswordCharsetCheck generates a random password from a given
 // set of characters and validates the generated password with crunchy
 func GeneratePasswordCharsetCheck(length int, chars string) string {
-	c := NewCrypticWithCrunchy(length)
+	c := NewCrypticWithCrunchy(length, false)
 	c.Chars = chars
 	return c.Password()
 }

--- a/pkg/pwgen/pwgen_test.go
+++ b/pkg/pwgen/pwgen_test.go
@@ -87,7 +87,7 @@ func TestContainsAllClasses(t *testing.T) {
 }
 
 func TestGeneratePasswordWithAllClasses(t *testing.T) {
-	pw, err := GeneratePasswordWithAllClasses(50)
+	pw, err := GeneratePasswordWithAllClasses(50, true)
 	assert.NoError(t, err)
 	assert.Equal(t, 50, len(pw))
 }


### PR DESCRIPTION
Fixes #1941

RELEASE_NOTES=[BUGFIX] Allow --strict to be chained with --symbols

Signed-off-by: Dominik Schulz <dominik.schulz@gauner.org>