### PR TITLE
Using sane default for partial config

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -61,7 +61,7 @@ gopass init
 ```
 
 This will prompt you for which GPG key you want to associate the store with.
-Then it will create a `.password-store` directory in your home directory.
+Then it will create a `.local/share/gopass/stores/root` directory in your home directory.
 
 If you don't want gopass to use this default directory, you can instead initialize a password store with:
 
@@ -85,15 +85,19 @@ If you already have an existing password store that exists in a Git repository, 
 gopass clone git@example.com/pass.git
 ```
 
-This runs `git clone` in the background. If you don't want gopass to use the default directory of "$HOME/.password-store", then you can specify an additional parameter:
+This runs `git clone` in the background. If you don't want gopass to use the default root mount of "$HOME/.local/share/gopass/stores/root", then you can specify an additional mount parameter:
 
 ```bash
-gopass clone git@example.com/pass-work.git work # This will initialize the password store in the "$HOME/.password-store-work" directory
+gopass clone git@example.com/pass-work.git work # This will initialize the password store in the "$HOME/.local/share/gopass/stores/work" directory
 ```
 
 Please note that all cloned repositories must already have been initialized with gopass. (See the previous section for more details.)
 
 Note too that unless you are already a recipient of the cloned repository, you must add the destination's public GPG key as a recipient to the existing store.
+
+Finally notice that if you really want your password-store directory at a specific location, you should `git clone` it manually at that location, and either set Gopass' `PASSWORD_STORE_DIR` env var to that location, or set Gopass' config `path` option to that location. 
+
+An existing `$HOME/.password-store` directory should also be automatically picked-up by Gopass upon first run.
 
 ### Adding Secrets
 

--- a/internal/config/io.go
+++ b/internal/config/io.go
@@ -104,8 +104,12 @@ type configer interface {
 
 func decode(buf []byte, relaxed bool) (*Config, error) {
 	mostRecent := &Config{
-		ExportKeys: true,
-		Parsing:    true,
+		AutoImport:    true,
+		ClipTimeout:   45,
+		ExportKeys:    true,
+		Notifications: true,
+		Parsing:       true,
+		Path:          PwStoreDir(""),
 	}
 	cfgs := []configer{
 		// most recent config must come first

--- a/tests/config_test.go
+++ b/tests/config_test.go
@@ -21,7 +21,7 @@ cliptimeout: 45
 exportkeys: false
 nocolor: false
 nopager: false
-notifications: false
+notifications: true
 parsing: true
 `
 	wanted += "path: " + ts.storeDir("root") + "\n"
@@ -75,7 +75,7 @@ cliptimeout: 45
 exportkeys: false
 nocolor: false
 nopager: false
-notifications: false
+notifications: true
 parsing: true
 path: `
 	wanted += ts.storeDir("root") + "\n"

--- a/tests/tester.go
+++ b/tests/tester.go
@@ -18,11 +18,8 @@ import (
 )
 
 const (
-	gopassConfig = `autoclip: false
-autoimport: true
-cliptimeout: 45
+	gopassConfig = `
 exportkeys: false
-parsing: true
 `
 	keyID = "BE73F104"
 )


### PR DESCRIPTION
RELEASE_NOTES=[BUGFIX] Use same default for partial config files

This is also upgrading the documentation regarding setup as we didn't reflect the move to the .local dir in there yet.

I've also removed most special cases for config in the tests, since now our defaults are as they should be.
I let the `exportkey` one set to false since I figured we didn't want to export keys during testing unless testing explicitly that.

This fixes #1654 and fixes #1967
Notice this doesn't remove the need for #1819.