### PR TITLE
Don't prompt to retype password unnecessarily with age backend

### DIFF
--- a/internal/action/create.go
+++ b/internal/action/create.go
@@ -108,7 +108,7 @@ func (s *Action) createWebsite(ctx context.Context, c *cli.Context) error {
 			return err
 		}
 	} else {
-		password, err = termio.AskForPassword(ctx, username)
+		password, err = termio.AskForPassword(ctx, fmt.Sprintf("password for %s", username), true)
 		if err != nil {
 			return err
 		}
@@ -217,7 +217,7 @@ func (s *Action) createPIN(ctx context.Context, c *cli.Context) error {
 			return err
 		}
 	} else {
-		password, err = termio.AskForPassword(ctx, "PIN")
+		password, err = termio.AskForPassword(ctx, "PIN", true)
 		if err != nil {
 			return err
 		}
@@ -296,7 +296,7 @@ func (s *Action) createGeneric(ctx context.Context, c *cli.Context) error {
 			return err
 		}
 	} else {
-		password, err = termio.AskForPassword(ctx, shortname)
+		password, err = termio.AskForPassword(ctx, fmt.Sprintf("password for %s", shortname), true)
 		if err != nil {
 			return err
 		}

--- a/internal/action/insert.go
+++ b/internal/action/insert.go
@@ -80,7 +80,7 @@ func (s *Action) insert(ctx context.Context, c *cli.Context, name, key string, e
 		})
 	}
 
-	pw, err := termio.AskForPassword(ctx, name)
+	pw, err := termio.AskForPassword(ctx, fmt.Sprintf("password for %s", name), true)
 	if err != nil {
 		return ExitError(ExitIO, err, "failed to ask for password: %s", err)
 	}

--- a/internal/action/setup.go
+++ b/internal/action/setup.go
@@ -103,7 +103,7 @@ func (s *Action) initGenerateIdentity(ctx context.Context, crypto backend.Crypto
 	}
 	if want {
 		pwGenerated = false
-		sv, err := termio.AskForPassword(ctx, "your new keypair")
+		sv, err := termio.AskForPassword(ctx, "passphrase for your new keypair", true)
 		if err != nil {
 			return fmt.Errorf("failed to read passphrase: %w", err)
 		}

--- a/pkg/pinentry/cli/fallback.go
+++ b/pkg/pinentry/cli/fallback.go
@@ -7,11 +7,13 @@ import (
 )
 
 // Client is pinentry CLI drop-in
-type Client struct{}
+type Client struct {
+	repeat bool
+}
 
 // New creates a new client
 func New() (*Client, error) {
-	return &Client{}, nil
+	return &Client{repeat: false}, nil
 }
 
 // Close is a no-op
@@ -22,8 +24,11 @@ func (c *Client) Confirm() bool {
 	return true
 }
 
-// Set is a no-op
-func (c *Client) Set(string, string) error {
+// Set is a no-op unless you're requesting a repeat
+func (c *Client) Set(key string, _ string) error {
+	if key == "REPEAT" {
+		c.repeat = true
+	}
 	return nil
 }
 
@@ -34,7 +39,7 @@ func (c *Client) Option(string) error {
 
 // GetPin prompts for the pin in the termnial and returns the output
 func (c *Client) GetPin() ([]byte, error) {
-	pw, err := termio.AskForPassword(context.TODO(), "Please enter your PIN")
+	pw, err := termio.AskForPassword(context.TODO(), "your PIN", c.repeat)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/termio/ask.go
+++ b/pkg/termio/ask.go
@@ -145,8 +145,8 @@ func AskForKeyImport(ctx context.Context, key string, names []string) bool {
 	return ok
 }
 
-// AskForPassword prompts for a password twice until both match
-func AskForPassword(ctx context.Context, name string) (string, error) {
+// AskForPassword prompts for a password, optionally prompting twice until both match
+func AskForPassword(ctx context.Context, name string, repeat bool) (string, error) {
 	if ctxutil.IsAlwaysYes(ctx) {
 		return "", nil
 	}
@@ -160,12 +160,15 @@ func AskForPassword(ctx context.Context, name string) (string, error) {
 		default:
 		}
 
-		pass, err := askFn(ctx, fmt.Sprintf("Enter password for %s", name))
+		pass, err := askFn(ctx, fmt.Sprintf("Enter %s", name))
+		if !repeat {
+			return pass, err
+		}
 		if err != nil {
 			return "", err
 		}
 
-		passAgain, err := askFn(ctx, fmt.Sprintf("Retype password for %s", name))
+		passAgain, err := askFn(ctx, fmt.Sprintf("Retype %s", name))
 		if err != nil {
 			return "", err
 		}

--- a/pkg/termio/ask_test.go
+++ b/pkg/termio/ask_test.go
@@ -214,7 +214,7 @@ func TestAskForPasswordNonInteractive(t *testing.T) {
 	ctx := context.Background()
 	ctx = ctxutil.WithInteractive(ctx, false)
 
-	_, err := AskForPassword(ctx, "test")
+	_, err := AskForPassword(ctx, "test", true)
 	assert.Error(t, err)
 
 	// provide value on redirected stdin
@@ -222,17 +222,22 @@ func TestAskForPasswordNonInteractive(t *testing.T) {
 foo
 foobar
 foobaz
+foobat
 `
 
 	Stdin = strings.NewReader(input)
 	ctx = ctxutil.WithAlwaysYes(ctx, false)
 	ctx = ctxutil.WithInteractive(ctx, true)
 	ctx = ctxutil.WithTerminal(ctx, false)
-	sv, err := AskForPassword(ctx, "test")
+	sv, err := AskForPassword(ctx, "test", true)
 	assert.NoError(t, err)
 	assert.Equal(t, "foo", sv)
 
-	sv, err = AskForPassword(ctx, "test")
+	sv, err = AskForPassword(ctx, "test", false)
+	assert.NoError(t, err)
+	assert.Equal(t, "foobar", sv)
+
+	sv, err = AskForPassword(ctx, "test", true)
 	assert.NoError(t, err)
 	assert.Equal(t, "", sv)
 }
@@ -253,7 +258,7 @@ func TestAskForPasswordInteractive(t *testing.T) {
 	ctx = ctxutil.WithInteractive(ctx, true)
 	ctx = WithPassPromptFunc(ctx, askFn)
 
-	pw, err := AskForPassword(ctx, "test")
+	pw, err := AskForPassword(ctx, "test", true)
 	assert.NoError(t, err)
 	assert.Equal(t, "test", pw)
 }


### PR DESCRIPTION
When gopass can't find a pinentry binary to use for prompting for a password to unlock an age keyring, it uses its own barebones fallback pinentry mechanism to prompt for a password in the terminal.  This fallback pinentry always asked the user to retype their password and required the passwords to match, even when decrypting a file using an already-existing password.  I've updated it to only prompt for a repeat when necessary, and also made the password prompt messages less awkward.

RELEASE_NOTES=[BUGFIX] Don't prompt to retype password unnecessarily with age backend when pinentry binary is unavailable.

Signed-off-by: Faye Duxovni <duxovni@duxovni.org>