### PR TITLE
Bump to Go 1.18 proper

### DIFF
--- a/.github/workflows/autorelease.yml
+++ b/.github/workflows/autorelease.yml
@@ -22,7 +22,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17
+          go-version: 1.18
       # ubuntu is missing wixl https://github.com/actions/virtual-environments/issues/3857
       -
         name: "Install GNOME msitools (wixl)"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,18 +16,11 @@ jobs:
         fetch-depth: 0
 
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
-        go-version: 1.17.5
-    - name: Install beta version
-      run: |
-        go install golang.org/dl/go1.18beta1@latest
-        go1.18beta1 download
-        cp $(which go1.18beta1) $(which go)
-        go version
+        go-version: 1.18
     - name: Ubuntu Dependencies
       run: sudo apt-get install --yes git gnupg
-
     - run: git config --global user.name nobody
     - run: git config --global user.email foo.bar@example.org
 
@@ -66,15 +59,9 @@ jobs:
         fetch-depth: 0
 
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
-        go-version: 1.17.5
-    - name: Install beta version
-      run: |
-        go install golang.org/dl/go1.18beta1@latest
-        go1.18beta1 download
-        cp $(which go1.18beta1) $(which go)
-        go version
+        go-version: 1.18
 
     - run: git config --global user.name nobody
     - run: git config --global user.email foo.bar@example.org
@@ -90,15 +77,9 @@ jobs:
         fetch-depth: 0
 
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
-        go-version: 1.17.5
-    - name: Install beta version
-      run: |
-        go install golang.org/dl/go1.18beta1@latest
-        go1.18beta1 download
-        cp $(which go1.18beta1) $(which go)
-        go version
+        go-version: 1.18
 
     - name: MacOS Dependencies
       run: brew install git gnupg

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -21,5 +21,5 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: latest # we have a linter whitelist in our .golangci.yml config file
+          version: latest # we have a list of linters in our .golangci.yml config file
           only-new-issues: true


### PR DESCRIPTION
RELEASE_NOTES=[CLEANUP] Use Go 1.18

Signed-off-by: Dominik Schulz <dominik.schulz@gauner.org>