### PR TITLE
Enforce TLSv1.3 for outgoing HTTPS connections

### DIFF
--- a/internal/cache/ghssh/github.go
+++ b/internal/cache/ghssh/github.go
@@ -3,12 +3,24 @@ package ghssh
 import (
 	"bufio"
 	"context"
+	"crypto/tls"
 	"fmt"
 	"net/http"
 	"strings"
 	"time"
 
 	"github.com/gopasspw/gopass/pkg/debug"
+)
+
+var (
+	httpClient = &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				// enforce TLS 1.3
+				MinVersion: tls.VersionTLS13,
+			},
+		},
+	}
 )
 
 // ListKeys returns the public keys for a github user. It will
@@ -44,7 +56,7 @@ func (c *Cache) fetchKeys(ctx context.Context, user string) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/updater/github.go
+++ b/internal/updater/github.go
@@ -83,7 +83,7 @@ func FetchLatestRelease(ctx context.Context) (Release, error) {
 	// pin to API version 3 to avoid breaking our structs
 	req.Header.Set("Accept", "application/vnd.github.v3+json")
 
-	resp, err := ctxhttp.Do(ctx, http.DefaultClient, req)
+	resp, err := ctxhttp.Do(ctx, httpClient, req)
 	if err != nil {
 		return Release{}, err
 	}


### PR DESCRIPTION
Only applies to connections to GitHub that supports it.
So no compatibility concerns. Middleboxes might cause
trouble but they are terrible and must go away.

RELEASE_NOTES=[ENHANCEMENT] Enforce TLSv1.3

Signed-off-by: Dominik Schulz <dominik.schulz@gauner.org>