### PR TITLE
Add capitalized words to memorable passwords

### DIFF
--- a/internal/action/generate.go
+++ b/internal/action/generate.go
@@ -219,7 +219,10 @@ func (s *Action) generatePassword(ctx context.Context, c *cli.Context, length, n
 	case "xkcd":
 		return s.generatePasswordXKCD(ctx, c, length)
 	case "memorable":
-		return pwgen.GenerateMemorablePassword(pwlen, symbols), nil
+		if c.Bool("strict") {
+			return pwgen.GenerateMemorablePassword(pwlen, symbols, true), nil
+		}
+		return pwgen.GenerateMemorablePassword(pwlen, symbols, false), nil
 	case "external":
 		return pwgen.GenerateExternal(pwlen)
 	default:

--- a/pkg/pwgen/memorable.go
+++ b/pkg/pwgen/memorable.go
@@ -4,15 +4,33 @@ import "strings"
 
 // GenerateMemorablePassword will generate a memorable password
 // with a minimum length
-func GenerateMemorablePassword(minLength int, symbols bool) string {
+func GenerateMemorablePassword(minLength int, symbols bool, capitals bool) string {
 	var sb strings.Builder
+	var upper = false
 	for sb.Len() < minLength {
-		sb.WriteString(randomWord())
+		if capitals {
+			if randomInteger(2) == 0 {
+				sb.WriteString(strings.Title(randomWord()))
+				upper = true
+			} else {
+				sb.WriteString(randomWord())
+			}
+		} else {
+			sb.WriteString(randomWord())
+		}
 		sb.WriteByte(Digits[randomInteger(len(Digits))])
 		if !symbols {
 			continue
 		}
 		sb.WriteByte(Syms[randomInteger(len(Syms))])
+	}
+	// If there isn't already a capitalized word, capitalize the first letter
+	if capitals {
+		if upper {
+			return sb.String()
+		}
+		var str = sb.String()
+		return strings.Title(string(str[0])) + str[1:]
 	}
 	return sb.String()
 }

--- a/pkg/pwgen/memorable.go
+++ b/pkg/pwgen/memorable.go
@@ -22,10 +22,7 @@ func GenerateMemorablePassword(minLength int, symbols bool, capitals bool) strin
 		sb.WriteByte(Syms[randomInteger(len(Syms))])
 	}
 	// If there isn't already a capitalized word, capitalize the first letter
-	if capitals {
-		if upper {
-			return sb.String()
-		}
+	if capitals && !upper {
 		var str = sb.String()
 		return strings.Title(string(str[0])) + str[1:]
 	}

--- a/pkg/pwgen/memorable.go
+++ b/pkg/pwgen/memorable.go
@@ -8,13 +8,10 @@ func GenerateMemorablePassword(minLength int, symbols bool, capitals bool) strin
 	var sb strings.Builder
 	var upper = false
 	for sb.Len() < minLength {
-		if capitals {
-			if randomInteger(2) == 0 {
-				sb.WriteString(strings.Title(randomWord()))
-				upper = true
-			} else {
-				sb.WriteString(randomWord())
-			}
+		// when requesting uppercase, we randomly uppercase words
+		if capitals && randomInteger(2) == 0 {
+			sb.WriteString(strings.Title(randomWord()))
+			upper = true
 		} else {
 			sb.WriteString(randomWord())
 		}

--- a/pkg/pwgen/pwgen_test.go
+++ b/pkg/pwgen/pwgen_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func ExampleGenerateMemorablePassword() {
-	fmt.Println(GenerateMemorablePassword(12, false))
+	fmt.Println(GenerateMemorablePassword(12, false, false))
 }
 
 func TestPwgen(t *testing.T) {
@@ -93,7 +93,12 @@ func TestGeneratePasswordWithAllClasses(t *testing.T) {
 }
 
 func TestGenerateMemorablePassword(t *testing.T) {
-	pw := GenerateMemorablePassword(20, false)
+	pw := GenerateMemorablePassword(20, false, false)
+	assert.GreaterOrEqual(t, len(pw), 20)
+}
+
+func TestGenerateMemorablePasswordCapital(t *testing.T) {
+	pw := GenerateMemorablePassword(20, false, true)
 	assert.GreaterOrEqual(t, len(pw), 20)
 }
 

--- a/pkg/pwgen/pwgen_test.go
+++ b/pkg/pwgen/pwgen_test.go
@@ -95,11 +95,13 @@ func TestGeneratePasswordWithAllClasses(t *testing.T) {
 func TestGenerateMemorablePassword(t *testing.T) {
 	pw := GenerateMemorablePassword(20, false, false)
 	assert.GreaterOrEqual(t, len(pw), 20)
+	assert.Equal(t, pw, strings.ToLower(pw))
 }
 
 func TestGenerateMemorablePasswordCapital(t *testing.T) {
 	pw := GenerateMemorablePassword(20, false, true)
 	assert.GreaterOrEqual(t, len(pw), 20)
+	assert.NotEqual(t, pw, strings.ToLower(pw))
 }
 
 func TestPrune(t *testing.T) {


### PR DESCRIPTION
Memorable passwords generated with --strict will now have at least one
capitalized word.

Closes #1984

RELEASE_NOTES=[FEATURE] Add capitalized words to memorable passwords

Signed-off-by: Elijah J. Passmore <elijah@elijahjpassmore.com>