### PR TITLE
Remove references to autosync in doc

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -52,6 +52,7 @@ This is a list of available options:
 | `askformore`     | `bool`   | If enabled - it will ask to add more data after use of `generate` command.  DEPRECATED in v1.10.0 |
 | `autoclip`       | `bool`   | Always copy the password created by `gopass generate`. Only applies to generate. |
 | `autoimport`     | `bool`   | Import missing keys stored in the pass repository without asking. |
+| `autosync`       | `bool`   | Always do a `git push` after a commit to the store. Makes sure your local changes are always available on your git remote. DEPRECATED in v1.10.0 |
 | `concurrency`    | `int`    | Number of threads to use for batch operations (such as reencrypting).  DEPRECATED in v1.9.3 |
 | `cliptimeout`    | `int`    | How many seconds the secret is stored when using `-c`. |
 | `exportkeys`     | `bool`   | Export public keys of all recipients to the store. |

--- a/docs/config.md
+++ b/docs/config.md
@@ -41,8 +41,8 @@ During start up, gopass will look for a configuration file at `$HOME/.config/gop
 All configuration options are also available for reading and writing through the sub-command `gopass config`.
 
 * To display all values: `gopass config`
-* To display a single value: `gopass config autosync`
-* To update a single value: `gopass config autosync false`
+* To display a single value: `gopass config autoclip`
+* To update a single value: `gopass config autoclip false`
 * As many other sub-commands this command accepts a `--store` flag to operate on a given sub-store, provided the sub-store is a remote one. Support for different local configurations per mount was dropped in v1.9.3.
 
 This is a list of available options:
@@ -52,7 +52,6 @@ This is a list of available options:
 | `askformore`     | `bool`   | If enabled - it will ask to add more data after use of `generate` command.  DEPRECATED in v1.10.0 |
 | `autoclip`       | `bool`   | Always copy the password created by `gopass generate`. Only applies to generate. |
 | `autoimport`     | `bool`   | Import missing keys stored in the pass repository without asking. |
-| `autosync`       | `bool`   | Always do a `git push` after a commit to the store. Makes sure your local changes are always available on your git remote. DEPRECATED in v1.10.0 |
 | `concurrency`    | `int`    | Number of threads to use for batch operations (such as reencrypting).  DEPRECATED in v1.9.3 |
 | `cliptimeout`    | `int`    | How many seconds the secret is stored when using `-c`. |
 | `exportkeys`     | `bool`   | Export public keys of all recipients to the store. |

--- a/docs/features.md
+++ b/docs/features.md
@@ -267,13 +267,23 @@ $ gopass sync
 Certain long running operations, like `gopass sync` or `copy to clipboard` will
 try to show desktop notifications [Linux only].
 
-### git auto-push and auto-pull
+### git auto-push and sync
 
-If you want gopass to always push changes in git to your default remote server (origin), enable auto sync:
+gopass always pushes changes to your default git remote server (origin).
+
+If you want to pull changes from git, you need to run the sync command:
 
 ```bash
-$ gopass config autosync true
+$ gopass sync 
 ```
+
+You can selectively pull changes into named stores:
+
+```bash
+$ gopass sync --store foo 
+```
+
+For details see: [`sync` command](commands/sync.md)
 
 ### Check Passwords for Common Flaws
 
@@ -350,7 +360,6 @@ Commands that support the `--store` flag:
 | `gopass init`              | `gopass init --store=foo`                     | Initialize and mount the new sub store *foo* |
 | `gopass recipients add`    | `gopass recipients add --store=foo GPGxID`    | Add the new recipient *GPGxID* to the store *foo* |
 | `gopass recipients remove` | `gopass recipients remove --store=foo GPGxID` | Remove the existing recipients *GPGxID* from the store *foo* |
-| `gopass config`            | `gopass config --store=foo autosync false`    | Set the config flag `autosync` to `false` for the store *foo* |
 
 ### Directly edit structured secrets aka. YAML support
 
@@ -386,7 +395,6 @@ $ gopass config
 askformore: false
 autoclip: true
 autoimport: false
-autosync: true
 cliptimeout: 10
 noconfirm: false
 path: /home/user/.password-store

--- a/internal/config/io_test.go
+++ b/internal/config/io_test.go
@@ -86,7 +86,6 @@ mounts:
 			cfg: `root:
   autoclip: true
   autoimport: false
-  autosync: false
   check_recipient_hash: false
   cliptimeout: 45
   concurrency: 50
@@ -102,7 +101,6 @@ mounts:
   foo/sub:
     autoclip: true
     autoimport: false
-    autosync: false
     check_recipient_hash: false
     cliptimeout: 45
     concurrency: 50
@@ -117,7 +115,6 @@ mounts:
   work:
     autoclip: true
     autoimport: false
-    autosync: false
     check_recipient_hash: false
     cliptimeout: 45
     concurrency: 50
@@ -151,7 +148,6 @@ mounts:
 			cfg: `root:
   askformore: false
   autoimport: false
-  autosync: false
   cliptimeout: 45
   noconfirm: false
   nopager: false
@@ -161,7 +157,6 @@ mounts:
   foo/sub:
     askformore: false
     autoimport: false
-    autosync: false
     cliptimeout: 45
     noconfirm: false
     nopager: false
@@ -170,7 +165,6 @@ mounts:
   work:
     askformore: false
     autoimport: false
-    autosync: false
     cliptimeout: 45
     noconfirm: false
     nopager: false
@@ -197,7 +191,6 @@ version: 1.4.0`,
 			name: "1.3.0",
 			cfg: `askformore: false
 autoimport: true
-autosync: false
 cliptimeout: 45
 mounts:
   dev: /Users/johndoe/.password-store-dev
@@ -352,7 +345,6 @@ version: "1.0.0"`,
 const testConfig = `root:
   askformore: true
   autoimport: true
-  autosync: true
   cliptimeout: 5
   noconfirm: true
   nopager: true
@@ -362,7 +354,6 @@ mounts:
   foo/sub:
     askformore: false
     autoimport: false
-    autosync: false
     cliptimeout: 45
     noconfirm: false
     nopager: false
@@ -371,7 +362,6 @@ mounts:
   work:
     askformore: false
     autoimport: false
-    autosync: false
     cliptimeout: 45
     noconfirm: false
     nopager: false

--- a/internal/config/io_test.go
+++ b/internal/config/io_test.go
@@ -86,6 +86,7 @@ mounts:
 			cfg: `root:
   autoclip: true
   autoimport: false
+  autosync: false
   check_recipient_hash: false
   cliptimeout: 45
   concurrency: 50
@@ -101,6 +102,7 @@ mounts:
   foo/sub:
     autoclip: true
     autoimport: false
+    autosync: false
     check_recipient_hash: false
     cliptimeout: 45
     concurrency: 50
@@ -115,6 +117,7 @@ mounts:
   work:
     autoclip: true
     autoimport: false
+    autosync: false
     check_recipient_hash: false
     cliptimeout: 45
     concurrency: 50
@@ -148,6 +151,7 @@ mounts:
 			cfg: `root:
   askformore: false
   autoimport: false
+  autosync: false
   cliptimeout: 45
   noconfirm: false
   nopager: false
@@ -157,6 +161,7 @@ mounts:
   foo/sub:
     askformore: false
     autoimport: false
+    autosync: false
     cliptimeout: 45
     noconfirm: false
     nopager: false
@@ -165,6 +170,7 @@ mounts:
   work:
     askformore: false
     autoimport: false
+    autosync: false
     cliptimeout: 45
     noconfirm: false
     nopager: false
@@ -191,6 +197,7 @@ version: 1.4.0`,
 			name: "1.3.0",
 			cfg: `askformore: false
 autoimport: true
+autosync: false
 cliptimeout: 45
 mounts:
   dev: /Users/johndoe/.password-store-dev
@@ -345,6 +352,7 @@ version: "1.0.0"`,
 const testConfig = `root:
   askformore: true
   autoimport: true
+  autosync: true
   cliptimeout: 5
   noconfirm: true
   nopager: true
@@ -354,6 +362,7 @@ mounts:
   foo/sub:
     askformore: false
     autoimport: false
+    autosync: false
     cliptimeout: 45
     noconfirm: false
     nopager: false
@@ -362,6 +371,7 @@ mounts:
   work:
     askformore: false
     autoimport: false
+    autosync: false
     cliptimeout: 45
     noconfirm: false
     nopager: false


### PR DESCRIPTION
Since `autosync` has been deprecated, this commit removes any documentation and test code that references this no longer used configuration option.

Note: There are failing tests, but they are the same tests that fail before this commit.

Fixes #1877 

RELEASE_NOTES=[CLEANUP] Remove references to autosync option