### PR TITLE
Fixing legacy config parsing of field `parsing`

### DIFF
--- a/internal/config/legacy.go
+++ b/internal/config/legacy.go
@@ -34,7 +34,7 @@ func (c *Pre1127) Config() *Config {
 		ExportKeys:    c.ExportKeys,
 		NoPager:       c.NoPager,
 		Notifications: c.Notifications,
-		Parsing:       true,
+		Parsing:       c.Parsing,
 		Path:          c.Path,
 		SafeContent:   c.SafeContent,
 		Mounts:        make(map[string]string, len(c.Mounts)),


### PR DESCRIPTION
The field 'parsing' is now honoured with legacy config pre v1.12.7

Fixes #1991 
