### PR TITLE
Prevent MD5Crypt to generate invalid salts

### DIFF
--- a/internal/tpl/funcs.go
+++ b/internal/tpl/funcs.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha1"
 	"fmt"
 	"strconv"
+	"strings"
 	"text/template"
 
 	"github.com/gopasspw/gopass/internal/pwschemes/argon2i"
@@ -75,7 +76,14 @@ func md5cryptFunc() func(...string) (string, error) {
 		if sl > 8 || sl < 1 {
 			sl = 4
 		}
-		return md5crypt.Generate(s[len(s)-1], sl)
+		var ret string
+		var err error
+		// Perform rejection sampling to avoid invalid salts
+		// TODO: remove this once https://github.com/jsimonetti/pwscheme/issues/1 is fixed
+		for strings.Count(ret, "$") != 3 {
+			ret, err = md5crypt.Generate(s[len(s)-1], sl)
+		}
+		return ret, err
 	}
 }
 


### PR DESCRIPTION
This fixes #2121 without disabling it for now, unlike #2122.

I'm using rejection sampling, and my tests show that the error has a ~2-3% chance of being triggered, so the rejection sampling seems fine and isn't at risk of falling into an infinite loop.
