### PR TITLE
Add --chars option to show to allow printing a subset of the secret only

### DIFF
--- a/docs/commands/show.md
+++ b/docs/commands/show.md
@@ -28,6 +28,7 @@ Flag | Aliases | Description
 `--password` | `-o` | Display only the password. For use in scripts. Takes precedence over other flags.
 `--revision` | `-r` | Display a specific revision of the entry. Use an exact version identifier from `gopass history` or the special `-<N>` syntax. Does not work with native (e.g. git) refs.
 `--noparsing` | `-n` | Do not parse the content, disable YAML and Key-Value functions.
+`--chars` | | Display selected characters from the password.
 
 ## Details
 

--- a/internal/action/commands.go
+++ b/internal/action/commands.go
@@ -52,6 +52,10 @@ func ShowFlags() []cli.Flag {
 			Aliases: []string{"n"},
 			Usage:   "Do not parse the output.",
 		},
+		&cli.StringFlag{
+			Name:  "chars",
+			Usage: "Print specific characters from the secret",
+		},
 	}
 }
 

--- a/internal/action/context.go
+++ b/internal/action/context.go
@@ -12,6 +12,7 @@ const (
 	ctxKeyKey
 	ctxKeyOnlyClip
 	ctxKeyAlsoClip
+	ctxKeyPrintChars
 )
 
 // WithClip returns a context with the value for clip (for copy to clipboard)
@@ -125,4 +126,18 @@ func GetKey(ctx context.Context) string {
 		return ""
 	}
 	return sv
+}
+
+// WithPrintChars returns the context with the print chars set.
+func WithPrintChars(ctx context.Context, c []int) context.Context {
+	return context.WithValue(ctx, ctxKeyPrintChars, c)
+}
+
+// GetPrintChars returns a map of all character positions to print.
+func GetPrintChars(ctx context.Context) []int {
+	mv, ok := ctx.Value(ctxKeyPrintChars).([]int)
+	if !ok {
+		return nil
+	}
+	return mv
 }

--- a/internal/out/print.go
+++ b/internal/out/print.go
@@ -18,7 +18,7 @@ var (
 	Stderr io.Writer = os.Stderr
 )
 
-// Secret is a string wrapper for strings containing secrets. These won't b.
+// Secret is a string wrapper for strings containing secrets. These won't be
 // logged as long a GOPASS_DEBUG_LOG_SECRETS is not set.
 type Secret string
 


### PR DESCRIPTION
Fixes #2068

RELEASE_NOTES=Add --chars option to print subset of secrets

Signed-off-by: Dominik Schulz <dominik.schulz@gauner.org>