### PR TITLE
Output full secret when not properly encoded for cat

### DIFF
--- a/internal/action/binary.go
+++ b/internal/action/binary.go
@@ -228,7 +228,8 @@ func (s *Action) binaryGet(ctx context.Context, name string) ([]byte, error) {
 	}
 
 	if cte, _ := sec.Get("content-transfer-encoding"); cte != "Base64" {
-		return []byte(sec.Body()), nil
+		// need to use sec.Bytes() otherwise the first line is missing.
+		return sec.Bytes(), nil
 	}
 
 	buf, err := base64.StdEncoding.DecodeString(sec.Body())

--- a/internal/action/binary_test.go
+++ b/internal/action/binary_test.go
@@ -187,6 +187,26 @@ func TestBinarySum(t *testing.T) {
 	})
 }
 
+func TestBinaryGet(t *testing.T) {
+	u := gptest.NewUnitTester(t)
+	defer u.Remove()
+
+	ctx := context.Background()
+	ctx = ctxutil.WithAlwaysYes(ctx, true)
+	ctx = ctxutil.WithHidden(ctx, true)
+
+	act, err := newMock(ctx, u)
+	require.NoError(t, err)
+	require.NotNil(t, act)
+
+	data := []byte("1\n2\n3\n")
+	assert.NoError(t, act.insertStdin(ctx, "x", data, false))
+
+	out, err := act.binaryGet(ctx, "x")
+	assert.NoError(t, err)
+	assert.Equal(t, data, out)
+}
+
 func writeBinfile(t *testing.T, fn string) {
 	// tests should be predicable
 	rand.Seed(42)


### PR DESCRIPTION
RELEASE_NOTES=[BUGFIX] Handle unencoded secret on cat

Fixes #2104

Signed-off-by: Dominik Schulz <dominik.schulz@gauner.org>