### PR TITLE
Check org.gpgtools.common UseKeychain on MacOS

### DIFF
--- a/internal/action/reminder.go
+++ b/internal/action/reminder.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 
+	"github.com/gopasspw/gopass/internal/env"
 	"github.com/gopasspw/gopass/internal/out"
 	"github.com/gopasspw/gopass/pkg/ctxutil"
 )
@@ -17,6 +18,18 @@ func (s *Action) printReminder(ctx context.Context) {
 	}
 	if sv := os.Getenv("GOPASS_NO_REMINDER"); sv != "" {
 		return
+	}
+
+	// this might be printed along other reminders
+	if s.rem.Overdue("env") {
+		msg, err := env.Check(ctx)
+		if err != nil {
+			out.Warningf(ctx, "Failed to check environment: %s", err)
+		}
+		if msg != "" {
+			out.Warningf(ctx, "%s", msg)
+		}
+		s.rem.Reset("env")
 	}
 
 	// Note: We only want to print one reminder per day (at most).

--- a/internal/env/env_darwin.go
+++ b/internal/env/env_darwin.go
@@ -1,0 +1,42 @@
+//go:build darwin
+// +build darwin
+
+package env
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+var (
+	// Stdin is exported for tests.
+	Stdin io.Reader = os.Stdin
+	// Stderr is exported for tests.
+	Stderr io.Writer = os.Stderr
+)
+
+func Check(ctx context.Context) (string, error) {
+	buf := &bytes.Buffer{}
+
+	cmd := exec.CommandContext(ctx, "defaults", "read", "org.gpgtools.common", "UseKeychain")
+	cmd.Stdin = Stdin
+	cmd.Stdout = buf
+	cmd.Stderr = Stderr
+
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+
+	// if the keychain is not used, we can skip the rest
+	if strings.ToUpper(strings.TrimSpace(buf.String())) == "NO" {
+		return "", nil
+	}
+
+	// gpg uses the keychain to store the passphrase, warn once in a while that users
+	// might want to change that because it's not secure.
+	return "pinentry-mac will use the MacOS Keychain to store your passphrase indefinitely. Consider running 'defaults write org.gpgtools.common UseKeychain NO' to disable that.", nil
+}

--- a/internal/env/env_others.go
+++ b/internal/env/env_others.go
@@ -1,0 +1,11 @@
+//go:build !darwin
+// +build !darwin
+
+package env
+
+import "context"
+
+// Check does nothing on these OSes, yet.
+func Check(ctx context.Context) (string, error) {
+	return "", nil
+}


### PR DESCRIPTION
RELEASE_NOTES=[ENHANCENMENT] Check for MacOS Keychain storing the GPG
passphrase.

Fixes #2137

Signed-off-by: Dominik Schulz <dominik.schulz@gauner.org>