### PR TITLE
Improve clipboard safety

### DIFF
--- a/pkg/clipboard/clipboard.go
+++ b/pkg/clipboard/clipboard.go
@@ -28,7 +28,7 @@ func CopyTo(ctx context.Context, name string, content []byte, timeout int) error
 		return nil
 	}
 
-	if err := clipboard.WriteAll(string(content)); err != nil {
+	if err := copyToClipboard(ctx, content); err != nil {
 		_ = notify.Notify(ctx, "gopass - clipboard", "failed to write to clipboard")
 		return fmt.Errorf("failed to write to clipboard: %w", err)
 	}

--- a/pkg/clipboard/clipboard_others.go
+++ b/pkg/clipboard/clipboard_others.go
@@ -6,13 +6,13 @@ package clipboard
 import (
 	"bytes"
 	"context"
-	"crypto/sha256"
 	"fmt"
 	"os"
 	"os/exec"
 	"strconv"
 	"syscall"
 
+	"github.com/gopasspw/gopass/internal/pwschemes/argon2id"
 	"github.com/gopasspw/gopass/pkg/ctxutil"
 )
 
@@ -21,7 +21,10 @@ import (
 // of the clipboard and erase it if it still contains the data gopass copied
 // to it.
 func clear(ctx context.Context, content []byte, timeout int) error {
-	hash := fmt.Sprintf("%x", sha256.Sum256(content))
+	hash, err := argon2id.Generate(string(content), 0)
+	if err != nil {
+		return err
+	}
 
 	// kill any pending unclip processes
 	_ = killPrecedessors()

--- a/pkg/clipboard/copy_darwin.go
+++ b/pkg/clipboard/copy_darwin.go
@@ -1,0 +1,77 @@
+//go:build darwin
+// +build darwin
+
+package clipboard
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+
+	"github.com/atotto/clipboard"
+	"github.com/gopasspw/gopass/pkg/debug"
+)
+
+func copyToClipboard(ctx context.Context, content []byte) error {
+	password := string(content)
+
+	// first try to copy via osascript, if that fails fallback to pbcopy
+	if err := copyViaOsascript(ctx, password); err != nil {
+		debug.Log("failed to copy via osascript: %s", err)
+		return clipboard.WriteAll(password)
+	}
+	return nil
+}
+
+func copyViaOsascript(ctx context.Context, password string) error {
+	args := []string{
+		// The Foundation library has the Objective C symbols for pasteboard
+		"-e", `use framework "Foundation"`,
+		// Need to use scripting additions for access to "do shell script"
+		"-e", "use scripting additions",
+		// type = a reference to the ObjC constant NSPasteboardTypeString
+		// which is needed to indentify clioboard contents as text
+		"-e", "set type to current application's NSPasteboardTypeString",
+		// pb = a reference to the system's pasteboard
+		"-e", "set pb to current application's NSPasteboard's generalPasteboard()",
+		// Must clear contents before adding a new item to pasteboard
+		"-e", "pb's clearContents()",
+		// Set the flag ConcealedType so clipboard history managers don't record the password.
+		// The first argument can by anything, but an empty string will do fine.
+		"-e", `pb's setString:"" forType:"org.nspasteboard.ConcealedType"`,
+		// AppleScript cannot read from stdin, so pipe fd#3 to stdin of cat and read the output.
+		// This output is put in the clipboard, setting type = string type
+		"-e", `pb's setString:(do shell script "cat 0<&3") forType:type`,
+	}
+	cmd := exec.CommandContext(ctx, "osascript", args...)
+	r, w, err := os.Pipe()
+	if err != nil {
+		return err
+	}
+
+	// This connects the pipe to stdin of the osascript command, see the "do shell script"
+	// part around line 46. The pipe is created and written to before the osascript command
+	// is run so we shouldn't need to worry about partial writes (I hope!).
+	//
+	// TODO: We might be able to use `cmd.Stdin = strings.NewReader(password)` instead
+	cmd.ExtraFiles = []*os.File{r} // Receiving end of pipes is connected to fd#3
+	go func() {
+		defer w.Close()
+		io.WriteString(w, password) // Write the password to fd#3
+	}()
+
+	out, err := cmd.Output()
+	if err != nil {
+		return err
+	}
+
+	// osascript should print true (return value of the last setString call) on success
+	if string(out) != "true\n" {
+		// Fallback to using attoto's pbcopy
+		return fmt.Errorf("osascript failed to set password: %s", string(out))
+	}
+	debug.Log("copied via osascript")
+	return nil
+}

--- a/pkg/clipboard/copy_others.go
+++ b/pkg/clipboard/copy_others.go
@@ -1,0 +1,14 @@
+//go:build !darwin
+// +build !darwin
+
+package clipboard
+
+import (
+	"context"
+
+	"github.com/atotto/clipboard"
+)
+
+func copyToClipboard(ctx context.Context, content []byte) error {
+	return clipboard.WriteAll(string(content))
+}


### PR DESCRIPTION
This commit finally incorporates the changes suggested by rianadon.

Additionally it switches the unclip checksum from SHA256 to Argon2id.
Although the risk is close to zero (i.e. if someone can access our
process env we're doomed anyway) but there is just no reason to not
do it properly.

RELEASE_NOTES=[ENHANCEMENT] Hide password on MacOS clipboards

Fixes #1816

Signed-off-by: Dominik Schulz <dominik.schulz@gauner.org>