### PR TITLE
Fossil support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -42,6 +42,7 @@ require (
 )
 
 require (
+	bitbucket.org/creachadair/stringset v0.0.10 // indirect
 	filippo.io/edwards25519 v1.0.0-rc.1 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+bitbucket.org/creachadair/stringset v0.0.10 h1:DZjkR57sJGMycZNVVbl+26bK7vW1kwLQE6qWICWLteI=
+bitbucket.org/creachadair/stringset v0.0.10/go.mod h1:6G0fsnHFxynEdWpihfZf44lnBPpTW6nkrcxITVTBHus=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSRU=
@@ -36,6 +38,7 @@ filippo.io/age v1.0.0/go.mod h1:PaX+Si/Sd5G8LgfCwldsSba3H1DDQZhIhFGkhbHaBq8=
 filippo.io/edwards25519 v1.0.0-rc.1 h1:m0VOOB23frXZvAOK44usCgLWvtsxIoMCTBGJZlpmGfU=
 filippo.io/edwards25519 v1.0.0-rc.1/go.mod h1:N1IkdkCkiLB6tki+MYJoSx2JTY9NUlxZE7eHn5EwJns=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/BurntSushi/toml v0.4.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
 github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=

--- a/internal/action/commands.go
+++ b/internal/action/commands.go
@@ -41,8 +41,9 @@ func ShowFlags() []cli.Flag {
 			Usage:   "Display only the password. Takes precedence over all other flags.",
 		},
 		&cli.StringFlag{
-			Name:  "revision",
-			Usage: "Show a past revision. Does NOT support RCS specific shortcuts. Use exact revision or -<N> to select the Nth oldest revision of this entry.",
+			Name:    "revision",
+			Aliases: []string{"r"},
+			Usage:   "Show a past revision. Does NOT support RCS specific shortcuts. Use exact revision or -<N> to select the Nth oldest revision of this entry.",
 		},
 		&cli.BoolFlag{
 			Name:    "noparsing",

--- a/internal/action/init.go
+++ b/internal/action/init.go
@@ -109,13 +109,15 @@ func (s *Action) init(ctx context.Context, alias, path string, keys ...string) e
 		}
 	}
 	path = fsutil.CleanPath(path)
-	debug.Log("action.init(%s, %s, %+v)", alias, path, keys)
 
-	debug.Log("Checking private keys for: %+v", keys)
+	debug.Log("Initializing Store %q in %q for %+v", alias, path, keys)
+
 	out.Printf(ctx, "🔑 Searching for usable private Keys ...")
+	debug.Log("Checking private keys for: %+v", keys)
 	crypto := s.getCryptoFor(ctx, alias)
 
 	// private key selection doesn't matter for plain. save one question.
+	// TODO should ask the backend
 	if crypto.Name() == "plain" {
 		keys, _ = crypto.ListIdentities(ctx)
 	}
@@ -128,13 +130,13 @@ func (s *Action) init(ctx context.Context, alias, path string, keys ...string) e
 		keys = []string{nk}
 	}
 
-	debug.Log("Initializing sub store - Alias: %s - Path: %s - Keys: %+v", alias, path, keys)
+	debug.Log("Initializing sub store - Alias: %q - Path: %q - Keys: %+v", alias, path, keys)
 	if err := s.Store.Init(ctx, alias, path, keys...); err != nil {
 		return fmt.Errorf("failed to init store %q at %q: %w", alias, path, err)
 	}
 
 	if alias != "" && path != "" {
-		debug.Log("Mounting sub store %s -> %s", alias, path)
+		debug.Log("Mounting sub store %q -> %q", alias, path)
 		if err := s.Store.AddMount(ctx, alias, path); err != nil {
 			return fmt.Errorf("failed to add mount %q: %w", alias, err)
 		}
@@ -147,6 +149,7 @@ func (s *Action) init(ctx context.Context, alias, path string, keys ...string) e
 			debug.Log("Stacktrace: %+v\n", err)
 			out.Errorf(ctx, "❌ Failed to init Version Control (%s): %s", bn, err)
 		}
+		debug.Log("RCS initialized as %s", s.Store.Storage(ctx, alias).Name())
 	} else {
 		debug.Log("not initializing RCS backend ...")
 	}

--- a/internal/action/rcs.go
+++ b/internal/action/rcs.go
@@ -31,7 +31,7 @@ func (s *Action) RCSInit(c *cli.Context) error {
 	}
 
 	if err := s.rcsInit(ctx, store, un, ue); err != nil {
-		return ExitError(ExitGit, err, "failed to initialize git: %s", err)
+		return ExitError(ExitGit, err, "failed to initialize %s: %s", backend.StorageBackendName(backend.GetStorageBackend(ctx)), err)
 	}
 	return nil
 }
@@ -47,16 +47,16 @@ func (s *Action) rcsInit(ctx context.Context, store, un, ue string) error {
 	userName, userEmail := s.getUserData(ctx, store, un, ue)
 	if err := s.Store.RCSInit(ctx, store, userName, userEmail); err != nil {
 		if errors.Is(err, backend.ErrNotSupported) {
-			debug.Log("RCSInit not supported for backend %s", bn)
+			debug.Log("RCSInit not supported for backend %s in %q", bn, store)
 			return nil
 		}
 		if gtv := os.Getenv("GPG_TTY"); gtv == "" {
 			out.Printf(ctx, "Git initialization failed. You may want to try to 'export GPG_TTY=$(tty)' and start over.")
 		}
-		return fmt.Errorf("failed to run git init: %w", err)
+		return fmt.Errorf("failed to run RCS init: %w", err)
 	}
 
-	out.Printf(ctx, "Initialized git repository (%s) for %s / %s...", bn, un, ue)
+	out.Printf(ctx, "Initialized %s repository (%s) for %s / %s...", be, bn, un, ue)
 	return nil
 }
 

--- a/internal/action/setup.go
+++ b/internal/action/setup.go
@@ -251,6 +251,7 @@ func (s *Action) initLocal(ctx context.Context) error {
 	}
 
 	if backend.GetStorageBackend(ctx) == backend.GitFS {
+		debug.Log("configuring git remotes")
 		if want, err := termio.AskForBool(ctx, "❓ Do you want to add a git remote?", false); err == nil && want {
 			out.Printf(ctx, "Configuring the git remote ...")
 			if err := s.initSetupGitRemote(ctx, "", ""); err != nil {
@@ -258,6 +259,7 @@ func (s *Action) initLocal(ctx context.Context) error {
 			}
 		}
 	}
+	// TODO remotes for fossil, etc.
 
 	// save config.
 	if err := s.cfg.Save(); err != nil {

--- a/internal/backend/storage/fossilfs.go
+++ b/internal/backend/storage/fossilfs.go
@@ -1,0 +1,3 @@
+package storage
+
+import _ "github.com/gopasspw/gopass/internal/backend/storage/fossilfs" // register fossilfs backend

--- a/internal/backend/storage/fossilfs/context.go
+++ b/internal/backend/storage/fossilfs/context.go
@@ -1,0 +1,20 @@
+package fossilfs
+
+import "context"
+
+type contextKey int
+
+const (
+	ctxKeyPathOverride contextKey = iota
+)
+
+func withPathOverride(ctx context.Context, path string) context.Context {
+	return context.WithValue(ctx, ctxKeyPathOverride, path)
+}
+
+func getPathOverride(ctx context.Context, def string) string {
+	if sv, ok := ctx.Value(ctxKeyPathOverride).(string); ok && sv != "" {
+		return sv
+	}
+	return def
+}

--- a/internal/backend/storage/fossilfs/fossil.go
+++ b/internal/backend/storage/fossilfs/fossil.go
@@ -1,0 +1,372 @@
+package fossilfs
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/blang/semver/v4"
+	"github.com/gopasspw/gopass/internal/backend"
+	"github.com/gopasspw/gopass/internal/backend/storage/fs"
+	"github.com/gopasspw/gopass/internal/out"
+	"github.com/gopasspw/gopass/internal/store"
+	"github.com/gopasspw/gopass/pkg/ctxutil"
+	"github.com/gopasspw/gopass/pkg/debug"
+	"github.com/gopasspw/gopass/pkg/fsutil"
+)
+
+const (
+	CheckoutMarker = ".fslckout"
+)
+
+// Fossil is a storage backend for Fossil.
+type Fossil struct {
+	fs *fs.Store
+}
+
+func New(path string) (*Fossil, error) {
+	marker := filepath.Join(path, CheckoutMarker)
+	if !fsutil.IsFile(marker) {
+		return nil, fmt.Errorf("no fossil checkout marker found at %s", marker)
+	}
+	return &Fossil{
+		fs: fs.New(path),
+	}, nil
+}
+
+func Clone(ctx context.Context, repo, path string) (*Fossil, error) {
+	f := &Fossil{
+		fs: fs.New(path),
+	}
+	if err := f.Cmd(withPathOverride(ctx, filepath.Dir(path)), "Clone", "clone", repo, path); err != nil {
+		return nil, err
+	}
+
+	// initialize the local fossil config.
+	if err := f.InitConfig(ctx, "", ""); err != nil {
+		return f, fmt.Errorf("failed to configure git: %s", err)
+	}
+	out.Printf(ctx, "fossil configured at %s", f.fs.Path())
+
+	return f, nil
+}
+
+// Init initializes this store's fossil repo.
+func Init(ctx context.Context, path, _, _ string) (*Fossil, error) {
+	f := &Fossil{
+		fs: fs.New(path),
+	}
+	// the fossil repo may be empty (i.e. no branches, cloned from a fresh remote)
+	// or already initialized. Only run fossil init if the folder is completely empty.
+	if !f.IsInitialized() {
+		repo := filepath.Join(filepath.Dir(path), "."+filepath.Base(path)+".fossil")
+		if err := f.Cmd(ctx, "Init", "init", repo); err != nil {
+			return nil, fmt.Errorf("failed to initialize fossil in %s: %s", repo, err)
+		}
+		if err := f.Cmd(ctx, "Open", "open", repo); err != nil {
+			return nil, fmt.Errorf("failed to open fossil in %s: %s", repo, err)
+		}
+		out.Printf(ctx, "fossil initialized at %s", f.fs.Path())
+	}
+
+	// TODO rename to IsRCSInitialized
+	if !ctxutil.IsGitInit(ctx) {
+		return f, nil
+	}
+
+	// initialize the local fossil config.
+	if err := f.InitConfig(ctx, "", ""); err != nil {
+		return f, fmt.Errorf("failed to configure fossil: %s", err)
+	}
+	out.Printf(ctx, "fossil configured at %s", f.fs.Path())
+
+	// add current content of the store.
+	if err := f.Add(ctx, f.fs.Path()); err != nil {
+		return f, fmt.Errorf("failed to add %q to fossil: %w", f.fs.Path(), err)
+	}
+
+	// commit if there is something to commit.
+	if !f.HasStagedChanges(ctx) {
+		debug.Log("No staged changes")
+		return f, nil
+	}
+
+	if err := f.Commit(ctx, "Add current content of password store"); err != nil {
+		return f, fmt.Errorf("failed to commit changes to fossil: %w", err)
+	}
+
+	return f, nil
+}
+
+func (f *Fossil) captureCmd(ctx context.Context, name string, args ...string) ([]byte, []byte, error) {
+	bufOut := &bytes.Buffer{}
+	bufErr := &bytes.Buffer{}
+
+	cmd := exec.CommandContext(ctx, "fossil", args[0:]...)
+	cmd.Dir = getPathOverride(ctx, f.fs.Path())
+	cmd.Stdout = bufOut
+	cmd.Stderr = bufErr
+
+	if debug.IsEnabled() && ctxutil.IsVerbose(ctx) {
+		cmd.Stdout = io.MultiWriter(bufOut, os.Stdout)
+		cmd.Stderr = io.MultiWriter(bufErr, os.Stderr)
+	}
+
+	debug.Log("fossil.%s: %s %+v (%s)", name, cmd.Path, cmd.Args, f.fs.Path())
+	err := cmd.Run()
+	return bufOut.Bytes(), bufErr.Bytes(), err
+}
+
+// Cmd runs an fossil command.
+func (f *Fossil) Cmd(ctx context.Context, name string, args ...string) error {
+	stdout, stderr, err := f.captureCmd(ctx, name, args...)
+	if err != nil {
+		debug.Log("CMD: %s %+v\nError: %s\nOutput:\n  Stdout: %q\n  Stderr: %q", name, args, err, string(stdout), string(stderr))
+		return fmt.Errorf("%s: %s", err, strings.TrimSpace(string(stderr)))
+	}
+
+	return nil
+}
+
+// Name returns 'fossil'.
+func (f *Fossil) Name() string {
+	return name
+}
+
+// Version returns the fossil version as major, minor and patch level.
+func (f *Fossil) Version(ctx context.Context) semver.Version {
+	v := semver.Version{}
+
+	cmd := exec.CommandContext(ctx, "fossil", "version")
+	cmdout, err := cmd.Output()
+	if err != nil {
+		debug.Log("Failed to run 'fossil version': %s", err)
+		return v
+	}
+
+	svStr := strings.TrimPrefix(string(cmdout), "This is fossil version ")
+	if p := strings.Fields(svStr); len(p) > 0 {
+		svStr = p[0]
+	}
+
+	sv, err := semver.ParseTolerant(svStr)
+	if err != nil {
+		debug.Log("Failed to parse %q as semver: %s", svStr, err)
+		return v
+	}
+	return sv
+}
+
+// IsInitialized returns true if this stores has an (probably) initialized Fossil chkecout.
+func (f *Fossil) IsInitialized() bool {
+	return fsutil.IsFile(filepath.Join(f.fs.Path(), CheckoutMarker))
+}
+
+// Add adds the listed files to the fossil index.
+func (f *Fossil) Add(ctx context.Context, files ...string) error {
+	if !f.IsInitialized() {
+		// TODO should rename to ErrRCSNotInitialized
+		return store.ErrGitNotInit
+	}
+
+	for i := range files {
+		files[i] = strings.TrimPrefix(files[i], f.fs.Path()+"/")
+	}
+
+	args := []string{"add", "--force", "--dotfiles"}
+	args = append(args, files...)
+
+	return f.Cmd(ctx, "fossilAdd", args...)
+}
+
+// HasStagedChanges returns true if there are any staged changes which can be committed.
+func (f *Fossil) HasStagedChanges(ctx context.Context) bool {
+	s, err := f.getStatus(ctx)
+	if err != nil {
+		// TODO should return an error
+		return true
+	}
+	return s.Staged().Len() > 0
+}
+
+// ListUntrackedFiles lists untracked files.
+func (f *Fossil) ListUntrackedFiles(ctx context.Context) []string {
+	s, err := f.getStatus(ctx)
+	if err != nil {
+		// TODO should return an error
+		return []string{fmt.Sprintf("ERROR: %s", err)}
+	}
+	return s.Untracked().Elements()
+}
+
+// Commit creates a new fossil commit with the given commit message.
+func (f *Fossil) Commit(ctx context.Context, msg string) error {
+	if !f.IsInitialized() {
+		return store.ErrGitNotInit
+	}
+
+	if !f.HasStagedChanges(ctx) {
+		return store.ErrGitNothingToCommit
+	}
+
+	return f.Cmd(
+		ctx,
+		"fossilCommit",
+		"commit",
+		"--date-override",
+		ctxutil.GetCommitTimestamp(ctx).UTC().Format("2006-01-02T15:04:05.000"),
+		"--no-warnings",
+		"-m",
+		msg,
+	)
+}
+
+// PushPull pushes the repo to it's origin.
+// optional arguments: remote and branch.
+func (f *Fossil) PushPull(ctx context.Context, op, remote, branch string) error {
+	if ctxutil.IsNoNetwork(ctx) {
+		debug.Log("Skipping network ops. NoNetwork=true")
+		return nil
+	}
+	if !f.IsInitialized() {
+		return store.ErrGitNotInit
+	}
+
+	if uf := f.ListUntrackedFiles(ctx); len(uf) > 0 {
+		out.Warningf(ctx, "Found untracked files: %+v", uf)
+	}
+	return f.Cmd(ctx, "fossilPush", "sync")
+}
+
+// Push pushes to the fossil remote.
+func (f *Fossil) Push(ctx context.Context, remote, branch string) error {
+	if ctxutil.IsNoNetwork(ctx) {
+		debug.Log("Skipping network ops. NoNetwork=true")
+		return nil
+	}
+	return f.PushPull(ctx, "push", remote, branch)
+}
+
+// Pull pulls from the fossil remote.
+func (f *Fossil) Pull(ctx context.Context, remote, branch string) error {
+	if ctxutil.IsNoNetwork(ctx) {
+		debug.Log("Skipping network ops. NoNetwork=true")
+		return nil
+	}
+	return f.PushPull(ctx, "pull", remote, branch)
+}
+
+// AddRemote adds a new remote.
+func (f *Fossil) AddRemote(ctx context.Context, remote, url string) error {
+	return f.Cmd(ctx, "fossilAddRemote", "remote", "add", remote, url)
+}
+
+// RemoveRemote removes a remote.
+func (f *Fossil) RemoveRemote(ctx context.Context, remote string) error {
+	return f.Cmd(ctx, "fossilRemoveRemote", "remote", "delete", remote)
+}
+
+// Revisions will list all available revisions of the named entity
+func (f *Fossil) Revisions(ctx context.Context, name string) ([]backend.Revision, error) {
+	args := []string{
+		"finfo",
+		"-W",
+		"0",
+		name,
+	}
+	stdout, stderr, err := f.captureCmd(ctx, "Revisions", args...)
+	if err != nil {
+		debug.Log("Command failed: %s", string(stderr))
+		return nil, err
+	}
+
+	revs := make([]backend.Revision, 0, strings.Count(string(stdout), "\n"))
+	for _, line := range strings.Split(string(stdout), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			debug.Log("empty line")
+			continue
+		}
+
+		debug.Log("Parsing line: %s", line)
+		body := line // retain full line for the body
+		date, line, found := strings.Cut(line, " ")
+		if !found {
+			debug.Log("Failed to parse date")
+			continue
+		}
+		rev, line, found := strings.Cut(line, " ")
+		if !found {
+			debug.Log("Failed to parse revision")
+			continue
+		}
+		rev = strings.Trim(rev, "[]")
+		subject, line, found := strings.Cut(line, "(")
+		if !found {
+			debug.Log("Failed to parse subject")
+			continue
+		}
+
+		author, _, found := strings.Cut(line, ",")
+		if !found {
+			debug.Log("Failed to parse author")
+			continue
+		}
+		author = strings.TrimPrefix(author, "user: ")
+
+		ts, err := time.Parse("2006-01-02", date)
+		if err != nil {
+			debug.Log("Failed to parse date %s: %s", date, err)
+			continue
+		}
+
+		r := backend.Revision{
+			Hash:       rev,
+			Date:       ts,
+			Body:       body,
+			Subject:    subject,
+			AuthorName: author,
+		}
+		revs = append(revs, r)
+	}
+	return revs, nil
+}
+
+// GetRevision will return the content of any revision of the named entity
+func (f *Fossil) GetRevision(ctx context.Context, name, revision string) ([]byte, error) {
+	name = strings.TrimSpace(name)
+	revision = strings.TrimSpace(revision)
+	args := []string{
+		"cat",
+		"-r",
+		revision,
+		name,
+	}
+	stdout, stderr, err := f.captureCmd(ctx, "GetRevision", args...)
+	if err != nil {
+		debug.Log("Command failed: %s", string(stderr))
+		return nil, err
+	}
+	return stdout, nil
+}
+
+// Status return the fossil status output.
+func (f *Fossil) Status(ctx context.Context) ([]byte, error) {
+	stdout, stderr, err := f.captureCmd(ctx, "FossilStatus", "status")
+	if err != nil {
+		debug.Log("Command failed: %s\n%s", string(stdout), string(stderr))
+		return nil, err
+	}
+	return stdout, nil
+}
+
+// Compact will run fossil rebuild.
+func (f *Fossil) Compact(ctx context.Context) error {
+	return f.Cmd(ctx, "fossilRebuild", "rebuild", "--compress", "--analyze", "--vacuum")
+}

--- a/internal/backend/storage/fossilfs/loader.go
+++ b/internal/backend/storage/fossilfs/loader.go
@@ -1,4 +1,4 @@
-package gitfs
+package fossilfs
 
 import (
 	"context"
@@ -7,15 +7,14 @@ import (
 
 	"github.com/gopasspw/gopass/internal/backend"
 	"github.com/gopasspw/gopass/pkg/fsutil"
-	"github.com/gopasspw/gopass/pkg/termio"
 )
 
 const (
-	name = "gitfs"
+	name = "fossilfs"
 )
 
 func init() {
-	backend.StorageRegistry.Register(backend.GitFS, name, &loader{})
+	backend.StorageRegistry.Register(backend.FossilFS, name, &loader{})
 }
 
 type loader struct{}
@@ -24,30 +23,28 @@ func (l loader) New(ctx context.Context, path string) (backend.Storage, error) {
 	return New(path)
 }
 
-// Open implements backend.RCSLoader.
 func (l loader) Open(ctx context.Context, path string) (backend.Storage, error) {
 	return New(path)
 }
 
-// Clone implements backend.RCSLoader.
 func (l loader) Clone(ctx context.Context, repo, path string) (backend.Storage, error) {
-	return Clone(ctx, repo, path, termio.DetectName(ctx, nil), termio.DetectEmail(ctx, nil))
+	return Clone(ctx, repo, path)
 }
 
-// Init implements backend.RCSLoader.
 func (l loader) Init(ctx context.Context, path string) (backend.Storage, error) {
-	return Init(ctx, path, termio.DetectName(ctx, nil), termio.DetectEmail(ctx, nil))
+	return Init(ctx, path, "", "")
 }
 
 func (l loader) Handles(ctx context.Context, path string) error {
-	if !fsutil.IsDir(filepath.Join(path, ".git")) {
-		return fmt.Errorf("no .git")
+	marker := filepath.Join(path, CheckoutMarker)
+	if !fsutil.IsFile(marker) {
+		return fmt.Errorf("no fossil checkout marker found at %s", marker)
 	}
 	return nil
 }
 
 func (l loader) Priority() int {
-	return 1
+	return 2
 }
 
 func (l loader) String() string {

--- a/internal/backend/storage/fossilfs/settings.go
+++ b/internal/backend/storage/fossilfs/settings.go
@@ -1,0 +1,93 @@
+package fossilfs
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/gopasspw/gopass/internal/store"
+	"github.com/gopasspw/gopass/pkg/debug"
+)
+
+func (f *Fossil) fixConfig(ctx context.Context) error {
+	// enable autosync
+	if err := f.ConfigSet(ctx, "autosync", "1"); err != nil {
+		return fmt.Errorf("failed to set fossil config autosync: %w", err)
+	}
+
+	// binary-glob
+	if err := f.ConfigSet(ctx, "binary-glob", "*.age,*.gpg"); err != nil {
+		return fmt.Errorf("failed to set fossil config binary-glob: %w", err)
+	}
+
+	return nil
+}
+
+func (f *Fossil) InitConfig(ctx context.Context, _, _ string) error {
+	// ensure a sane fossil config.
+	if err := f.fixConfig(ctx); err != nil {
+		return fmt.Errorf("failed to fix fossil config: %w", err)
+	}
+
+	return nil
+}
+
+// ConfigSet sets a local config value.
+func (f *Fossil) ConfigSet(ctx context.Context, key, value string) error {
+	return f.Cmd(ctx, "fossilConfigSet", "settings", "--exact", key, value)
+}
+
+// ConfigGet returns a given config value.
+func (f *Fossil) ConfigGet(ctx context.Context, key string) (string, error) {
+	if !f.IsInitialized() {
+		return "", store.ErrGitNotInit
+	}
+
+	buf := &strings.Builder{}
+
+	cmd := exec.CommandContext(ctx, "fossil", "settings", "--exact", key)
+	cmd.Dir = f.fs.Path()
+	cmd.Stdout = buf
+	cmd.Stderr = os.Stderr
+
+	debug.Log("%s %+v", cmd.Path, cmd.Args)
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+
+	sv := strings.Fields(strings.TrimSpace(buf.String()))
+	return sv[len(sv)-1], nil
+}
+
+// ConfigList returns all fossil config settings.
+func (f *Fossil) ConfigList(ctx context.Context) (map[string]string, error) {
+	if !f.IsInitialized() {
+		return nil, store.ErrGitNotInit
+	}
+
+	buf := &strings.Builder{}
+
+	cmd := exec.CommandContext(ctx, "fossil", "settings")
+	cmd.Dir = f.fs.Path()
+	cmd.Stdout = buf
+	cmd.Stderr = os.Stderr
+
+	debug.Log("%s %+v", cmd.Path, cmd.Args)
+	if err := cmd.Run(); err != nil {
+		return nil, err
+	}
+
+	lines := strings.Split(buf.String(), "\n")
+	kv := make(map[string]string, len(lines))
+	for _, line := range lines {
+		p := strings.Fields(strings.TrimSpace(line))
+		// only record settings with a value
+		if len(p) < 2 {
+			continue
+		}
+		kv[p[0]] = p[len(p)-1]
+	}
+	return kv, nil
+}

--- a/internal/backend/storage/fossilfs/status.go
+++ b/internal/backend/storage/fossilfs/status.go
@@ -1,0 +1,55 @@
+package fossilfs
+
+import (
+	"context"
+	"strings"
+
+	"bitbucket.org/creachadair/stringset"
+)
+
+type fossilStatus struct {
+	Extra     stringset.Set
+	Added     stringset.Set
+	Edited    stringset.Set
+	Unchanged stringset.Set
+}
+
+func (f *Fossil) getStatus(ctx context.Context) (fossilStatus, error) {
+	stdout, _, err := f.captureCmd(ctx, "fossilStatus", "status", "--extra", "--all")
+	if err != nil {
+		return fossilStatus{}, err
+	}
+
+	s := fossilStatus{
+		Extra:     stringset.New(),
+		Added:     stringset.New(),
+		Edited:    stringset.New(),
+		Unchanged: stringset.New(),
+	}
+	for _, line := range strings.Split(string(stdout), "\n") {
+		op, file, found := strings.Cut(line, " ")
+		if !found {
+			continue
+		}
+		switch op {
+		case "ADDED":
+			s.Added.Add(strings.TrimSpace(file))
+		case "UNCHANGED":
+			s.Unchanged.Add(strings.TrimSpace(file))
+		case "EXTRA":
+			s.Added.Add(strings.TrimSpace(file))
+		case "EDITED":
+			s.Edited.Add(strings.TrimSpace(file))
+		}
+	}
+
+	return s, nil
+}
+
+func (fs *fossilStatus) Untracked() stringset.Set {
+	return fs.Extra.Union(fs.Added).Union(fs.Edited)
+}
+
+func (fs *fossilStatus) Staged() stringset.Set {
+	return fs.Edited.Union(fs.Added)
+}

--- a/internal/backend/storage/fossilfs/storage.go
+++ b/internal/backend/storage/fossilfs/storage.go
@@ -1,0 +1,67 @@
+package fossilfs
+
+import (
+	"context"
+	"fmt"
+)
+
+// Get retrieves the named content.
+func (f *Fossil) Get(ctx context.Context, name string) ([]byte, error) {
+	return f.fs.Get(ctx, name)
+}
+
+// Set writes the given content.
+func (f *Fossil) Set(ctx context.Context, name string, value []byte) error {
+	return f.fs.Set(ctx, name, value)
+}
+
+// Delete removes the named entity.
+func (f *Fossil) Delete(ctx context.Context, name string) error {
+	return f.fs.Delete(ctx, name)
+}
+
+// Exists checks if the named entity exists.
+func (f *Fossil) Exists(ctx context.Context, name string) bool {
+	return f.fs.Exists(ctx, name)
+}
+
+// List returns a list of all entities
+// e.g. foo, far/bar baz/.bang
+// directory separator are normalized using `/`.
+func (f *Fossil) List(ctx context.Context, prefix string) ([]string, error) {
+	return f.fs.List(ctx, prefix)
+}
+
+// IsDir returns true if the named entity is a directory.
+func (f *Fossil) IsDir(ctx context.Context, name string) bool {
+	return f.fs.IsDir(ctx, name)
+}
+
+// Prune removes a named directory.
+func (f *Fossil) Prune(ctx context.Context, prefix string) error {
+	return f.fs.Prune(ctx, prefix)
+}
+
+// String implements fmt.Stringer.
+func (f *Fossil) String() string {
+	return fmt.Sprintf("fossilfs(%s,path:%s)", f.Version(context.TODO()).String(), f.fs.Path())
+}
+
+// Path returns the path to this storage.
+func (f *Fossil) Path() string {
+	return f.fs.Path()
+}
+
+// Fsck checks the storage integrity.
+func (f *Fossil) Fsck(ctx context.Context) error {
+	// ensure sane fossil config.
+	if err := f.fixConfig(ctx); err != nil {
+		return fmt.Errorf("failed to fix fossil config: %w", err)
+	}
+	return f.fs.Fsck(ctx)
+}
+
+// Link creates a symlink.
+func (f *Fossil) Link(ctx context.Context, from, to string) error {
+	return f.fs.Link(ctx, from, to)
+}

--- a/internal/backend/storage/gitfs/storage.go
+++ b/internal/backend/storage/gitfs/storage.go
@@ -44,7 +44,7 @@ func (g *Git) Prune(ctx context.Context, prefix string) error {
 
 // String implements fmt.Stringer.
 func (g *Git) String() string {
-	return fmt.Sprintf("gitfs(v0.1.0,path:%s)", g.fs.Path())
+	return fmt.Sprintf("gitfs(%s,path:%s)", g.Version(context.TODO()).String(), g.fs.Path())
 }
 
 // Path returns the path to this storage.

--- a/internal/store/leaf/rcs.go
+++ b/internal/store/leaf/rcs.go
@@ -51,9 +51,11 @@ func (s *Store) GetRevision(ctx context.Context, name, revision string) (gopass.
 
 // GitStatus shows the git status output.
 func (s *Store) GitStatus(ctx context.Context, _ string) error {
+	debug.Log("RCS status for %s", s.path)
 	buf, err := s.storage.Status(ctx)
 	if err != nil {
-		return err
+		debug.Log("RCS status failed for %s: %s", s.path, err)
+		return fmt.Errorf("failed to get RCS status for %s: %w", s.path, err)
 	}
 	out.Printf(ctx, string(buf))
 	return nil


### PR DESCRIPTION
This commit adds HIGHLY EXPERIMENTAL support for the Fossil SCM.
It's barely tested but seems to support the most basic use cases
already. A lot of Fossil specifics aren't supported, yet. Cloning
for examples isn't supported so far.

This should be threated as an experiment only so far. If there is some interest we
will probably built this out further in the future. Fossil definitely has some
very nice properties and should be much simpler to support than git.

Fixes #2022

RELEASE_NOTES=[EXPERIMENTAL] Support the Fossil SCM

Signed-off-by: Dominik Schulz <dominik.schulz@gauner.org>