### PR TITLE
Add gopass merge

### DIFF
--- a/fish.completion
+++ b/fish.completion
@@ -208,6 +208,7 @@ complete -c $PROG -f -n '__fish_gopass_uses_command insert' -a "(__fish_gopass_p
 complete -c $PROG -f -n '__fish_gopass_needs_command' -a link -d 'Command: Create a symlink'
 complete -c $PROG -f -n '__fish_gopass_needs_command' -a list -d 'Command: List existing secrets'
 complete -c $PROG -f -n '__fish_gopass_uses_command list' -a "(__fish_gopass_print_dir)"
+complete -c $PROG -f -n '__fish_gopass_needs_command' -a merge -d 'Command: Merge multiple secrets into one'
 complete -c $PROG -f -n '__fish_gopass_needs_command' -a mounts -d 'Command: Edit mounted stores'
 complete -c $PROG -f -n '__fish_gopass_uses_command mounts' -a add -d 'Subcommand: Mount a password store'
 complete -c $PROG -f -n '__fish_gopass_uses_command mounts add -l yes -d "Always answer yes to yes/no questions"'

--- a/internal/action/commands.go
+++ b/internal/action/commands.go
@@ -678,7 +678,11 @@ func (s *Action) GetCommands() []*cli.Command {
 			Usage:     "Merge multiple secrets into one",
 			ArgsUsage: "[to] [from]...",
 			Description: "" +
-				"TODO",
+				"This command implements a merge workflow to help deduplicate " +
+				"secrets. It requires exactly one destination (may already exist) " +
+				"and at least one source (must exist, can be multiple). gopass will " +
+				"then merge all entries into one, drop into an editor, save the result " +
+				"and remove all merged entries.",
 			Before:       s.IsInitialized,
 			Action:       s.Merge,
 			BashComplete: s.Complete,

--- a/internal/action/commands.go
+++ b/internal/action/commands.go
@@ -693,6 +693,11 @@ func (s *Action) GetCommands() []*cli.Command {
 					Usage:   "Remove merged entries",
 					Value:   true,
 				},
+				&cli.BoolFlag{
+					Name:    "force",
+					Aliases: []string{"f"},
+					Usage:   "Skip editor, merge entries unattended",
+				},
 			},
 		},
 		{

--- a/internal/action/commands.go
+++ b/internal/action/commands.go
@@ -674,6 +674,24 @@ func (s *Action) GetCommands() []*cli.Command {
 			},
 		},
 		{
+			Name:      "merge",
+			Usage:     "Merge multiple secrets into one",
+			ArgsUsage: "[to] [from]...",
+			Description: "" +
+				"TODO",
+			Before:       s.IsInitialized,
+			Action:       s.Merge,
+			BashComplete: s.Complete,
+			Flags: []cli.Flag{
+				&cli.BoolFlag{
+					Name:    "delete",
+					Aliases: []string{"d"},
+					Usage:   "Remove merged entries",
+					Value:   true,
+				},
+			},
+		},
+		{
 			Name:      "move",
 			Aliases:   []string{"mv"},
 			Usage:     "Move secrets from one location to another",

--- a/internal/action/merge.go
+++ b/internal/action/merge.go
@@ -1,0 +1,83 @@
+package action
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/gopasspw/gopass/internal/audit"
+	"github.com/gopasspw/gopass/internal/editor"
+	"github.com/gopasspw/gopass/internal/out"
+	"github.com/gopasspw/gopass/pkg/ctxutil"
+	"github.com/gopasspw/gopass/pkg/gopass/secrets"
+	"github.com/urfave/cli/v2"
+)
+
+func (s *Action) Merge(c *cli.Context) error {
+	ctx := ctxutil.WithGlobalFlags(c)
+	to := c.Args().First()
+	from := c.Args().Tail()
+
+	if to == "" {
+		return ExitError(ExitUsage, nil, "usage: %s merge <to> <from> [<from>]", s.Name)
+	}
+	if len(from) < 1 {
+		return ExitError(ExitUsage, nil, "usage: %s merge <to> <from> [<from>]", s.Name)
+	}
+
+	ed := editor.Path(c)
+	if err := editor.Check(ctx, ed); err != nil {
+		out.Warningf(ctx, "Failed to check editor config: %s", err)
+	}
+
+	content := &bytes.Buffer{}
+	for _, k := range c.Args().Slice() {
+		if !s.Store.Exists(ctx, k) {
+			continue
+		}
+		sec, err := s.Store.Get(ctxutil.WithShowParsing(ctx, false), k)
+		if err != nil {
+			return ExitError(ExitDecrypt, err, "failed to decrypt: %s: %w", k, err)
+		}
+		_, err = content.WriteString("\n# Secret: " + k + "\n")
+		if err != nil {
+			return ExitError(ExitUnknown, err, "failed to write: %w", err)
+		}
+		_, err = content.Write(sec.Bytes())
+		if err != nil {
+			return ExitError(ExitUnknown, err, "failed to write: %w", err)
+		}
+	}
+
+	// invoke the editor to let the user edit the content
+	newContent, err := editor.Invoke(ctx, ed, content.Bytes())
+	if err != nil {
+		return ExitError(ExitUnknown, err, "failed to invoke editor: %s", err)
+	}
+	// If content is equal, nothing changed, exiting
+	if bytes.Equal(content.Bytes(), newContent) {
+		return nil
+	}
+
+	nSec := secrets.ParsePlain(newContent)
+
+	// if the secret has a password, we check it's strength
+	if pw := nSec.Password(); pw != "" {
+		audit.Single(ctx, pw)
+	}
+
+	// write result (back) to store
+	if err := s.Store.Set(ctxutil.WithCommitMessage(ctx, fmt.Sprintf("Merged %+v", c.Args().Slice())), to, nSec); err != nil {
+		return ExitError(ExitEncrypt, err, "failed to encrypt secret %s: %s", to, err)
+	}
+
+	if !c.Bool("delete") {
+		return nil
+	}
+
+	for _, old := range from {
+		if err := s.Store.Delete(ctx, old); err != nil {
+			return ExitError(ExitUnknown, err, "failed to delete %s: %w", old, err)
+		}
+	}
+	return nil
+}

--- a/main_test.go
+++ b/main_test.go
@@ -76,6 +76,7 @@ var commandsWithError = map[string]struct{}{
 	".init":              {},
 	".insert":            {},
 	".link":              {},
+	".merge":             {},
 	".mounts.add":        {},
 	".mounts.remove":     {},
 	".move":              {},

--- a/main_test.go
+++ b/main_test.go
@@ -122,7 +122,7 @@ func TestGetCommands(t *testing.T) {
 	c.Context = ctx
 
 	commands := getCommands(act, app)
-	assert.Equal(t, 37, len(commands))
+	assert.Equal(t, 38, len(commands))
 
 	prefix := ""
 	testCommands(t, c, commands, prefix)

--- a/zsh.completion
+++ b/zsh.completion
@@ -174,6 +174,12 @@ WARNING: This will update the secret content to the latest format. This might be
 	      _gopass_complete_folders
 	      
 	      ;;
+	  merge)
+	      _arguments : "--delete[Remove merged entries]" "--force[Skip editor, merge entries unattended]"
+	      _describe -t commands "gopass merge" subcommands
+	      
+	      
+	      ;;
 	  mounts)
 	      local -a subcommands
 	      subcommands=(
@@ -198,7 +204,7 @@ WARNING: This will update the secret content to the latest format. This might be
 	      
 	      ;;
 	  pwgen)
-	      _arguments : "--no-numerals[Do not include numerals in the generated passwords.]" "--no-capitalize[Do not include capital letter in the generated passwords.]" "--ambiguous[Do not include characters that could be easily confused with each other, like '1' and 'l' or '0' and 'O']" "--one-per-line[Print one password per line]" "--xkcd[Use multiple random english words combined to a password. By default, space is used as separator and all words are lowercase]" "--sep[Word separator for generated xkcd style password. If no separator is specified, the words are combined without spaces/separator and the first character of words is capitalised. This flag implies -xkcd]" "--lang[Language to generate password from, currently de (german) and en (english, default) are supported]"
+	      _arguments : "--no-numerals[Do not include numerals in the generated passwords.]" "--no-capitalize[Do not include capital letter in the generated passwords.]" "--ambiguous[Do not include characters that could be easily confused with each other, like '1' and 'l' or '0' and 'O']" "--symbols[Include at least one symbol in the password.]" "--one-per-line[Print one password per line]" "--xkcd[Use multiple random english words combined to a password. By default, space is used as separator and all words are lowercase]" "--sep[Word separator for generated xkcd style password. If no separator is specified, the words are combined without spaces/separator and the first character of words is capitalised. This flag implies -xkcd]" "--lang[Language to generate password from, currently de (german) and en (english, default) are supported]"
 	      _describe -t commands "gopass pwgen" subcommands
 	      
 	      
@@ -305,6 +311,7 @@ WARNING: This will update the secret content to the latest format. This might be
 	  "insert:Insert a new secret"
 	  "link:Create a symlink"
 	  "list:List existing secrets"
+	  "merge:Merge multiple secrets into one"
 	  "mounts:Edit mounted stores"
 	  "move:Move secrets from one location to another"
 	  "otp:Generate time- or hmac-based tokens"


### PR DESCRIPTION
Add a subcommand to implement a merge workflow.
This command accepts multiple entries to be merged
into one to help deduplicating secrets.

Fixes #1948

RELEASE_NOTES=[ENHACNEMENT] Add gopass merge

Signed-off-by: Dominik Schulz <dominik.schulz@gauner.org>