### PR TITLE
Add --symbols flag to gopass pwgen

### DIFF
--- a/internal/action/pwgen/commands.go
+++ b/internal/action/pwgen/commands.go
@@ -29,6 +29,11 @@ func GetCommands() []*cli.Command {
 					Usage:   "Do not include characters that could be easily confused with each other, like '1' and 'l' or '0' and 'O'",
 				},
 				&cli.BoolFlag{
+					Name:    "symbols",
+					Aliases: []string{"y"},
+					Usage:   "Include at least one symbol in the password.",
+				},
+				&cli.BoolFlag{
 					Name:    "one-per-line",
 					Aliases: []string{"1"},
 					Usage:   "Print one password per line",

--- a/internal/action/pwgen/pwgen.go
+++ b/internal/action/pwgen/pwgen.go
@@ -70,6 +70,9 @@ func pwGen(c *cli.Context, pwLen, pwNum int) error {
 	if c.Bool("ambiguous") {
 		charset = pwgen.Prune(charset, pwgen.Ambiq)
 	}
+	if c.Bool("symbols") {
+		charset += pwgen.Syms
+	}
 	for i := 0; i < pwNum; i++ {
 		for j := 0; j < perLine; j++ {
 			fmt.Print(pwgen.GeneratePasswordCharset(pwLen, charset))


### PR DESCRIPTION
RELEASE_NOTES=[ENHANCEMENT] Add --symbols to gopass pwgen

Fixes #1965

Signed-off-by: Dominik Schulz <dominik.schulz@gauner.org>