### PR TITLE
Fix completion when password name contains quotes

### DIFF
--- a/internal/action/completion.go
+++ b/internal/action/completion.go
@@ -14,13 +14,19 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-var escapeRegExp = regexp.MustCompile(`(\s|\(|\)|\<|\>|\&|\;|\#|\\|\||\*|\?)`)
+var escapeRegExp = regexp.MustCompile(`('|"|\s|\(|\)|\<|\>|\&|\;|\#|\\|\||\*|\?)`)
 
 // bashEscape Escape special characters with `\`.
 func bashEscape(s string) string {
 	return escapeRegExp.ReplaceAllStringFunc(s, func(c string) string {
 		if c == `\` {
 			return `\\\\`
+		}
+		if c == `'` {
+			return `\` + c
+		}
+		if c == `"` {
+			return `\\\` + c
 		}
 		return `\\` + c
 	})

--- a/internal/action/completion_test.go
+++ b/internal/action/completion_test.go
@@ -15,10 +15,26 @@ import (
 )
 
 func TestBashEscape(t *testing.T) {
-	expected := `a\\<\\>\\|\\\\and\\ sometimes\\?\\*\\(\\)\\&\\;\\#`
-	if escaped := bashEscape(`a<>|\and sometimes?*()&;#`); escaped != expected {
-		t.Errorf("Expected %q, but got %q", expected, escaped)
-	}
+	t.Run("bash escape", func(t *testing.T) {
+		expected := `a\\<\\>\\|\\\\and\\ sometimes\\?\\*\\(\\)\\&\\;\\#`
+		if escaped := bashEscape(`a<>|\and sometimes?*()&;#`); escaped != expected {
+			t.Errorf("Expected %q, but got %q", expected, escaped)
+		}
+	})
+
+	t.Run("bash escape single quote", func(t *testing.T) {
+		expected := `good\\ ol\'\\ days`
+		if escaped := bashEscape(`good ol' days`); escaped != expected {
+			t.Errorf("Expected %q, but got %q", expected, escaped)
+		}
+	})
+
+	t.Run("bash escape double quote", func(t *testing.T) {
+		expected := `my\\ \\\"bad\\\"\\ password`
+		if escaped := bashEscape(`my "bad" password`); escaped != expected {
+			t.Errorf("Expected %q, but got %q", expected, escaped)
+		}
+	})
 }
 
 func TestComplete(t *testing.T) {


### PR DESCRIPTION
This PR fixes shell completion when some passwords names contain single or double quotes.

Without this change, completion either returns nothing or inconsistent results depending on the number of quotes passwords matching the requested completion contain.

TODO:
- [x] add unit tests.