### PR TITLE
Better progress bar handling for OTP

### DIFF
--- a/internal/out/print.go
+++ b/internal/out/print.go
@@ -27,6 +27,12 @@ func (s Secret) SafeStr() string {
 	return "(elided)"
 }
 
+// OutputIsRedirected returns true if the current os.Stdout is a pipe instead of a terminal
+func OutputIsRedirected() bool {
+	o, _ := os.Stdout.Stat()
+	return (o.Mode() & os.ModeCharDevice) != os.ModeCharDevice
+}
+
 func newline(ctx context.Context) string {
 	if HasNewline(ctx) {
 		return "\n"


### PR DESCRIPTION
RELEASE_NOTES=[BUGFIX] Do not print OTP progress bar if not in terminal
RELEASE_NOTES=[UX] Use new progress bar for OTP expiry time

This is making the expiry time for OTP visually go from 0 to expiry time in terminal, but prevents printing the progress bar when not in a terminal.

![image](https://user-images.githubusercontent.com/10077203/139052258-248a1e8e-f1e1-4270-aa9b-7a9f9cdf0ee2.png)


I also replaced the special handling of the remaining time until expiry to use `Truncate` instead.

Sadly, I'm yet again adding some "special handling" to detect whether we are in a terminal or not. We might want to heavily refactor all such things.

This fixes #2017.