### PR TITLE
Add env variables for custom clipboard commands

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -4,35 +4,37 @@
 
 Some configuration options are only available through setting environment variables.
 
-| **Option**              | **Type** | **Description**                                                                                              |
-|-------------------------|----------|--------------------------------------------------------------------------------------------------------------|
-| `CHECKPOINT_DISABLE`    | `bool`   | Set to any non-empty value to disable calling the GitHub API when running `gopass version`.                  |
-| `GOPASS_DEBUG`          | `bool`   | Set to any non-empty value to enable verbose debug output                                                    |
-| `GOPASS_DEBUG_LOG` | `string` | Set to a filename to enable debug logging |
-| `GOPASS_DEBUG_LOG_SECRETS` | `bool` | Set to any non-empty value to enable logging of credentials |
-| `GOPASS_DEBUG_FUNCS` | `string` | Comma separated filter for console debug output (functions) |
-| `GOPASS_DEBUG_FILES` | `string` | Comma separated filter for console debug output (files) |
-| `GOPASS_UMASK`          | `octal`  | Set to any valid umask to mask bits of files created by gopass                                               |
-| `GOPASS_GPG_OPTS`       | `string` | Add any extra arguments, e.g. `--armor` you want to pass to GPG on every invocation                          |
-| `GOPASS_EXTERNAL_PWGEN` | `string` | Use an external password generator. See [Features](features.md#using-custom-password-generators) for details |
-| `GOPASS_CHARACTER_SET`  | `bool`   | Set to any non-empty value to restrict the characters used in generated passwords                            |
-| `GOPASS_CONFIG`         | `string` | Set this to the absolute path to the configuration file                                                      |
-| `GOPASS_HOMEDIR`        | `string` | Set this to the absolute path of the directory containing the `.config/` tree                                |
-| `GOPASS_FORCE_UPDATE`   | `bool`   | Set to any non-empty value to force an update (if available)                                                 |
-| `GOPASS_NO_NOTIFY`      | `bool`   | Set to any non-empty value to prevent notifications                                                          |
-| `GOPASS_NO_REMINDER`      | `bool`   | Set to any non-empty value to prevent reminders                                                          |
+| **Option**                   | **Type** | **Description**                                                                                                  |
+| ---------------------------- | -------- | ---------------------------------------------------------------------------------------------------------------- |
+| `CHECKPOINT_DISABLE`         | `bool`   | Set to any non-empty value to disable calling the GitHub API when running `gopass version`.                      |
+| `GOPASS_DEBUG`               | `bool`   | Set to any non-empty value to enable verbose debug output                                                        |
+| `GOPASS_DEBUG_LOG`           | `string` | Set to a filename to enable debug logging                                                                        |
+| `GOPASS_DEBUG_LOG_SECRETS`   | `bool`   | Set to any non-empty value to enable logging of credentials                                                      |
+| `GOPASS_DEBUG_FUNCS`         | `string` | Comma separated filter for console debug output (functions)                                                      |
+| `GOPASS_DEBUG_FILES`         | `string` | Comma separated filter for console debug output (files)                                                          |
+| `GOPASS_UMASK`               | `octal`  | Set to any valid umask to mask bits of files created by gopass                                                   |
+| `GOPASS_GPG_OPTS`            | `string` | Add any extra arguments, e.g. `--armor` you want to pass to GPG on every invocation                              |
+| `GOPASS_EXTERNAL_PWGEN`      | `string` | Use an external password generator. See [Features](features.md#using-custom-password-generators) for details     |
+| `GOPASS_CHARACTER_SET`       | `bool`   | Set to any non-empty value to restrict the characters used in generated passwords                                |
+| `GOPASS_CONFIG`              | `string` | Set this to the absolute path to the configuration file                                                          |
+| `GOPASS_HOMEDIR`             | `string` | Set this to the absolute path of the directory containing the `.config/` tree                                    |
+| `GOPASS_FORCE_UPDATE`        | `bool`   | Set to any non-empty value to force an update (if available)                                                     |
+| `GOPASS_NO_NOTIFY`           | `bool`   | Set to any non-empty value to prevent notifications                                                              |
+| `GOPASS_NO_REMINDER`         | `bool`   | Set to any non-empty value to prevent reminders                                                                  |
+| `GOPASS_CLIPBOARD_COPY_CMD`  | `string` | Use an external command to copy a password to the clipboard. See [GPaste](usecases/gpaste.md) for an example     |
+| `GOPASS_CLIPBOARD_CLEAR_CMD` | `string` | Use an external command to remove a password from the clipboard. See [GPaste](usecases/gpaste.md) for an example |
 
 Variables not exclusively used by gopass
 
 | **Option**             | **Type** | **Description**                                                                                        |
-|------------------------|----------|--------------------------------------------------------------------------------------------------------|
+| ---------------------- | -------- | ------------------------------------------------------------------------------------------------------ |
 | `PASSWORD_STORE_DIR`   | `string` | absolute path containing the password store (a directory). Only supported during initialization!       |
 | `PASSWORD_STORE_UMASK` | `string` | Set to any valid umask to mask bits of files created by gopass (GOPASS_UMASK has precedence over this) |
 | `EDITOR`               | `string` | command name to execute for editing password entries                                                   |
 | `PAGER`                | `string` | the pager program used for `gopass list`. See [Features](features.md#auto-pager) for details           |
 | `GIT_AUTHOR_NAME`      | `string` | name of the author, used by the rcs backend to create a commit                                         |
 | `GIT_AUTHOR_EMAIL`     | `string` | email of the author, used by the rcs backend to create a commit                                        |
-| `NO_COLOR`             | `bool`   | disable color output. See [no-color.org](https://no-color.org) for more information.
+| `NO_COLOR`             | `bool`   | disable color output. See [no-color.org](https://no-color.org) for more information.                   |
 
 ## Configuration Options
 
@@ -47,20 +49,20 @@ All configuration options are also available for reading and writing through the
 
 This is a list of available options:
 
-| **Option**       | **Type** | Description |
-| ---------------- | -------- | ----------- |
-| `askformore`     | `bool`   | If enabled - it will ask to add more data after use of `generate` command.  DEPRECATED in v1.10.0 |
-| `autoclip`       | `bool`   | Always copy the password created by `gopass generate`. Only applies to generate. |
-| `autoimport`     | `bool`   | Import missing keys stored in the pass repository without asking. |
-| `autosync`       | `bool`   | Always do a `git push` after a commit to the store. Makes sure your local changes are always available on your git remote. DEPRECATED in v1.10.0 |
-| `concurrency`    | `int`    | Number of threads to use for batch operations (such as reencrypting).  DEPRECATED in v1.9.3 |
-| `cliptimeout`    | `int`    | How many seconds the secret is stored when using `-c`. |
-| `exportkeys`     | `bool`   | Export public keys of all recipients to the store. |
-| `recipient_hash` | `map`    | Map of recipient ids to their hashes.  DEPRECATED in v1.10.0 |
-| `usesymbols`     | `bool`   | If enabled - it will use symbols when generating passwords.  DEPRECATED in v1.9.3 |
-| `nocolor`        | `bool`   | Do not use color. |
-| `nopager`        | `bool`   | Do not invoke a pager to display long lists. |
-| `notifications`  | `bool`   | Enable desktop notifications. |
-| `parsing`        | `bool`   | Enable parsing of output to have key-value and yaml secrets. |
-| `path`           | `string` | Path to the root store. |
+| **Option**       | **Type** | Description                                                                                                                                                                                    |
+| ---------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `askformore`     | `bool`   | If enabled - it will ask to add more data after use of `generate` command.  DEPRECATED in v1.10.0                                                                                              |
+| `autoclip`       | `bool`   | Always copy the password created by `gopass generate`. Only applies to generate.                                                                                                               |
+| `autoimport`     | `bool`   | Import missing keys stored in the pass repository without asking.                                                                                                                              |
+| `autosync`       | `bool`   | Always do a `git push` after a commit to the store. Makes sure your local changes are always available on your git remote. DEPRECATED in v1.10.0                                               |
+| `concurrency`    | `int`    | Number of threads to use for batch operations (such as reencrypting).  DEPRECATED in v1.9.3                                                                                                    |
+| `cliptimeout`    | `int`    | How many seconds the secret is stored when using `-c`.                                                                                                                                         |
+| `exportkeys`     | `bool`   | Export public keys of all recipients to the store.                                                                                                                                             |
+| `recipient_hash` | `map`    | Map of recipient ids to their hashes.  DEPRECATED in v1.10.0                                                                                                                                   |
+| `usesymbols`     | `bool`   | If enabled - it will use symbols when generating passwords.  DEPRECATED in v1.9.3                                                                                                              |
+| `nocolor`        | `bool`   | Do not use color.                                                                                                                                                                              |
+| `nopager`        | `bool`   | Do not invoke a pager to display long lists.                                                                                                                                                   |
+| `notifications`  | `bool`   | Enable desktop notifications.                                                                                                                                                                  |
+| `parsing`        | `bool`   | Enable parsing of output to have key-value and yaml secrets.                                                                                                                                   |
+| `path`           | `string` | Path to the root store.                                                                                                                                                                        |
 | `safecontent`    | `bool`   | Only output _safe content_ (i.e. everything but the first line of a secret) to the terminal. Use _copy_ (`-c`) to retrieve the password in the clipboard, or _force_ (`-f`) to still print it. |

--- a/docs/usecases/gpaste.md
+++ b/docs/usecases/gpaste.md
@@ -1,0 +1,56 @@
+# Use case: GPaste Clipboard management system
+
+## Summary
+
+On Linux one might want to use the [GPaste](https://github.com/Keruspe/GPaste) clipboard manager. Using the `GOPASS_CLIPBOARD_COPY_CMD` and `GOPASS_CLIPBOARD_CLEAR_CMD` environment variables one can instruct gopass to use the GPaste client directly. This hides passwords when viewed in the manager and removes them by name after the timeout.
+
+## Usage
+
+### Helper scripts
+
+Both environment variables expect a path to an executable or the name of an executable in the `PATH` environment variable. The executables receive the name of the password as the first argument and the password (copy) or its checksum (clear) in `STDIN`. To use the GPaste client one has to use helper scripts like this:
+
+`~/.local/scripts/gopass_clipboard_copy_cmd.sh`
+```sh
+#!/bin/sh
+
+# gpaste-client will use the password in /dev/stdin
+gpaste-client add-password "$1"
+```
+
+`~/.local/scripts/gopass_clipboard_clear_cmd.sh`
+```sh
+#!/bin/sh
+
+gpaste-client delete-password "$1"
+```
+
+Make sure both are executable: `chmod +x ~/.local/scripts/gopass_clipboard_{copy,clear}_cmd.sh`
+
+### Setting the environment variables
+
+#### Shell
+
+You can set the environment variables in the `.profile` file of your shell, for example:
+
+`~/.bash_profile`
+```sh
+# [...]
+export GOPASS_CLIPBOARD_COPY_CMD="$HOME/.local/scripts/gopass_clipboard_copy_cmd.sh"
+export GOPASS_CLIPBOARD_CLEAR_CMD="$HOME/.local/scripts/gopass_clipboard_clear_cmd.sh"
+# [...]
+```
+
+#### Graphical environment
+
+If you are using X11 you can set the above in `~/.xprofile`.
+
+On Wayland one may use systemd user environment variables:
+
+`~/.config/environment.d/gopass.conf`
+```sh
+GOPASS_CLIPBOARD_COPY_CMD="$HOME/.local/scripts/gopass_clipboard_copy_cmd.sh"
+GOPASS_CLIPBOARD_CLEAR_CMD="$HOME/.local/scripts/gopass_clipboard_clear_cmd.sh"
+```
+
+A reboot might be required.

--- a/internal/action/action.go
+++ b/internal/action/action.go
@@ -15,6 +15,7 @@ import (
 var (
 	stdin  io.Reader = os.Stdin
 	stdout io.Writer = os.Stdout
+	stderr io.Writer = os.Stderr
 )
 
 // Action knows everything to run gopass CLI actions.

--- a/internal/action/show_test.go
+++ b/internal/action/show_test.go
@@ -220,12 +220,17 @@ func TestShowAutoClip(t *testing.T) {
 	require.NotNil(t, act)
 
 	color.NoColor = true
-	buf := &bytes.Buffer{}
-	out.Stdout = buf
-	stdout = buf
+	stdoutBuf := &bytes.Buffer{}
+	stderrBuf := &bytes.Buffer{}
+	out.Stdout = stdoutBuf
+	stdout = stdoutBuf
+	out.Stderr = stderrBuf
+	stderr = stderrBuf
 	defer func() {
 		stdout = os.Stdout
 		out.Stdout = os.Stdout
+		stderr = os.Stderr
+		out.Stderr = os.Stderr
 	}()
 
 	// terminal=false
@@ -243,9 +248,10 @@ func TestShowAutoClip(t *testing.T) {
 
 		c := gptest.CliCtx(ctx, t, "foo")
 		assert.NoError(t, act.Show(c))
-		assert.NotContains(t, buf.String(), "WARNING")
-		assert.Contains(t, buf.String(), "secret")
-		buf.Reset()
+		assert.NotContains(t, stderrBuf.String(), "WARNING")
+		assert.Contains(t, stdoutBuf.String(), "secret")
+		stdoutBuf.Reset()
+		stderrBuf.Reset()
 	})
 
 	// gopass show -c foo
@@ -253,9 +259,10 @@ func TestShowAutoClip(t *testing.T) {
 	t.Run("gopass show -c foo", func(t *testing.T) {
 		c := gptest.CliCtxWithFlags(ctx, t, map[string]string{"clip": "true"}, "foo")
 		assert.NoError(t, act.Show(c))
-		assert.Contains(t, buf.String(), "WARNING")
-		assert.NotContains(t, buf.String(), "secret")
-		buf.Reset()
+		assert.Contains(t, stderrBuf.String(), "WARNING")
+		assert.NotContains(t, stdoutBuf.String(), "secret")
+		stdoutBuf.Reset()
+		stderrBuf.Reset()
 	})
 
 	// gopass show -C foo
@@ -263,10 +270,11 @@ func TestShowAutoClip(t *testing.T) {
 	t.Run("gopass show -C foo", func(t *testing.T) {
 		c := gptest.CliCtxWithFlags(ctx, t, map[string]string{"alsoclip": "true"}, "foo")
 		assert.NoError(t, act.Show(c))
-		assert.Contains(t, buf.String(), "WARNING")
-		assert.Contains(t, buf.String(), "secret")
-		assert.Contains(t, buf.String(), "second")
-		buf.Reset()
+		assert.Contains(t, stderrBuf.String(), "WARNING")
+		assert.Contains(t, stdoutBuf.String(), "secret")
+		assert.Contains(t, stdoutBuf.String(), "second")
+		stdoutBuf.Reset()
+		stderrBuf.Reset()
 	})
 
 	// gopass show -f foo
@@ -274,10 +282,11 @@ func TestShowAutoClip(t *testing.T) {
 	t.Run("gopass show -f foo", func(t *testing.T) {
 		c := gptest.CliCtxWithFlags(ctx, t, map[string]string{"unsafe": "true"}, "foo")
 		assert.NoError(t, act.Show(c))
-		assert.NotContains(t, buf.String(), "WARNING")
-		assert.Contains(t, buf.String(), "secret")
-		assert.Contains(t, buf.String(), "second")
-		buf.Reset()
+		assert.NotContains(t, stderrBuf.String(), "WARNING")
+		assert.Contains(t, stdoutBuf.String(), "secret")
+		assert.Contains(t, stdoutBuf.String(), "second")
+		stdoutBuf.Reset()
+		stderrBuf.Reset()
 	})
 
 	// gopass show foo
@@ -285,9 +294,10 @@ func TestShowAutoClip(t *testing.T) {
 	t.Run("gopass show foo", func(t *testing.T) {
 		c := gptest.CliCtx(ctx, t, "foo")
 		assert.NoError(t, act.Show(c))
-		assert.NotContains(t, buf.String(), "WARNING")
-		assert.Contains(t, buf.String(), "secret")
-		buf.Reset()
+		assert.NotContains(t, stderrBuf.String(), "WARNING")
+		assert.Contains(t, stdoutBuf.String(), "secret")
+		stdoutBuf.Reset()
+		stderrBuf.Reset()
 	})
 
 	// gopass show -c foo
@@ -295,9 +305,10 @@ func TestShowAutoClip(t *testing.T) {
 	t.Run("gopass show -c foo", func(t *testing.T) {
 		c := gptest.CliCtxWithFlags(ctx, t, map[string]string{"clip": "true"}, "foo")
 		assert.NoError(t, act.Show(c))
-		assert.Contains(t, buf.String(), "WARNING")
-		assert.NotContains(t, buf.String(), "secret")
-		buf.Reset()
+		assert.Contains(t, stderrBuf.String(), "WARNING")
+		assert.NotContains(t, stdoutBuf.String(), "secret")
+		stdoutBuf.Reset()
+		stderrBuf.Reset()
 	})
 
 	// gopass show -C foo
@@ -305,10 +316,11 @@ func TestShowAutoClip(t *testing.T) {
 	t.Run("gopass show -C foo", func(t *testing.T) {
 		c := gptest.CliCtxWithFlags(ctx, t, map[string]string{"alsoclip": "true"}, "foo")
 		assert.NoError(t, act.Show(c))
-		assert.Contains(t, buf.String(), "WARNING")
-		assert.Contains(t, buf.String(), "secret")
-		assert.Contains(t, buf.String(), "second")
-		buf.Reset()
+		assert.Contains(t, stderrBuf.String(), "WARNING")
+		assert.Contains(t, stdoutBuf.String(), "secret")
+		assert.Contains(t, stdoutBuf.String(), "second")
+		stdoutBuf.Reset()
+		stderrBuf.Reset()
 	})
 
 	// gopass show -f foo
@@ -316,10 +328,11 @@ func TestShowAutoClip(t *testing.T) {
 	t.Run("gopass show -f foo", func(t *testing.T) {
 		c := gptest.CliCtxWithFlags(ctx, t, map[string]string{"unsafe": "true"}, "foo")
 		assert.NoError(t, act.Show(c))
-		assert.NotContains(t, buf.String(), "WARNING")
-		assert.Contains(t, buf.String(), "secret")
-		assert.Contains(t, buf.String(), "second")
-		buf.Reset()
+		assert.NotContains(t, stderrBuf.String(), "WARNING")
+		assert.Contains(t, stdoutBuf.String(), "secret")
+		assert.Contains(t, stdoutBuf.String(), "second")
+		stdoutBuf.Reset()
+		stderrBuf.Reset()
 	})
 }
 

--- a/internal/action/unclip.go
+++ b/internal/action/unclip.go
@@ -14,10 +14,11 @@ func (s *Action) Unclip(c *cli.Context) error {
 	ctx := ctxutil.WithGlobalFlags(c)
 	force := c.Bool("force")
 	timeout := c.Int("timeout")
+	name := os.Getenv("GOPASS_UNCLIP_NAME")
 	checksum := os.Getenv("GOPASS_UNCLIP_CHECKSUM")
 
 	time.Sleep(time.Second * time.Duration(timeout))
-	if err := clipboard.Clear(ctx, checksum, force); err != nil {
+	if err := clipboard.Clear(ctx, name, checksum, force); err != nil {
 		return ExitError(ExitIO, err, "Failed to clear clipboard: %s", err)
 	}
 	return nil

--- a/pkg/clipboard/clipboard_others.go
+++ b/pkg/clipboard/clipboard_others.go
@@ -16,11 +16,11 @@ import (
 	"github.com/gopasspw/gopass/pkg/ctxutil"
 )
 
-// clear will spwan a copy of gopass that waits in a detached background
+// clear will spawn a copy of gopass that waits in a detached background
 // process group until the timeout is expired. It will then compare the contents
 // of the clipboard and erase it if it still contains the data gopass copied
 // to it.
-func clear(ctx context.Context, content []byte, timeout int) error {
+func clear(ctx context.Context, name string, content []byte, timeout int) error {
 	hash, err := argon2id.Generate(string(content), 0)
 	if err != nil {
 		return err
@@ -34,7 +34,8 @@ func clear(ctx context.Context, content []byte, timeout int) error {
 	cmd.SysProcAttr = &syscall.SysProcAttr{
 		Setpgid: true,
 	}
-	cmd.Env = append(os.Environ(), "GOPASS_UNCLIP_CHECKSUM="+hash)
+	cmd.Env = append(os.Environ(), "GOPASS_UNCLIP_NAME="+name)
+	cmd.Env = append(cmd.Env, "GOPASS_UNCLIP_CHECKSUM="+hash)
 	if !ctxutil.IsNotifications(ctx) {
 		cmd.Env = append(cmd.Env, "GOPASS_NO_NOTIFY=true")
 	}

--- a/pkg/clipboard/clipboard_test.go
+++ b/pkg/clipboard/clipboard_test.go
@@ -12,11 +12,15 @@ import (
 
 	"github.com/atotto/clipboard"
 	"github.com/gopasspw/gopass/internal/out"
+	"github.com/gopasspw/gopass/tests/gptest"
 	ps "github.com/mitchellh/go-ps"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestNotExistingClipboardCopyCommand(t *testing.T) {
+	r1 := gptest.UnsetVars("GOPASS_NO_NOTIFY", "GOPASS_CLIPBOARD_COPY_CMD")
+	defer r1()
+
 	_ = os.Setenv("GOPASS_NO_NOTIFY", "true")
 	_ = os.Setenv("GOPASS_CLIPBOARD_COPY_CMD", "not_existing_command")
 	ctx, cancel := context.WithCancel(context.Background())
@@ -28,8 +32,10 @@ func TestNotExistingClipboardCopyCommand(t *testing.T) {
 }
 
 func TestUnsupportedCopyToClipboard(t *testing.T) {
+	r1 := gptest.UnsetVars("GOPASS_NO_NOTIFY")
+	defer r1()
+
 	_ = os.Setenv("GOPASS_NO_NOTIFY", "true")
-	_ = os.Setenv("GOPASS_CLIPBOARD_COPY_CMD", "")
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	clipboard.Unsupported = true

--- a/pkg/clipboard/clipboard_windows.go
+++ b/pkg/clipboard/clipboard_windows.go
@@ -17,14 +17,15 @@ import (
 // process group until the timeout is expired. It will then compare the contents
 // of the clipboard and erase it if it still contains the data gopass copied
 // to it.
-func clear(ctx context.Context, content []byte, timeout int) error {
+func clear(ctx context.Context, name string, content []byte, timeout int) error {
 	hash, err := argon2id.Generate(string(content), 0)
 	if err != nil {
 		return err
 	}
 
 	cmd := exec.CommandContext(ctx, os.Args[0], "unclip", "--timeout", strconv.Itoa(timeout))
-	cmd.Env = append(os.Environ(), "GOPASS_UNCLIP_CHECKSUM="+hash)
+	cmd.Env = append(os.Environ(), "GOPASS_UNCLIP_NAME="+name)
+	cmd.Env = append(cmd.Env, "GOPASS_UNCLIP_CHECKSUM="+hash)
 	if !ctxutil.IsNotifications(ctx) {
 		cmd.Env = append(cmd.Env, "GOPASS_NO_NOTIFY=true")
 	}

--- a/pkg/clipboard/unclip_test.go
+++ b/pkg/clipboard/unclip_test.go
@@ -8,10 +8,14 @@ import (
 
 	"github.com/gopasspw/gopass/internal/out"
 	"github.com/gopasspw/gopass/pkg/ctxutil"
+	"github.com/gopasspw/gopass/tests/gptest"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestNotExistingClipboardClearCommand(t *testing.T) {
+	r1 := gptest.UnsetVars("GOPASS_CLIPBOARD_CLEAR_CMD")
+	defer r1()
+
 	ctx := context.Background()
 	ctx = ctxutil.WithAlwaysYes(ctx, true)
 
@@ -25,8 +29,6 @@ func TestNotExistingClipboardClearCommand(t *testing.T) {
 func TestUnclip(t *testing.T) {
 	ctx := context.Background()
 	ctx = ctxutil.WithAlwaysYes(ctx, true)
-
-	_ = os.Setenv("GOPASS_CLIPBOARD_CLEAR_CMD", "")
 
 	buf := &bytes.Buffer{}
 	out.Stdout = buf

--- a/pkg/clipboard/unclip_test.go
+++ b/pkg/clipboard/unclip_test.go
@@ -11,9 +11,22 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestNotExistingClipboardClearCommand(t *testing.T) {
+	ctx := context.Background()
+	ctx = ctxutil.WithAlwaysYes(ctx, true)
+
+	_ = os.Setenv("GOPASS_CLIPBOARD_CLEAR_CMD", "not_existing_command")
+
+	maybeErr := Clear(ctx, "", "", false)
+	assert.Error(t, maybeErr)
+	assert.Contains(t, maybeErr.Error(), "\"not_existing_command\": executable file not found in")
+}
+
 func TestUnclip(t *testing.T) {
 	ctx := context.Background()
 	ctx = ctxutil.WithAlwaysYes(ctx, true)
+
+	_ = os.Setenv("GOPASS_CLIPBOARD_CLEAR_CMD", "")
 
 	buf := &bytes.Buffer{}
 	out.Stdout = buf
@@ -21,5 +34,5 @@ func TestUnclip(t *testing.T) {
 		out.Stdout = os.Stdout
 	}()
 
-	assert.EqualError(t, Clear(ctx, "", false), ErrNotSupported.Error())
+	assert.EqualError(t, Clear(ctx, "", "", false), ErrNotSupported.Error())
 }

--- a/tests/show_test.go
+++ b/tests/show_test.go
@@ -53,7 +53,7 @@ func TestShow(t *testing.T) {
 
 		out, err = ts.run("show fixed/twoliner")
 		assert.NoError(t, err)
-		assert.Equal(t, "and\nmore stuff", out)
+		assert.Equal(t, "first line\nsecond line", out)
 
 		out, err = ts.run("show --qr fixed/secret")
 		assert.NoError(t, err)
@@ -78,8 +78,8 @@ func TestShow(t *testing.T) {
 		out, err = ts.run("show fixed/twoliner")
 		assert.NoError(t, err)
 		assert.NotContains(t, out, "password: ***")
-		assert.Contains(t, out, "more stuff")
-		assert.NotContains(t, out, "and")
+		assert.Contains(t, out, "second line")
+		assert.NotContains(t, out, "first line")
 	})
 
 	t.Run("force showing full secret", func(t *testing.T) {
@@ -96,23 +96,23 @@ func TestShow(t *testing.T) {
 
 		out, err = ts.run("show -u fixed/twoliner")
 		assert.NoError(t, err)
-		assert.Equal(t, "and\nmore stuff", out)
+		assert.Equal(t, "first line\nsecond line", out)
 
 		out, err = ts.run("show -o fixed/twoliner")
 		assert.NoError(t, err)
-		assert.Equal(t, "and", out)
+		assert.Equal(t, "first line", out)
 
 		out, err = ts.run("show -c fixed/twoliner")
 		assert.NoError(t, err)
 		assert.NotContains(t, out, "***")
 		assert.NotContains(t, out, "safecontent=true")
-		assert.NotContains(t, out, "and")
-		assert.NotContains(t, out, "more stuff")
+		assert.NotContains(t, out, "first line")
+		assert.NotContains(t, out, "second line")
 
 		out, err = ts.run("show -C fixed/twoliner")
 		assert.NoError(t, err)
-		assert.Contains(t, out, "more stuff")
-		assert.NotContains(t, out, "and")
+		assert.Contains(t, out, "second line")
+		assert.NotContains(t, out, "first line")
 	})
 
 	t.Run("Regression test for #1574 and #1575", func(t *testing.T) {

--- a/tests/tester.go
+++ b/tests/tester.go
@@ -204,6 +204,6 @@ func (ts *tester) initSecrets(prefix string) {
 	out, err = ts.runCmd([]string{ts.Binary, "insert", prefix + "fixed/secret"}, []byte("moar"))
 	require.NoError(ts.t, err, "failed to insert password:\n%s", out)
 
-	out, err = ts.runCmd([]string{ts.Binary, "insert", prefix + "fixed/twoliner"}, []byte("and\nmore stuff"))
+	out, err = ts.runCmd([]string{ts.Binary, "insert", prefix + "fixed/twoliner"}, []byte("first line\nsecond line"))
 	require.NoError(ts.t, err, "failed to insert password:\n%s", out)
 }


### PR DESCRIPTION
Adds `GOPASS_CLIPBOARD_COPY_CMD` and `GOPASS_CLIPBOARD_CLEAR_CMD` environment variables which are called instead of the normal implementation if set. The commands receive the name of the password as their first parameter and the password or its checksum on `STDIN`.

Resolves #2042.