### PR TITLE
#1939: improve show/revision documentation

### DIFF
--- a/docs/commands/show.md
+++ b/docs/commands/show.md
@@ -26,7 +26,7 @@ Flag | Aliases | Description
 `--qr` | | Encode the password field as a QR code and print it. Note: When combining with `-c`/`-C` the unencoded password is copied. Not the QR code.
 `--unsafe` | `-u` | Display unsafe content (e.g. the password) even when the `safecontent` option is set. No-op when `safecontent` is `false`.
 `--password` | `-o` | Display only the password. For use in scripts. Takes precedence over other flags.
-`--revision` | `-r` | Display a specific revision of the entry. Use an exact version identifier from `gopass history` or the special `-N` syntax. Does not work with native (e.g. git) refs.
+`--revision` | `-r` | Display a specific revision of the entry. Use an exact version identifier from `gopass history` or the special `-<N>` syntax. Does not work with native (e.g. git) refs.
 `--noparsing` | `-n` | Do not parse the content, disable YAML and Key-Value functions.
 
 ## Details

--- a/gopass.1
+++ b/gopass.1
@@ -1,5 +1,5 @@
 
-.TH GOPASS "1" "November 2021" "gopass (github.com/gopasspw/gopass) 1.13.0" "User Commands"
+.TH GOPASS "1" "December 2021" "gopass (github.com/gopasspw/gopass) 1.13.0" "User Commands"
 .SH NAME
 gopass - The standard Unix password manager
 .SH SYNOPSIS
@@ -28,7 +28,7 @@ Display only the password. Takes precedence over all other flags.
 Print the password as a QR Code
 .TP
 \fB\-\-revision\fR,
-Show a past revision. Does NOT support RCS specific shortcuts. Use exact revision or -N to select the Nth oldest revision of this entry.
+Show a past revision. Does NOT support RCS specific shortcuts. Use exact revision or -<N> to select the Nth oldest revision of this entry.
 .TP
 \fB\-\-unsafe\fR,
 \fB\-\-u\fR,
@@ -50,7 +50,7 @@ Decrypt all secrets and scan for weak or leaked passwords
 
 This command decrypts all secrets and checks for common flaws and (optionally) against a list of previously leaked passwords.
 .SS cat
-Print content of a secret to stdout, or insert from stdin
+Decode and print content of a binary secret to stdout, or encode and insert from stdin
 
 This command is similar to the way cat works on the command line. It can either be used to retrieve the decoded content of a secret similar to 'cat file' or vice versa to encode the content from STDIN to a secret.
 .SS clone
@@ -457,7 +457,7 @@ Display only the password. Takes precedence over all other flags.
 Print the password as a QR Code
 .TP
 \fB\-\-revision\fR,
-Show a past revision. Does NOT support RCS specific shortcuts. Use exact revision or -N to select the Nth oldest revision of this entry.
+Show a past revision. Does NOT support RCS specific shortcuts. Use exact revision or -<N> to select the Nth oldest revision of this entry.
 .TP
 \fB\-\-unsafe\fR,
 \fB\-\-u\fR,

--- a/internal/action/commands.go
+++ b/internal/action/commands.go
@@ -42,7 +42,7 @@ func ShowFlags() []cli.Flag {
 		},
 		&cli.StringFlag{
 			Name:  "revision",
-			Usage: "Show a past revision. Does NOT support RCS specific shortcuts. Use exact revision or -N to select the Nth oldest revision of this entry.",
+			Usage: "Show a past revision. Does NOT support RCS specific shortcuts. Use exact revision or -<N> to select the Nth oldest revision of this entry.",
 		},
 		&cli.BoolFlag{
 			Name:    "noparsing",
@@ -97,7 +97,7 @@ func (s *Action) GetCommands() []*cli.Command {
 		},
 		{
 			Name:      "cat",
-			Usage:     "Print content of a secret to stdout, or insert from stdin",
+			Usage:     "Decode and print content of a binary secret to stdout, or encode and insert from stdin",
 			ArgsUsage: "[secret]",
 			Description: "" +
 				"This command is similar to the way cat works on the command line. " +


### PR DESCRIPTION
improve show/revision documentation
also add cat documentation in man-page

RELEASE_NOTES=[DOCUMENTATION] improve 'gopass show -revision -<N>'
RELEASE_NOTES=[DOCUMENTATION] improve 'gopass cat'

Signed-off-by: Thomas Mantl <thomas.mantl@redgears.net>

resolves #1939 