### PR TITLE
Normalize recipient IDs before comparsion

### DIFF
--- a/pkg/fsutil/fsutil.go
+++ b/pkg/fsutil/fsutil.go
@@ -82,7 +82,7 @@ func IsEmptyDir(path string) (bool, error) {
 		if fi.IsDir() && (fi.Name() == "." || fi.Name() == "..") {
 			return filepath.SkipDir
 		}
-		if fi.Mode().IsRegular() {
+		if !fi.IsDir() {
 			empty = false
 		}
 		return nil


### PR DESCRIPTION
Fixes #1900

RELEASE_NOTES=[BUGFIX] Normalize recipient IDs before comparison

Signed-off-by: Dominik Schulz <dominik.schulz@gauner.org>