### PR TITLE
Add bytes option to the progress bar

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gopasspw/gopass
 
-go 1.12
+go 1.16
 
 require (
 	filippo.io/age v1.0.0-rc.3
@@ -11,6 +11,7 @@ require (
 	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e
 	github.com/cpuguy83/go-md2man/v2 v2.0.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/dustin/go-humanize v1.0.0 // indirect
 	github.com/fatih/color v1.12.0
 	github.com/godbus/dbus v0.0.0-20190623212516-8a1682060722
 	github.com/gokyle/twofactor v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -61,6 +61,8 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
+github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=

--- a/internal/action/fsck.go
+++ b/internal/action/fsck.go
@@ -47,7 +47,8 @@ func (s *Action) Fsck(c *cli.Context) error {
 
 	pwList := t.List(tree.INF)
 
-	bar := termio.NewProgressBar(int64(len(pwList)*2), ctxutil.IsHidden(ctx))
+	bar := termio.NewProgressBar(int64(len(pwList) * 2))
+	bar.Hidden = ctxutil.IsHidden(ctx)
 	ctx = ctxutil.WithProgressCallback(ctx, func() {
 		bar.Inc()
 	})

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -110,7 +110,8 @@ func Batch(ctx context.Context, secrets []string, secStore secretGetter) error {
 	messages := make(map[string][]string)
 	errors := make(map[string][]string)
 
-	bar := termio.NewProgressBar(int64(len(secrets)), ctxutil.IsHidden(ctx))
+	bar := termio.NewProgressBar(int64(len(secrets)))
+	bar.Hidden = ctxutil.IsHidden(ctx)
 
 	i := 0
 	for secret := range checked {

--- a/internal/store/leaf/convert.go
+++ b/internal/store/leaf/convert.go
@@ -66,7 +66,8 @@ func (s *Store) Convert(ctx context.Context, cryptoBe backend.CryptoBackend, sto
 	}
 
 	out.Printf(ctx, "Converting store ...")
-	bar := termio.NewProgressBar(int64(len(entries)), ctxutil.IsHidden(ctx))
+	bar := termio.NewProgressBar(int64(len(entries)))
+	bar.Hidden = ctxutil.IsHidden(ctx)
 	if !ctxutil.IsTerminal(ctx) || ctxutil.IsHidden(ctx) {
 		bar = nil
 	}

--- a/internal/store/leaf/reencrypt.go
+++ b/internal/store/leaf/reencrypt.go
@@ -33,7 +33,9 @@ func (s *Store) reencrypt(ctx context.Context) error {
 		ctx := ctxutil.WithGitCommit(ctx, false)
 
 		// progress bar
-		bar := termio.NewProgressBar(int64(len(entries)), !ctxutil.IsTerminal(ctx) || ctxutil.IsHidden(ctx))
+		bar := termio.NewProgressBar(int64(len(entries)))
+		bar.Hidden = !ctxutil.IsTerminal(ctx) || ctxutil.IsHidden(ctx)
+
 		var wg sync.WaitGroup
 		jobs := make(chan string)
 		// We use a logger to write without race condition on stdout

--- a/internal/updater/download.go
+++ b/internal/updater/download.go
@@ -52,7 +52,9 @@ func download(ctx context.Context, url string) ([]byte, error) {
 
 	var body io.ReadCloser
 	// do not show progress bar for small assets, like SHA256SUMS
-	bar := termio.NewProgressBar(resp.ContentLength, ctxutil.IsHidden(ctx) || resp.ContentLength < 10000)
+	bar := termio.NewProgressBar(resp.ContentLength)
+	bar.Hidden = ctxutil.IsHidden(ctx) || resp.ContentLength < 10000
+
 	body = &passThru{
 		ReadCloser: resp.Body,
 		Bar:        bar,

--- a/pkg/termio/progress_test.go
+++ b/pkg/termio/progress_test.go
@@ -9,9 +9,11 @@ import (
 
 func ExampleProgressBar() {
 	max := 100
-	pb := NewProgressBar(int64(max), false)
+	pb := NewProgressBar(int64(max))
 	for i := 0; i < max+20; i++ {
 		pb.Inc()
+		pb.Add(23)
+		pb.Set(42)
 		time.Sleep(150 * time.Millisecond)
 	}
 	time.Sleep(5 * time.Second)
@@ -20,7 +22,20 @@ func ExampleProgressBar() {
 
 func TestProgress(t *testing.T) {
 	max := 2
-	pb := NewProgressBar(int64(max), true)
+	pb := NewProgressBar(int64(max))
+	pb.Hidden = true
 	pb.Inc()
 	assert.Equal(t, int64(1), pb.current)
+}
+
+func TestProgressBytes(t *testing.T) {
+	max := 2 << 24
+	pb := NewProgressBar(int64(max))
+	pb.Hidden = true
+	pb.Bytes = true
+	for i := 0; i < 24; i++ {
+		pb.Set(2 << (i + 1))
+	}
+	assert.Equal(t, int64(max), pb.current)
+	pb.Done()
 }


### PR DESCRIPTION
This commit adds the option to format the progress bar numbers as human
readable bytes.

RELEASE_NOTES=n/a

Signed-off-by: Dominik Schulz <dominik.schulz@gauner.org>