### PR TITLE
Fix autoclip-on-generate behavior.

### DIFF
--- a/internal/action/generate.go
+++ b/internal/action/generate.go
@@ -120,7 +120,7 @@ func (s *Action) generateCopyOrPrint(ctx context.Context, c *cli.Context, name, 
 	// copy to clipboard if:
 	// - explicitly requested with -c
 	// - autoclip=true, but only if output is not being redirected
-	if IsClip(ctx) || (s.cfg.AutoClip && !ctxutil.IsTerminal(ctx)) {
+	if IsClip(ctx) || (s.cfg.AutoClip && ctxutil.IsTerminal(ctx)) {
 		if err := clipboard.CopyTo(ctx, name, []byte(password), s.cfg.ClipTimeout); err != nil {
 			return ExitError(ExitIO, err, "failed to copy to clipboard: %s", err)
 		}

--- a/internal/action/generate_test.go
+++ b/internal/action/generate_test.go
@@ -150,6 +150,38 @@ func TestGenerate(t *testing.T) {
 		assert.NoError(t, act.Generate(gptest.CliCtxWithFlags(ctx, t, map[string]string{"force": "true", "xkcd": "true", "print": "true", "lang": "en"}, "foobar", "baz")))
 		buf.Reset()
 	})
+
+	// regression test for #2023
+	t.Run("generate --force foobar (in a terminal)", func(t *testing.T) {
+		ctx = ctxutil.WithTerminal(ctx, true)
+
+		origAutoclip := act.cfg.AutoClip
+		act.cfg.AutoClip = true
+
+		assert.NoError(t, act.Generate(gptest.CliCtxWithFlags(ctx, t, map[string]string{"force": "true"}, "foobar")))
+		if !strings.Contains(buf.String(), "Copied to clipboard") {
+			t.Errorf("password did not copy to clipboard when it should have")
+		}
+
+		act.cfg.AutoClip = origAutoclip
+		buf.Reset()
+	})
+
+	// regression test for #2023
+	t.Run("generate --force foobar (not in a terminal)", func(t *testing.T) {
+		ctx = ctxutil.WithTerminal(ctx, false)
+
+		origAutoclip := act.cfg.AutoClip
+		act.cfg.AutoClip = true
+
+		assert.NoError(t, act.Generate(gptest.CliCtxWithFlags(ctx, t, map[string]string{"force": "true"}, "foobar")))
+		if strings.Contains(buf.String(), "Copied to clipboard") {
+			t.Errorf("password copied to clipboard when it should not have")
+		}
+
+		act.cfg.AutoClip = origAutoclip
+		buf.Reset()
+	})
 }
 
 func passIsAlphaNum(t *testing.T, buf string, want bool) {


### PR DESCRIPTION
Fix #2023 

Previously, secrets would autoclip only when output was being
redirected, which is incorrect. Secrets should autoclip when output is
not being redirected (i.e. we're on a TTY).

RELEASE_NOTES=[BUGFIX] Fixed autoclip when generating secrets.

Signed-off-by: Adriano Caloiaro <github@adriano.fyi>