### PR TITLE
Migrating to Golangci-Lint

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,25 @@
+name: golangci-lint
+on:
+  workflow_dispatch:
+      #  push: # Disabled until Golangci-lint GHA is compiled with Go 1.18
+      #    tags:
+      #      - v*
+      #    branches:
+      #      - master
+      #      - main
+      #  pull_request:
+permissions:
+  contents: read
+  pull-requests: read
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v2
+        with:
+          # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
+          version: latest # we have a linter whitelist in our .golangci.yml config file
+          only-new-issues: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,76 @@
+linters-settings:
+  gocyclo:
+    min-complexity: 22
+  staticcheck:
+    go: "1.18"
+    # https://staticcheck.io/docs/options#checks
+    checks: ["all","-SA1019"]
+
+linters:
+  disable-all: true
+
+  enable:
+        - asciicheck
+        - forcetypeassert
+        - gci
+        - gocyclo
+        - gofmt
+        - goimports
+        - gomoddirectives
+        - gomodguard
+        - goprintffuncname
+        - ifshort
+        - ineffassign
+        - misspell
+        - nakedret
+        - nolintlint
+        - prealloc
+    ## These are working but disabled for now
+          ##  - dogsled # two occurences we cannot really correct
+          ##  - dupl # some dups in tests
+          ##  - gochecknoinits # we use a lot of init
+          ##  - goconst # annoying?
+          ##  - godot # annoying?
+          ##  - godox # we have a few todo...
+          ##  - paralleltest # lots of work to pass
+          ##  - nestif # some work to refactor
+          ##  - revive # currently a bit buggy with Go 1.18 but works mostly
+    ## These are untested yet
+      #    - predeclared
+      #    - rowserrcheck
+      #    - staticcheck
+      #    - structcheck
+      #    - stylecheck
+      #    - tagliatelle
+      #    - testpackage
+      #    - thelper
+      #    - tparallel
+      #    - typecheck
+      #    - unconvert
+      #    - varcheck
+      #    - wastedassign
+      #    - wrapcheck
+      #
+## To enable once they work with Go 1.18:
+###  - deadcode
+###  - depguard
+###  - durationcheck
+###  - errcheck
+###  - errorlint
+###  - exhaustive
+###  - exportloopref
+###  - gocritic
+###  - goerr113
+###  - gosec
+###  - gosimple
+###  - govet
+###  - importas
+###  - makezero
+###  - nilerr
+###  - unparam
+###  - unused
+
+issues:
+  exclude-use-default: false # disable filtering of defaults for better zero-issue policy
+  max-per-linter: 0 # disable limit; report all issues of a linter
+  max-same-issues: 0 # disable limit; report all issues of the same issue

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -25,6 +25,7 @@ linters:
         - nakedret
         - nolintlint
         - prealloc
+        - predeclared
     ## These are working but disabled for now
           ##  - dogsled # two occurences we cannot really correct
           ##  - dupl # some dups in tests
@@ -32,25 +33,12 @@ linters:
           ##  - goconst # annoying?
           ##  - godot # annoying?
           ##  - godox # we have a few todo...
-          ##  - paralleltest # lots of work to pass
           ##  - nestif # some work to refactor
+          ##  - paralleltest # lots of work to pass
           ##  - revive # currently a bit buggy with Go 1.18 but works mostly
-    ## These are untested yet
-      #    - predeclared
-      #    - rowserrcheck
-      #    - staticcheck
-      #    - structcheck
-      #    - stylecheck
-      #    - tagliatelle
-      #    - testpackage
-      #    - thelper
-      #    - tparallel
-      #    - typecheck
-      #    - unconvert
-      #    - varcheck
-      #    - wastedassign
-      #    - wrapcheck
-      #
+          ##  - tagliatelle # requires some refactoring
+          ##  - testpackage # complains for a lot of packages
+
 ## To enable once they work with Go 1.18:
 ###  - deadcode
 ###  - depguard
@@ -67,8 +55,19 @@ linters:
 ###  - importas
 ###  - makezero
 ###  - nilerr
+###  - rowserrcheck
+###  - staticcheck
+###  - structcheck
+###  - stylecheck
+###  - thelper
+###  - tparallel
+###  - typecheck
+###  - unconvert
 ###  - unparam
 ###  - unused
+###  - varcheck
+###  - wastedassign
+###  - wrapcheck
 
 issues:
   exclude-use-default: false # disable filtering of defaults for better zero-issue policy

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ OK := $(shell tput setaf 6; echo ' [OK]'; tput sgr0;)
 all: sysinfo build
 build: $(GOPASS_OUTPUT)
 completion: $(BASH_COMPLETION_OUTPUT) $(FISH_COMPLETION_OUTPUT) $(ZSH_COMPLETION_OUTPUT)
-travis: sysinfo crosscompile build fulltest codequality completion
+travis: sysinfo crosscompile build fulltest completion
 travis-osx: sysinfo build test completion
 travis-windows: sysinfo build test-win completion
 
@@ -147,35 +147,12 @@ codequality:
 	@$(GO) vet ./...
 	@printf '%s\n' '$(OK)'
 
-	@echo -n "     CYCLO     "
-	@which gocyclo > /dev/null; if [ $$? -ne 0 ]; then \
-		$(GO) install github.com/fzipp/gocyclo/cmd/gocyclo@latest; \
-	fi
-	@$(foreach gofile, $(GOFILES_NOVENDOR),\
-			gocyclo -over 22 $(gofile) || exit 0;)
-	@printf '%s\n' '$(OK)'
-
 	@echo -n "     LINT      "
 	@which golint > /dev/null; if [ $$? -ne 0 ]; then \
 		$(GO) install golang.org/x/lint/golint@latest; \
 	fi
 	@$(foreach pkg, $(PKGS),\
 			golint -set_exit_status $(pkg) || exit 0;)
-	@printf '%s\n' '$(OK)'
-
-	@echo -n "     INEFF     "
-	@which ineffassign > /dev/null; if [ $$? -ne 0 ]; then \
-		$(GO) install github.com/gordonklaus/ineffassign@latest; \
-	fi
-	@ineffassign . || exit 0
-	@printf '%s\n' '$(OK)'
-
-	@echo -n "     SPELL     "
-	@which misspell > /dev/null; if [ $$? -ne 0 ]; then \
-		$(GO) install github.com/client9/misspell/cmd/misspell@latest; \
-	fi
-	@$(foreach gofile, $(GOFILES_NOVENDOR),\
-			misspell --error $(gofile) || exit 1;)
 	@printf '%s\n' '$(OK)'
 
 	@echo -n "     STATICCHECK "
@@ -190,6 +167,13 @@ codequality:
 		$(GO) install mvdan.cc/unparam@latest; \
 	fi
 	@unparam -exported=false $(PKGS) || exit 0
+	@printf '%s\n' '$(OK)'
+
+	@echo -n "     GOLANGCI-LINT "
+	@which golangci-lint > /dev/null; if [ $$? -ne 0 ]; then \
+		$(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@latest; \
+	fi
+	@golangci-lint run || exit 0
 	@printf '%s\n' '$(OK)'
 
 gen:


### PR DESCRIPTION
Adding a GHA that is currently not running automatically until it's supporting Go 1.18 (can be launched manually to test it).

Adding the proper config files for Golangci-lint, with the linters whitelisted in #2073, still some extra work to test them all. 

Removing codequality from CI in Makefile, since it's now meant to be handled in a GHA.
Phasing out some of the codequality linters too since they are in golangci already.