### PR TITLE
update gnupg *.deb dependency

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
         go-version: 1.17
 
     - name: Ubuntu Dependencies
-      run: sudo apt-get install --yes git gnupg2
+      run: sudo apt-get install --yes git gnupg
 
     - run: git config --global user.name nobody
     - run: git config --global user.email foo.bar@example.org

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -61,19 +61,31 @@ release:
   prerelease: auto
 
 nfpms:
-  - id: gopass
+  - id: gopass_deb
     vendor: Gopass Authors
     homepage: "https://www.gopass.pw"
     maintainer: "Gopass Authors <gopass@gopass.pw>"
     license: MIT
     formats:
       - deb
+    dependencies:
+      - git
+      - gnupg
+    recommends:
+      - rng-tools
+  - id: gopass_rpm
+    vendor: Gopass Authors
+    homepage: "https://www.gopass.pw"
+    maintainer: "Gopass Authors <gopass@gopass.pw>"
+    license: MIT
+    formats:
       - rpm
     dependencies:
       - git
       - gnupg2
     recommends:
       - rng-tools
+
 source:
   enabled: true
   name_template: "{{.ProjectName}}-{{.Version}}"

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -23,10 +23,8 @@ key generation if these are available for your platform.
 
 ```bash
 apt-get update
-apt-get install gnupg2 git rng-tools
+apt-get install git gnupg rng-tools
 ```
-
-_Note:_ installing on Ubuntu prior to 16.04 and similarly old Debian versions might require you to install `gnupg` instead of `gnupg2`.
 
 #### RHEL & CentOS
 


### PR DESCRIPTION
In all upstream supported debian & ubuntu releases the package gnupg2 is
a dummy transitional package depending on gnupg. Depend directly on
gnupg instead of the transition.

This fixes #2049 

I hope the `.goreleaser.yml` syntax is correct.