### PR TITLE
[Go 1.18] Use strings.Cut instead of strings.Split where feasible

### DIFF
--- a/helpers/release/main.go
+++ b/helpers/release/main.go
@@ -404,11 +404,10 @@ func changelogEntries(since semver.Version) ([]string, error) {
 			if !strings.HasPrefix(line, "RELEASE_NOTES=") {
 				continue
 			}
-			p := strings.Split(line, "=")
-			if len(p) < 2 {
+			_, val, found := strings.Cut(line, "=")
+			if !found {
 				continue
 			}
-			val := p[1]
 			if strings.ToLower(val) == "n/a" {
 				continue
 			}

--- a/internal/backend/crypto/gpg/cli/utils.go
+++ b/internal/backend/crypto/gpg/cli/utils.go
@@ -42,7 +42,7 @@ func gpgConfig() (map[string]string, error) {
 }
 
 func parseGpgConfig(fh io.Reader) (map[string]string, error) {
-	val := make(map[string]string, 20)
+	vals := make(map[string]string, 20)
 	scanner := bufio.NewScanner(fh)
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
@@ -50,18 +50,14 @@ func parseGpgConfig(fh io.Reader) (map[string]string, error) {
 		if strings.HasPrefix(line, "#") {
 			continue
 		}
-		p := strings.SplitN(line, " ", 2)
-		if len(p) < 1 {
+		key, val, found := strings.Cut(line, " ")
+		if !found {
 			continue
 		}
-		val[p[0]] = ""
-		if len(p) < 2 {
-			continue
-		}
-		val[p[0]] = strings.TrimSpace(p[1])
+		vals[key] = strings.TrimSpace(val)
 	}
 
-	return val, nil
+	return vals, nil
 }
 
 // GPGOpts parses extra GPG options from the environment

--- a/internal/backend/storage/gitfs/config.go
+++ b/internal/backend/storage/gitfs/config.go
@@ -133,12 +133,11 @@ func (g *Git) ConfigList(ctx context.Context) (map[string]string, error) {
 	lines := strings.Split(buf.String(), "\n")
 	kv := make(map[string]string, len(lines))
 	for _, line := range lines {
-		line = strings.TrimSpace(line)
-		p := strings.SplitN(line, "=", 2)
-		if len(p) < 2 {
+		key, val, found := strings.Cut(strings.TrimSpace(line), "=")
+		if !found {
 			continue
 		}
-		kv[p[0]] = p[1]
+		kv[key] = val
 	}
 	return kv, nil
 }

--- a/pkg/gopass/secrets/kv.go
+++ b/pkg/gopass/secrets/kv.go
@@ -201,23 +201,15 @@ func ParseKV(in []byte) (*KV, error) {
 		}
 		line = strings.TrimRight(line, "\n")
 
-		parts := strings.SplitN(line, ":", 2)
-		// should not happen
-		if len(parts) < 1 {
+		key, val, found := strings.Cut(line, ":")
+		if !found {
 			continue
 		}
-		for i, part := range parts {
-			parts[i] = strings.TrimSpace(part)
-		}
+		key = strings.TrimSpace(key)
+		val = strings.TrimSpace(val)
 		// we only store lower case keys for KV
-		parts[0] = strings.ToLower(parts[0])
-		// preserve key only entries
-		if len(parts) < 2 {
-			k.data[parts[0]] = append(k.data[parts[0]], "")
-			continue
-		}
-
-		k.data[parts[0]] = append(k.data[parts[0]], parts[1])
+		key = strings.ToLower(key)
+		k.data[key] = append(k.data[key], val)
 	}
 	if len(k.data) < 1 {
 		debug.Log("no KV entries")


### PR DESCRIPTION
Fixes #2029

RELEASE_NOTES=n/a

Signed-off-by: Dominik Schulz <dominik.schulz@gauner.org>