### PR TITLE
Enable more lint checks

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,62 +1,68 @@
+run:
+  skip-dirs:
+    - helpers/
+  go: 1.18
+
 linters-settings:
   gocyclo:
     min-complexity: 22
+  cyclop:
+    max-complexity: 22
+    skip-tests: true
   staticcheck:
     go: "1.18"
     # https://staticcheck.io/docs/options#checks
     checks: ["all","-SA1019"]
+  funlen:
+    lines: -1
+    statements: 100
 
 linters:
-  disable-all: true
-
-  enable:
-        - asciicheck
-        - forcetypeassert
-        - gci
-        # - gocyclo # need to refactor internal/create/wizard
-        - gofmt
-        - gomoddirectives
-        - gomodguard
-        - goprintffuncname
-        - ifshort
-        - ineffassign
-        - misspell
-        - nakedret
-        - nolintlint
-        - prealloc
-        - predeclared
-        - godot
-        - nestif
-        #- revive # currently a bit buggy with Go 1.18 but works mostly
-        ## To enable once they work with Go 1.18:
-        ### - deadcode
-        ### - depguard
-        ### - durationcheck
-        ### - errcheck
-        ### - errorlint
-        ### - exhaustive
-        ### - exportloopref
-        ### - gocritic
-        ### - goerr113
-        ### - gosec
-        ### - gosimple
-        ### - govet
-        ### - importas
-        ### - makezero
-        ### - nilerr
-        ### - rowserrcheck
-        ### - staticcheck
-        ### - structcheck
-        ### - stylecheck
-        ### - thelper
-        ### - tparallel
-        ### - typecheck
-        ### - unconvert
-        ### - unparam
-        ### - unused
-        ### - varcheck
-        ### - wastedassign
-        ### - wrapcheck
+  enable-all: true
+  disable:
+  - bodyclose
+  - contextcheck
+  - durationcheck
+  - dupl
+  - exhaustivestruct
+  - forbidigo
+  - gochecknoglobals
+  - gochecknoinits
+  - gocognit
+  - goconst
+  - gocritic
+  - gocyclo
+  - godox
+  - goerr113
+  - golint
+  - gomnd
+  - gosec
+  - gosimple
+  - govet
+  - interfacer
+  - ireturn
+  - lll
+  - maintidx
+  - maligned
+  - nilerr
+  - noctx
+  - revive
+  - rowserrcheck
+  - scopelint
+  - sqlclosecheck
+  - staticcheck
+  - structcheck
+  - stylecheck
+  - tagliatelle
+  - testpackage
+  - tparallel
+  - typecheck
+  - unparam
+  - unused
+  - varnamelen
+  - wastedassign
+  - wrapcheck
+  - wsl
 
 issues:
   exclude-use-default: false # disable filtering of defaults for better zero-issue policy

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ OK := $(shell tput setaf 6; echo ' [OK]'; tput sgr0;)
 all: sysinfo build
 build: $(GOPASS_OUTPUT)
 completion: $(BASH_COMPLETION_OUTPUT) $(FISH_COMPLETION_OUTPUT) $(ZSH_COMPLETION_OUTPUT)
-travis: sysinfo crosscompile build fulltest completion
+travis: sysinfo crosscompile build fulltest completion codequality
 travis-osx: sysinfo build test completion
 travis-windows: sysinfo build test-win completion
 
@@ -131,14 +131,6 @@ crosscompile:
 codequality:
 	@echo ">> CODE QUALITY"
 
-	@echo -n "     GOCRITIC "
-	@which gocritic > /dev/null; if [ $$? -ne 0 ]; then \
-		$(GO) install github.com/go-critic/go-critic/cmd/gocritic@latest; \
-	fi
-	@gocritic check -disable='exitAfterDefer,appendAssign,dupArg' ./... || exit 0
-
-	@printf '%s\n' '$(OK)'
-
 	@echo -n "     GOLANGCI-LINT "
 	@which golangci-lint > /dev/null; if [ $$? -ne 0 ]; then \
 		$(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@latest; \
@@ -151,7 +143,7 @@ gen:
 	@$(GO) generate ./...
 
 fmt:
-	@gofumpt -l -w $(GOFILES_NOVENDOR)
+	@gofumpt -s -l -w $(GOFILES_NOVENDOR)
 	@gci write $(GOFILES_NOVENDOR)
 	@$(GO) mod tidy
 

--- a/helpers/release/main.go
+++ b/helpers/release/main.go
@@ -39,6 +39,7 @@ func getVersion() semver.Version {
 	if err == nil {
 		return sv
 	}
+
 	return semver.Version{
 		Major: {{ .Major }},
 		Minor: {{ .Minor }},

--- a/internal/action/action_test.go
+++ b/internal/action/action_test.go
@@ -41,6 +41,8 @@ func newMock(ctx context.Context, u *gptest.Unit) (*Action, error) {
 }
 
 func TestAction(t *testing.T) {
+	t.Parallel()
+
 	u := gptest.NewUnitTester(t)
 	defer u.Remove()
 
@@ -64,6 +66,8 @@ func TestAction(t *testing.T) {
 }
 
 func TestNew(t *testing.T) {
+	t.Parallel()
+
 	td, err := os.MkdirTemp("", "gopass-")
 	require.NoError(t, err)
 	defer func() {
@@ -73,12 +77,12 @@ func TestNew(t *testing.T) {
 	cfg := config.New()
 	sv := semver.Version{}
 
-	t.Run("init a new store", func(t *testing.T) {
+	t.Run("init a new store", func(t *testing.T) { //nolint:paralleltest
 		_, err = New(cfg, sv)
 		require.NoError(t, err)
 	})
 
-	t.Run("init an existing plain store", func(t *testing.T) {
+	t.Run("init an existing plain store", func(t *testing.T) { //nolint:paralleltest
 		cfg.Path = filepath.Join(td, "store")
 		assert.NoError(t, os.MkdirAll(cfg.Path, 0o700))
 		assert.NoError(t, os.WriteFile(filepath.Join(cfg.Path, plain.IDFile), []byte("foobar"), 0o600))

--- a/internal/action/aliases.go
+++ b/internal/action/aliases.go
@@ -19,10 +19,12 @@ func (s *Action) AliasesPrint(c *cli.Context) error {
 	for k := range aliases {
 		keys = append(keys, k)
 	}
+
 	sort.Strings(keys)
 	for _, k := range keys {
 		out.Printf(c.Context, "- %s -> %s", k, strings.Join(aliases[k], ", "))
 	}
+
 	return nil
 }
 
@@ -41,6 +43,7 @@ func (s *Action) AliasesAdd(c *cli.Context) error {
 	}
 
 	out.Printf(ctx, "Added alias %q to domain %q", alias, domain)
+
 	return nil
 }
 
@@ -59,6 +62,7 @@ func (s *Action) AliasesRemove(c *cli.Context) error {
 	}
 
 	out.Printf(ctx, "Remove alias %q from domain %q", alias, domain)
+
 	return nil
 }
 
@@ -76,5 +80,6 @@ func (s *Action) AliasesDelete(c *cli.Context) error {
 	}
 
 	out.Printf(ctx, "Remove aliases for domain %q", domain)
+
 	return nil
 }

--- a/internal/action/audit.go
+++ b/internal/action/audit.go
@@ -18,7 +18,7 @@ func (s *Action) Audit(c *cli.Context) error {
 	if expiry > 0 {
 		out.Print(ctx, "Auditing password expiration ...")
 	} else {
-		s.rem.Reset("audit")
+		_ = s.rem.Reset("audit")
 		out.Print(ctx, "Auditing passwords for common flaws ...")
 	}
 
@@ -39,6 +39,7 @@ func (s *Action) Audit(c *cli.Context) error {
 
 	if len(list) < 1 {
 		out.Printf(ctx, "No secrets found")
+
 		return nil
 	}
 

--- a/internal/action/audit_test.go
+++ b/internal/action/audit_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestAudit(t *testing.T) {
+func TestAudit(t *testing.T) { //nolint:paralleltest
 	u := gptest.NewUnitTester(t)
 	defer u.Remove()
 
@@ -33,7 +33,7 @@ func TestAudit(t *testing.T) {
 		stdout = os.Stdout
 	}()
 
-	t.Run("expect audit complaints on very weak passwords", func(t *testing.T) {
+	t.Run("expect audit complaints on very weak passwords", func(t *testing.T) { //nolint:paralleltest
 		sec := &secrets.Plain{}
 		sec.SetPassword("123")
 		assert.NoError(t, act.Store.Set(ctx, "bar", sec))
@@ -43,13 +43,13 @@ func TestAudit(t *testing.T) {
 		buf.Reset()
 	})
 
-	t.Run("test with filter and very passwords", func(t *testing.T) {
+	t.Run("test with filter and very passwords", func(t *testing.T) { //nolint:paralleltest
 		c := gptest.CliCtx(ctx, t, "foo")
 		assert.Error(t, act.Audit(c))
 		buf.Reset()
 	})
 
-	t.Run("test empty store", func(t *testing.T) {
+	t.Run("test empty store", func(t *testing.T) { //nolint:paralleltest
 		for _, v := range []string{"foo", "bar", "baz"} {
 			assert.NoError(t, act.Store.Delete(ctx, v))
 		}

--- a/internal/action/binary.go
+++ b/internal/action/binary.go
@@ -58,6 +58,7 @@ func (s *Action) Cat(c *cli.Context) error {
 	}
 
 	fmt.Fprint(stdout, string(buf))
+
 	return nil
 }
 
@@ -69,7 +70,7 @@ func secFromBytes(dst, src string, in []byte) gopass.Secret {
 		debug.Log("Failed to set Content-Disposition: %q", err)
 	}
 
-	sec.Write([]byte(base64.StdEncoding.EncodeToString(in)))
+	_, _ = sec.Write([]byte(base64.StdEncoding.EncodeToString(in)))
 	if err := sec.Set("Content-Transfer-Encoding", "Base64"); err != nil {
 		debug.Log("Failed to set Content-Transfer-Encoding: %q", err)
 	}
@@ -88,6 +89,7 @@ func (s *Action) BinaryCopy(c *cli.Context) error {
 	if err := s.binaryCopy(ctx, c, from, to, false); err != nil {
 		return exit.Error(exit.Unknown, err, "%s", err)
 	}
+
 	return nil
 }
 
@@ -103,6 +105,7 @@ func (s *Action) BinaryMove(c *cli.Context) error {
 	if err := s.binaryCopy(ctx, c, from, to, true); err != nil {
 		return exit.Error(exit.Unknown, err, "%s", err)
 	}
+
 	return nil
 }
 
@@ -118,6 +121,7 @@ func (s *Action) binaryCopy(ctx context.Context, c *cli.Context, from, to string
 		if deleteSource {
 			op = "move"
 		}
+
 		return fmt.Errorf("usage: %s fs%s from to", c.App.Name, op)
 	}
 
@@ -165,6 +169,7 @@ func (s *Action) binaryCopyFromFileToStore(ctx context.Context, from, to string,
 	if err := fsutil.Shred(from, 8); err != nil {
 		return fmt.Errorf("failed to shred data: %w", err)
 	}
+
 	return nil
 }
 
@@ -193,6 +198,7 @@ func (s *Action) binaryCopyFromStoreToFile(ctx context.Context, from, to string,
 	if err := s.Store.Delete(ctx, from); err != nil {
 		return fmt.Errorf("failed to delete %q from the store: %w", from, err)
 	}
+
 	return nil
 }
 
@@ -217,6 +223,7 @@ func (s *Action) binaryValidate(ctx context.Context, buf []byte, name string) er
 	if fileSum != storeSum {
 		return fmt.Errorf("hashsum mismatch (file: %s, store: %s)", fileSum, storeSum)
 	}
+
 	return nil
 }
 
@@ -235,6 +242,7 @@ func (s *Action) binaryGet(ctx context.Context, name string) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to encode to base64: %w", err)
 	}
+
 	return buf, nil
 }
 

--- a/internal/action/binary_test.go
+++ b/internal/action/binary_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestBinary(t *testing.T) {
+func TestBinary(t *testing.T) { //nolint:paralleltest
 	u := gptest.NewUnitTester(t)
 	defer u.Remove()
 
@@ -39,7 +39,7 @@ func TestBinary(t *testing.T) {
 	assert.Error(t, act.Sum(gptest.CliCtx(ctx, t)))
 }
 
-func TestBinaryCat(t *testing.T) {
+func TestBinaryCat(t *testing.T) { //nolint:paralleltest
 	u := gptest.NewUnitTester(t)
 	defer u.Remove()
 
@@ -62,16 +62,16 @@ func TestBinaryCat(t *testing.T) {
 	infile := filepath.Join(u.Dir, "input.txt")
 	writeBinfile(t, infile)
 
-	t.Run("populate store", func(t *testing.T) {
+	t.Run("populate store", func(t *testing.T) { //nolint:paralleltest
 		assert.NoError(t, act.binaryCopy(ctx, gptest.CliCtx(ctx, t), infile, "bar", true))
 	})
 
-	t.Run("binary cat bar", func(t *testing.T) {
+	t.Run("binary cat bar", func(t *testing.T) { //nolint:paralleltest
 		assert.NoError(t, act.Cat(gptest.CliCtx(ctx, t, "bar")))
 	})
 
 	stdinfile := filepath.Join(u.Dir, "stdin")
-	t.Run("binary cat baz from stdin", func(t *testing.T) {
+	t.Run("binary cat baz from stdin", func(t *testing.T) { //nolint:paralleltest
 		writeBinfile(t, stdinfile)
 
 		fd, err := os.Open(stdinfile)
@@ -79,13 +79,13 @@ func TestBinaryCat(t *testing.T) {
 		binstdin = fd
 		defer func() {
 			binstdin = os.Stdin
-			fd.Close()
+			_ = fd.Close()
 		}()
 
 		assert.NoError(t, act.Cat(gptest.CliCtx(ctx, t, "baz")))
 	})
 
-	t.Run("compare output", func(t *testing.T) {
+	t.Run("compare output", func(t *testing.T) { //nolint:paralleltest
 		buf, err := os.ReadFile(stdinfile)
 		require.NoError(t, err)
 		sec, err := act.binaryGet(ctx, "baz")
@@ -94,7 +94,7 @@ func TestBinaryCat(t *testing.T) {
 	})
 }
 
-func TestBinaryCopy(t *testing.T) {
+func TestBinaryCopy(t *testing.T) { //nolint:paralleltest
 	u := gptest.NewUnitTester(t)
 	defer u.Remove()
 
@@ -112,7 +112,7 @@ func TestBinaryCopy(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, act)
 
-	t.Run("copy textfile", func(t *testing.T) {
+	t.Run("copy textfile", func(t *testing.T) { //nolint:paralleltest
 		defer buf.Reset()
 
 		infile := filepath.Join(u.Dir, "input.txt")
@@ -122,41 +122,41 @@ func TestBinaryCopy(t *testing.T) {
 
 	infile := filepath.Join(u.Dir, "input.raw")
 	outfile := filepath.Join(u.Dir, "output.raw")
-	t.Run("copy binary file", func(t *testing.T) {
+	t.Run("copy binary file", func(t *testing.T) { //nolint:paralleltest
 		defer buf.Reset()
 
 		writeBinfile(t, infile)
 		assert.NoError(t, act.binaryCopy(ctx, gptest.CliCtx(ctx, t), infile, "bar", true))
 	})
 
-	t.Run("binary copy bar tempdir/bar", func(t *testing.T) {
+	t.Run("binary copy bar tempdir/bar", func(t *testing.T) { //nolint:paralleltest
 		defer buf.Reset()
 		assert.NoError(t, act.BinaryCopy(gptest.CliCtx(ctx, t, "bar", outfile)))
 	})
 
-	t.Run("binary copy tempdir/bar tempdir/bar", func(t *testing.T) {
+	t.Run("binary copy tempdir/bar tempdir/bar", func(t *testing.T) { //nolint:paralleltest
 		defer buf.Reset()
 
 		assert.Error(t, act.BinaryCopy(gptest.CliCtx(ctx, t, outfile, outfile)))
 	})
 
-	t.Run("binary copy bar bar", func(t *testing.T) {
+	t.Run("binary copy bar bar", func(t *testing.T) { //nolint:paralleltest
 		defer buf.Reset()
 		assert.Error(t, act.BinaryCopy(gptest.CliCtx(ctx, t, "bar", "bar")))
 	})
 
-	t.Run("binary move tempdir/bar bar2", func(t *testing.T) {
+	t.Run("binary move tempdir/bar bar2", func(t *testing.T) { //nolint:paralleltest
 		defer buf.Reset()
 		assert.NoError(t, act.BinaryMove(gptest.CliCtx(ctx, t, outfile, "bar2")))
 	})
 
-	t.Run("binary move bar2 tempdir/bar", func(t *testing.T) {
+	t.Run("binary move bar2 tempdir/bar", func(t *testing.T) { //nolint:paralleltest
 		defer buf.Reset()
 		assert.NoError(t, act.BinaryMove(gptest.CliCtx(ctx, t, "bar2", outfile)))
 	})
 }
 
-func TestBinarySum(t *testing.T) {
+func TestBinarySum(t *testing.T) { //nolint:paralleltest
 	u := gptest.NewUnitTester(t)
 	defer u.Remove()
 
@@ -176,18 +176,18 @@ func TestBinarySum(t *testing.T) {
 
 	infile := filepath.Join(u.Dir, "input.raw")
 
-	t.Run("populate store", func(t *testing.T) {
+	t.Run("populate store", func(t *testing.T) { //nolint:paralleltest
 		writeBinfile(t, infile)
 		assert.NoError(t, act.binaryCopy(ctx, gptest.CliCtx(ctx, t), infile, "bar", true))
 	})
 
-	t.Run("binary sum bar", func(t *testing.T) {
+	t.Run("binary sum bar", func(t *testing.T) { //nolint:paralleltest
 		assert.NoError(t, act.Sum(gptest.CliCtx(ctx, t, "bar")))
 		buf.Reset()
 	})
 }
 
-func TestBinaryGet(t *testing.T) {
+func TestBinaryGet(t *testing.T) { //nolint:paralleltest
 	u := gptest.NewUnitTester(t)
 	defer u.Remove()
 
@@ -208,6 +208,8 @@ func TestBinaryGet(t *testing.T) {
 }
 
 func writeBinfile(t *testing.T, fn string) {
+	t.Helper()
+
 	// tests should be predicable
 	rand.Seed(42)
 

--- a/internal/action/clihelper.go
+++ b/internal/action/clihelper.go
@@ -12,6 +12,7 @@ func (a argList) Get(n int) string {
 	if len(a) > n {
 		return a[n]
 	}
+
 	return ""
 }
 
@@ -23,6 +24,7 @@ func parseArgs(c *cli.Context) (argList, map[string]string) {
 		// the secret name, so don't attempt to
 		// parse into args and kvps
 		args = append(args, c.Args().Get(0))
+
 		return args, kvps
 	}
 OUTER:
@@ -34,13 +36,16 @@ OUTER:
 			p := strings.Split(arg, sep)
 			if len(p) < 2 {
 				args = append(args, arg)
+
 				continue OUTER
 			}
 			key := p[0]
 			kvps[key] = strings.Join(p[1:], ":")
+
 			continue OUTER
 		}
 		args = append(args, arg)
 	}
+
 	return args, kvps
 }

--- a/internal/action/clihelper_test.go
+++ b/internal/action/clihelper_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestParseArgs(t *testing.T) {
+	t.Parallel()
+
 	for _, tc := range []struct {
 		name   string
 		argIn  []string
@@ -65,14 +67,18 @@ func TestParseArgs(t *testing.T) {
 		},
 	} {
 		tc := tc
+
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
+
 			if tc.argOut == nil {
 				tc.argOut = argList{}
 			}
+
 			if tc.kvOut == nil {
 				tc.kvOut = map[string]string{}
 			}
+
 			app := cli.NewApp()
 			fs := flag.NewFlagSet("default", flag.ContinueOnError)
 			assert.NoError(t, fs.Parse(tc.argIn), tc.name)

--- a/internal/action/clone.go
+++ b/internal/action/clone.go
@@ -29,9 +29,11 @@ func (s *Action) Clone(c *cli.Context) error {
 	if c.IsSet("crypto") {
 		ctx = backend.WithCryptoBackendString(ctx, c.String("crypto"))
 	}
+
 	if c.IsSet("storage") {
 		ctx = backend.WithStorageBackendString(ctx, c.String("storage"))
 	}
+
 	path := c.String("path")
 
 	if c.Args().Len() < 1 {
@@ -78,14 +80,17 @@ func (s *Action) Clone(c *cli.Context) error {
 	if err != nil {
 		return exit.Error(exit.Unknown, err, "Failed to check store status: %s", err)
 	}
+
 	if !inited {
 		out.Errorf(ctx, "Failed to clone")
+
 		return nil
 	}
 
 	if !c.Bool("check-keys") {
 		return nil
 	}
+
 	return s.cloneCheckDecryptionKeys(ctx, mount)
 }
 
@@ -96,13 +101,17 @@ func storageBackendOrDefault(ctx context.Context, repo string) backend.StorageBa
 	if be := backend.GetStorageBackend(ctx); be != backend.FS {
 		return be
 	}
+
 	if strings.HasSuffix(repo, ".fossil") {
 		return backend.FossilFS
 	}
+
 	if strings.HasSuffix(repo, ".git") {
 		return backend.GitFS
 	}
+
 	debug.Log("falling back to the default storage backend for clone (GitFS)")
+
 	return backend.GitFS
 }
 
@@ -110,10 +119,12 @@ func (s *Action) clone(ctx context.Context, repo, mount, path string) error {
 	if path == "" {
 		path = config.PwStoreDir(mount)
 	}
+
 	inited, err := s.Store.IsInitialized(ctxutil.WithGitInit(ctx, false))
 	if err != nil {
 		return exit.Error(exit.Unknown, err, "Failed to initialized stores: %s", err)
 	}
+
 	if mount == "" && inited {
 		return exit.Error(exit.AlreadyInitialized, nil, "Can not clone %s to the root store, as this store is already initialized. Please try cloning to a submount: `%s clone %s sub`", repo, s.Name, repo)
 	}
@@ -161,6 +172,7 @@ func (s *Action) clone(ctx context.Context, repo, mount, path string) error {
 	if mount != "" {
 		mount = " " + mount
 	}
+
 	out.Printf(ctx, "Your password store is ready to use! Have a look around: `%s list%s`\n", s.Name, mount)
 
 	return nil
@@ -192,11 +204,14 @@ func (s *Action) cloneCheckDecryptionKeys(ctx context.Context, mount string) err
 	ids, err := crypto.ListIdentities(ctx)
 	if err != nil {
 		out.Warningf(ctx, "Failed to check decryption keys: %s", err)
+
 		return nil
 	}
+
 	idSet := stringset.New(ids...)
 	if idSet.IsSubset(recpSet) {
 		out.Noticef(ctx, "Found valid decryption keys. You can now decrypt your passwords.")
+
 		return nil
 	}
 
@@ -228,13 +243,16 @@ func (s *Action) cloneAddMount(ctx context.Context, mount, path string) error {
 	if err != nil {
 		return exit.Error(exit.Unknown, err, "Failed to initialize store: %s", err)
 	}
+
 	if !inited {
 		return exit.Error(exit.NotInitialized, nil, "Root-Store is not initialized. Clone or init root store first")
 	}
+
 	if err := s.Store.AddMount(ctx, mount, path); err != nil {
 		return exit.Error(exit.Mount, err, "Failed to add mount: %s", err)
 	}
 	out.Printf(ctx, "Mounted password store %s at mount point `%s` ...", path, mount)
+
 	return nil
 }
 
@@ -251,6 +269,7 @@ func (s *Action) cloneGetGitConfig(ctx context.Context, name string) (string, st
 			return "", "", exit.Error(exit.IO, err, "Failed to read user input: %s", err)
 		}
 	}
+
 	if email == "" {
 		email = termio.DetectEmail(ctx, nil)
 		var err error
@@ -259,5 +278,6 @@ func (s *Action) cloneGetGitConfig(ctx context.Context, name string) (string, st
 			return "", "", exit.Error(exit.IO, err, "Failed to read user input: %s", err)
 		}
 	}
+
 	return username, email, nil
 }

--- a/internal/action/clone_test.go
+++ b/internal/action/clone_test.go
@@ -20,7 +20,9 @@ import (
 )
 
 // aGitRepo creates and initializes a small git repo.
-func aGitRepo(ctx context.Context, u *gptest.Unit, t *testing.T, name string) string {
+func aGitRepo(ctx context.Context, t *testing.T, u *gptest.Unit, name string) string {
+	t.Helper()
+
 	gd := filepath.Join(u.Dir, name)
 	assert.NoError(t, os.MkdirAll(gd, 0o700))
 
@@ -37,7 +39,7 @@ func aGitRepo(ctx context.Context, u *gptest.Unit, t *testing.T, name string) st
 	return gd
 }
 
-func TestClone(t *testing.T) {
+func TestClone(t *testing.T) { //nolint:paralleltest
 	u := gptest.NewUnitTester(t)
 	defer u.Remove()
 
@@ -60,25 +62,25 @@ func TestClone(t *testing.T) {
 		stdout = os.Stdout
 	}()
 
-	t.Run("no args", func(t *testing.T) {
+	t.Run("no args", func(t *testing.T) { //nolint:paralleltest
 		defer buf.Reset()
 		c := gptest.CliCtx(ctx, t)
 		assert.Error(t, act.Clone(c))
 	})
 
-	t.Run("clone to initialized store", func(t *testing.T) {
+	t.Run("clone to initialized store", func(t *testing.T) { //nolint:paralleltest
 		defer buf.Reset()
 		assert.Error(t, act.clone(ctx, "/tmp/non-existing-repo.git", "", filepath.Join(u.Dir, "store")))
 	})
 
-	t.Run("clone to mount", func(t *testing.T) {
+	t.Run("clone to mount", func(t *testing.T) { //nolint:paralleltest
 		defer buf.Reset()
-		gd := aGitRepo(ctx, u, t, "other-repo")
+		gd := aGitRepo(ctx, t, u, "other-repo")
 		assert.NoError(t, act.clone(ctx, gd, "gd", filepath.Join(u.Dir, "mount")))
 	})
 }
 
-func TestCloneBackendIsStoredForMount(t *testing.T) {
+func TestCloneBackendIsStoredForMount(t *testing.T) { //nolint:paralleltest
 	u := gptest.NewUnitTester(t)
 	defer u.Remove()
 
@@ -106,7 +108,7 @@ func TestCloneBackendIsStoredForMount(t *testing.T) {
 	c := gptest.CliCtx(ctx, t)
 	require.NoError(t, act.IsInitialized(c))
 
-	repo := aGitRepo(ctx, u, t, "my-project")
+	repo := aGitRepo(ctx, t, u, "my-project")
 
 	c = gptest.CliCtxWithFlags(ctx, t, map[string]string{"check-keys": "false"}, repo, "the-project")
 	assert.NoError(t, act.Clone(c))
@@ -114,7 +116,7 @@ func TestCloneBackendIsStoredForMount(t *testing.T) {
 	require.NotNil(t, act.cfg.Mounts["the-project"])
 }
 
-func TestCloneGetGitConfig(t *testing.T) {
+func TestCloneGetGitConfig(t *testing.T) { //nolint:paralleltest
 	u := gptest.NewUnitTester(t)
 	defer u.Remove()
 

--- a/internal/action/commands.go
+++ b/internal/action/commands.go
@@ -975,16 +975,19 @@ func (s *Action) GetCommands() []*cli.Command {
 		bc, ok := be.(commander)
 		if !ok {
 			debug.Log("Backend %s does not implement commander interface\n", be)
+
 			continue
 		}
 		nc := bc.Commands()
 		debug.Log("Backend %s added %d commands", be, len(nc))
 		cmds = append(cmds, nc...)
 	}
+
 	for _, be := range backend.StorageRegistry.Backends() {
 		bc, ok := be.(storeCommander)
 		if !ok {
 			debug.Log("Backend %s does not implement commander interface\n", be)
+
 			continue
 		}
 		nc := bc.Commands(s.IsInitialized, func(alias string) (string, error) {
@@ -992,6 +995,7 @@ func (s *Action) GetCommands() []*cli.Command {
 			if err != nil || sub == nil {
 				return "", fmt.Errorf("failed to get sub store for %s: %w", alias, err)
 			}
+
 			return sub.Path(), nil
 		})
 		debug.Log("Backend %s added %d commands", be, len(nc))

--- a/internal/action/commands_test.go
+++ b/internal/action/commands_test.go
@@ -12,11 +12,15 @@ import (
 )
 
 func testCommand(t *testing.T, cmd *cli.Command) {
+	t.Helper()
+
 	if len(cmd.Subcommands) < 1 {
 		assert.NotNil(t, cmd.Action, cmd.Name)
 	}
+
 	assert.NotEmpty(t, cmd.Usage)
 	assert.NotEmpty(t, cmd.Description)
+
 	for _, flag := range cmd.Flags {
 		switch v := flag.(type) {
 		case *cli.StringFlag:
@@ -27,12 +31,15 @@ func testCommand(t *testing.T, cmd *cli.Command) {
 			assert.NotEmpty(t, v.Usage)
 		}
 	}
+
 	for _, scmd := range cmd.Subcommands {
 		testCommand(t, scmd)
 	}
 }
 
 func TestCommands(t *testing.T) {
+	t.Parallel()
+
 	u := gptest.NewUnitTester(t)
 	defer u.Remove()
 
@@ -43,7 +50,10 @@ func TestCommands(t *testing.T) {
 	require.NotNil(t, act)
 
 	for _, cmd := range act.GetCommands() {
+		cmd := cmd
 		t.Run(cmd.Name, func(t *testing.T) {
+			t.Parallel()
+
 			testCommand(t, cmd)
 		})
 	}

--- a/internal/action/completion.go
+++ b/internal/action/completion.go
@@ -22,12 +22,15 @@ func bashEscape(s string) string {
 		if c == `\` {
 			return `\\\\`
 		}
+
 		if c == `'` {
 			return `\` + c
 		}
+
 		if c == `"` {
 			return `\\\` + c
 		}
+
 		return `\\` + c
 	})
 }
@@ -38,6 +41,7 @@ func (s *Action) Complete(c *cli.Context) {
 	_, err := s.Store.IsInitialized(ctx) // important to make sure the structs are not nil.
 	if err != nil {
 		out.Errorf(ctx, "Store not initialized: %s", err)
+
 		return
 	}
 	list, err := s.Store.List(ctx, tree.INF)
@@ -70,6 +74,7 @@ set -A complete_gopass -- $PASS_LIST %s
 	}
 
 	fmt.Fprintf(stdout, out, strings.Join(opts, " "))
+
 	return nil
 }
 
@@ -106,6 +111,7 @@ func (s *Action) CompletionFish(a *cli.App) error {
 	}
 
 	fmt.Fprintln(stdout, comp)
+
 	return nil
 }
 
@@ -117,5 +123,6 @@ func (s *Action) CompletionZSH(a *cli.App) error {
 	}
 
 	fmt.Fprintln(stdout, comp)
+
 	return nil
 }

--- a/internal/action/completion_test.go
+++ b/internal/action/completion_test.go
@@ -15,7 +15,11 @@ import (
 )
 
 func TestBashEscape(t *testing.T) {
+	t.Parallel()
+
 	t.Run("bash escape", func(t *testing.T) {
+		t.Parallel()
+
 		expected := `a\\<\\>\\|\\\\and\\ sometimes\\?\\*\\(\\)\\&\\;\\#`
 		if escaped := bashEscape(`a<>|\and sometimes?*()&;#`); escaped != expected {
 			t.Errorf("Expected %q, but got %q", expected, escaped)
@@ -23,6 +27,8 @@ func TestBashEscape(t *testing.T) {
 	})
 
 	t.Run("bash escape single quote", func(t *testing.T) {
+		t.Parallel()
+
 		expected := `good\\ ol\'\\ days`
 		if escaped := bashEscape(`good ol' days`); escaped != expected {
 			t.Errorf("Expected %q, but got %q", expected, escaped)
@@ -30,6 +36,8 @@ func TestBashEscape(t *testing.T) {
 	})
 
 	t.Run("bash escape double quote", func(t *testing.T) {
+		t.Parallel()
+
 		expected := `my\\ \\\"bad\\\"\\ password`
 		if escaped := bashEscape(`my "bad" password`); escaped != expected {
 			t.Errorf("Expected %q, but got %q", expected, escaped)
@@ -37,7 +45,7 @@ func TestBashEscape(t *testing.T) {
 	})
 }
 
-func TestComplete(t *testing.T) {
+func TestComplete(t *testing.T) { //nolint:paralleltest
 	u := gptest.NewUnitTester(t)
 	defer u.Remove()
 
@@ -63,21 +71,21 @@ func TestComplete(t *testing.T) {
 		},
 	}
 
-	t.Run("complete foo", func(t *testing.T) {
+	t.Run("complete foo", func(t *testing.T) { //nolint:paralleltest
 		defer buf.Reset()
 
 		act.Complete(gptest.CliCtx(ctx, t))
 		assert.Equal(t, "foo\n", buf.String())
 	})
 
-	t.Run("bash completion", func(t *testing.T) {
+	t.Run("bash completion", func(t *testing.T) { //nolint:paralleltest
 		defer buf.Reset()
 
 		assert.NoError(t, act.CompletionBash(nil))
 		assert.Contains(t, buf.String(), "action.test")
 	})
 
-	t.Run("fish completion", func(t *testing.T) {
+	t.Run("fish completion", func(t *testing.T) { //nolint:paralleltest
 		defer buf.Reset()
 
 		assert.NoError(t, act.CompletionFish(app))
@@ -85,7 +93,7 @@ func TestComplete(t *testing.T) {
 		assert.Error(t, act.CompletionFish(nil))
 	})
 
-	t.Run("zsh completion", func(t *testing.T) {
+	t.Run("zsh completion", func(t *testing.T) { //nolint:paralleltest
 		defer buf.Reset()
 
 		assert.NoError(t, act.CompletionZSH(app))
@@ -93,7 +101,7 @@ func TestComplete(t *testing.T) {
 		assert.Error(t, act.CompletionZSH(nil))
 	})
 
-	t.Run("openbsdksh completion", func(t *testing.T) {
+	t.Run("openbsdksh completion", func(t *testing.T) { //nolint:paralleltest
 		defer buf.Reset()
 
 		assert.NoError(t, act.CompletionOpenBSDKsh(app))

--- a/internal/action/config.go
+++ b/internal/action/config.go
@@ -16,11 +16,13 @@ func (s *Action) Config(c *cli.Context) error {
 	ctx := ctxutil.WithGlobalFlags(c)
 	if c.Args().Len() < 1 {
 		s.printConfigValues(ctx)
+
 		return nil
 	}
 
 	if c.Args().Len() == 1 {
 		s.printConfigValues(ctx, c.Args().Get(0))
+
 		return nil
 	}
 
@@ -31,6 +33,7 @@ func (s *Action) Config(c *cli.Context) error {
 	if err := s.setConfigValue(ctx, c.Args().Get(0), c.Args().Get(1)); err != nil {
 		return exit.Error(exit.Unknown, err, "Error setting config value")
 	}
+
 	return nil
 }
 
@@ -41,10 +44,12 @@ func (s *Action) printConfigValues(ctx context.Context, needles ...string) {
 		// useful for scriping, e.g. `$ cd $(gopass config path)`.
 		if len(needles) == 1 {
 			out.Printf(ctx, "%s", m[k])
+
 			continue
 		}
 		out.Printf(ctx, "%s: %s", k, m[k])
 	}
+
 	for alias, path := range s.cfg.Mounts {
 		if len(needles) < 1 {
 			out.Printf(ctx, "mount %q => %q", alias, path)
@@ -60,7 +65,9 @@ func filterMap(haystack map[string]string, needles []string) []string {
 		}
 		out = append(out, k)
 	}
+
 	sort.Strings(out)
+
 	return out
 }
 
@@ -68,11 +75,13 @@ func contains(haystack []string, needle string) bool {
 	if len(haystack) < 1 {
 		return true
 	}
+
 	for _, blade := range haystack {
 		if blade == needle {
 			return true
 		}
 	}
+
 	return false
 }
 
@@ -80,7 +89,9 @@ func (s *Action) setConfigValue(ctx context.Context, key, value string) error {
 	if err := s.cfg.SetConfigValue(key, value); err != nil {
 		return fmt.Errorf("failed to set config value %q: %w", key, err)
 	}
+
 	s.printConfigValues(ctx, key)
+
 	return nil
 }
 
@@ -90,6 +101,7 @@ func (s *Action) configKeys() []string {
 	for k := range cm {
 		keys = append(keys, k)
 	}
+
 	keys = append(keys, "remote")
 	sort.Strings(keys)
 

--- a/internal/action/config_test.go
+++ b/internal/action/config_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestConfig(t *testing.T) {
+func TestConfig(t *testing.T) { //nolint:paralleltest
 	u := gptest.NewUnitTester(t)
 	defer u.Remove()
 
@@ -32,7 +32,7 @@ func TestConfig(t *testing.T) {
 		stdout = os.Stdout
 	}()
 
-	t.Run("display config", func(t *testing.T) {
+	t.Run("display config", func(t *testing.T) { //nolint:paralleltest
 		defer buf.Reset()
 
 		c := gptest.CliCtx(ctx, t)
@@ -51,20 +51,20 @@ parsing: true
 		assert.Equal(t, want, buf.String())
 	})
 
-	t.Run("set valid config value", func(t *testing.T) {
+	t.Run("set valid config value", func(t *testing.T) { //nolint:paralleltest
 		defer buf.Reset()
 
 		assert.NoError(t, act.setConfigValue(ctx, "nopager", "true"))
 		assert.Equal(t, "true", strings.TrimSpace(buf.String()), "action.setConfigValue")
 	})
 
-	t.Run("set invalid config value", func(t *testing.T) {
+	t.Run("set invalid config value", func(t *testing.T) { //nolint:paralleltest
 		defer buf.Reset()
 
 		assert.Error(t, act.setConfigValue(ctx, "foobar", "true"))
 	})
 
-	t.Run("print single config value", func(t *testing.T) {
+	t.Run("print single config value", func(t *testing.T) { //nolint:paralleltest
 		defer buf.Reset()
 
 		act.printConfigValues(ctx, "nopager")
@@ -73,7 +73,7 @@ parsing: true
 		assert.Equal(t, want, strings.TrimSpace(buf.String()), "action.printConfigValues")
 	})
 
-	t.Run("print all config values", func(t *testing.T) {
+	t.Run("print all config values", func(t *testing.T) { //nolint:paralleltest
 		defer buf.Reset()
 
 		act.printConfigValues(ctx)
@@ -92,7 +92,7 @@ parsing: true
 		delete(act.cfg.Mounts, "foo")
 	})
 
-	t.Run("show autoimport value", func(t *testing.T) {
+	t.Run("show autoimport value", func(t *testing.T) { //nolint:paralleltest
 		defer buf.Reset()
 
 		c := gptest.CliCtx(ctx, t, "autoimport")
@@ -100,7 +100,7 @@ parsing: true
 		assert.Equal(t, "true", strings.TrimSpace(buf.String()))
 	})
 
-	t.Run("disable autoimport", func(t *testing.T) {
+	t.Run("disable autoimport", func(t *testing.T) { //nolint:paralleltest
 		defer buf.Reset()
 
 		c := gptest.CliCtx(ctx, t, "autoimport", "false")
@@ -108,7 +108,7 @@ parsing: true
 		assert.Equal(t, "false", strings.TrimSpace(buf.String()))
 	})
 
-	t.Run("complete config items", func(t *testing.T) {
+	t.Run("complete config items", func(t *testing.T) { //nolint:paralleltest
 		defer buf.Reset()
 
 		act.ConfigComplete(gptest.CliCtx(ctx, t))
@@ -126,7 +126,7 @@ safecontent
 		assert.Equal(t, want, buf.String())
 	})
 
-	t.Run("set autoimport to invalid value", func(t *testing.T) {
+	t.Run("set autoimport to invalid value", func(t *testing.T) { //nolint:paralleltest
 		defer buf.Reset()
 
 		c := gptest.CliCtx(ctx, t, "autoimport", "false", "42")

--- a/internal/action/context.go
+++ b/internal/action/context.go
@@ -27,6 +27,7 @@ func IsClip(ctx context.Context) bool {
 	if !ok {
 		return false
 	}
+
 	return bv
 }
 
@@ -42,6 +43,7 @@ func IsAlsoClip(ctx context.Context) bool {
 	if !ok {
 		return false
 	}
+
 	return bv
 }
 
@@ -57,6 +59,7 @@ func IsOnlyClip(ctx context.Context) bool {
 	if !ok {
 		return false
 	}
+
 	return bv
 }
 
@@ -71,6 +74,7 @@ func IsPasswordOnly(ctx context.Context) bool {
 	if !ok {
 		return false
 	}
+
 	return bv
 }
 
@@ -85,6 +89,7 @@ func IsPrintQR(ctx context.Context) bool {
 	if !ok {
 		return false
 	}
+
 	return bv
 }
 
@@ -96,6 +101,7 @@ func WithRevision(ctx context.Context, rev string) context.Context {
 // HasRevision returns true if a value for revision was set in this context.
 func HasRevision(ctx context.Context) bool {
 	sv, ok := ctx.Value(ctxKeyRevision).(string)
+
 	return ok && sv != ""
 }
 
@@ -105,6 +111,7 @@ func GetRevision(ctx context.Context) string {
 	if !ok {
 		return ""
 	}
+
 	return sv
 }
 
@@ -116,6 +123,7 @@ func WithKey(ctx context.Context, sv string) context.Context {
 // HasKey returns true if the key is set.
 func HasKey(ctx context.Context) bool {
 	_, ok := ctx.Value(ctxKeyKey).(string)
+
 	return ok
 }
 
@@ -125,6 +133,7 @@ func GetKey(ctx context.Context) string {
 	if !ok {
 		return ""
 	}
+
 	return sv
 }
 
@@ -139,5 +148,6 @@ func GetPrintChars(ctx context.Context) []int {
 	if !ok {
 		return nil
 	}
+
 	return mv
 }

--- a/internal/action/context_test.go
+++ b/internal/action/context_test.go
@@ -8,6 +8,8 @@ import (
 )
 
 func TestWithClip(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 
 	if IsClip(ctx) {
@@ -20,6 +22,8 @@ func TestWithClip(t *testing.T) {
 }
 
 func TestWithPasswordOnly(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 
 	if IsPasswordOnly(ctx) {
@@ -32,6 +36,8 @@ func TestWithPasswordOnly(t *testing.T) {
 }
 
 func TestWithPrintQR(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 
 	assert.False(t, IsPrintQR(ctx))
@@ -39,6 +45,8 @@ func TestWithPrintQR(t *testing.T) {
 }
 
 func TestWithRevision(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 
 	assert.Equal(t, "", GetRevision(ctx))
@@ -48,6 +56,8 @@ func TestWithRevision(t *testing.T) {
 }
 
 func TestWithKey(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 
 	assert.Equal(t, "", GetKey(ctx))
@@ -55,6 +65,8 @@ func TestWithKey(t *testing.T) {
 }
 
 func TestWithOnlyClip(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 
 	assert.False(t, IsOnlyClip(ctx))
@@ -62,6 +74,8 @@ func TestWithOnlyClip(t *testing.T) {
 }
 
 func TestWithAlsoClip(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 
 	assert.False(t, IsAlsoClip(ctx))

--- a/internal/action/convert.go
+++ b/internal/action/convert.go
@@ -16,6 +16,7 @@ func (s *Action) Convert(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
+
 	crypto, err := backend.CryptoRegistry.Backend(c.String("crypto"))
 	if err != nil {
 		return err

--- a/internal/action/copy_test.go
+++ b/internal/action/copy_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestCopy(t *testing.T) {
+func TestCopy(t *testing.T) { //nolint:paralleltest
 	u := gptest.NewUnitTester(t)
 	defer u.Remove()
 

--- a/internal/action/create.go
+++ b/internal/action/create.go
@@ -45,11 +45,13 @@ func (s *Action) createPrintOrCopy(ctx context.Context, c *cli.Context, name, pa
 
 	if c.Bool("print") {
 		fmt.Fprintf(out.Stdout, "The generated password for %s is:\n%s\n", name, password)
+
 		return nil
 	}
 
 	if err := clipboard.CopyTo(ctx, name, []byte(password), s.cfg.ClipTimeout); err != nil {
 		return exit.Error(exit.IO, err, "failed to copy to clipboard: %s", err)
 	}
+
 	return nil
 }

--- a/internal/action/create_test.go
+++ b/internal/action/create_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestCreate(t *testing.T) {
+func TestCreate(t *testing.T) { //nolint:paralleltest
 	u := gptest.NewUnitTester(t)
 	defer u.Remove()
 

--- a/internal/action/delete.go
+++ b/internal/action/delete.go
@@ -48,12 +48,14 @@ func (s *Action) Delete(c *cli.Context) error {
 			return exit.Error(exit.Unknown, err, "failed to prune %q: %s", name, err)
 		}
 		debug.Log("pruned %q", name)
+
 		return nil
 	}
 
 	// deletes a single key from a YAML doc.
 	if key != "" {
 		debug.Log("removing key %q from %q", key, name)
+
 		return s.deleteKeyFromYAML(ctx, name, key)
 	}
 
@@ -61,6 +63,7 @@ func (s *Action) Delete(c *cli.Context) error {
 	if err := s.Store.Delete(ctx, name); err != nil {
 		return exit.Error(exit.IO, err, "Can not delete %q: %s", name, err)
 	}
+
 	return nil
 }
 
@@ -70,9 +73,12 @@ func (s *Action) deleteKeyFromYAML(ctx context.Context, name, key string) error 
 	if err != nil {
 		return exit.Error(exit.IO, err, "Can not delete key %q from %q: %s", key, name, err)
 	}
+
 	sec.Del(key)
+
 	if err := s.Store.Set(ctxutil.WithCommitMessage(ctx, "Updated Key"), name, sec); err != nil {
 		return exit.Error(exit.IO, err, "Can not delete key %q from %q: %s", key, name, err)
 	}
+
 	return nil
 }

--- a/internal/action/delete_test.go
+++ b/internal/action/delete_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestDelete(t *testing.T) {
+func TestDelete(t *testing.T) { //nolint:paralleltest
 	u := gptest.NewUnitTester(t)
 	defer u.Remove()
 

--- a/internal/action/edit.go
+++ b/internal/action/edit.go
@@ -45,6 +45,7 @@ func (s *Action) edit(ctx context.Context, c *cli.Context, name string) error {
 	if err != nil {
 		return exit.Error(exit.Unknown, err, "failed to invoke editor: %s", err)
 	}
+
 	return s.editUpdate(ctx, name, content, newContent, changed, ed)
 }
 
@@ -65,6 +66,7 @@ func (s *Action) editUpdate(ctx context.Context, name string, content, nContent 
 	if err := s.Store.Set(ctxutil.WithCommitMessage(ctx, fmt.Sprintf("Edited with %s", ed)), name, nSec); err != nil {
 		return exit.Error(exit.Encrypt, err, "failed to encrypt secret %s: %s", name, err)
 	}
+
 	return nil
 }
 
@@ -84,6 +86,7 @@ func (s *Action) editGetContent(ctx context.Context, name string, create bool) (
 		if err != nil {
 			return name, nil, false, exit.Error(exit.Decrypt, err, "failed to decrypt %s: %s", name, err)
 		}
+
 		return name, sec.Bytes(), false, nil
 	}
 
@@ -105,10 +108,12 @@ func (s *Action) editFindName(ctx context.Context, name string) (string, error) 
 	// capture only the name of the selected secret.
 	cb := func(ctx context.Context, c *cli.Context, selectedName string, recurse bool) error {
 		newName = selectedName
+
 		return nil
 	}
 	if err := s.find(ctx, nil, name, cb, false); err != nil {
 		debug.Log("failed to find secret %s: %s", name, err)
+
 		return name, nil
 	}
 
@@ -116,8 +121,10 @@ func (s *Action) editFindName(ctx context.Context, name string) (string, error) 
 	if err != nil {
 		return name, err
 	}
+
 	if cont {
 		return newName, nil
 	}
+
 	return name, nil
 }

--- a/internal/action/edit_test.go
+++ b/internal/action/edit_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestEdit(t *testing.T) {
+func TestEdit(t *testing.T) { //nolint:paralleltest
 	u := gptest.NewUnitTester(t)
 	defer u.Remove()
 
@@ -43,7 +43,7 @@ func TestEdit(t *testing.T) {
 	buf.Reset()
 }
 
-func TestEditUpdate(t *testing.T) {
+func TestEditUpdate(t *testing.T) { //nolint:paralleltest
 	u := gptest.NewUnitTester(t)
 	defer u.Remove()
 

--- a/internal/action/env.go
+++ b/internal/action/env.go
@@ -67,5 +67,6 @@ func (s *Action) Env(c *cli.Context) error {
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = stdout
 	cmd.Stderr = os.Stderr
+
 	return cmd.Run()
 }

--- a/internal/action/env_test.go
+++ b/internal/action/env_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestEnvLeafHappyPath(t *testing.T) {
+func TestEnvLeafHappyPath(t *testing.T) { //nolint:paralleltest
 	u := gptest.NewUnitTester(t)
 	defer u.Remove()
 
@@ -48,7 +48,7 @@ func TestEnvLeafHappyPath(t *testing.T) {
 	assert.Contains(t, buf.String(), fmt.Sprintf("BAZ=%s\n", pw))
 }
 
-func TestEnvSecretNotFound(t *testing.T) {
+func TestEnvSecretNotFound(t *testing.T) { //nolint:paralleltest
 	u := gptest.NewUnitTester(t)
 	defer u.Remove()
 
@@ -64,7 +64,7 @@ func TestEnvSecretNotFound(t *testing.T) {
 		"Secret non-existing not found")
 }
 
-func TestEnvProgramNotFound(t *testing.T) {
+func TestEnvProgramNotFound(t *testing.T) { //nolint:paralleltest
 	u := gptest.NewUnitTester(t)
 	defer u.Remove()
 
@@ -88,7 +88,7 @@ func TestEnvProgramNotFound(t *testing.T) {
 }
 
 // Crash regression.
-func TestEnvProgramNotSpecified(t *testing.T) {
+func TestEnvProgramNotSpecified(t *testing.T) { //nolint:paralleltest
 	u := gptest.NewUnitTester(t)
 	defer u.Remove()
 

--- a/internal/action/exit/errors.go
+++ b/internal/action/exit/errors.go
@@ -58,5 +58,6 @@ func Error(exitCode int, err error, format string, args ...any) error {
 	if err != nil {
 		debug.LogN(1, "%s - stacktrace: %+v", msg, err)
 	}
+
 	return cli.Exit(msg, exitCode)
 }

--- a/internal/action/exit/errors_test.go
+++ b/internal/action/exit/errors_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestError(t *testing.T) {
+func TestError(t *testing.T) { //nolint:paralleltest
 	buf := &bytes.Buffer{}
 	out.Stdout = buf
 	defer func() {

--- a/internal/action/find.go
+++ b/internal/action/find.go
@@ -62,9 +62,11 @@ func (s *Action) find(ctx context.Context, c *cli.Context, needle string, cb sho
 	if len(choices) == 1 {
 		if cb == nil {
 			out.Printf(ctx, choices[0])
+
 			return nil
 		}
 		out.OKf(ctx, "Found exact match in %q", choices[0])
+
 		return cb(ctx, c, choices[0], false)
 	}
 
@@ -86,6 +88,7 @@ func (s *Action) find(ctx context.Context, c *cli.Context, needle string, cb sho
 		for _, value := range choices {
 			out.Printf(ctx, value)
 		}
+
 		return nil
 	}
 
@@ -104,28 +107,34 @@ func (s *Action) findSelection(ctx context.Context, c *cli.Context, choices []st
 	sort.Strings(choices)
 	act, sel := cui.GetSelection(ctx, "Found secrets - Please select an entry", choices)
 	debug.Log("Action: %s - Selection: %d", act, sel)
+
 	switch act {
 	case "default":
 		// display or copy selected entry.
 		fmt.Fprintln(stdout, choices[sel])
+
 		return cb(ctx, c, choices[sel], false)
 	case "copy":
 		// display selected entry.
 		fmt.Fprintln(stdout, choices[sel])
+
 		return cb(WithClip(ctx, true), c, choices[sel], false)
 	case "show":
 		// display selected entry.
 		fmt.Fprintln(stdout, choices[sel])
+
 		return cb(WithClip(ctx, false), c, choices[sel], false)
 	case "sync":
 		// run sync and re-run show/find workflow.
 		if err := s.Sync(c); err != nil {
 			return err
 		}
+
 		return cb(ctx, c, needle, true)
 	case "edit":
 		// edit selected entry.
 		fmt.Fprintln(stdout, choices[sel])
+
 		return s.edit(ctx, c, choices[sel])
 	default:
 		return exit.Error(exit.Aborted, nil, "user aborted")
@@ -139,5 +148,6 @@ func filter(l []string, needle string) []string {
 			choices = append(choices, value)
 		}
 	}
+
 	return choices
 }

--- a/internal/action/find_test.go
+++ b/internal/action/find_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-func TestFind(t *testing.T) {
+func TestFind(t *testing.T) { //nolint:paralleltest
 	u := gptest.NewUnitTester(t)
 	defer u.Remove()
 

--- a/internal/action/fsck.go
+++ b/internal/action/fsck.go
@@ -17,7 +17,7 @@ import (
 
 // Fsck checks the store integrity.
 func (s *Action) Fsck(c *cli.Context) error {
-	s.rem.Reset("fsck")
+	_ = s.rem.Reset("fsck")
 
 	ctx := ctxutil.WithGlobalFlags(c)
 	if c.IsSet("decrypt") {
@@ -59,5 +59,6 @@ func (s *Action) Fsck(c *cli.Context) error {
 		return exit.Error(exit.Fsck, err, "fsck found errors: %s", err)
 	}
 	bar.Done()
+
 	return nil
 }

--- a/internal/action/fsck_test.go
+++ b/internal/action/fsck_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestFsck(t *testing.T) {
+func TestFsck(t *testing.T) { //nolint:paralleltest
 	u := gptest.NewUnitTester(t)
 	defer u.Remove()
 

--- a/internal/action/generate.go
+++ b/internal/action/generate.go
@@ -125,16 +125,20 @@ func (s *Action) generateCopyOrPrint(ctx context.Context, c *cli.Context, name, 
 		// at least leave a notice that we did indeed copy it.
 		if s.cfg.AutoClip && !c.Bool("print") {
 			out.Print(ctx, "Copied to clipboard")
+
 			return nil
 		}
 	}
 
 	if !c.Bool("print") {
 		out.Printf(ctx, "Not printing secrets by default. Use 'gopass show %s' to display the password.", entry)
+
 		return nil
 	}
+
 	if c.IsSet("print") && !c.Bool("print") && ctxutil.IsShowSafeContent(ctx) {
 		debug.Log("safecontent suppresing printing")
+
 		return nil
 	}
 
@@ -143,6 +147,7 @@ func (s *Action) generateCopyOrPrint(ctx context.Context, c *cli.Context, name, 
 		"⚠ The generated password is:\n\n%s\n",
 		out.Secret(password),
 	)
+
 	return nil
 }
 
@@ -154,6 +159,7 @@ func hasPwRuleForSecret(name string) (string, pwrules.Rule) {
 		}
 		name = path.Dir(name)
 	}
+
 	return "", pwrules.Rule{}
 }
 
@@ -196,6 +202,7 @@ func (s *Action) generatePassword(ctx context.Context, c *cli.Context, length, n
 		if c.Bool("strict") {
 			return pwgen.GenerateMemorablePassword(pwlen, symbols, true), nil
 		}
+
 		return pwgen.GenerateMemorablePassword(pwlen, symbols, false), nil
 	case "external":
 		return pwgen.GenerateExternal(pwlen)
@@ -203,6 +210,7 @@ func (s *Action) generatePassword(ctx context.Context, c *cli.Context, length, n
 		if c.Bool("strict") {
 			return pwgen.GeneratePasswordWithAllClasses(pwlen, symbols)
 		}
+
 		return pwgen.GeneratePassword(pwlen, symbols), nil
 	}
 }
@@ -211,9 +219,11 @@ func clamp(min, max, value int) int {
 	if value < min {
 		return min
 	}
+
 	if value > max {
 		return max
 	}
+
 	return value
 }
 
@@ -229,6 +239,7 @@ func (s *Action) generatePasswordForRule(ctx context.Context, c *cli.Context, le
 	if err != nil {
 		return "", exit.Error(exit.Usage, err, "password length must be a number")
 	}
+
 	iv = clamp(rule.Minlen, rule.Maxlen, iv)
 
 	pw := pwgen.NewCrypticForDomain(iv, domain).Password()
@@ -279,11 +290,13 @@ func (s *Action) generateSetPassword(ctx context.Context, name, key, password st
 		if err != nil {
 			return ctx, exit.Error(exit.Encrypt, err, "failed to set key %q of %q: %s", key, name, err)
 		}
+
 		setMetadata(sec, kvps)
-		sec.Set(key, password)
+		_ = sec.Set(key, password)
 		if err := s.Store.Set(ctxutil.WithCommitMessage(ctx, "Generated password for key"), name, sec); err != nil {
 			return ctx, exit.Error(exit.Encrypt, err, "failed to set key %q of %q: %s", key, name, err)
 		}
+
 		return ctx, nil
 	}
 
@@ -293,6 +306,7 @@ func (s *Action) generateSetPassword(ctx context.Context, name, key, password st
 		if err == nil {
 			return ctx, nil
 		}
+
 		out.Errorf(ctx, "Failed to read existing secret. Creating anew. Error: %s", err.Error())
 	}
 
@@ -301,7 +315,7 @@ func (s *Action) generateSetPassword(ctx context.Context, name, key, password st
 	sec = secrets.New()
 	sec.SetPassword(password)
 	if u := hasChangeURL(name); u != "" {
-		sec.Set("password-change-url", u)
+		_ = sec.Set("password-change-url", u)
 	}
 
 	if content, found := s.renderTemplate(ctx, name, []byte(password)); found {
@@ -316,6 +330,7 @@ func (s *Action) generateSetPassword(ctx context.Context, name, key, password st
 	if err := s.Store.Set(ctxutil.WithCommitMessage(ctx, "Generated Password"), name, sec); err != nil {
 		return ctx, exit.Error(exit.Encrypt, err, "failed to create %q: %s", name, err)
 	}
+
 	return ctx, nil
 }
 
@@ -326,6 +341,7 @@ func hasChangeURL(name string) string {
 			return u
 		}
 	}
+
 	return ""
 }
 
@@ -346,7 +362,7 @@ func (s *Action) generateReplaceExisting(ctx context.Context, name, key, passwor
 
 func setMetadata(sec gopass.Secret, kvps map[string]string) {
 	for k, v := range kvps {
-		sec.Set(k, v)
+		_ = sec.Set(k, v)
 	}
 }
 
@@ -361,8 +377,10 @@ func (s *Action) CompleteGenerate(c *cli.Context) {
 	_, err := s.Store.IsInitialized(ctx) // important to make sure the structs are not nil.
 	if err != nil {
 		out.Errorf(ctx, "Store not initialized: %s", err)
+
 		return
 	}
+
 	list, err := s.Store.List(ctx, tree.INF)
 	if err != nil {
 		return
@@ -387,6 +405,7 @@ func extractEmails(list []string) []string {
 			results = append(results, e)
 		}
 	}
+
 	return results
 }
 
@@ -400,6 +419,7 @@ func extractDomains(list []string) []string {
 			results = append(results, e)
 		}
 	}
+
 	return results
 }
 
@@ -408,11 +428,14 @@ func uniq(in []string) []string {
 	for _, e := range in {
 		set[e] = struct{}{}
 	}
+
 	out := make([]string, 0, len(set))
 	for k := range set {
 		out = append(out, k)
 	}
+
 	sort.Strings(out)
+
 	return out
 }
 
@@ -423,5 +446,6 @@ func filterPrefix(in []string, prefix string) []string {
 			out = append(out, e)
 		}
 	}
+
 	return out
 }

--- a/internal/action/generate_test.go
+++ b/internal/action/generate_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"flag"
+	"fmt"
 	"os"
 	"regexp"
 	"runtime"
@@ -20,11 +21,13 @@ import (
 )
 
 func TestRuleLookup(t *testing.T) {
+	t.Parallel()
+
 	domain, _ := hasPwRuleForSecret("foo/gopass.pw")
 	assert.Equal(t, "", domain)
 }
 
-func TestGenerate(t *testing.T) {
+func TestGenerate(t *testing.T) { //nolint:paralleltest
 	u := gptest.NewUnitTester(t)
 	defer u.Remove()
 
@@ -48,13 +51,13 @@ func TestGenerate(t *testing.T) {
 	color.NoColor = true
 
 	// generate
-	t.Run("generate", func(t *testing.T) {
+	t.Run("generate", func(t *testing.T) { //nolint:paralleltest
 		assert.Error(t, act.Generate(gptest.CliCtx(ctx, t)))
 		buf.Reset()
 	})
 
 	// generate foobar
-	t.Run("generate foobar", func(t *testing.T) {
+	t.Run("generate foobar", func(t *testing.T) { //nolint:paralleltest
 		if testing.Short() {
 			t.Skip("skipping test in short mode.")
 		}
@@ -65,7 +68,7 @@ func TestGenerate(t *testing.T) {
 
 	// generate foobar
 	// should succeed because of always yes
-	t.Run("generate foobar again", func(t *testing.T) {
+	t.Run("generate foobar again", func(t *testing.T) { //nolint:paralleltest
 		if testing.Short() {
 			t.Skip("skipping test in short mode.")
 		}
@@ -75,7 +78,7 @@ func TestGenerate(t *testing.T) {
 	})
 
 	// generate --edit foobar
-	t.Run("generate --edit foobar", func(t *testing.T) {
+	t.Run("generate --edit foobar", func(t *testing.T) { //nolint:paralleltest
 		if testing.Short() || runtime.GOOS == "windows" {
 			t.Skip("skipping test in short mode.")
 		}
@@ -85,7 +88,7 @@ func TestGenerate(t *testing.T) {
 	})
 
 	// generate --force foobar
-	t.Run("generate --force foobar", func(t *testing.T) {
+	t.Run("generate --force foobar", func(t *testing.T) { //nolint:paralleltest
 		if testing.Short() {
 			t.Skip("skipping test in short mode.")
 		}
@@ -95,7 +98,7 @@ func TestGenerate(t *testing.T) {
 	})
 
 	// generate --force foobar 32
-	t.Run("generate --force foobar 32", func(t *testing.T) {
+	t.Run("generate --force foobar 32", func(t *testing.T) { //nolint:paralleltest
 		if testing.Short() {
 			t.Skip("skipping test in short mode.")
 		}
@@ -105,7 +108,7 @@ func TestGenerate(t *testing.T) {
 	})
 
 	// generate --force --symbols foobar 32
-	t.Run("generate --force --symbols foobar 32", func(t *testing.T) {
+	t.Run("generate --force --symbols foobar 32", func(t *testing.T) { //nolint:paralleltest
 		if testing.Short() {
 			t.Skip("skipping test in short mode.")
 		}
@@ -116,7 +119,7 @@ func TestGenerate(t *testing.T) {
 	})
 
 	// generate --force --symbols=false foobar 32
-	t.Run("generate --force --symbols=False foobar 32", func(t *testing.T) {
+	t.Run("generate --force --symbols=False foobar 32", func(t *testing.T) { //nolint:paralleltest
 		if testing.Short() {
 			t.Skip("skipping test in short mode.")
 		}
@@ -127,31 +130,31 @@ func TestGenerate(t *testing.T) {
 	})
 
 	// generate --force --xkcd foobar 32
-	t.Run("generate --force --xkcd foobar 32", func(t *testing.T) {
+	t.Run("generate --force --xkcd foobar 32", func(t *testing.T) { //nolint:paralleltest
 		assert.NoError(t, act.Generate(gptest.CliCtxWithFlags(ctx, t, map[string]string{"force": "true", "xkcd": "true", "lang": "en"}, "foobar", "32")))
 		buf.Reset()
 	})
 
 	// generate --force --xkcd foobar baz 32
-	t.Run("generate --force --xkcd foobar baz 32", func(t *testing.T) {
+	t.Run("generate --force --xkcd foobar baz 32", func(t *testing.T) { //nolint:paralleltest
 		assert.NoError(t, act.Generate(gptest.CliCtxWithFlags(ctx, t, map[string]string{"force": "true", "xkcd": "true", "lang": "en"}, "foobar", "baz", "32")))
 		buf.Reset()
 	})
 
 	// generate --force --xkcd foobar baz
-	t.Run("generate --force --xkcd foobar baz", func(t *testing.T) {
+	t.Run("generate --force --xkcd foobar baz", func(t *testing.T) { //nolint:paralleltest
 		assert.NoError(t, act.Generate(gptest.CliCtxWithFlags(ctx, t, map[string]string{"force": "true", "xkcd": "true", "lang": "en"}, "foobar", "baz")))
 		buf.Reset()
 	})
 
 	// generate --force --xkcd --print foobar baz
-	t.Run("generate --force --xkcd --print foobar baz", func(t *testing.T) {
+	t.Run("generate --force --xkcd --print foobar baz", func(t *testing.T) { //nolint:paralleltest
 		assert.NoError(t, act.Generate(gptest.CliCtxWithFlags(ctx, t, map[string]string{"force": "true", "xkcd": "true", "print": "true", "lang": "en"}, "foobar", "baz")))
 		buf.Reset()
 	})
 
 	// generate --force foobar 24 w/ autoclip and output redirection
-	t.Run("generate --force foobar 24", func(t *testing.T) {
+	t.Run("generate --force foobar 24", func(t *testing.T) { //nolint:paralleltest
 		ov := act.cfg.AutoClip
 		defer func() {
 			act.cfg.AutoClip = ov
@@ -164,7 +167,7 @@ func TestGenerate(t *testing.T) {
 	})
 
 	// generate --force foobar 24 w/ autoclip and no output redirection
-	t.Run("generate --force foobar 24", func(t *testing.T) {
+	t.Run("generate --force foobar 24", func(t *testing.T) { //nolint:paralleltest
 		ov := act.cfg.AutoClip
 		defer func() {
 			act.cfg.AutoClip = ov
@@ -178,6 +181,8 @@ func TestGenerate(t *testing.T) {
 }
 
 func passIsAlphaNum(t *testing.T, buf string, want bool) {
+	t.Helper()
+
 	reAlphaNum := regexp.MustCompile(`^[A-Za-z0-9]+$`)
 	lines := strings.Split(strings.TrimSpace(buf), "\n")
 	if len(lines) < 1 {
@@ -190,9 +195,9 @@ func passIsAlphaNum(t *testing.T, buf string, want bool) {
 }
 
 func TestKeyAndLength(t *testing.T) {
-	app := cli.NewApp()
+	t.Parallel()
 
-	for _, tc := range []struct {
+	for _, tc := range []struct { //nolint:paralleltest
 		in     []string
 		key    string
 		length string
@@ -218,18 +223,27 @@ func TestKeyAndLength(t *testing.T) {
 			length: "",
 		},
 	} {
-		fs := flag.NewFlagSet("default", flag.ContinueOnError)
-		assert.NoError(t, fs.Parse(append([]string{"foobar"}, tc.in...)))
-		c := cli.NewContext(app, fs, nil)
-		args, _ := parseArgs(c)
-		k, l := keyAndLength(args)
-		assert.Equal(t, tc.key, k, "Key from %+v", tc.in)
-		assert.Equal(t, tc.length, l, "Length from %+v", tc.in)
+		tc := tc
+
+		t.Run(fmt.Sprintf("%v", tc.in), func(t *testing.T) {
+			t.Parallel()
+
+			app := cli.NewApp()
+			fs := flag.NewFlagSet("default", flag.ContinueOnError)
+			assert.NoError(t, fs.Parse(append([]string{"foobar"}, tc.in...)))
+			c := cli.NewContext(app, fs, nil)
+			args, _ := parseArgs(c)
+			k, l := keyAndLength(args)
+			assert.Equal(t, tc.key, k, "Key from %+v", tc.in)
+			assert.Equal(t, tc.length, l, "Length from %+v", tc.in)
+		})
 	}
 }
 
 func TestExtractEmails(t *testing.T) {
-	for _, tc := range []struct {
+	t.Parallel()
+
+	for _, tc := range []struct { //nolint:paralleltest
 		in  []string
 		out []string
 	}{
@@ -241,12 +255,19 @@ func TestExtractEmails(t *testing.T) {
 			out: []string{"john.doe@example.org", "user@example.org"},
 		},
 	} {
-		assert.Equal(t, tc.out, extractEmails(tc.in))
+		tc := tc
+		t.Run(fmt.Sprintf("%v", tc.in), func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tc.out, extractEmails(tc.in))
+		})
 	}
 }
 
 func TestExtractDomains(t *testing.T) {
-	for _, tc := range []struct {
+	t.Parallel()
+
+	for _, tc := range []struct { //nolint:paralleltest
 		in  []string
 		out []string
 	}{
@@ -258,12 +279,19 @@ func TestExtractDomains(t *testing.T) {
 			out: []string{"gmail.com", "live.com", "web.de"},
 		},
 	} {
-		assert.Equal(t, tc.out, extractDomains(tc.in))
+		tc := tc
+		t.Run(fmt.Sprintf("%v", tc.in), func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tc.out, extractDomains(tc.in))
+		})
 	}
 }
 
 func TestUniq(t *testing.T) {
-	for _, tc := range []struct {
+	t.Parallel()
+
+	for _, tc := range []struct { //nolint:paralleltest
 		in  []string
 		out []string
 	}{
@@ -275,12 +303,19 @@ func TestUniq(t *testing.T) {
 			out: []string{"bar", "foo"},
 		},
 	} {
-		assert.Equal(t, tc.out, uniq(tc.in))
+		tc := tc
+		t.Run(fmt.Sprintf("%v", tc.in), func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tc.out, uniq(tc.in))
+		})
 	}
 }
 
 func TestFilterPrefix(t *testing.T) {
-	for _, tc := range []struct {
+	t.Parallel()
+
+	for _, tc := range []struct { //nolint:paralleltest
 		in     []string
 		prefix string
 		out    []string
@@ -299,6 +334,11 @@ func TestFilterPrefix(t *testing.T) {
 			out:    []string{"foo/bar", "foo/baz"},
 		},
 	} {
-		assert.Equal(t, tc.out, filterPrefix(tc.in, tc.prefix))
+		tc := tc
+		t.Run(fmt.Sprintf("%v", tc.in), func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tc.out, filterPrefix(tc.in, tc.prefix))
+		})
 	}
 }

--- a/internal/action/grep.go
+++ b/internal/action/grep.go
@@ -45,6 +45,7 @@ func (s *Action) Grep(c *cli.Context) error {
 		sec, err := s.Store.Get(ctx, v)
 		if err != nil {
 			out.Errorf(ctx, "failed to decrypt %s: %v", v, err)
+
 			continue
 		}
 
@@ -57,5 +58,6 @@ func (s *Action) Grep(c *cli.Context) error {
 		out.Warningf(ctx, "%d secrets failed to decrypt", errors)
 	}
 	out.Printf(ctx, "\nScanned %d secrets. %d matches, %d errors", len(haystack), matches, errors)
+
 	return nil
 }

--- a/internal/action/grep_test.go
+++ b/internal/action/grep_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestGrep(t *testing.T) {
+func TestGrep(t *testing.T) { //nolint:paralleltest
 	u := gptest.NewUnitTester(t)
 	defer u.Remove()
 
@@ -32,12 +32,12 @@ func TestGrep(t *testing.T) {
 	}()
 
 	c := gptest.CliCtx(ctx, t, "foo")
-	t.Run("empty store", func(t *testing.T) {
+	t.Run("empty store", func(t *testing.T) { //nolint:paralleltest
 		defer buf.Reset()
 		assert.NoError(t, act.Grep(c))
 	})
 
-	t.Run("add some secret", func(t *testing.T) {
+	t.Run("add some secret", func(t *testing.T) { //nolint:paralleltest
 		defer buf.Reset()
 		sec := &secrets.Plain{}
 		sec.SetPassword("foobar")
@@ -45,12 +45,12 @@ func TestGrep(t *testing.T) {
 		assert.NoError(t, act.Store.Set(ctx, "foo", sec))
 	})
 
-	t.Run("should find existing", func(t *testing.T) {
+	t.Run("should find existing", func(t *testing.T) { //nolint:paralleltest
 		defer buf.Reset()
 		assert.NoError(t, act.Grep(c))
 	})
 
-	t.Run("RE2", func(t *testing.T) {
+	t.Run("RE2", func(t *testing.T) { //nolint:paralleltest
 		defer buf.Reset()
 		c := gptest.CliCtxWithFlags(ctx, t, map[string]string{"regexp": "true"}, "f..bar")
 		assert.NoError(t, act.Grep(c))

--- a/internal/action/history.go
+++ b/internal/action/history.go
@@ -42,5 +42,6 @@ func (s *Action) History(c *cli.Context) error {
 		}
 		out.Printf(ctx, "%s - %s <%s> - %s - %s%s\n", rev.Hash, rev.AuthorName, rev.AuthorEmail, rev.Date.Format(time.RFC3339), rev.Subject, pw)
 	}
+
 	return nil
 }

--- a/internal/action/history_test.go
+++ b/internal/action/history_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestHistory(t *testing.T) {
+func TestHistory(t *testing.T) { //nolint:paralleltest
 	u := gptest.NewUnitTester(t)
 	defer u.Remove()
 
@@ -39,7 +39,7 @@ func TestHistory(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, act)
 
-	t.Run("can initialize", func(t *testing.T) {
+	t.Run("can initialize", func(t *testing.T) { //nolint:paralleltest
 		require.NoError(t, act.IsInitialized(gptest.CliCtx(ctx, t)))
 	})
 
@@ -49,23 +49,23 @@ func TestHistory(t *testing.T) {
 		out.Stdout = os.Stdout
 	}()
 
-	t.Run("init git", func(t *testing.T) {
+	t.Run("init git", func(t *testing.T) { //nolint:paralleltest
 		defer buf.Reset()
 		require.NoError(t, act.rcsInit(ctx, "", "foo bar", "foo.bar@example.org"))
 		t.Logf("init git: %s", buf.String())
 	})
 
-	t.Run("insert bar", func(t *testing.T) {
+	t.Run("insert bar", func(t *testing.T) { //nolint:paralleltest
 		defer buf.Reset()
 		assert.NoError(t, act.Insert(gptest.CliCtx(ctx, t, "bar")))
 	})
 
-	t.Run("history bar", func(t *testing.T) {
+	t.Run("history bar", func(t *testing.T) { //nolint:paralleltest
 		defer buf.Reset()
 		assert.NoError(t, act.History(gptest.CliCtx(ctx, t, "bar")))
 	})
 
-	t.Run("history --password bar", func(t *testing.T) {
+	t.Run("history --password bar", func(t *testing.T) { //nolint:paralleltest
 		defer buf.Reset()
 		assert.NoError(t, act.History(gptest.CliCtxWithFlags(ctx, t, map[string]string{"password": "true"}, "bar")))
 	})

--- a/internal/action/init.go
+++ b/internal/action/init.go
@@ -33,9 +33,11 @@ func (s *Action) IsInitialized(c *cli.Context) error {
 	if err != nil {
 		return exit.Error(exit.Unknown, err, "Failed to initialize store: %s", err)
 	}
+
 	if inited {
 		debug.Log("Store is fully initialized and ready to go\n\nAll systems go. 🚀\n")
 		s.printReminder(ctx)
+
 		return nil
 	}
 
@@ -64,13 +66,16 @@ func (s *Action) Init(c *cli.Context) error {
 	if name := termio.DetectName(c.Context, c); name != "" {
 		ctx = ctxutil.WithUsername(ctx, name)
 	}
+
 	if email := termio.DetectEmail(c.Context, c); email != "" {
 		ctx = ctxutil.WithEmail(ctx, email)
 	}
+
 	inited, err := s.Store.IsInitialized(ctx)
 	if err != nil {
 		return exit.Error(exit.Unknown, err, "Failed to initialized store: %s", err)
 	}
+
 	if inited {
 		out.Errorf(ctx, "Store is already initialized!")
 	}
@@ -78,6 +83,7 @@ func (s *Action) Init(c *cli.Context) error {
 	if err := s.init(ctx, alias, path, c.Args().Slice()...); err != nil {
 		return exit.Error(exit.Unknown, err, "Failed to initialize store: %s", err)
 	}
+
 	return nil
 }
 
@@ -85,6 +91,7 @@ func initParseContext(ctx context.Context, c *cli.Context) context.Context {
 	if c.IsSet("crypto") {
 		ctx = backend.WithCryptoBackendString(ctx, c.String("crypto"))
 	}
+
 	if c.IsSet("storage") {
 		ctx = backend.WithStorageBackendString(ctx, c.String("storage"))
 	}
@@ -93,6 +100,7 @@ func initParseContext(ctx context.Context, c *cli.Context) context.Context {
 		debug.Log("Using default Crypto Backend (GPGCLI)")
 		ctx = backend.WithCryptoBackend(ctx, backend.GPGCLI)
 	}
+
 	if !backend.HasStorageBackend(ctx) {
 		debug.Log("Using default storage backend (GitFS)")
 		ctx = backend.WithStorageBackend(ctx, backend.GitFS)
@@ -122,6 +130,7 @@ func (s *Action) init(ctx context.Context, alias, path string, keys ...string) e
 	if crypto.Name() == "plain" {
 		keys, _ = crypto.ListIdentities(ctx)
 	}
+
 	if len(keys) < 1 {
 		out.Notice(ctx, "Hint: Use 'gopass init <subkey> to use subkeys!'")
 		nk, err := cui.AskForPrivateKey(ctx, crypto, "🎮 Please select a private key for encrypting secrets:")

--- a/internal/action/init_test.go
+++ b/internal/action/init_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestInit(t *testing.T) {
+func TestInit(t *testing.T) { //nolint:paralleltest
 	u := gptest.NewUnitTester(t)
 	defer u.Remove()
 
@@ -61,7 +61,7 @@ func TestInit(t *testing.T) {
 	buf.Reset()
 }
 
-func TestInitParseContext(t *testing.T) {
+func TestInitParseContext(t *testing.T) { //nolint:paralleltest
 	buf := &bytes.Buffer{}
 	out.Stdout = buf
 	out.Stderr = buf
@@ -82,6 +82,7 @@ func TestInitParseContext(t *testing.T) {
 				if be := backend.GetCryptoBackend(ctx); be != backend.Age {
 					return fmt.Errorf("wrong backend: %d", be)
 				}
+
 				return nil
 			},
 		},
@@ -91,12 +92,16 @@ func TestInitParseContext(t *testing.T) {
 				if backend.GetStorageBackend(ctx) != backend.GitFS {
 					return fmt.Errorf("wrong backend")
 				}
+
 				return nil
 			},
 		},
 	} {
 		tc := tc
+
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
 			c := gptest.CliCtxWithFlags(context.Background(), t, tc.flags)
 			assert.NoError(t, tc.check(initParseContext(c.Context, c)), tc.name)
 			buf.Reset()

--- a/internal/action/insert_test.go
+++ b/internal/action/insert_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestInsert(t *testing.T) {
+func TestInsert(t *testing.T) { //nolint:paralleltest
 	u := gptest.NewUnitTester(t)
 	defer u.Remove()
 
@@ -36,17 +36,17 @@ func TestInsert(t *testing.T) {
 		out.Stdout = os.Stdout
 	}()
 
-	t.Run("insert bar", func(t *testing.T) {
+	t.Run("insert bar", func(t *testing.T) { //nolint:paralleltest
 		assert.NoError(t, act.Insert(gptest.CliCtx(ctx, t, "bar")))
 		buf.Reset()
 	})
 
-	t.Run("insert bar baz", func(t *testing.T) {
+	t.Run("insert bar baz", func(t *testing.T) { //nolint:paralleltest
 		assert.NoError(t, act.Insert(gptest.CliCtx(ctx, t, "bar", "baz")))
 		buf.Reset()
 	})
 
-	t.Run("insert baz via stdin w/o newline", func(t *testing.T) {
+	t.Run("insert baz via stdin w/o newline", func(t *testing.T) { //nolint:paralleltest
 		assert.NoError(t, act.insertStdin(ctx, "baz", []byte("foobar"), false))
 		buf.Reset()
 
@@ -55,7 +55,7 @@ func TestInsert(t *testing.T) {
 		buf.Reset()
 	})
 
-	t.Run("insert baz via stdin w/ newline", func(t *testing.T) {
+	t.Run("insert baz via stdin w/ newline", func(t *testing.T) { //nolint:paralleltest
 		assert.NoError(t, act.insertStdin(ctx, "baz", []byte("foobar\n"), false))
 		buf.Reset()
 
@@ -64,7 +64,7 @@ func TestInsert(t *testing.T) {
 		buf.Reset()
 	})
 
-	t.Run("insert baz via stdin w/ yaml", func(t *testing.T) {
+	t.Run("insert baz via stdin w/ yaml", func(t *testing.T) { //nolint:paralleltest
 		assert.NoError(t, act.insertStdin(ctx, "baz", []byte("foobar\n---\nuser: name\nother: meh"), false))
 		buf.Reset()
 
@@ -73,7 +73,7 @@ func TestInsert(t *testing.T) {
 		buf.Reset()
 	})
 
-	t.Run("insert baz via stdin w/ k-v", func(t *testing.T) {
+	t.Run("insert baz via stdin w/ k-v", func(t *testing.T) { //nolint:paralleltest
 		assert.NoError(t, act.insertStdin(ctx, "baz", []byte("foobar\ninvalid key-value\nOther: meh\nUser: name\nbody text"), false))
 		buf.Reset()
 
@@ -86,7 +86,7 @@ func TestInsert(t *testing.T) {
 		buf.Reset()
 	})
 
-	t.Run("insert zab#key", func(t *testing.T) {
+	t.Run("insert zab#key", func(t *testing.T) { //nolint:paralleltest
 		ctx = ctxutil.WithInteractive(ctx, false)
 		ctx = ctxutil.WithShowSafeContent(ctx, true)
 		assert.NoError(t, act.insertYAML(ctx, "zab", "key", []byte("foobar"), nil))
@@ -95,19 +95,19 @@ func TestInsert(t *testing.T) {
 		buf.Reset()
 	})
 
-	t.Run("insert --multiline bar baz", func(t *testing.T) {
+	t.Run("insert --multiline bar baz", func(t *testing.T) { //nolint:paralleltest
 		assert.NoError(t, act.Insert(gptest.CliCtxWithFlags(ctx, t, map[string]string{"multiline": "true"}, "bar", "baz")))
 		buf.Reset()
 	})
 
-	t.Run("insert key:value", func(t *testing.T) {
+	t.Run("insert key:value", func(t *testing.T) { //nolint:paralleltest
 		assert.NoError(t, act.Insert(gptest.CliCtxWithFlags(ctx, t, nil, "keyvaltest", "baz:val")))
 		assert.NoError(t, act.show(ctx, gptest.CliCtx(ctx, t), "keyvaltest", false))
 		assert.Contains(t, buf.String(), "baz: val")
 		buf.Reset()
 	})
 
-	t.Run("insert baz via stdin w/ yaml and input parsing and safecontent", func(t *testing.T) {
+	t.Run("insert baz via stdin w/ yaml and input parsing and safecontent", func(t *testing.T) { //nolint:paralleltest
 		assert.NoError(t, act.insertStdin(ctx, "baz", []byte("foobar\n---\nuser: name\nother: 0123"), false))
 		buf.Reset()
 
@@ -116,7 +116,7 @@ func TestInsert(t *testing.T) {
 		buf.Reset()
 	})
 
-	t.Run("insert baz via stdin w/ yaml and no input parsing", func(t *testing.T) {
+	t.Run("insert baz via stdin w/ yaml and no input parsing", func(t *testing.T) { //nolint:paralleltest
 		ctx = ctxutil.WithShowParsing(ctx, false)
 		ctx = ctxutil.WithShowSafeContent(ctx, false)
 		assert.NoError(t, act.insertStdin(ctx, "baz", []byte("foobar\n---\nuser: name\nother: 0123"), false))
@@ -130,7 +130,7 @@ func TestInsert(t *testing.T) {
 	})
 }
 
-func TestInsertStdin(t *testing.T) {
+func TestInsertStdin(t *testing.T) { //nolint:paralleltest
 	u := gptest.NewUnitTester(t)
 	defer u.Remove()
 

--- a/internal/action/list.go
+++ b/internal/action/list.go
@@ -31,6 +31,7 @@ func (s *Action) List(c *cli.Context) error {
 	// print the path if the argument is a direct hit.
 	if s.Store.Exists(ctx, filter) && !s.Store.IsDir(ctx, filter) {
 		fmt.Println(filter)
+
 		return nil
 	}
 
@@ -54,7 +55,7 @@ func (s *Action) List(c *cli.Context) error {
 }
 
 func (s *Action) listFiltered(ctx context.Context, l *tree.Root, limit int, flat, folders, stripPrefix bool, filter string) error {
-	sep := string(leaf.Sep)
+	sep := leaf.Sep
 
 	if filter == "" || filter == sep {
 		// We list all entries then.
@@ -85,6 +86,7 @@ func (s *Action) listFiltered(ctx context.Context, l *tree.Root, limit int, flat
 			}
 			fmt.Fprintln(stdout, e)
 		}
+
 		return nil
 	}
 
@@ -97,6 +99,7 @@ func (s *Action) listFiltered(ctx context.Context, l *tree.Root, limit int, flat
 			return exit.Error(exit.Unknown, err, "failed to invoke pager: %s", err)
 		}
 	}
+
 	return nil
 }
 
@@ -118,6 +121,7 @@ func redirectPager(ctx context.Context, subtree *tree.Root) (io.Writer, *bytes.B
 	}
 	color.NoColor = true
 	buf := &bytes.Buffer{}
+
 	return buf, buf
 }
 
@@ -126,6 +130,7 @@ func (s *Action) pager(ctx context.Context, buf io.Reader) error {
 	pager := os.Getenv("PAGER")
 	if pager == "" {
 		fmt.Fprintln(stdout, buf)
+
 		return nil
 	}
 

--- a/internal/action/list_test.go
+++ b/internal/action/list_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestList(t *testing.T) {
+func TestList(t *testing.T) { //nolint:paralleltest
 	u := gptest.NewUnitTester(t)
 	defer u.Remove()
 
@@ -48,7 +48,7 @@ func TestList(t *testing.T) {
 	// add foo/bar and list folder foo
 	sec := &secrets.Plain{}
 	sec.SetPassword("123")
-	sec.Set("bar", "zab")
+	assert.Error(t, sec.Set("bar", "zab"))
 	assert.NoError(t, act.Store.Set(ctx, "foo/bar", sec))
 	buf.Reset()
 
@@ -89,7 +89,7 @@ foo2/
 	buf.Reset()
 }
 
-func TestListLimit(t *testing.T) {
+func TestListLimit(t *testing.T) { //nolint:paralleltest
 	u := gptest.NewUnitTester(t)
 	defer u.Remove()
 
@@ -172,7 +172,7 @@ foo2/bar2
 	buf.Reset()
 }
 
-func TestRedirectPager(t *testing.T) {
+func TestRedirectPager(t *testing.T) { //nolint:paralleltest
 	ctx := context.Background()
 
 	var buf *bytes.Buffer

--- a/internal/action/merge.go
+++ b/internal/action/merge.go
@@ -25,6 +25,7 @@ func (s *Action) Merge(c *cli.Context) error {
 	if to == "" {
 		return exit.Error(exit.Usage, nil, "usage: %s merge <to> <from> [<from>]", s.Name)
 	}
+
 	if len(from) < 1 {
 		return exit.Error(exit.Usage, nil, "usage: %s merge <to> <from> [<from>]", s.Name)
 	}
@@ -43,10 +44,12 @@ func (s *Action) Merge(c *cli.Context) error {
 		if err != nil {
 			return exit.Error(exit.Decrypt, err, "failed to decrypt: %s: %s", k, err)
 		}
+
 		_, err = content.WriteString("\n# Secret: " + k + "\n")
 		if err != nil {
 			return exit.Error(exit.Unknown, err, "failed to write: %s", err)
 		}
+
 		_, err = content.Write(sec.Bytes())
 		if err != nil {
 			return exit.Error(exit.Unknown, err, "failed to write: %s", err)
@@ -102,5 +105,6 @@ func (s *Action) Merge(c *cli.Context) error {
 			return exit.Error(exit.Unknown, err, "failed to delete %s: %s", old, err)
 		}
 	}
+
 	return nil
 }

--- a/internal/action/mount_test.go
+++ b/internal/action/mount_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestMounts(t *testing.T) {
+func TestMounts(t *testing.T) { //nolint:paralleltest
 	u := gptest.NewUnitTester(t)
 	defer u.Remove()
 
@@ -35,33 +35,33 @@ func TestMounts(t *testing.T) {
 		stdout = os.Stdout
 	}()
 
-	t.Run("print mounts", func(t *testing.T) {
+	t.Run("print mounts", func(t *testing.T) { //nolint:paralleltest
 		defer buf.Reset()
 		assert.NoError(t, act.MountsPrint(gptest.CliCtx(ctx, t)))
 	})
 
-	t.Run("complete mounts", func(t *testing.T) {
+	t.Run("complete mounts", func(t *testing.T) { //nolint:paralleltest
 		defer buf.Reset()
 		act.MountsComplete(gptest.CliCtx(ctx, t))
 		assert.Equal(t, buf.String(), "")
 	})
 
-	t.Run("remove no non-existing mount", func(t *testing.T) {
+	t.Run("remove no non-existing mount", func(t *testing.T) { //nolint:paralleltest
 		defer buf.Reset()
 		assert.Error(t, act.MountRemove(gptest.CliCtx(ctx, t)))
 	})
 
-	t.Run("remove non-existing mount", func(t *testing.T) {
+	t.Run("remove non-existing mount", func(t *testing.T) { //nolint:paralleltest
 		defer buf.Reset()
 		assert.NoError(t, act.MountRemove(gptest.CliCtx(ctx, t, "foo")))
 	})
 
-	t.Run("add non-existing mount", func(t *testing.T) {
+	t.Run("add non-existing mount", func(t *testing.T) { //nolint:paralleltest
 		defer buf.Reset()
 		assert.Error(t, act.MountAdd(gptest.CliCtx(ctx, t, "foo", filepath.Join(u.Dir, "mount1"))))
 	})
 
-	t.Run("add some mounts", func(t *testing.T) {
+	t.Run("add some mounts", func(t *testing.T) { //nolint:paralleltest
 		defer buf.Reset()
 		assert.NoError(t, u.InitStore("mount1"))
 		assert.NoError(t, u.InitStore("mount2"))
@@ -69,7 +69,7 @@ func TestMounts(t *testing.T) {
 		assert.NoError(t, act.Store.AddMount(ctx, "mount2", u.StoreDir("mount2")))
 	})
 
-	t.Run("print mounts", func(t *testing.T) {
+	t.Run("print mounts", func(t *testing.T) { //nolint:paralleltest
 		defer buf.Reset()
 		assert.NoError(t, act.MountsPrint(gptest.CliCtx(ctx, t)))
 	})

--- a/internal/action/move_test.go
+++ b/internal/action/move_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestMove(t *testing.T) {
+func TestMove(t *testing.T) { //nolint:paralleltest
 	u := gptest.NewUnitTester(t)
 	defer u.Remove()
 

--- a/internal/action/otp_test.go
+++ b/internal/action/otp_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestOTP(t *testing.T) {
+func TestOTP(t *testing.T) { //nolint:paralleltest
 	u := gptest.NewUnitTester(t)
 	defer u.Remove()
 
@@ -34,12 +34,12 @@ func TestOTP(t *testing.T) {
 		out.Stdout = os.Stdout
 	}()
 
-	t.Run("display non-otp secret", func(t *testing.T) {
+	t.Run("display non-otp secret", func(t *testing.T) { //nolint:paralleltest
 		defer buf.Reset()
 		assert.Error(t, act.OTP(gptest.CliCtx(ctx, t, "foo")))
 	})
 
-	t.Run("create and display valid OTP", func(t *testing.T) {
+	t.Run("create and display valid OTP", func(t *testing.T) { //nolint:paralleltest
 		defer buf.Reset()
 		sec := &secrets.Plain{}
 		sec.SetPassword("foo")
@@ -49,12 +49,12 @@ func TestOTP(t *testing.T) {
 		assert.NoError(t, act.OTP(gptest.CliCtx(ctx, t, "bar")))
 	})
 
-	t.Run("copy to clipboard", func(t *testing.T) {
+	t.Run("copy to clipboard", func(t *testing.T) { //nolint:paralleltest
 		defer buf.Reset()
 		assert.NoError(t, act.otp(ctx, "bar", "", true, false, false))
 	})
 
-	t.Run("write QR file", func(t *testing.T) {
+	t.Run("write QR file", func(t *testing.T) { //nolint:paralleltest
 		defer buf.Reset()
 		fn := filepath.Join(u.Dir, "qr.png")
 		assert.NoError(t, act.OTP(gptest.CliCtxWithFlags(ctx, t, map[string]string{"qr": fn}, "bar")))

--- a/internal/action/process_test.go
+++ b/internal/action/process_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestProcess(t *testing.T) {
+func TestProcess(t *testing.T) { //nolint:paralleltest
 	u := gptest.NewUnitTester(t)
 	defer u.Remove()
 
@@ -36,7 +36,7 @@ func TestProcess(t *testing.T) {
 	require.NotNil(t, act)
 
 	sec := secrets.New()
-	sec.Set("username", "admin")
+	assert.NoError(t, sec.Set("username", "admin"))
 	sec.SetPassword("hunter2")
 	require.NoError(t, act.Store.Set(ctx, "server/local/mysql", sec))
 

--- a/internal/action/pwgen/commands_test.go
+++ b/internal/action/pwgen/commands_test.go
@@ -9,11 +9,15 @@ import (
 )
 
 func testCommand(t *testing.T, cmd *cli.Command) {
+	t.Helper()
+
 	if len(cmd.Subcommands) < 1 {
 		assert.NotNil(t, cmd.Action, cmd.Name)
 	}
+
 	assert.NotEmpty(t, cmd.Usage)
 	assert.NotEmpty(t, cmd.Description)
+
 	for _, flag := range cmd.Flags {
 		switch v := flag.(type) {
 		case *cli.StringFlag:
@@ -24,12 +28,15 @@ func testCommand(t *testing.T, cmd *cli.Command) {
 			assert.NotEmpty(t, v.Usage)
 		}
 	}
+
 	for _, scmd := range cmd.Subcommands {
 		testCommand(t, scmd)
 	}
 }
 
 func TestCommands(t *testing.T) {
+	t.Parallel()
+
 	u := gptest.NewUnitTester(t)
 	defer u.Remove()
 

--- a/internal/action/pwgen/pwgen.go
+++ b/internal/action/pwgen/pwgen.go
@@ -54,6 +54,7 @@ func xkcdGen(c *cli.Context, num int) error {
 		}
 		fmt.Println(s)
 	}
+
 	return nil
 }
 

--- a/internal/action/rcs.go
+++ b/internal/action/rcs.go
@@ -34,6 +34,7 @@ func (s *Action) RCSInit(c *cli.Context) error {
 	if err := s.rcsInit(ctx, store, un, ue); err != nil {
 		return exit.Error(exit.Git, err, "failed to initialize %s: %s", backend.StorageBackendName(backend.GetStorageBackend(ctx)), err)
 	}
+
 	return nil
 }
 
@@ -49,21 +50,26 @@ func (s *Action) rcsInit(ctx context.Context, store, un, ue string) error {
 	if err := s.Store.RCSInit(ctx, store, userName, userEmail); err != nil {
 		if errors.Is(err, backend.ErrNotSupported) {
 			debug.Log("RCSInit not supported for backend %s in %q", bn, store)
+
 			return nil
 		}
+
 		if gtv := os.Getenv("GPG_TTY"); gtv == "" {
 			out.Printf(ctx, "Git initialization failed. You may want to try to 'export GPG_TTY=$(tty)' and start over.")
 		}
+
 		return fmt.Errorf("failed to run RCS init: %w", err)
 	}
 
 	out.Printf(ctx, "Initialized %s repository (%s) for %s / %s...", be, bn, un, ue)
+
 	return nil
 }
 
 func (s *Action) getUserData(ctx context.Context, store, name, email string) (string, string) {
 	if name != "" && email != "" {
 		debug.Log("Username: %s, Email: %s (provided)", name, email)
+
 		return name, email
 	}
 
@@ -82,6 +88,7 @@ func (s *Action) getUserData(ctx context.Context, store, name, email string) (st
 			out.Errorf(ctx, "Failed to ask for user input: %s", err)
 		}
 	}
+
 	if email == "" {
 		if userEmail == "" {
 			userEmail = termio.DetectEmail(ctx, nil)
@@ -95,6 +102,7 @@ func (s *Action) getUserData(ctx context.Context, store, name, email string) (st
 	}
 
 	debug.Log("Username: %s, Email: %s (detected)", name, email)
+
 	return name, email
 }
 
@@ -145,11 +153,14 @@ func (s *Action) RCSPush(c *cli.Context) error {
 	if err := s.Store.RCSPush(ctx, store, origin, branch); err != nil {
 		if errors.Is(err, si.ErrGitNoRemote) {
 			out.Noticef(ctx, "No Git remote. Not pushing")
+
 			return nil
 		}
+
 		return exit.Error(exit.Git, err, "Failed to push to remote")
 	}
 	out.OKf(ctx, "Pushed to git remote")
+
 	return nil
 }
 

--- a/internal/action/rcs_test.go
+++ b/internal/action/rcs_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestGit(t *testing.T) {
+func TestGit(t *testing.T) { //nolint:paralleltest
 	u := gptest.NewUnitTester(t)
 	defer u.Remove()
 

--- a/internal/action/recipients.go
+++ b/internal/action/recipients.go
@@ -42,6 +42,7 @@ func (s *Action) RecipientsPrint(c *cli.Context) error {
 	}
 
 	fmt.Fprintln(stdout, t.Format(tree.INF))
+
 	return nil
 }
 
@@ -49,6 +50,7 @@ func (s *Action) recipientsList(ctx context.Context) []string {
 	t, err := s.Store.RecipientsTree(ctxutil.WithHidden(ctx, true), false)
 	if err != nil {
 		debug.Log("failed to list recipients: %s", err)
+
 		return nil
 	}
 
@@ -79,7 +81,7 @@ func (s *Action) RecipientsAdd(c *cli.Context) error {
 	crypto := s.Store.Crypto(ctx, store)
 
 	// select recipient.
-	recipients := []string(c.Args().Slice())
+	recipients := c.Args().Slice()
 	if len(recipients) < 1 {
 		debug.Log("no recipients given, asking for selection")
 		r, err := s.recipientsSelectForAdd(ctx, store)
@@ -111,6 +113,7 @@ func (s *Action) RecipientsAdd(c *cli.Context) error {
 			out.Printf(ctx, "If this is your key: gpg --edit-key %s; trust (set to ultimate); quit", r)
 			out.Printf(ctx, "If this is not your key: gpg --edit-key %s; lsign; trust; save; quit", r)
 			out.Printf(ctx, "You may need to run 'gpg --update-trustdb' afterwards")
+
 			continue
 		}
 
@@ -132,6 +135,7 @@ func (s *Action) RecipientsAdd(c *cli.Context) error {
 
 	out.Printf(ctx, "\nAdded %d recipients", added)
 	out.Printf(ctx, "You need to run 'gopass sync' to push these changes")
+
 	return nil
 }
 
@@ -150,7 +154,7 @@ func (s *Action) RecipientsRemove(c *cli.Context) error {
 	crypto := s.Store.Crypto(ctx, store)
 
 	// select recipient.
-	recipients := []string(c.Args().Slice())
+	recipients := c.Args().Slice()
 	if len(recipients) < 1 {
 		rs, err := s.recipientsSelectForRemoval(ctx, store)
 		if err != nil {
@@ -183,6 +187,7 @@ func (s *Action) RecipientsRemove(c *cli.Context) error {
 			out.Printf(ctx, "If this is your key: gpg --edit-key %s; trust (set to ultimate); quit", r)
 			out.Printf(ctx, "If this is not your key: gpg --edit-key %s; lsign; trust; save; quit", r)
 			out.Printf(ctx, "You may need to run 'gpg --update-trustdb' afterwards")
+
 			continue
 		}
 
@@ -203,6 +208,7 @@ func (s *Action) RecipientsRemove(c *cli.Context) error {
 
 	out.Printf(ctx, "\nRemoved %d recipients", removed)
 	out.Printf(ctx, "You need to run 'gopass sync' to push these changes")
+
 	return nil
 }
 
@@ -214,6 +220,7 @@ func (s *Action) recipientsSelectForRemoval(ctx context.Context, store string) (
 	for _, id := range ids {
 		choices = append(choices, crypto.FormatKey(ctx, id, ""))
 	}
+
 	if len(choices) < 1 {
 		return nil, nil
 	}
@@ -237,6 +244,7 @@ func (s *Action) recipientsSelectForAdd(ctx context.Context, store string) ([]st
 	for _, key := range kl {
 		choices = append(choices, crypto.FormatKey(ctx, key, ""))
 	}
+
 	if len(choices) < 1 {
 		return nil, nil
 	}

--- a/internal/action/recipients_test.go
+++ b/internal/action/recipients_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestRecipients(t *testing.T) {
+func TestRecipients(t *testing.T) { //nolint:paralleltest
 	u := gptest.NewUnitTester(t)
 	defer u.Remove()
 
@@ -37,7 +37,7 @@ func TestRecipients(t *testing.T) {
 		stdout = os.Stdout
 	}()
 
-	t.Run("print recipients tree", func(t *testing.T) {
+	t.Run("print recipients tree", func(t *testing.T) { //nolint:paralleltest
 		defer buf.Reset()
 		assert.NoError(t, act.RecipientsPrint(gptest.CliCtx(ctx, t)))
 
@@ -49,34 +49,34 @@ func TestRecipients(t *testing.T) {
 		assert.Contains(t, buf.String(), want)
 	})
 
-	t.Run("complete recipients", func(t *testing.T) {
+	t.Run("complete recipients", func(t *testing.T) { //nolint:paralleltest
 		defer buf.Reset()
 		act.RecipientsComplete(gptest.CliCtx(ctx, t))
 		want := "0xDEADBEEF\n"
 		assert.Equal(t, want, buf.String())
 	})
 
-	t.Run("add recipients w/o args", func(t *testing.T) {
+	t.Run("add recipients w/o args", func(t *testing.T) { //nolint:paralleltest
 		defer buf.Reset()
 		assert.Error(t, act.RecipientsAdd(gptest.CliCtx(ctx, t)))
 	})
 
-	t.Run("remove recipients w/o args", func(t *testing.T) {
+	t.Run("remove recipients w/o args", func(t *testing.T) { //nolint:paralleltest
 		defer buf.Reset()
 		assert.Error(t, act.RecipientsRemove(gptest.CliCtx(ctx, t)))
 	})
 
-	t.Run("add recipient 0xFEEDBEEF", func(t *testing.T) {
+	t.Run("add recipient 0xFEEDBEEF", func(t *testing.T) { //nolint:paralleltest
 		defer buf.Reset()
 		assert.NoError(t, act.RecipientsAdd(gptest.CliCtx(ctx, t, "0xFEEDBEEF")))
 	})
 
-	t.Run("add recipient 0xBEEFFEED", func(t *testing.T) {
+	t.Run("add recipient 0xBEEFFEED", func(t *testing.T) { //nolint:paralleltest
 		defer buf.Reset()
 		assert.NoError(t, act.RecipientsAdd(gptest.CliCtx(ctx, t, "0xBEEFFEED")))
 	})
 
-	t.Run("remove recipient 0xDEADBEEF", func(t *testing.T) {
+	t.Run("remove recipient 0xDEADBEEF", func(t *testing.T) { //nolint:paralleltest
 		defer buf.Reset()
 		assert.NoError(t, act.RecipientsRemove(gptest.CliCtx(ctx, t, "0xDEADBEEF")))
 	})

--- a/internal/action/reminder.go
+++ b/internal/action/reminder.go
@@ -13,9 +13,11 @@ func (s *Action) printReminder(ctx context.Context) {
 	if !ctxutil.IsInteractive(ctx) {
 		return
 	}
+
 	if !ctxutil.IsTerminal(ctx) {
 		return
 	}
+
 	if sv := os.Getenv("GOPASS_NO_REMINDER"); sv != "" {
 		return
 	}
@@ -29,7 +31,7 @@ func (s *Action) printReminder(ctx context.Context) {
 		if msg != "" {
 			out.Warningf(ctx, "%s", msg)
 		}
-		s.rem.Reset("env")
+		_ = s.rem.Reset("env")
 	}
 
 	// Note: We only want to print one reminder per day (at most).
@@ -37,16 +39,19 @@ func (s *Action) printReminder(ctx context.Context) {
 	// for the following days.
 	if s.rem.Overdue("update") {
 		out.Notice(ctx, "You haven't checked for updates in a while. Run 'gopass version' or 'gopass update' to check.")
+
 		return
 	}
 
 	if s.rem.Overdue("fsck") {
 		out.Notice(ctx, "You haven't run 'gopass fsck' in a while.")
+
 		return
 	}
 
 	if s.rem.Overdue("audit") {
 		out.Notice(ctx, "You haven't run 'gopass audit' in a while.")
+
 		return
 	}
 }

--- a/internal/action/setup.go
+++ b/internal/action/setup.go
@@ -35,6 +35,7 @@ func (s *Action) Setup(c *cli.Context) error {
 	if name := termio.DetectName(ctx, c); name != "" {
 		ctx = ctxutil.WithUsername(ctx, name)
 	}
+
 	if email := termio.DetectEmail(ctx, c); email != "" {
 		ctx = ctxutil.WithEmail(ctx, email)
 	}
@@ -57,8 +58,10 @@ func (s *Action) Setup(c *cli.Context) error {
 	if err != nil {
 		return exit.Error(exit.Unknown, err, "Failed to check store status: %s", err)
 	}
+
 	if inited {
 		out.Errorf(ctx, "Store is already initialized. Aborting wizard to avoid overwriting existing data.")
+
 		return nil
 	}
 
@@ -90,6 +93,7 @@ func (s *Action) Setup(c *cli.Context) error {
 		if create {
 			return s.initCreateTeam(ctx, team, remote)
 		}
+
 		return s.initJoinTeam(ctx, team, remote)
 	}
 
@@ -158,9 +162,11 @@ func (s *Action) initGenerateIdentity(ctx context.Context, crypto backend.Crypto
 	if err != nil {
 		return fmt.Errorf("failed to list private keys: %w", err)
 	}
+
 	if len(kl) > 1 {
 		out.Notice(ctx, "More than one private key detected. Make sure to use the correct one!")
 	}
+
 	if len(kl) < 1 {
 		return fmt.Errorf("failed to create a usable key pair")
 	}
@@ -170,6 +176,7 @@ func (s *Action) initGenerateIdentity(ctx context.Context, crypto backend.Crypto
 		return err
 	}
 	out.OKf(ctx, "Key pair validated")
+
 	return nil
 }
 
@@ -181,6 +188,7 @@ func (s *Action) initExportPublicKey(ctx context.Context, crypto backend.Crypto,
 	exp, ok := crypto.(keyExporter)
 	if !ok {
 		debug.Log("crypto backend %T can not export public keys", crypto)
+
 		return nil
 	}
 
@@ -189,18 +197,23 @@ func (s *Action) initExportPublicKey(ctx context.Context, crypto backend.Crypto,
 	if err != nil {
 		return err
 	}
+
 	if !want {
 		return nil
 	}
+
 	pk, err := exp.ExportPublicKey(ctx, key)
 	if err != nil {
 		return fmt.Errorf("failed to export public key: %w", err)
 	}
+
 	if err := os.WriteFile(fn, pk, 0o6444); err != nil {
 		out.Errorf(ctx, "❌ Failed to export public key %q: %q", fn, err)
+
 		return err
 	}
 	out.Printf(ctx, "✴ Public key exported to %q", fn)
+
 	return nil
 }
 
@@ -235,6 +248,7 @@ func (s *Action) initSetupGitRemote(ctx context.Context, team, remote string) er
 	if err := s.Store.RCSPush(ctx, team, "origin", ""); err != nil {
 		return fmt.Errorf("failed to push to git remote: %w", err)
 	}
+
 	return nil
 }
 
@@ -268,6 +282,7 @@ func (s *Action) initLocal(ctx context.Context) error {
 	}
 
 	out.OKf(ctx, "Configuration written to %s", s.cfg.Path)
+
 	return nil
 }
 
@@ -298,6 +313,7 @@ func (s *Action) initCreateTeam(ctx context.Context, team, remote string) error 
 		return fmt.Errorf("failed to setup git remote: %w", err)
 	}
 	out.OKf(ctx, "Done. Created Team %q", team)
+
 	return nil
 }
 
@@ -330,5 +346,6 @@ func (s *Action) initJoinTeam(ctx context.Context, team, remote string) error {
 	}
 	out.OKf(ctx, "Done. Joined Team %q", team)
 	out.Noticef(ctx, "You still need to request access to decrypt secrets!")
+
 	return nil
 }

--- a/internal/action/show_test.go
+++ b/internal/action/show_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestShowMulti(t *testing.T) {
+func TestShowMulti(t *testing.T) { //nolint:paralleltest
 	u := gptest.NewUnitTester(t)
 	defer u.Remove()
 
@@ -39,25 +39,25 @@ func TestShowMulti(t *testing.T) {
 		out.Stdout = os.Stdout
 	}()
 
-	t.Run("show foo", func(t *testing.T) {
+	t.Run("show foo", func(t *testing.T) { //nolint:paralleltest
 		defer buf.Reset()
 		c := gptest.CliCtx(ctx, t, "foo")
 		assert.NoError(t, act.Show(c))
 		assert.Contains(t, buf.String(), "secret")
 	})
 
-	t.Run("show --sync foo", func(t *testing.T) {
+	t.Run("show --sync foo", func(t *testing.T) { //nolint:paralleltest
 		defer buf.Reset()
 		c := gptest.CliCtxWithFlags(ctx, t, map[string]string{"sync": "true"}, "foo")
 		assert.NoError(t, act.Show(c))
 		assert.Contains(t, buf.String(), "secret")
 	})
 
-	t.Run("show dir", func(t *testing.T) {
+	t.Run("show dir", func(t *testing.T) { //nolint:paralleltest
 		// first add another entry in a subdir
 		sec := secrets.NewKV()
 		sec.SetPassword("123")
-		sec.Set("bar", "zab")
+		assert.NoError(t, sec.Set("bar", "zab"))
 		assert.NoError(t, act.Store.Set(ctx, "bar/baz", sec))
 		buf.Reset()
 
@@ -67,7 +67,7 @@ func TestShowMulti(t *testing.T) {
 		buf.Reset()
 	})
 
-	t.Run("show twoliner with safecontent enabled", func(t *testing.T) {
+	t.Run("show twoliner with safecontent enabled", func(t *testing.T) { //nolint:paralleltest
 		ctx := ctxutil.WithShowSafeContent(ctx, true)
 		c := gptest.CliCtx(ctx, t, "bar/baz")
 
@@ -78,7 +78,7 @@ func TestShowMulti(t *testing.T) {
 		buf.Reset()
 	})
 
-	t.Run("show foo with safecontent enabled, should error out", func(t *testing.T) {
+	t.Run("show foo with safecontent enabled, should error out", func(t *testing.T) { //nolint:paralleltest
 		ctx := ctxutil.WithShowSafeContent(ctx, true)
 
 		c := gptest.CliCtx(ctx, t, "foo")
@@ -87,14 +87,14 @@ func TestShowMulti(t *testing.T) {
 		buf.Reset()
 	})
 
-	t.Run("show foo with safecontent enabled, with the force flag", func(t *testing.T) {
+	t.Run("show foo with safecontent enabled, with the force flag", func(t *testing.T) { //nolint:paralleltest
 		c := gptest.CliCtxWithFlags(ctx, t, map[string]string{"unsafe": "true"}, "foo")
 		assert.NoError(t, act.Show(c))
 		assert.Contains(t, buf.String(), "secret")
 		buf.Reset()
 	})
 
-	t.Run("show twoliner with safecontent enabled, but with the clip flag, which should copy just the secret", func(t *testing.T) {
+	t.Run("show twoliner with safecontent enabled, but with the clip flag, which should copy just the secret", func(t *testing.T) { //nolint:paralleltest
 		ctx := ctxutil.WithShowSafeContent(ctx, true)
 		c := gptest.CliCtxWithFlags(ctx, t, map[string]string{"clip": "true"}, "bar/baz")
 
@@ -103,13 +103,13 @@ func TestShowMulti(t *testing.T) {
 		buf.Reset()
 	})
 
-	t.Run("show entry with unsafe keys", func(t *testing.T) {
+	t.Run("show entry with unsafe keys", func(t *testing.T) { //nolint:paralleltest
 		sec := secrets.NewKV()
 		sec.SetPassword("123")
-		sec.Set("bar", "zab")
-		sec.Set("foo", "baz")
-		sec.Set("hello", "world")
-		sec.Set("unsafe-keys", "foo, bar")
+		assert.NoError(t, sec.Set("bar", "zab"))
+		assert.NoError(t, sec.Set("foo", "baz"))
+		assert.NoError(t, sec.Set("hello", "world"))
+		assert.NoError(t, sec.Set("unsafe-keys", "foo, bar"))
 		assert.NoError(t, act.Store.Set(ctx, "unsafe/keys", sec))
 		buf.Reset()
 
@@ -122,7 +122,7 @@ func TestShowMulti(t *testing.T) {
 		buf.Reset()
 	})
 
-	t.Run("show twoliner with safecontent enabled", func(t *testing.T) {
+	t.Run("show twoliner with safecontent enabled", func(t *testing.T) { //nolint:paralleltest
 		ctx := ctxutil.WithShowSafeContent(ctx, true)
 		c := gptest.CliCtx(ctx, t, "bar/baz")
 
@@ -133,7 +133,7 @@ func TestShowMulti(t *testing.T) {
 		buf.Reset()
 	})
 
-	t.Run("show twoliner with parsing disabled and safecontent enabled", func(t *testing.T) {
+	t.Run("show twoliner with parsing disabled and safecontent enabled", func(t *testing.T) { //nolint:paralleltest
 		ctx := ctxutil.WithShowSafeContent(ctx, true)
 		ctx = ctxutil.WithShowParsing(ctx, false)
 		c := gptest.CliCtx(ctx, t, "bar/baz")
@@ -146,7 +146,7 @@ func TestShowMulti(t *testing.T) {
 		buf.Reset()
 	})
 
-	t.Run("show key with parsing enabled", func(t *testing.T) {
+	t.Run("show key with parsing enabled", func(t *testing.T) { //nolint:paralleltest
 		ctx := ctxutil.WithShowParsing(ctx, true)
 		c := gptest.CliCtx(ctx, t, "bar/baz", "bar")
 
@@ -155,7 +155,7 @@ func TestShowMulti(t *testing.T) {
 		buf.Reset()
 	})
 
-	t.Run("show key with parsing disabled", func(t *testing.T) {
+	t.Run("show key with parsing disabled", func(t *testing.T) { //nolint:paralleltest
 		ctx := ctxutil.WithShowParsing(ctx, false)
 		c := gptest.CliCtx(ctx, t, "bar/baz", "bar")
 
@@ -164,7 +164,7 @@ func TestShowMulti(t *testing.T) {
 		buf.Reset()
 	})
 
-	t.Run("show nonexisting key with parsing enabled", func(t *testing.T) {
+	t.Run("show nonexisting key with parsing enabled", func(t *testing.T) { //nolint:paralleltest
 		ctx := ctxutil.WithShowParsing(ctx, true)
 		c := gptest.CliCtx(ctx, t, "bar/baz", "nonexisting")
 
@@ -172,7 +172,7 @@ func TestShowMulti(t *testing.T) {
 		buf.Reset()
 	})
 
-	t.Run("show keys with mixed case", func(t *testing.T) {
+	t.Run("show keys with mixed case", func(t *testing.T) { //nolint:paralleltest
 		ctx := ctxutil.WithShowParsing(ctx, true)
 
 		assert.NoError(t, act.insertStdin(ctx, "baz", []byte("foobar\nOther: meh\nuser: name\nbody text"), false))
@@ -184,7 +184,7 @@ func TestShowMulti(t *testing.T) {
 		buf.Reset()
 	})
 
-	t.Run("show value with format strings", func(t *testing.T) {
+	t.Run("show value with format strings", func(t *testing.T) { //nolint:paralleltest
 		ctx := ctxutil.WithShowParsing(ctx, true)
 
 		pw := "some-chars-are-odd-%s-%p-%q"
@@ -200,7 +200,7 @@ func TestShowMulti(t *testing.T) {
 	})
 }
 
-func TestShowAutoClip(t *testing.T) {
+func TestShowAutoClip(t *testing.T) { //nolint:paralleltest
 	// make sure we consistently get the unsupported error message
 	ov := clipboard.Unsupported
 	defer func() {
@@ -240,7 +240,7 @@ func TestShowAutoClip(t *testing.T) {
 	// -> w/o terminal
 	// -> Print password
 	// for use in scripts
-	t.Run("gopass show foo", func(t *testing.T) {
+	t.Run("gopass show foo", func(t *testing.T) { //nolint:paralleltest
 		// terminal=false
 		ctx = ctxutil.WithTerminal(ctx, false)
 		// initialize context with config values, also detects if we're running in a terminal
@@ -256,7 +256,7 @@ func TestShowAutoClip(t *testing.T) {
 
 	// gopass show -c foo
 	// -> Copy to clipboard
-	t.Run("gopass show -c foo", func(t *testing.T) {
+	t.Run("gopass show -c foo", func(t *testing.T) { //nolint:paralleltest
 		c := gptest.CliCtxWithFlags(ctx, t, map[string]string{"clip": "true"}, "foo")
 		assert.NoError(t, act.Show(c))
 		assert.Contains(t, stderrBuf.String(), "WARNING")
@@ -267,7 +267,7 @@ func TestShowAutoClip(t *testing.T) {
 
 	// gopass show -C foo
 	// -> Copy to clipboard AND print
-	t.Run("gopass show -C foo", func(t *testing.T) {
+	t.Run("gopass show -C foo", func(t *testing.T) { //nolint:paralleltest
 		c := gptest.CliCtxWithFlags(ctx, t, map[string]string{"alsoclip": "true"}, "foo")
 		assert.NoError(t, act.Show(c))
 		assert.Contains(t, stderrBuf.String(), "WARNING")
@@ -279,7 +279,7 @@ func TestShowAutoClip(t *testing.T) {
 
 	// gopass show -f foo
 	// -> ONLY print
-	t.Run("gopass show -f foo", func(t *testing.T) {
+	t.Run("gopass show -f foo", func(t *testing.T) { //nolint:paralleltest
 		c := gptest.CliCtxWithFlags(ctx, t, map[string]string{"unsafe": "true"}, "foo")
 		assert.NoError(t, act.Show(c))
 		assert.NotContains(t, stderrBuf.String(), "WARNING")
@@ -291,7 +291,7 @@ func TestShowAutoClip(t *testing.T) {
 
 	// gopass show foo
 	// -> Copy to clipboard
-	t.Run("gopass show foo", func(t *testing.T) {
+	t.Run("gopass show foo", func(t *testing.T) { //nolint:paralleltest
 		c := gptest.CliCtx(ctx, t, "foo")
 		assert.NoError(t, act.Show(c))
 		assert.NotContains(t, stderrBuf.String(), "WARNING")
@@ -302,7 +302,7 @@ func TestShowAutoClip(t *testing.T) {
 
 	// gopass show -c foo
 	// -> Copy to clipboard
-	t.Run("gopass show -c foo", func(t *testing.T) {
+	t.Run("gopass show -c foo", func(t *testing.T) { //nolint:paralleltest
 		c := gptest.CliCtxWithFlags(ctx, t, map[string]string{"clip": "true"}, "foo")
 		assert.NoError(t, act.Show(c))
 		assert.Contains(t, stderrBuf.String(), "WARNING")
@@ -313,7 +313,7 @@ func TestShowAutoClip(t *testing.T) {
 
 	// gopass show -C foo
 	// -> Copy to clipboard AND print
-	t.Run("gopass show -C foo", func(t *testing.T) {
+	t.Run("gopass show -C foo", func(t *testing.T) { //nolint:paralleltest
 		c := gptest.CliCtxWithFlags(ctx, t, map[string]string{"alsoclip": "true"}, "foo")
 		assert.NoError(t, act.Show(c))
 		assert.Contains(t, stderrBuf.String(), "WARNING")
@@ -325,7 +325,7 @@ func TestShowAutoClip(t *testing.T) {
 
 	// gopass show -f foo
 	// -> ONLY Print
-	t.Run("gopass show -f foo", func(t *testing.T) {
+	t.Run("gopass show -f foo", func(t *testing.T) { //nolint:paralleltest
 		c := gptest.CliCtxWithFlags(ctx, t, map[string]string{"unsafe": "true"}, "foo")
 		assert.NoError(t, act.Show(c))
 		assert.NotContains(t, stderrBuf.String(), "WARNING")
@@ -336,7 +336,7 @@ func TestShowAutoClip(t *testing.T) {
 	})
 }
 
-func TestShowHandleRevision(t *testing.T) {
+func TestShowHandleRevision(t *testing.T) { //nolint:paralleltest
 	u := gptest.NewUnitTester(t)
 	defer u.Remove()
 
@@ -365,7 +365,7 @@ func TestShowHandleRevision(t *testing.T) {
 	})
 }
 
-func TestShowHandleError(t *testing.T) {
+func TestShowHandleError(t *testing.T) { //nolint:paralleltest
 	u := gptest.NewUnitTester(t)
 	defer u.Remove()
 
@@ -391,7 +391,7 @@ func TestShowHandleError(t *testing.T) {
 	buf.Reset()
 }
 
-func TestShowPrintQR(t *testing.T) {
+func TestShowPrintQR(t *testing.T) { //nolint:paralleltest
 	u := gptest.NewUnitTester(t)
 	defer u.Remove()
 

--- a/internal/action/sync.go
+++ b/internal/action/sync.go
@@ -80,11 +80,13 @@ func (s *Action) syncMount(ctx context.Context, mp string) error {
 	sub, err := s.Store.GetSubStore(mp)
 	if err != nil {
 		out.Errorf(ctx, "Failed to get sub store %q: %s", name, err)
-		return fmt.Errorf("failed to get sub stores (%s)", err)
+
+		return fmt.Errorf("failed to get sub stores (%w)", err)
 	}
 
 	if sub == nil {
 		out.Errorf(ctx, "Failed to get sub stores '%s: nil'", name)
+
 		return fmt.Errorf("failed to get sub stores (nil)")
 	}
 
@@ -95,6 +97,7 @@ func (s *Action) syncMount(ctx context.Context, mp string) error {
 
 	out.Printf(ctxno, "\n   "+color.GreenString("%s pull and push ... ", sub.Storage().Name()))
 	err = sub.Storage().Push(ctx, "", "")
+
 	switch {
 	case err == nil:
 		debug.Log("Push succeeded")
@@ -102,6 +105,7 @@ func (s *Action) syncMount(ctx context.Context, mp string) error {
 	case errors.Is(err, store.ErrGitNoRemote):
 		out.Printf(ctx, "Skipped (no remote)")
 		debug.Log("Failed to push %q to its remote: %s", name, err)
+
 		return err
 	case errors.Is(err, backend.ErrNotSupported):
 		out.Printf(ctxno, "Skipped (not supported)")
@@ -109,6 +113,7 @@ func (s *Action) syncMount(ctx context.Context, mp string) error {
 		out.Printf(ctxno, "Skipped (no Git repo)")
 	default: // any other error
 		out.Errorf(ctx, "Failed to push %q to its remote: %s", name, err)
+
 		return err
 	}
 
@@ -128,6 +133,7 @@ func (s *Action) syncMount(ctx context.Context, mp string) error {
 		}
 	}
 	out.Printf(ctx, "\n   "+color.GreenString("done"))
+
 	return nil
 }
 
@@ -136,9 +142,11 @@ func syncImportKeys(ctx context.Context, sub *leaf.Store, name string) error {
 	out.Printf(ctx, "\n   "+color.GreenString("importing missing keys ... "))
 	if err := sub.ImportMissingPublicKeys(ctx); err != nil {
 		out.Errorf(ctx, "Failed to import missing public keys for %q: %s", name, err)
+
 		return err
 	}
 	out.Printf(ctx, color.GreenString("OK"))
+
 	return nil
 }
 
@@ -148,25 +156,30 @@ func syncExportKeys(ctx context.Context, sub *leaf.Store, name string) error {
 	rs, err := sub.GetRecipients(ctx, "")
 	if err != nil {
 		out.Errorf(ctx, "Failed to load recipients for %q: %s", name, err)
+
 		return err
 	}
 	exported, err := sub.ExportMissingPublicKeys(ctx, rs)
 	if err != nil {
 		out.Errorf(ctx, "Failed to export missing public keys for %q: %s", name, err)
+
 		return err
 	}
 
 	// only run second push if we did export any keys.
 	if !exported {
 		out.Printf(ctx, color.GreenString("nothing to do"))
+
 		return nil
 	}
 
 	if err := sub.Storage().Push(ctx, "", ""); err != nil {
 		out.Errorf(ctx, "Failed to push %q to its remote: %s", name, err)
+
 		return err
 	}
 	out.Printf(ctx, color.GreenString("OK"))
+
 	return nil
 }
 

--- a/internal/action/sync_test.go
+++ b/internal/action/sync_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestSync(t *testing.T) {
+func TestSync(t *testing.T) { //nolint:paralleltest
 	u := gptest.NewUnitTester(t)
 	defer u.Remove()
 
@@ -31,12 +31,12 @@ func TestSync(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, act)
 
-	t.Run("default", func(t *testing.T) {
+	t.Run("default", func(t *testing.T) { //nolint:paralleltest
 		defer buf.Reset()
 		assert.NoError(t, act.Sync(gptest.CliCtx(ctx, t)))
 	})
 
-	t.Run("sync --store=root", func(t *testing.T) {
+	t.Run("sync --store=root", func(t *testing.T) { //nolint:paralleltest
 		defer buf.Reset()
 		assert.NoError(t, act.Sync(gptest.CliCtxWithFlags(ctx, t, map[string]string{"store": "root"})))
 	})

--- a/internal/action/templates.go
+++ b/internal/action/templates.go
@@ -29,7 +29,7 @@ const (
 # Available Template functions:
 # - md5sum: e.g. {{ .Content | md5sum }}
 # - sha1sum: e.g. {{ .Content | sha1sum }}
-# - md5crypt: e.g. {{ .Content | md5crypt }}
+# - md5crypt: e.g. {{ .Content | md5crypt }}
 # - ssha: e.g. {{ .Content | ssha }}
 # - ssha256: e.g. {{ .Content | ssha256 }}
 # - ssha512: e.g. {{ .Content | ssha512 }}
@@ -45,6 +45,7 @@ func (s *Action) TemplatesPrint(c *cli.Context) error {
 		return exit.Error(exit.List, err, "failed to list templates: %s", err)
 	}
 	fmt.Fprintln(stdout, t.Format(tree.INF))
+
 	return nil
 }
 
@@ -59,6 +60,7 @@ func (s *Action) TemplatePrint(c *cli.Context) error {
 	}
 
 	fmt.Fprintln(stdout, string(content))
+
 	return nil
 }
 
@@ -112,6 +114,7 @@ func (s *Action) templatesList(ctx context.Context) []string {
 	t, err := s.Store.TemplateTree(ctx)
 	if err != nil {
 		debug.Log("failed to list templates: %s", err)
+
 		return nil
 	}
 
@@ -131,12 +134,14 @@ func (s *Action) renderTemplate(ctx context.Context, name string, content []byte
 	tName, tmpl, found := s.Store.LookupTemplate(ctx, name)
 	if !found {
 		debug.Log("No template found for %s", name)
+
 		return content, false
 	}
 
 	tmplStr := strings.TrimSpace(string(tmpl))
 	if tmplStr == "" {
 		debug.Log("Skipping empty template %q, for %s", tName, name)
+
 		return content, false
 	}
 
@@ -144,6 +149,7 @@ func (s *Action) renderTemplate(ctx context.Context, name string, content []byte
 	nc, err := tpl.Execute(ctx, string(tmpl), name, content, s.Store)
 	if err != nil {
 		fmt.Fprintf(stdout, "failed to execute template %q: %s\n", tName, err)
+
 		return content, false
 	}
 

--- a/internal/action/templates_test.go
+++ b/internal/action/templates_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestTemplates(t *testing.T) {
+func TestTemplates(t *testing.T) { //nolint:paralleltest
 	u := gptest.NewUnitTester(t)
 	defer u.Remove()
 
@@ -37,13 +37,13 @@ func TestTemplates(t *testing.T) {
 		out.Stdout = os.Stdout
 	}()
 
-	t.Run("display empty template tree", func(t *testing.T) {
+	t.Run("display empty template tree", func(t *testing.T) { //nolint:paralleltest
 		defer buf.Reset()
 		assert.NoError(t, act.TemplatesPrint(gptest.CliCtx(ctx, t, "foo")))
 		assert.Equal(t, "gopass\n\n", buf.String())
 	})
 
-	t.Run("add template", func(t *testing.T) {
+	t.Run("add template", func(t *testing.T) { //nolint:paralleltest
 		defer buf.Reset()
 		assert.NoError(t, act.Store.SetTemplate(ctx, "foo", []byte("foobar")))
 		assert.NoError(t, act.TemplatesPrint(gptest.CliCtx(ctx, t, "foo")))
@@ -54,24 +54,24 @@ func TestTemplates(t *testing.T) {
 		assert.Contains(t, buf.String(), want)
 	})
 
-	t.Run("complete templates", func(t *testing.T) {
+	t.Run("complete templates", func(t *testing.T) { //nolint:paralleltest
 		defer buf.Reset()
 		act.TemplatesComplete(gptest.CliCtx(ctx, t, "foo"))
 		assert.Equal(t, "foo\n", buf.String())
 	})
 
-	t.Run("print template", func(t *testing.T) {
+	t.Run("print template", func(t *testing.T) { //nolint:paralleltest
 		defer buf.Reset()
 		assert.NoError(t, act.TemplatePrint(gptest.CliCtx(ctx, t, "foo")))
 		assert.Equal(t, "foobar\n", buf.String())
 	})
 
-	t.Run("edit template", func(t *testing.T) {
+	t.Run("edit template", func(t *testing.T) { //nolint:paralleltest
 		defer buf.Reset()
 		assert.Error(t, act.TemplateEdit(gptest.CliCtx(ctx, t, "foo")))
 	})
 
-	t.Run("remove template", func(t *testing.T) {
+	t.Run("remove template", func(t *testing.T) { //nolint:paralleltest
 		defer buf.Reset()
 		assert.NoError(t, act.TemplateRemove(gptest.CliCtx(ctx, t, "foo")))
 	})

--- a/internal/action/unclip.go
+++ b/internal/action/unclip.go
@@ -22,5 +22,6 @@ func (s *Action) Unclip(c *cli.Context) error {
 	if err := clipboard.Clear(ctx, name, checksum, force); err != nil {
 		return exit.Error(exit.IO, err, "Failed to clear clipboard: %s", err)
 	}
+
 	return nil
 }

--- a/internal/action/unclip_test.go
+++ b/internal/action/unclip_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestUnclip(t *testing.T) {
+func TestUnclip(t *testing.T) { //nolint:paralleltest
 	u := gptest.NewUnitTester(t)
 	defer u.Remove()
 

--- a/internal/action/update.go
+++ b/internal/action/update.go
@@ -13,12 +13,13 @@ import (
 
 // Update will start the interactive update assistant.
 func (s *Action) Update(c *cli.Context) error {
-	s.rem.Reset("update")
+	_ = s.rem.Reset("update")
 
 	ctx := ctxutil.WithGlobalFlags(c)
 
 	if s.version.String() == "0.0.0+HEAD" {
 		out.Errorf(ctx, "Can not check version against HEAD")
+
 		return nil
 	}
 
@@ -32,5 +33,6 @@ func (s *Action) Update(c *cli.Context) error {
 	}
 
 	out.OKf(ctx, "gopass is up to date")
+
 	return nil
 }

--- a/internal/action/update_test.go
+++ b/internal/action/update_test.go
@@ -49,6 +49,8 @@ const testUpdateJSON = `{
   }`
 
 func TestUpdate(t *testing.T) {
+	t.Parallel()
+
 	updater.UpdateMoveAfterQuit = false
 
 	u := gptest.NewUnitTester(t)
@@ -66,10 +68,12 @@ func TestUpdate(t *testing.T) {
 		defer func() {
 			_ = gzw.Close()
 		}()
+
 		tw := tar.NewWriter(gzw)
 		defer func() {
 			_ = tw.Close()
 		}()
+
 		body := "foobar"
 		hdr := &tar.Header{
 			Typeflag: tar.TypeReg,
@@ -79,10 +83,12 @@ func TestUpdate(t *testing.T) {
 		}
 		if err := tw.WriteHeader(hdr); err != nil {
 			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+
 			return
 		}
 		if _, err := tw.Write([]byte(body)); err != nil {
 			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+
 			return
 		}
 	}))

--- a/internal/action/version_test.go
+++ b/internal/action/version_test.go
@@ -17,6 +17,8 @@ import (
 )
 
 func TestVersion(t *testing.T) {
+	t.Parallel()
+
 	u := gptest.NewUnitTester(t)
 	defer u.Remove()
 

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -76,12 +76,14 @@ func Batch(ctx context.Context, secrets []string, secStore secretGetter, expirat
 			if match.Score < 3 {
 				return fmt.Errorf("weak password (%d / 4)", match.Score)
 			}
+
 			return nil
 		},
 		func(name string, sec gopass.Secret) error {
 			if name == sec.Password() {
 				return fmt.Errorf("password equals name")
 			}
+
 			return nil
 		},
 	}
@@ -161,6 +163,7 @@ func audit(ctx context.Context, secStore secretGetter, validators []validator, e
 		case <-ctx.Done():
 			as.err = errors.New("user aborted")
 			checked <- as
+
 			continue
 		default:
 		}
@@ -177,6 +180,7 @@ func audit(ctx context.Context, secStore secretGetter, validators []validator, e
 
 		if len(validators) < 1 {
 			checked <- as
+
 			continue
 		}
 
@@ -189,6 +193,7 @@ func audit(ctx context.Context, secStore secretGetter, validators []validator, e
 			}
 			// failed to properly retrieve the secret.
 			checked <- as
+
 			continue
 		}
 		as.content = sec.Password()
@@ -196,6 +201,7 @@ func audit(ctx context.Context, secStore secretGetter, validators []validator, e
 		// do not check empty secrets.
 		if as.content == "" {
 			checked <- as
+
 			continue
 		}
 
@@ -205,6 +211,7 @@ func audit(ctx context.Context, secStore secretGetter, validators []validator, e
 				as.messages = append(as.messages, e.Error())
 			}
 			checked <- as
+
 			continue
 		}
 
@@ -221,6 +228,7 @@ func allValid(vs []validator, name string, sec gopass.Secret) []error {
 			errs = append(errs, err)
 		}
 	}
+
 	return errs
 }
 
@@ -270,9 +278,11 @@ func auditPrintResults(ctx context.Context, duplicates, messages, errors map[str
 
 	if foundWeakPasswords || foundDuplicates || foundErrors {
 		_ = notify.Notify(ctx, "gopass - audit", "Finished. Found weak passwords and/or duplicates")
+
 		return fmt.Errorf("found weak passwords or duplicates")
 	}
 
 	_ = notify.Notify(ctx, "gopass - audit", "Finished. No weak passwords or duplicates found!")
+
 	return nil
 }

--- a/internal/backend/context.go
+++ b/internal/backend/context.go
@@ -6,7 +6,6 @@ type contextKey int
 
 const (
 	ctxKeyCryptoBackend contextKey = iota
-	ctxKeyRCSBackend
 	ctxKeyStorageBackend
 )
 
@@ -15,6 +14,7 @@ func CryptoBackendName(cb CryptoBackend) string {
 	if name, err := CryptoRegistry.BackendName(cb); err == nil {
 		return name
 	}
+
 	return ""
 }
 
@@ -23,6 +23,7 @@ func WithCryptoBackendString(ctx context.Context, be string) context.Context {
 	if cb, err := CryptoRegistry.Backend(be); err == nil {
 		ctx = WithCryptoBackend(ctx, cb)
 	}
+
 	return ctx
 }
 
@@ -34,6 +35,7 @@ func WithCryptoBackend(ctx context.Context, be CryptoBackend) context.Context {
 // HasCryptoBackend returns true if a value for crypto backend has been set in the context.
 func HasCryptoBackend(ctx context.Context) bool {
 	_, ok := ctx.Value(ctxKeyCryptoBackend).(CryptoBackend)
+
 	return ok
 }
 
@@ -43,6 +45,7 @@ func GetCryptoBackend(ctx context.Context) CryptoBackend {
 	if !ok {
 		return GPGCLI
 	}
+
 	return be
 }
 
@@ -51,6 +54,7 @@ func WithStorageBackendString(ctx context.Context, sb string) context.Context {
 	if be, err := StorageRegistry.Backend(sb); err == nil {
 		return WithStorageBackend(ctx, be)
 	}
+
 	return WithStorageBackend(ctx, FS)
 }
 
@@ -65,12 +69,14 @@ func GetStorageBackend(ctx context.Context) StorageBackend {
 	if !ok {
 		return FS
 	}
+
 	return be
 }
 
 // HasStorageBackend returns true if a value for store backend was set.
 func HasStorageBackend(ctx context.Context) bool {
 	_, ok := ctx.Value(ctxKeyStorageBackend).(StorageBackend)
+
 	return ok
 }
 
@@ -79,5 +85,6 @@ func StorageBackendName(sb StorageBackend) string {
 	if name, err := StorageRegistry.BackendName(sb); err == nil {
 		return name
 	}
+
 	return ""
 }

--- a/internal/backend/context_test.go
+++ b/internal/backend/context_test.go
@@ -8,6 +8,8 @@ import (
 )
 
 func TestCryptoBackend(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 
 	assert.Equal(t, GPGCLI, GetCryptoBackend(ctx))
@@ -17,6 +19,8 @@ func TestCryptoBackend(t *testing.T) {
 }
 
 func TestStorageBackend(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 
 	assert.Equal(t, "fs", StorageBackendName(FS))
@@ -27,6 +31,8 @@ func TestStorageBackend(t *testing.T) {
 }
 
 func TestComposite(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	ctx = WithCryptoBackend(ctx, Age)
 	ctx = WithStorageBackend(ctx, FS)

--- a/internal/backend/crypto.go
+++ b/internal/backend/crypto.go
@@ -24,6 +24,7 @@ func (c CryptoBackend) String() string {
 	if be, err := CryptoRegistry.BackendName(c); err == nil {
 		return be
 	}
+
 	return ""
 }
 
@@ -63,6 +64,7 @@ func NewCrypto(ctx context.Context, id CryptoBackend) (Crypto, error) {
 	if be, err := CryptoRegistry.Get(id); err == nil {
 		return be.New(ctx)
 	}
+
 	return nil, fmt.Errorf("unknown backend %d: %w", id, ErrNotFound)
 }
 
@@ -78,12 +80,14 @@ func DetectCrypto(ctx context.Context, storage Storage) (Crypto, error) {
 		debug.Log("Trying %s for %s", be, storage)
 		if err := be.Handles(ctx, storage); err != nil {
 			debug.Log("failed to use crypto %s for %s", be, storage)
+
 			continue
 		}
 		debug.Log("Using %s for %s", be, storage)
+
 		return be.New(ctx)
 	}
 	debug.Log("No valid crypto provider found for %s", storage)
 	// TODO: this should return ErrNotSupported, but need to fix some tests for that
-	return nil, nil
+	return nil, nil //nolint:nilnil
 }

--- a/internal/backend/crypto/age/age.go
+++ b/internal/backend/crypto/age/age.go
@@ -39,6 +39,7 @@ func New() (*Age, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	return &Age{
 		ghCache:   ghc,
 		recpCache: rc,

--- a/internal/backend/crypto/age/context.go
+++ b/internal/backend/crypto/age/context.go
@@ -20,5 +20,6 @@ func IsOnlyNative(ctx context.Context) bool {
 	if !ok {
 		return false
 	}
+
 	return bv
 }

--- a/internal/backend/crypto/age/decrypt.go
+++ b/internal/backend/crypto/age/decrypt.go
@@ -18,6 +18,7 @@ func (a *Age) Decrypt(ctx context.Context, ciphertext []byte) ([]byte, error) {
 		debug.Log("no password callback found, redirecting to askPass")
 		ctx = ctxutil.WithPasswordCallback(ctx, func(prompt string, _ bool) ([]byte, error) {
 			pw, err := a.askPass.Passphrase(prompt, fmt.Sprintf("to load the keyring at %s", a.identity), false)
+
 			return []byte(pw), err
 		})
 	}
@@ -26,6 +27,7 @@ func (a *Age) Decrypt(ctx context.Context, ciphertext []byte) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	return a.decrypt(ciphertext, ids...)
 }
 
@@ -41,6 +43,7 @@ func (a *Age) decrypt(ciphertext []byte, ids ...age.Identity) ([]byte, error) {
 		return nil, fmt.Errorf("failed to write plaintext to buffer: %w", err)
 	}
 	debug.Log("Decrypted %d bytes of ciphertext to %d bytes of plaintext", len(ciphertext), n)
+
 	return out.Bytes(), nil
 }
 
@@ -73,5 +76,6 @@ func (a *Age) getAllIds(ctx context.Context) ([]age.Identity, error) {
 	for _, id := range ids {
 		idl = append(idl, id)
 	}
+
 	return idl, nil
 }

--- a/internal/backend/crypto/age/encrypt.go
+++ b/internal/backend/crypto/age/encrypt.go
@@ -26,6 +26,7 @@ func (a *Age) Encrypt(ctx context.Context, plaintext []byte, recipients []string
 	}
 
 	recp = dedupe(append(recp, idRecps...))
+
 	return a.encrypt(plaintext, recp...)
 }
 
@@ -38,6 +39,7 @@ func dedupe(recp []age.Recipient) []age.Recipient {
 		// handle non-native recipients.
 		if !ok {
 			out = append(out, r)
+
 			continue
 		}
 		set[k.String()] = r
@@ -47,6 +49,7 @@ func dedupe(recp []age.Recipient) []age.Recipient {
 		out = append(out, r)
 	}
 	debug.Log("in: %+v - out: %+v", recp, out)
+
 	return out
 }
 
@@ -64,6 +67,7 @@ func (a *Age) encrypt(plaintext []byte, recp ...age.Recipient) ([]byte, error) {
 		return nil, err
 	}
 	debug.Log("Encrypted %d bytes of plaintext to %d bytes of ciphertext for %q", n, out.Len(), recp)
+
 	return out.Bytes(), nil
 }
 

--- a/internal/backend/crypto/age/encrypt_test.go
+++ b/internal/backend/crypto/age/encrypt_test.go
@@ -14,6 +14,8 @@ import (
 )
 
 func TestDedupe(t *testing.T) {
+	t.Parallel()
+
 	i1, err := age.GenerateX25519Identity()
 	require.NoError(t, err)
 

--- a/internal/backend/crypto/age/identities.go
+++ b/internal/backend/crypto/age/identities.go
@@ -24,6 +24,7 @@ func (a *Age) Identities(ctx context.Context) ([]age.Identity, error) {
 		debug.Log("no password callback found, redirecting to askPass")
 		ctx = ctxutil.WithPasswordCallback(ctx, func(prompt string, confirm bool) ([]byte, error) {
 			pw, err := a.askPass.Passphrase(prompt, fmt.Sprintf("to read the age keyring from %s", a.identity), confirm)
+
 			return []byte(pw), err
 		})
 	}
@@ -35,6 +36,7 @@ func (a *Age) Identities(ctx context.Context) ([]age.Identity, error) {
 		if !os.IsNotExist(err) {
 			return nil, fmt.Errorf("failed to decrypt %s: %w", a.identity, err)
 		}
+
 		return nil, nil
 	}
 
@@ -42,7 +44,9 @@ func (a *Age) Identities(ctx context.Context) ([]age.Identity, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	debug.Log("read %d native identities from %s", len(ids), a.identity)
+
 	return ids, nil
 }
 
@@ -59,6 +63,7 @@ func (a *Age) IdentityRecipients(ctx context.Context) ([]age.Recipient, error) {
 		if errors.Is(err, os.ErrNotExist) {
 			return nil, nil
 		}
+
 		return nil, err
 	}
 
@@ -68,9 +73,11 @@ func (a *Age) IdentityRecipients(ctx context.Context) ([]age.Recipient, error) {
 			r = append(r, x.Recipient())
 		}
 	}
+
 	if err := a.recpCache.Set(idRecpCacheKey, recipientsToBech32(r)); err != nil {
 		debug.Log("failed to cache identity recipients: %s", err)
 	}
+
 	return r, nil
 }
 
@@ -81,7 +88,9 @@ func (a *Age) GenerateIdentity(ctx context.Context, _ string, _ string, pw strin
 			return []byte(pw), nil
 		})
 	}
+
 	_, err := a.addIdentity(ctx)
+
 	return err
 }
 
@@ -97,7 +106,9 @@ func (a *Age) ListIdentities(ctx context.Context) ([]string, error) {
 	for k := range ids {
 		idStr = append(idStr, k)
 	}
+
 	sort.Strings(idStr)
+
 	return idStr, nil
 }
 
@@ -114,35 +125,44 @@ OUTER:
 			if r == k {
 				matches = append(matches, k)
 				debug.Log("found matching recipient %s", k)
+
 				continue OUTER
 			}
 		}
 		debug.Log("%s not found in %q", k, ids)
 	}
+
 	sort.Strings(matches)
+
 	return matches, nil
 }
 
 func (a *Age) cachedIDRecpipients() []age.Recipient {
 	if a.recpCache.ModTime(idRecpCacheKey).Before(modTime(a.identity)) {
 		debug.Log("identity cache expired")
-		a.recpCache.Remove(idRecpCacheKey)
+		_ = a.recpCache.Remove(idRecpCacheKey)
+
 		return nil
 	}
+
 	recps, err := a.recpCache.Get(idRecpCacheKey)
 	if err != nil {
 		debug.Log("failed to get recipients from cache: %s", err)
+
 		return nil
 	}
+
 	rs := make([]age.Recipient, 0, len(recps))
 	for _, recp := range recps {
 		r, err := age.ParseX25519Recipient(recp)
 		if err != nil {
 			debug.Log("failed to parse recipient %s: %s", recp, err)
+
 			continue
 		}
 		rs = append(rs, r)
 	}
+
 	return rs
 }
 
@@ -175,6 +195,7 @@ func (a *Age) saveIdentities(ctx context.Context, ids []string, newFile bool) er
 		debug.Log("no password callback found, redirecting to askPass")
 		ctx = ctxutil.WithPasswordCallback(ctx, func(prompt string, confirm bool) ([]byte, error) {
 			pw, err := a.askPass.Passphrase(prompt, fmt.Sprintf("to save the age keyring to %s", a.identity), confirm)
+
 			return []byte(pw), err
 		})
 	}
@@ -182,6 +203,7 @@ func (a *Age) saveIdentities(ctx context.Context, ids []string, newFile bool) er
 	// ensure directory exists.
 	if err := os.MkdirAll(filepath.Dir(a.identity), 0o700); err != nil {
 		debug.Log("failed to create directory for the keyring at %s: %s", a.identity, err)
+
 		return err
 	}
 
@@ -190,6 +212,7 @@ func (a *Age) saveIdentities(ctx context.Context, ids []string, newFile bool) er
 	}
 
 	debug.Log("saved %d identities to %s", len(ids), a.identity)
+
 	return nil
 }
 
@@ -203,6 +226,7 @@ func (a *Age) getAllIdentities(ctx context.Context) (map[string]age.Identity, er
 
 	if IsOnlyNative(ctx) {
 		debug.Log("returning only native identities")
+
 		return native, nil
 	}
 
@@ -211,6 +235,7 @@ func (a *Age) getAllIdentities(ctx context.Context) (map[string]age.Identity, er
 	if err != nil {
 		return nil, err
 	}
+
 	debug.Log("got %d ssh identities", len(ssh))
 
 	// merge both.
@@ -239,10 +264,12 @@ func idMap(ids []age.Identity) map[string]age.Identity {
 	for _, id := range ids {
 		if x, ok := id.(*age.X25519Identity); ok {
 			m[x.Recipient().String()] = id
+
 			continue
 		}
 		debug.Log("unknown Identity type: %T", id)
 	}
+
 	return m
 }
 
@@ -251,6 +278,7 @@ func recipientsToBech32(recps []age.Recipient) []string {
 	for _, recp := range recps {
 		r = append(r, fmt.Sprintf("%s", recp))
 	}
+
 	return r
 }
 
@@ -259,6 +287,7 @@ func identitiesToString(ids []age.Identity) []string {
 	for _, id := range ids {
 		r = append(r, fmt.Sprintf("%s", id))
 	}
+
 	return r
 }
 
@@ -266,7 +295,9 @@ func modTime(path string) time.Time {
 	fi, err := os.Stat(path)
 	if err != nil {
 		debug.Log("failed to stat %s: %s", path, err)
+
 		return time.Time{}
 	}
+
 	return fi.ModTime()
 }

--- a/internal/backend/crypto/age/keyring.go
+++ b/internal/backend/crypto/age/keyring.go
@@ -33,6 +33,7 @@ func migrate(ctx context.Context, s backend.Storage) error {
 			out.Errorf(ctx, "Failed to remove %s: %s", oldIDPath, err)
 		}
 	}
+
 	if fsutil.IsFile(oldIDPath) {
 		out.Noticef(ctx, "Found %s. Migrating to %s.", oldIDPath, newIDPath)
 		if err := os.Rename(oldIDPath, newIDPath); err != nil {
@@ -50,12 +51,14 @@ func migrate(ctx context.Context, s backend.Storage) error {
 		debug.Log("no password callback found, redirecting to askPass")
 		ctx = ctxutil.WithPasswordCallback(ctx, func(prompt string, _ bool) ([]byte, error) {
 			pw, err := a.askPass.Passphrase(prompt, fmt.Sprintf("to load the age keyring at %s", OldKeyring), false)
+
 			return []byte(pw), err
 		})
 	}
 
 	if fsutil.IsFile(OldKeyring) && fsutil.IsFile(a.identity) {
 		out.Warningf(ctx, "Both %s and %s exist. Keeping both. Recover any identities from %s as needed.", OldKeyring, a.identity, OldKeyring)
+
 		return nil
 	}
 	if !fsutil.IsFile(OldKeyring) {
@@ -73,6 +76,7 @@ func migrate(ctx context.Context, s backend.Storage) error {
 	if err := a.saveIdentities(ctx, ids, false); err != nil {
 		return err
 	}
+
 	return os.Remove(OldKeyring)
 }
 
@@ -92,12 +96,14 @@ func (a *Age) loadIdentitiesFromKeyring(ctx context.Context) ([]string, error) {
 	buf, err := a.decryptFile(ctx, OldKeyring)
 	if err != nil {
 		debug.Log("can't decrypt keyring at %s: %s", OldKeyring, err)
+
 		return nil, err
 	}
 
 	var kr Keyring
 	if err := json.Unmarshal(buf, &kr); err != nil {
 		debug.Log("can't parse keyring at %s: %s", OldKeyring, err)
+
 		return nil, err
 	}
 
@@ -110,5 +116,6 @@ func (a *Age) loadIdentitiesFromKeyring(ctx context.Context) ([]string, error) {
 		valid = append(valid, k.Identity)
 	}
 	debug.Log("loaded keyring with %d valid entries from %s", len(kr), OldKeyring)
+
 	return valid, nil
 }

--- a/internal/backend/crypto/age/loader.go
+++ b/internal/backend/crypto/age/loader.go
@@ -21,6 +21,7 @@ type loader struct{}
 
 func (l loader) New(ctx context.Context) (backend.Crypto, error) {
 	debug.Log("Using Crypto Backend: %s", name)
+
 	return New()
 }
 
@@ -30,11 +31,13 @@ func (l loader) Handles(ctx context.Context, s backend.Storage) error {
 			out.Errorf(ctx, "Failed to migrate age backend: %s", err)
 		}
 		out.OKf(ctx, "Migrated age backend to new format")
+
 		return nil
 	}
 	if s.Exists(ctx, IDFile) {
 		return nil
 	}
+
 	return fmt.Errorf("not supported")
 }
 

--- a/internal/backend/crypto/age/recipients.go
+++ b/internal/backend/crypto/age/recipients.go
@@ -18,11 +18,13 @@ func (a *Age) FindRecipients(ctx context.Context, search ...string) ([]string, e
 	for _, key := range search {
 		if !strings.HasPrefix(key, "github:") {
 			local = append(local, key)
+
 			continue
 		}
 		pks, err := a.ghCache.ListKeys(ctx, strings.TrimPrefix(key, "github:"))
 		if err != nil {
 			debug.Log("Failed to get key %s from github: %s", key, err)
+
 			continue
 		}
 		remote = append(remote, pks...)
@@ -41,6 +43,7 @@ func (a *Age) FindRecipients(ctx context.Context, search ...string) ([]string, e
 	}
 	recp := append(ids, remote...)
 	debug.Log("found usable keys for %q: %q (all: %q)", search, recp, append(ids, remote...))
+
 	return recp, nil
 }
 
@@ -51,18 +54,22 @@ func (a *Age) parseRecipients(ctx context.Context, recipients []string) ([]age.R
 			id, err := age.ParseX25519Recipient(r)
 			if err != nil {
 				debug.Log("Failed to parse recipient %q as X25519: %s", r, err)
+
 				continue
 			}
 			out = append(out, id)
+
 			continue
 		}
 		if strings.HasPrefix(r, "ssh-") {
 			id, err := agessh.ParseRecipient(r)
 			if err != nil {
 				debug.Log("Failed to parse recipient %q as SSH: %s", r, err)
+
 				continue
 			}
 			out = append(out, id)
+
 			continue
 		}
 		if strings.HasPrefix(r, "github:") {
@@ -74,11 +81,13 @@ func (a *Age) parseRecipients(ctx context.Context, recipients []string) ([]age.R
 				id, err := agessh.ParseRecipient(r)
 				if err != nil {
 					debug.Log("Failed to parse GitHub recipient %q: %q: %s", r, pk, err)
+
 					continue
 				}
 				out = append(out, id)
 			}
 		}
 	}
+
 	return out, nil
 }

--- a/internal/backend/crypto/age/ssh.go
+++ b/internal/backend/crypto/age/ssh.go
@@ -2,6 +2,7 @@ package age
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -19,30 +20,36 @@ func (a *Age) getSSHIdentities(ctx context.Context) (map[string]age.Identity, er
 	if sshCache != nil {
 		return sshCache, nil
 	}
+
 	uhd, err := os.UserHomeDir()
 	if err != nil {
 		return nil, err
 	}
+
 	sshDir := filepath.Join(uhd, ".ssh")
 	files, err := os.ReadDir(sshDir)
 	if err != nil {
 		return nil, err
 	}
+
 	ids := make(map[string]age.Identity, len(files))
 	for _, file := range files {
 		fn := filepath.Join(sshDir, file.Name())
 		if !strings.HasSuffix(fn, ".pub") {
 			continue
 		}
+
 		recp, id, err := a.parseSSHIdentity(ctx, fn)
 		if err != nil {
 			// debug.Log("Failed to parse SSH identity %s: %s", fn, err)
 			continue
 		}
+
 		// debug.Log("parsed SSH identity %s from %s", recp, fn)
 		ids[recp] = id
 	}
 	sshCache = ids
+
 	return ids, nil
 }
 
@@ -53,29 +60,37 @@ func (a *Age) parseSSHIdentity(ctx context.Context, pubFn string) (string, age.I
 	if err != nil {
 		return "", nil, err
 	}
+
 	pubBuf, err := os.ReadFile(pubFn)
 	if err != nil {
 		return "", nil, err
 	}
+
 	privBuf, err := os.ReadFile(privFn)
 	if err != nil {
 		return "", nil, err
 	}
-	pubkey, _, _, _, err := ssh.ParseAuthorizedKey(pubBuf)
+
+	pubkey, _, _, _, err := ssh.ParseAuthorizedKey(pubBuf) //nolint:dogsled
 	if err != nil {
 		return "", nil, err
 	}
+
 	recp := strings.TrimSuffix(string(ssh.MarshalAuthorizedKey(pubkey)), "\n")
 	id, err := agessh.ParseIdentity(privBuf)
 	if err != nil {
 		// handle encrypted SSH identities here.
-		if _, ok := err.(*ssh.PassphraseMissingError); ok {
+		var perr *ssh.PassphraseMissingError
+		if errors.As(err, &perr) {
 			id, err := agessh.NewEncryptedSSHIdentity(pubkey, privBuf, func() ([]byte, error) {
 				return ctxutil.GetPasswordCallback(ctx)(pubFn, false)
 			})
+
 			return recp, id, err
 		}
+
 		return "", nil, err
 	}
+
 	return recp, id, nil
 }

--- a/internal/backend/crypto/gpg/cli/decrypt.go
+++ b/internal/backend/crypto/gpg/cli/decrypt.go
@@ -17,5 +17,6 @@ func (g *GPG) Decrypt(ctx context.Context, ciphertext []byte) ([]byte, error) {
 	cmd.Stderr = os.Stderr
 
 	debug.Log("%s %+v", cmd.Path, cmd.Args)
+
 	return cmd.Output()
 }

--- a/internal/backend/crypto/gpg/cli/encrypt.go
+++ b/internal/backend/crypto/gpg/cli/encrypt.go
@@ -21,12 +21,14 @@ func (g *GPG) Encrypt(ctx context.Context, plaintext []byte, recipients []string
 		// explicitly opt-in to do this
 		args = append(args, "--trust-model=always")
 	}
+
 	for _, r := range recipients {
 		kl, err := g.listKeys(ctx, "public", r)
 		if err != nil {
 			debug.Log("Failed to check key %s. Adding anyway. %s", err)
 		} else if len(kl.UseableKeys(gpg.IsAlwaysTrust(ctx))) < 1 {
 			out.Printf(ctx, "Not using invalid key %s for encryption. (Check its expiration date or its encryption capabilities.)", r)
+
 			continue
 		}
 		args = append(args, "--recipient", r)
@@ -42,5 +44,6 @@ func (g *GPG) Encrypt(ctx context.Context, plaintext []byte, recipients []string
 
 	debug.Log("%s %+v", cmd.Path, cmd.Args)
 	err := cmd.Run()
+
 	return buf.Bytes(), err
 }

--- a/internal/backend/crypto/gpg/cli/generate.go
+++ b/internal/backend/crypto/gpg/cli/generate.go
@@ -36,7 +36,9 @@ Expire-Date: 0
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("failed to run command: '%s %+v': %q - %w", cmd.Path, cmd.Args, out.String(), err)
 	}
+
 	g.privKeys = nil
 	g.pubKeys = nil
+
 	return nil
 }

--- a/internal/backend/crypto/gpg/cli/gpg.go
+++ b/internal/backend/crypto/gpg/cli/gpg.go
@@ -74,6 +74,7 @@ func New(ctx context.Context, cfg Config) (*GPG, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to detect binary: %w", err)
 	}
+
 	g.binary = bin
 	debug.Log("binary detected as %s", bin)
 
@@ -111,5 +112,6 @@ func (g *GPG) Binary() string {
 	if g == nil {
 		return ""
 	}
+
 	return g.binary
 }

--- a/internal/backend/crypto/gpg/cli/gpg_others_test.go
+++ b/internal/backend/crypto/gpg/cli/gpg_others_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestEncrypt(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 
 	g := &GPG{}
@@ -21,6 +23,8 @@ func TestEncrypt(t *testing.T) {
 }
 
 func TestDecrypt(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 
 	g := &GPG{}
@@ -31,6 +35,8 @@ func TestDecrypt(t *testing.T) {
 }
 
 func TestGenerateIdentity(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 
 	g := &GPG{}

--- a/internal/backend/crypto/gpg/cli/gpg_test.go
+++ b/internal/backend/crypto/gpg/cli/gpg_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestGPG(t *testing.T) {
+	t.Parallel()
+
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")
 	}

--- a/internal/backend/crypto/gpg/cli/gpg_windows_test.go
+++ b/internal/backend/crypto/gpg/cli/gpg_windows_test.go
@@ -8,6 +8,8 @@ import (
 )
 
 func TestEncrypt(t *testing.T) {
+	t.Parallel()
+
 	ctx, cancel := context.WithCancel(context.Background())
 
 	g := &GPG{}
@@ -19,6 +21,8 @@ func TestEncrypt(t *testing.T) {
 }
 
 func TestDecrypt(t *testing.T) {
+	t.Parallel()
+
 	ctx, cancel := context.WithCancel(context.Background())
 
 	g := &GPG{}
@@ -30,6 +34,8 @@ func TestDecrypt(t *testing.T) {
 }
 
 func TestGenerateIdentity(t *testing.T) {
+	t.Parallel()
+
 	ctx, cancel := context.WithCancel(context.Background())
 
 	g := &GPG{}

--- a/internal/backend/crypto/gpg/cli/identities.go
+++ b/internal/backend/crypto/gpg/cli/identities.go
@@ -15,9 +15,11 @@ func (g *GPG) ListIdentities(ctx context.Context) ([]string, error) {
 		}
 		g.privKeys = kl
 	}
+
 	if gpg.IsAlwaysTrust(ctx) {
 		return g.privKeys.Recipients(), nil
 	}
+
 	return g.privKeys.UseableKeys(gpg.IsAlwaysTrust(ctx)).Recipients(), nil
 }
 
@@ -27,9 +29,11 @@ func (g *GPG) FindIdentities(ctx context.Context, search ...string) ([]string, e
 	if err != nil || kl == nil {
 		return nil, err
 	}
+
 	if gpg.IsAlwaysTrust(ctx) {
 		return kl.Recipients(), nil
 	}
+
 	return kl.UseableKeys(gpg.IsAlwaysTrust(ctx)).Recipients(), nil
 }
 
@@ -38,10 +42,12 @@ func (g *GPG) findKey(ctx context.Context, id string) (gpg.Key, bool) {
 	if len(kl) >= 1 {
 		return kl[0], true
 	}
+
 	kl, _ = g.listKeys(ctx, "public", id)
 	if len(kl) >= 1 {
 		return kl[0], true
 	}
+
 	return gpg.Key{
 		Fingerprint: id,
 	}, false

--- a/internal/backend/crypto/gpg/cli/keyring_test.go
+++ b/internal/backend/crypto/gpg/cli/keyring_test.go
@@ -66,6 +66,8 @@ oLGNPe8bErLNfny6AWU0Enam6a13BxwbBrtr
 `
 
 func TestReadNamesFromKey(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	ctx = ctxutil.WithAlwaysYes(ctx, true)
 
@@ -79,6 +81,8 @@ func TestReadNamesFromKey(t *testing.T) {
 }
 
 func TestExportPublicKey(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	g, err := New(ctx, Config{})
 	require.NoError(t, err)
@@ -88,6 +92,8 @@ func TestExportPublicKey(t *testing.T) {
 }
 
 func TestImport(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 
 	g := &GPG{}

--- a/internal/backend/crypto/gpg/cli/loader.go
+++ b/internal/backend/crypto/gpg/cli/loader.go
@@ -24,6 +24,7 @@ type loader struct{}
 // New implements backend.CryptoLoader.
 func (l loader) New(ctx context.Context) (backend.Crypto, error) {
 	debug.Log("Using Crypto Backend: %s", name)
+
 	return New(ctx, Config{
 		Umask:  fsutil.Umask(),
 		Args:   gpgconf.GPGOpts(),
@@ -35,6 +36,7 @@ func (l loader) Handles(ctx context.Context, s backend.Storage) error {
 	if s.Exists(ctx, IDFile) {
 		return nil
 	}
+
 	return fmt.Errorf("not supported")
 }
 

--- a/internal/backend/crypto/gpg/cli/recipients_test.go
+++ b/internal/backend/crypto/gpg/cli/recipients_test.go
@@ -7,6 +7,8 @@ import (
 )
 
 func TestSplitPacket(t *testing.T) {
+	t.Parallel()
+
 	for in, out := range map[string]map[string]string{
 		"": {},
 		":pubkey enc packet: version 3, algo 1, keyid 00F0FF00FFC00F0F": {

--- a/internal/backend/crypto/gpg/colons/parse_colons.go
+++ b/internal/backend/crypto/gpg/colons/parse_colons.go
@@ -79,10 +79,12 @@ func Parse(reader io.Reader) gpg.KeyList {
 			if cur.Fingerprint != "" && cur.KeyLength > 0 {
 				kl = append(kl, cur)
 			}
+
 			validity := fields[1]
 			if validity == "" && fields[0] == "sec" {
 				validity = "u"
 			}
+
 			cur = gpg.Key{
 				KeyType:        fields[0],
 				Validity:       validity,
@@ -121,15 +123,19 @@ func parseKeyCaps(field string) gpg.Capabilities {
 	if strings.Contains(field, "S") {
 		keycaps.Sign = true
 	}
+
 	if strings.Contains(field, "E") {
 		keycaps.Encrypt = true
 	}
+
 	if strings.Contains(field, "C") {
 		keycaps.Certify = true
 	}
+
 	if strings.Contains(field, "A") {
 		keycaps.Authentication = true
 	}
+
 	if strings.Contains(field, "D") {
 		keycaps.Deactivated = true
 	}
@@ -141,31 +147,38 @@ func parseColonIdentity(fields []string) gpg.Identity {
 	for i, f := range fields {
 		fields[i] = strings.ReplaceAll(f, "\\x3a", ":")
 	}
+
 	id := fields[9]
 	ni := gpg.Identity{
 		Name:           id,
 		CreationDate:   parseTS(fields[5]),
 		ExpirationDate: parseTS(fields[6]),
 	}
+
 	if reUIDComment.MatchString(id) {
 		if m := reUIDComment.FindStringSubmatch(id); len(m) > 3 {
 			ni.Name = m[1]
 			ni.Comment = strings.Trim(m[2], "()")
 			ni.Email = m[3]
+
 			return ni
 		}
 	}
+
 	if reUIDNoEmailComment.MatchString(id) {
 		if m := reUIDNoEmailComment.FindStringSubmatch(id); len(m) > 2 {
 			ni.Name = m[1]
 			ni.Comment = strings.Trim(m[2], "()")
 		}
+
 		return ni
 	}
+
 	if reUID.MatchString(id) {
 		if m := reUID.FindStringSubmatch(id); len(m) > 2 {
 			ni.Name = m[1]
 			ni.Email = m[2]
+
 			return ni
 		}
 	}

--- a/internal/backend/crypto/gpg/colons/parse_colons_test.go
+++ b/internal/backend/crypto/gpg/colons/parse_colons_test.go
@@ -8,6 +8,8 @@ import (
 )
 
 func TestParseColonIdentity(t *testing.T) {
+	t.Parallel()
+
 	for _, tc := range []struct {
 		in      string
 		name    string
@@ -39,9 +41,14 @@ func TestParseColonIdentity(t *testing.T) {
 			email:   "",
 		},
 	} {
-		gi := parseColonIdentity(strings.Split(tc.in, ":"))
-		assert.Equal(t, tc.name, gi.Name)
-		assert.Equal(t, tc.comment, gi.Comment)
-		assert.Equal(t, tc.email, gi.Email)
+		tc := tc
+		t.Run(tc.in, func(t *testing.T) {
+			t.Parallel()
+
+			gi := parseColonIdentity(strings.Split(tc.in, ":"))
+			assert.Equal(t, tc.name, gi.Name)
+			assert.Equal(t, tc.comment, gi.Comment)
+			assert.Equal(t, tc.email, gi.Email)
+		})
 	}
 }

--- a/internal/backend/crypto/gpg/context.go
+++ b/internal/backend/crypto/gpg/context.go
@@ -21,6 +21,7 @@ func IsAlwaysTrust(ctx context.Context) bool {
 	if !ok {
 		return false
 	}
+
 	return bv
 }
 
@@ -35,5 +36,6 @@ func UseCache(ctx context.Context) bool {
 	if !ok {
 		return false
 	}
+
 	return nc
 }

--- a/internal/backend/crypto/gpg/context_test.go
+++ b/internal/backend/crypto/gpg/context_test.go
@@ -6,6 +6,8 @@ import (
 )
 
 func TestAlwaysTrust(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 
 	if IsAlwaysTrust(ctx) {

--- a/internal/backend/crypto/gpg/gpgconf/binary.go
+++ b/internal/backend/crypto/gpg/gpgconf/binary.go
@@ -11,7 +11,9 @@ import (
 func Binary(ctx context.Context, bin string) (string, error) {
 	if sv := os.Getenv("GOPASS_GPG_BINARY"); sv != "" {
 		debug.Log("Using GOPASS_GPG_BINARY: %s", sv)
+
 		return sv, nil
 	}
+
 	return detectBinary(ctx, bin)
 }

--- a/internal/backend/crypto/gpg/gpgconf/binary_others.go
+++ b/internal/backend/crypto/gpg/gpgconf/binary_others.go
@@ -16,6 +16,7 @@ func detectBinary(_ context.Context, name string) (string, error) {
 	if name != "" {
 		return exec.LookPath(name)
 	}
+
 	// try to get the proper binary from gpgconf(1)
 	p, err := Path("gpg")
 	if err != nil || p == "" || !fsutil.IsFile(p) {
@@ -26,5 +27,6 @@ func detectBinary(_ context.Context, name string) (string, error) {
 	}
 
 	debug.Log("gpgconf returned %q for gpg", p)
+
 	return p, nil
 }

--- a/internal/backend/crypto/gpg/gpgconf/binary_windows.go
+++ b/internal/backend/crypto/gpg/gpgconf/binary_windows.go
@@ -19,6 +19,7 @@ func detectBinary(ctx context.Context, bin string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+
 	bv := make(byVersion, 0, len(bins))
 	for _, b := range bins {
 		debug.Log("Looking for %q ...", b)
@@ -31,11 +32,14 @@ func detectBinary(ctx context.Context, bin string) (string, error) {
 			bv = append(bv, gb)
 		}
 	}
+
 	if len(bv) < 1 {
 		return "", errors.New("no gpg binary found")
 	}
+
 	binary := bv[0].path
 	debug.Log("using %q", binary)
+
 	return binary, nil
 }
 
@@ -88,6 +92,7 @@ func searchPath(bin string, bins []string) ([]string, error) {
 		if err != nil {
 			continue
 		}
+
 		if fsutil.IsFile(gpgPath) {
 			bins = append(bins, gpgPath)
 		}

--- a/internal/backend/crypto/gpg/gpgconf/utils.go
+++ b/internal/backend/crypto/gpg/gpgconf/utils.go
@@ -15,6 +15,7 @@ func GPGOpts() []string {
 			return strings.Fields(opts)
 		}
 	}
+
 	return nil
 }
 
@@ -25,6 +26,7 @@ func gpgConfigLoc() string {
 	}
 
 	uhd, _ := os.UserHomeDir()
+
 	return filepath.Join(uhd, ".gnupg", "gpg.conf")
 }
 
@@ -34,7 +36,9 @@ func Config() (map[string]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer fh.Close()
+	defer func() {
+		_ = fh.Close()
+	}()
 
 	return parseGpgConfig(fh)
 }
@@ -48,6 +52,7 @@ func parseGpgConfig(fh io.Reader) (map[string]string, error) {
 		if strings.HasPrefix(line, "#") {
 			continue
 		}
+
 		key, val, found := strings.Cut(line, " ")
 		if !found {
 			continue

--- a/internal/backend/crypto/gpg/gpgconf/utils_linux.go
+++ b/internal/backend/crypto/gpg/gpgconf/utils_linux.go
@@ -17,6 +17,7 @@ func TTY() string {
 	if err != nil {
 		return ""
 	}
+
 	return dest
 }
 

--- a/internal/backend/crypto/gpg/gpgconf/utils_linux_test.go
+++ b/internal/backend/crypto/gpg/gpgconf/utils_linux_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func TestTTY(t *testing.T) {
+	t.Parallel()
+
 	fd0 = "/tmp/foobar"
 	assert.Equal(t, "", TTY())
 }

--- a/internal/backend/crypto/gpg/gpgconf/utils_test.go
+++ b/internal/backend/crypto/gpg/gpgconf/utils_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestGpgOpts(t *testing.T) {
+func TestGpgOpts(t *testing.T) { //nolint:paralleltest
 	for _, vn := range []string{"GOPASS_GPG_OPTS", "PASSWORD_STORE_GPG_OPTS"} {
 		for in, out := range map[string][]string{
 			"": nil,
@@ -23,6 +23,8 @@ func TestGpgOpts(t *testing.T) {
 }
 
 func TestGPGConfig(t *testing.T) {
+	t.Parallel()
+
 	in := `
 #-----------------------------
 # default key

--- a/internal/backend/crypto/gpg/gpgconf/version.go
+++ b/internal/backend/crypto/gpg/gpgconf/version.go
@@ -55,5 +55,6 @@ func Version(ctx context.Context, binary string) semver.Version {
 
 		return sv
 	}
+
 	return v
 }

--- a/internal/backend/crypto/gpg/identity.go
+++ b/internal/backend/crypto/gpg/identity.go
@@ -14,10 +14,13 @@ type Identity struct {
 // ID returns the GPG ID format.
 func (i Identity) ID() string {
 	out := i.Name
+
 	if i.Comment != "" {
 		out += " (" + i.Comment + ")"
 	}
+
 	out += " <" + i.Email + ">"
+
 	return out
 }
 

--- a/internal/backend/crypto/gpg/identity_test.go
+++ b/internal/backend/crypto/gpg/identity_test.go
@@ -8,6 +8,8 @@ import (
 )
 
 func TestIdentity(t *testing.T) {
+	t.Parallel()
+
 	id := Identity{
 		Name:           "John Doe",
 		Comment:        "johnny",

--- a/internal/backend/crypto/gpg/key.go
+++ b/internal/backend/crypto/gpg/key.go
@@ -34,15 +34,19 @@ func (k Key) IsUseable(alwaysTrust bool) bool {
 	if k.Caps.Deactivated {
 		return false
 	}
+
 	if !k.Caps.Encrypt {
 		return false
 	}
+
 	if !k.ExpirationDate.IsZero() && k.ExpirationDate.Before(time.Now()) {
 		return false
 	}
+
 	if alwaysTrust {
 		return true
 	}
+
 	switch k.Validity {
 	case "m":
 		return true
@@ -51,6 +55,7 @@ func (k Key) IsUseable(alwaysTrust bool) bool {
 	case "u":
 		return true
 	}
+
 	return false
 }
 
@@ -61,14 +66,17 @@ func (k Key) String() string {
 	if len(k.Fingerprint) > 24 {
 		fp = k.Fingerprint[24:]
 	}
+
 	out := fmt.Sprintf("%s   %dD/0x%s %s", k.KeyType, k.KeyLength, fp, k.CreationDate.Format("2006-01-02"))
 	if !k.ExpirationDate.IsZero() {
 		out += fmt.Sprintf(" [expires: %s]", k.ExpirationDate.Format("2006-01-02"))
 	}
+
 	out += "\n      Key fingerprint = " + k.Fingerprint
 	for _, id := range k.Identities {
 		out += fmt.Sprintf("\n" + id.String())
 	}
+
 	return out
 }
 
@@ -78,6 +86,7 @@ func (k Key) OneLine() string {
 	if len(k.Fingerprint) < 24 {
 		return fmt.Sprintf("(invalid:%s)", k.Fingerprint)
 	}
+
 	return fmt.Sprintf("0x%s - %s", k.Fingerprint[24:], k.Identity().ID())
 }
 
@@ -87,12 +96,15 @@ func (k Key) Identity() Identity {
 	for _, i := range k.Identities {
 		ids = append(ids, i)
 	}
+
 	sort.Slice(ids, func(i, j int) bool {
 		return ids[i].CreationDate.After(ids[j].CreationDate)
 	})
+
 	for _, i := range ids {
 		return i
 	}
+
 	return Identity{}
 }
 
@@ -101,5 +113,6 @@ func (k Key) ID() string {
 	if len(k.Fingerprint) < 25 {
 		return ""
 	}
+
 	return fmt.Sprintf("0x%s", k.Fingerprint[24:])
 }

--- a/internal/backend/crypto/gpg/key_list.go
+++ b/internal/backend/crypto/gpg/key_list.go
@@ -6,6 +6,9 @@ import (
 	"strings"
 )
 
+// ErrKeyNotFound is returned when a key is not found.
+var ErrKeyNotFound = fmt.Errorf("no matching key found")
+
 // KeyList is a searchable slice of Keys.
 type KeyList []Key
 
@@ -13,14 +16,18 @@ type KeyList []Key
 func (kl KeyList) Recipients() []string {
 	sort.Sort(kl)
 	u := make(map[string]struct{}, len(kl))
+
 	for _, k := range kl {
 		u[k.ID()] = struct{}{}
 	}
+
 	l := make([]string, 0, len(kl))
 	for k := range u {
 		l = append(l, k)
 	}
+
 	sort.Strings(l)
+
 	return l
 }
 
@@ -28,53 +35,66 @@ func (kl KeyList) Recipients() []string {
 func (kl KeyList) UseableKeys(alwaysTrust bool) KeyList {
 	nkl := make(KeyList, 0, len(kl))
 	sort.Sort(kl)
+
 	for _, k := range kl {
 		if !k.IsUseable(alwaysTrust) {
 			continue
 		}
+
 		nkl = append(nkl, k)
 	}
+
 	return nkl
 }
 
 // UnusableKeys returns the list of unusable keys (invalid keys).
 func (kl KeyList) UnusableKeys(alwaysTrust bool) KeyList {
 	nkl := make(KeyList, 0, len(kl))
+
 	for _, k := range kl {
 		if k.IsUseable(alwaysTrust) {
 			continue
 		}
+
 		nkl = append(nkl, k)
 	}
+
 	sort.Sort(nkl)
+
 	return nkl
 }
 
 // FindKey will try to find the requested key.
 func (kl KeyList) FindKey(id string) (Key, error) {
 	id = strings.TrimPrefix(id, "0x")
+
 	for _, k := range kl {
 		if k.Fingerprint == id {
 			return k, nil
 		}
+
 		if strings.HasSuffix(k.Fingerprint, id) {
 			return k, nil
 		}
+
 		for _, ident := range k.Identities {
 			if ident.Name == id {
 				return k, nil
 			}
+
 			if ident.Email == id {
 				return k, nil
 			}
 		}
+
 		for sk := range k.SubKeys {
 			if strings.HasSuffix(sk, id) {
 				return k, nil
 			}
 		}
 	}
-	return Key{}, fmt.Errorf("no matching key found")
+
+	return Key{}, ErrKeyNotFound
 }
 
 func (kl KeyList) Len() int {

--- a/internal/backend/crypto/gpg/key_list_test.go
+++ b/internal/backend/crypto/gpg/key_list_test.go
@@ -7,6 +7,8 @@ import (
 )
 
 func TestKeyList(t *testing.T) {
+	t.Parallel()
+
 	kl := KeyList{
 		genTestKey("John", "johnny", "Doe", "john.doe@example.org"),
 		genTestKey("Jane", "jane", "Doe", "jane.doe@example.org", "25FF1614B8F87B52FFFF99B962AF4031C82E0019"),

--- a/internal/backend/crypto/gpg/key_test.go
+++ b/internal/backend/crypto/gpg/key_test.go
@@ -13,26 +13,32 @@ func genTestKey(args ...string) Key {
 	if len(args) > 0 && args[0] != "" {
 		first = args[0]
 	}
+
 	nick := "johnny"
 	if len(args) > 1 && args[1] != "" {
 		nick = args[1]
 	}
+
 	last := "Doe"
 	if len(args) > 2 && args[2] != "" {
 		last = args[2]
 	}
+
 	email := "john.doe@example.org"
 	if len(args) > 3 && args[3] != "" {
 		email = args[3]
 	}
+
 	fp := "25FF1614B8F87B52FFFF99B962AF4031C82E0039"
 	if len(args) > 4 && args[4] != "" {
 		fp = args[4]
 	}
+
 	validity := "u"
 	if len(args) > 5 && args[5] != "" {
 		validity = args[5]
 	}
+
 	trust := "ultimate"
 	if len(args) > 6 && args[6] != "" {
 		trust = args[6]
@@ -40,6 +46,7 @@ func genTestKey(args ...string) Key {
 
 	creation := time.Date(2018, 1, 1, 1, 1, 1, 0, time.UTC)
 	expiration := time.Date(2218, 1, 1, 1, 1, 1, 0, time.UTC)
+
 	return Key{
 		KeyType:        "sec",
 		KeyLength:      2048,
@@ -68,6 +75,8 @@ func genTestKey(args ...string) Key {
 }
 
 func TestKey(t *testing.T) {
+	t.Parallel()
+
 	k := Key{
 		Identities: map[string]Identity{},
 	}
@@ -81,6 +90,8 @@ func TestKey(t *testing.T) {
 }
 
 func TestIdentitySort(t *testing.T) {
+	t.Parallel()
+
 	creation := time.Date(2017, 1, 1, 1, 1, 1, 0, time.UTC)
 	expiration := time.Date(2018, 1, 1, 1, 1, 1, 0, time.UTC)
 
@@ -96,6 +107,8 @@ func TestIdentitySort(t *testing.T) {
 }
 
 func TestUseability(t *testing.T) {
+	t.Parallel()
+
 	// invalid
 	for _, k := range []Key{
 		{},

--- a/internal/backend/crypto/plain/backend.go
+++ b/internal/backend/crypto/plain/backend.go
@@ -68,6 +68,7 @@ func (m *Mocker) FindRecipients(ctx context.Context, keys ...string) ([]string, 
 			}
 		}
 	}
+
 	return res, nil
 }
 

--- a/internal/backend/crypto/plain/backend_test.go
+++ b/internal/backend/crypto/plain/backend_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestPlain(t *testing.T) {
+	t.Parallel()
+
 	td, err := os.MkdirTemp("", "gopass-")
 	require.NoError(t, err)
 	defer func() {
@@ -74,6 +76,8 @@ func TestPlain(t *testing.T) {
 }
 
 func TestLoader(t *testing.T) {
+	t.Parallel()
+
 	l := &loader{}
 	b, err := l.New(context.Background())
 	assert.NoError(t, err)

--- a/internal/backend/crypto/plain/loader.go
+++ b/internal/backend/crypto/plain/loader.go
@@ -21,6 +21,7 @@ type loader struct{}
 // New implements backend.CryptoLoader.
 func (l loader) New(ctx context.Context) (backend.Crypto, error) {
 	debug.Log("Using Crypto Backend: %s (NO ENCRYPTION)", name)
+
 	return New(), nil
 }
 
@@ -28,6 +29,7 @@ func (l loader) Handles(ctx context.Context, s backend.Storage) error {
 	if s.Exists(ctx, IDFile) {
 		return nil
 	}
+
 	return fmt.Errorf("not supported")
 }
 

--- a/internal/backend/rcs.go
+++ b/internal/backend/rcs.go
@@ -55,7 +55,9 @@ func (r Revisions) Swap(i, j int) {
 func Clone(ctx context.Context, id StorageBackend, repo, path string) (Storage, error) {
 	if be, err := StorageRegistry.Get(id); err == nil {
 		debug.Log("Cloning with %s", be.String())
+
 		return be.Clone(ctx, repo, path)
 	}
+
 	return nil, fmt.Errorf("unknown backend %d: %w", id, ErrNotFound)
 }

--- a/internal/backend/rcs_test.go
+++ b/internal/backend/rcs_test.go
@@ -14,6 +14,8 @@ import (
 )
 
 func TestClone(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 
 	td, err := os.MkdirTemp("", "gopass-")
@@ -37,6 +39,8 @@ func TestClone(t *testing.T) {
 }
 
 func TestInitRCS(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 
 	td, err := os.MkdirTemp("", "gopass-")

--- a/internal/backend/registry.go
+++ b/internal/backend/registry.go
@@ -66,6 +66,7 @@ func (r *Registry[K, V]) Register(backend K, name string, loader V) {
 func (r *Registry[K, V]) BackendNames() []string {
 	names := maps.Keys(r.nameToBackend)
 	sort.Strings(names)
+
 	return names
 }
 
@@ -74,6 +75,7 @@ func (r *Registry[K, V]) Backends() []V {
 	for _, be := range r.backends {
 		bes = append(bes, be)
 	}
+
 	return bes
 }
 
@@ -82,6 +84,7 @@ func (r *Registry[K, V]) Prioritized() []V {
 	sort.Slice(bes, func(i, j int) bool {
 		return bes[i].Priority() < bes[j].Priority()
 	})
+
 	return bes
 }
 
@@ -90,6 +93,7 @@ func (r *Registry[K, V]) Get(key K) (V, error) {
 		return be, nil
 	}
 	var zero V
+
 	return zero, ErrNotFound
 }
 
@@ -100,8 +104,10 @@ func (r *Registry[K, V]) Backend(name string) (K, error) {
 	backend, ok := r.nameToBackend[name]
 	if !ok {
 		var zero K
+
 		return zero, ErrNotFound
 	}
+
 	return backend, nil
 }
 
@@ -110,5 +116,6 @@ func (r *Registry[K, V]) BackendName(backend K) (string, error) {
 	if !ok {
 		return "", ErrNotFound
 	}
+
 	return name, nil
 }

--- a/internal/backend/registry_test.go
+++ b/internal/backend/registry_test.go
@@ -31,6 +31,8 @@ func (l fakeCryptoLoader) Priority() int {
 }
 
 func TestCryptoLoader(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	backend.CryptoRegistry.Register(backend.Plain, "plain", fakeCryptoLoader{})
 	c, err := backend.NewCrypto(ctx, backend.Plain)

--- a/internal/backend/storage.go
+++ b/internal/backend/storage.go
@@ -27,6 +27,7 @@ func (s StorageBackend) String() string {
 	if be, err := StorageRegistry.BackendName(s); err == nil {
 		return be
 	}
+
 	return ""
 }
 
@@ -58,6 +59,7 @@ func DetectStorage(ctx context.Context, path string) (Storage, error) {
 		st, err := be.New(ctx, path)
 		if err == nil {
 			debug.Log("Using requested %s for %s", be, path)
+
 			return st, nil
 		}
 		debug.Log("Failed to use requested %s for %s: %s", be, path, err)
@@ -67,7 +69,8 @@ func DetectStorage(ctx context.Context, path string) (Storage, error) {
 		if err != nil {
 			return nil, err
 		}
-		debug.Log("Using fallback %s for %s", be, path)
+		debug.Log("Using fallback %q for %q", be, path)
+
 		return be.Init(ctx, path)
 	}
 
@@ -76,9 +79,11 @@ func DetectStorage(ctx context.Context, path string) (Storage, error) {
 		debug.Log("Trying %s for %s", be, path)
 		if err := be.Handles(ctx, path); err != nil {
 			debug.Log("failed to use %s for %s: %s", be, path, err)
+
 			continue
 		}
 		debug.Log("Using detected %s for %s", be, path)
+
 		return be.New(ctx, path)
 	}
 
@@ -87,7 +92,8 @@ func DetectStorage(ctx context.Context, path string) (Storage, error) {
 	if err != nil {
 		return nil, err
 	}
-	debug.Log("Using fallback %s for %s", be, path)
+	debug.Log("Using default fallback %q for %q", be, path)
+
 	return be.Init(ctx, path)
 }
 
@@ -95,8 +101,10 @@ func DetectStorage(ctx context.Context, path string) (Storage, error) {
 func NewStorage(ctx context.Context, id StorageBackend, path string) (Storage, error) {
 	if be, err := StorageRegistry.Get(id); err == nil {
 		debug.Log("Using %s for %s", be, path)
+
 		return be.New(ctx, path)
 	}
+
 	return nil, fmt.Errorf("unknown backend %q: %w", path, ErrNotFound)
 }
 
@@ -104,7 +112,9 @@ func NewStorage(ctx context.Context, id StorageBackend, path string) (Storage, e
 func InitStorage(ctx context.Context, id StorageBackend, path string) (Storage, error) {
 	if be, err := StorageRegistry.Get(id); err == nil {
 		debug.Log("Using %s for %s", be, path)
+
 		return be.Init(ctx, path)
 	}
+
 	return nil, fmt.Errorf("unknown backend %q: %w", path, ErrNotFound)
 }

--- a/internal/backend/storage/fossilfs/context.go
+++ b/internal/backend/storage/fossilfs/context.go
@@ -16,5 +16,6 @@ func getPathOverride(ctx context.Context, def string) string {
 	if sv, ok := ctx.Value(ctxKeyPathOverride).(string); ok && sv != "" {
 		return sv
 	}
+
 	return def
 }

--- a/internal/backend/storage/fossilfs/loader.go
+++ b/internal/backend/storage/fossilfs/loader.go
@@ -40,6 +40,7 @@ func (l loader) Handles(ctx context.Context, path string) error {
 	if !fsutil.IsFile(marker) {
 		return fmt.Errorf("no fossil checkout marker found at %s", marker)
 	}
+
 	return nil
 }
 

--- a/internal/backend/storage/fossilfs/settings.go
+++ b/internal/backend/storage/fossilfs/settings.go
@@ -59,6 +59,7 @@ func (f *Fossil) ConfigGet(ctx context.Context, key string) (string, error) {
 	}
 
 	sv := strings.Fields(strings.TrimSpace(buf.String()))
+
 	return sv[len(sv)-1], nil
 }
 
@@ -90,5 +91,6 @@ func (f *Fossil) ConfigList(ctx context.Context) (map[string]string, error) {
 		}
 		kv[p[0]] = p[len(p)-1]
 	}
+
 	return kv, nil
 }

--- a/internal/backend/storage/fossilfs/storage.go
+++ b/internal/backend/storage/fossilfs/storage.go
@@ -58,6 +58,7 @@ func (f *Fossil) Fsck(ctx context.Context) error {
 	if err := f.fixConfig(ctx); err != nil {
 		return fmt.Errorf("failed to fix fossil config: %w", err)
 	}
+
 	return f.fs.Fsck(ctx)
 }
 

--- a/internal/backend/storage/fs/fsck.go
+++ b/internal/backend/storage/fs/fsck.go
@@ -23,6 +23,7 @@ func (s *Store) Fsck(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+
 	dirs := make(map[string]struct{}, len(entries))
 	for _, entry := range entries {
 		pcb()
@@ -53,6 +54,7 @@ func (s *Store) Fsck(ctx context.Context) error {
 	}
 
 	debug.Log("checking git config")
+
 	return s.InitConfig(ctx, termio.DetectName(ctx, nil), termio.DetectEmail(ctx, nil))
 }
 
@@ -73,6 +75,7 @@ func (s *Store) fsckCheckFile(ctx context.Context, filename string) error {
 	if err := syscall.Chmod(filename, np); err != nil {
 		out.Errorf(ctx, "  Failed to set permissions for %s to rw-------: %s", filename, err)
 	}
+
 	return nil
 }
 
@@ -101,8 +104,10 @@ func (s *Store) fsckCheckDir(ctx context.Context, dirname string) error {
 	}
 	if isEmpty {
 		out.Errorf(ctx, "Folder %s is empty. Removing", dirname)
+
 		return os.Remove(dirname)
 	}
+
 	return nil
 }
 
@@ -125,6 +130,7 @@ func (s *Store) fsckCheckEmptyDirs() error {
 		// add candidate
 		debug.Log("adding candidate %q", fp)
 		v = append(v, fp)
+
 		return nil
 	}); err != nil {
 		return err
@@ -140,6 +146,7 @@ func (s *Store) fsckCheckEmptyDirs() error {
 			return err
 		}
 	}
+
 	return nil
 }
 
@@ -150,9 +157,11 @@ func fsckRemoveEmptyDir(fp string) error {
 	}
 	if len(ls) > 0 {
 		debug.Log("dir %q is not empty (%d)", fp, len(ls))
+
 		return nil
 	}
 
 	debug.Log("removing %q ...", fp)
+
 	return os.Remove(fp)
 }

--- a/internal/backend/storage/fs/fsck_test.go
+++ b/internal/backend/storage/fs/fsck_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestFsck(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	ctx = ctxutil.WithHidden(ctx, true)
 

--- a/internal/backend/storage/fs/link.go
+++ b/internal/backend/storage/fs/link.go
@@ -17,6 +17,7 @@ func addRel(src, dst string) string {
 	for i := 0; i < strings.Count(dst, "/"); i++ {
 		src = "../" + src
 	}
+
 	return src
 }
 
@@ -26,12 +27,15 @@ func longestCommonPrefix(l, r string) string {
 	for i := 0; i < len(l) && i < len(r); i++ {
 		if l[i] != r[i] {
 			prefix = l[:i]
+
 			break
 		}
 	}
+
 	if !strings.Contains(prefix, "/") {
 		return prefix
 	}
+
 	return prefix[:strings.LastIndex(prefix, "/")]
 }
 
@@ -53,8 +57,9 @@ func (s *Store) Link(ctx context.Context, from, to string) error {
 	if err != nil {
 		return fmt.Errorf("can not get current working directory: %w", err)
 	}
+
 	defer func() {
-		os.Chdir(cwd)
+		_ = os.Chdir(cwd)
 	}()
 
 	toDir := filepath.Dir(toPath)
@@ -70,5 +75,6 @@ func (s *Store) Link(ctx context.Context, from, to string) error {
 
 	debug.Log("path: %q\n\tfromPath:\t%q\n\ttoPath:\t\t%q\n\tprefix:\t\t%q\n\tfromRel:\t%q\n\ttoRel:\t\t%q\n\ttoDir:\t\t%q\n\tlinkDst:\t%q",
 		s.path, fromPath, toPath, prefix, fromRel, toRel, toDir, linkDst)
+
 	return os.Symlink(linkDst, filepath.Base(toRel))
 }

--- a/internal/backend/storage/fs/link_test.go
+++ b/internal/backend/storage/fs/link_test.go
@@ -7,6 +7,8 @@ import (
 )
 
 func TestLongestCommonPrefix(t *testing.T) {
+	t.Parallel()
+
 	for _, tc := range []struct {
 		Src    string
 		Dst    string
@@ -24,6 +26,8 @@ func TestLongestCommonPrefix(t *testing.T) {
 }
 
 func TestAddRel(t *testing.T) {
+	t.Parallel()
+
 	for _, tc := range []struct {
 		Src string
 		Dst string

--- a/internal/backend/storage/fs/loader.go
+++ b/internal/backend/storage/fs/loader.go
@@ -27,6 +27,7 @@ func (l loader) New(ctx context.Context, path string) (backend.Storage, error) {
 	}
 	be := New(path)
 	debug.Log("Using Storage Backend: %s", be.String())
+
 	return be, nil
 }
 
@@ -34,6 +35,7 @@ func (l loader) Init(ctx context.Context, path string) (backend.Storage, error) 
 	if err := os.MkdirAll(path, 0o700); err != nil {
 		return nil, err
 	}
+
 	return l.New(ctx, path)
 }
 
@@ -48,6 +50,7 @@ func (l loader) Handles(ctx context.Context, path string) error {
 	if fsutil.IsDir(path) {
 		return nil
 	}
+
 	return fmt.Errorf("dir not found")
 }
 

--- a/internal/backend/storage/fs/rcs.go
+++ b/internal/backend/storage/fs/rcs.go
@@ -68,6 +68,7 @@ func (s *Store) GetRevision(ctx context.Context, name string, revision string) (
 	if revision == "HEAD" || revision == "latest" {
 		return s.Get(ctx, name)
 	}
+
 	return []byte(""), backend.ErrNotSupported
 }
 

--- a/internal/backend/storage/fs/rcs_test.go
+++ b/internal/backend/storage/fs/rcs_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func TestRCS(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	path, cleanup := newTempDir(t)
 	defer cleanup()

--- a/internal/backend/storage/fs/store.go
+++ b/internal/backend/storage/fs/store.go
@@ -26,6 +26,7 @@ func New(dir string) *Store {
 	if d, err := filepath.EvalSymlinks(dir); err == nil {
 		dir = d
 	}
+
 	return &Store{
 		path: dir,
 	}
@@ -36,8 +37,10 @@ func (s *Store) Get(ctx context.Context, name string) ([]byte, error) {
 	if runtime.GOOS == "windows" {
 		name = filepath.FromSlash(name)
 	}
+
 	path := filepath.Join(s.path, filepath.Clean(name))
 	debug.Log("Reading %s from %s", name, path)
+
 	return os.ReadFile(path)
 }
 
@@ -46,14 +49,17 @@ func (s *Store) Set(ctx context.Context, name string, value []byte) error {
 	if runtime.GOOS == "windows" {
 		name = filepath.FromSlash(name)
 	}
+
 	filename := filepath.Join(s.path, filepath.Clean(name))
 	filedir := filepath.Dir(filename)
+
 	if !fsutil.IsDir(filedir) {
 		if err := os.MkdirAll(filedir, 0o700); err != nil {
 			return err
 		}
 	}
 	debug.Log("Writing %s to %s", name, filepath.Join(s.path, name))
+
 	return os.WriteFile(filepath.Join(s.path, name), value, 0o644)
 }
 
@@ -106,6 +112,7 @@ func (s *Store) Exists(ctx context.Context, name string) bool {
 	path := filepath.Join(s.path, filepath.Clean(name))
 	found := fsutil.IsFile(path)
 	debug.Log("Checking if %s exists at %s: %t", name, path, found)
+
 	return found
 }
 
@@ -123,6 +130,7 @@ func (s *Store) List(ctx context.Context, prefix string) ([]string, error) {
 		relPath := strings.TrimPrefix(path, s.path+string(filepath.Separator)) + string(filepath.Separator)
 		if info.IsDir() && strings.HasPrefix(info.Name(), ".") && path != s.path && !strings.HasPrefix(prefix, relPath) {
 			debug.Log("skipping dot dir (relPath: %s, prefix: %s)", relPath, prefix)
+
 			return filepath.SkipDir
 		}
 		if info.IsDir() {
@@ -139,11 +147,13 @@ func (s *Store) List(ctx context.Context, prefix string) ([]string, error) {
 			return nil
 		}
 		files = append(files, name)
+
 		return nil
 	}); err != nil {
 		return nil, err
 	}
 	sort.Strings(files)
+
 	return files, nil
 }
 
@@ -155,6 +165,7 @@ func (s *Store) IsDir(ctx context.Context, name string) bool {
 	path := filepath.Join(s.path, filepath.Clean(name))
 	isDir := fsutil.IsDir(path)
 	debug.Log("%s at %s is a directory? %t", name, path, isDir)
+
 	return isDir
 }
 

--- a/internal/backend/storage/fs/store_others.go
+++ b/internal/backend/storage/fs/store_others.go
@@ -4,14 +4,16 @@
 package fs
 
 import (
+	"errors"
 	"os"
 	"syscall"
 )
 
 func notEmptyErr(err error) bool {
-	e, ok := err.(*os.PathError)
-	if !ok {
-		return false
+	var perr *os.PathError
+	if errors.As(err, &perr) {
+		return errors.Is(perr.Err, syscall.ENOTEMPTY)
 	}
-	return e.Err == syscall.ENOTEMPTY
+
+	return false
 }

--- a/internal/backend/storage/fs/store_test.go
+++ b/internal/backend/storage/fs/store_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func TestSetAndGet(t *testing.T) {
+	t.Parallel()
+
 	initialContent := []byte(`initial file content`)
 	otherContent := []byte(`other file content`)
 	ctx := context.Background()
@@ -43,6 +45,8 @@ func TestSetAndGet(t *testing.T) {
 }
 
 func TestRemoveEmptyParentDirectories(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name          string
 		storeRoot     []string
@@ -89,7 +93,11 @@ func TestRemoveEmptyParentDirectories(t *testing.T) {
 	}
 
 	for _, test := range tests {
+		test := test
+
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
 			td, cleanup := newTempDir(t)
 			defer cleanup()
 
@@ -127,6 +135,8 @@ func TestRemoveEmptyParentDirectories(t *testing.T) {
 }
 
 func TestDelete(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name      string
 		location  []string
@@ -168,7 +178,10 @@ func TestDelete(t *testing.T) {
 	}
 
 	for _, test := range tests {
+		test := test
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
 			path, cleanup := newTempDir(t)
 			defer cleanup()
 
@@ -207,10 +220,12 @@ func TestDelete(t *testing.T) {
 
 func newTempDir(t *testing.T) (string, func()) {
 	t.Helper()
+
 	td, err := os.MkdirTemp("", "gopass-")
 	if err != nil {
 		t.Error(err)
 	}
+
 	return td, func() {
 		_ = os.RemoveAll(td)
 	}

--- a/internal/backend/storage/gitfs/config.go
+++ b/internal/backend/storage/gitfs/config.go
@@ -139,5 +139,6 @@ func (g *Git) ConfigList(ctx context.Context) (map[string]string, error) {
 		}
 		kv[key] = val
 	}
+
 	return kv, nil
 }

--- a/internal/backend/storage/gitfs/config_test.go
+++ b/internal/backend/storage/gitfs/config_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestGitConfig(t *testing.T) {
+func TestGitConfig(t *testing.T) { //nolint:paralleltest
 	td, err := os.MkdirTemp("", "gopass-")
 	require.NoError(t, err)
 	defer func() {

--- a/internal/backend/storage/gitfs/git_test.go
+++ b/internal/backend/storage/gitfs/git_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestGit(t *testing.T) {
+func TestGit(t *testing.T) { //nolint:paralleltest
 	td, err := os.MkdirTemp("", "gopass-")
 	require.NoError(t, err)
 	defer func() {
@@ -34,7 +34,7 @@ func TestGit(t *testing.T) {
 		out.Stdout = os.Stdout
 	}()
 
-	t.Run("init new repo", func(t *testing.T) {
+	t.Run("init new repo", func(t *testing.T) { //nolint:paralleltest
 		git, err := Init(ctx, gitdir, "Dead Beef", "dead.beef@example.org")
 		require.NoError(t, err)
 		require.NotNil(t, git)
@@ -54,7 +54,7 @@ func TestGit(t *testing.T) {
 		assert.Error(t, git.Pull(ctx, "origin", "master"))
 	})
 
-	t.Run("open existing repo", func(t *testing.T) {
+	t.Run("open existing repo", func(t *testing.T) { //nolint:paralleltest
 		git, err := New(gitdir)
 		require.NoError(t, err)
 		require.NotNil(t, git)
@@ -64,7 +64,7 @@ func TestGit(t *testing.T) {
 		assert.Error(t, git.RemoveRemote(ctx, "foo"))
 	})
 
-	t.Run("clone existing repo", func(t *testing.T) {
+	t.Run("clone existing repo", func(t *testing.T) { //nolint:paralleltest
 		git, err := Clone(ctx, gitdir, gitdir2, "", "")
 		require.NoError(t, err)
 		require.NotNil(t, git)

--- a/internal/backend/storage/gitfs/loader.go
+++ b/internal/backend/storage/gitfs/loader.go
@@ -43,6 +43,7 @@ func (l loader) Handles(ctx context.Context, path string) error {
 	if !fsutil.IsDir(filepath.Join(path, ".git")) {
 		return fmt.Errorf("no .git")
 	}
+
 	return nil
 }
 

--- a/internal/backend/storage/gitfs/storage.go
+++ b/internal/backend/storage/gitfs/storage.go
@@ -65,6 +65,7 @@ func (g *Git) Fsck(ctx context.Context) error {
 	if err := g.addUntrackedFiles(ctx); err != nil {
 		return fmt.Errorf("failed to add untracked files: %w", err)
 	}
+
 	return g.fs.Fsck(ctx)
 }
 
@@ -72,12 +73,15 @@ func (g *Git) addUntrackedFiles(ctx context.Context) error {
 	ut := g.ListUntrackedFiles(ctx)
 	if len(ut) < 1 && !g.HasStagedChanges(ctx) {
 		debug.Log("no untracked or staged files found")
+
 		return nil
 	}
+
 	debug.Log("untracked files found: %v", ut)
 	if err := g.Add(ctx, ut...); err != nil {
 		return fmt.Errorf("failed to add untracked files: %w", err)
 	}
+
 	return g.Commit(ctx, "fsck")
 }
 

--- a/internal/backend/storage_test.go
+++ b/internal/backend/storage_test.go
@@ -8,16 +8,12 @@ import (
 
 	"github.com/gopasspw/gopass/pkg/ctxutil"
 	"github.com/gopasspw/gopass/pkg/debug"
-	"github.com/gopasspw/gopass/tests/gptest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestDetectStorage(t *testing.T) {
+func TestDetectStorage(t *testing.T) { //nolint:paralleltest
 	ctx := context.Background()
-
-	uv := gptest.UnsetVars("GOPASS_HOMEDIR")
-	defer uv()
 
 	td, err := os.MkdirTemp("", "gopass-")
 	require.NoError(t, err)
@@ -26,9 +22,10 @@ func TestDetectStorage(t *testing.T) {
 	}()
 
 	// all tests involving age should set GOPASS_HOMEDIR
-	os.Setenv("GOPASS_HOMEDIR", td)
+	t.Setenv("GOPASS_HOMEDIR", td)
 	ctx = ctxutil.WithPasswordCallback(ctx, func(_ string, _ bool) ([]byte, error) {
 		debug.Log("static test password callback")
+
 		return []byte("gopass"), nil
 	})
 

--- a/internal/cache/disk.go
+++ b/internal/cache/disk.go
@@ -29,6 +29,7 @@ func NewOnDisk(name string, ttl time.Duration) (*OnDisk, error) {
 		name: name,
 		dir:  d,
 	}
+
 	return o, o.ensureDir()
 }
 
@@ -36,6 +37,7 @@ func (o *OnDisk) ensureDir() error {
 	if err := os.MkdirAll(o.dir, 0o700); err != nil {
 		return fmt.Errorf("failed to create ondisk cache dir %s: %w", o.dir, err)
 	}
+
 	return nil
 }
 
@@ -70,6 +72,7 @@ func (o *OnDisk) Set(key string, value []string) error {
 	if err := os.WriteFile(fn, []byte(strings.Join(value, "\n")), 0o644); err != nil {
 		return fmt.Errorf("failed to write %s to %s: %w", key, fn, err)
 	}
+
 	return nil
 }
 
@@ -81,6 +84,7 @@ func (o *OnDisk) ModTime(key string) time.Time {
 	if err != nil {
 		return time.Time{}
 	}
+
 	return fi.ModTime()
 }
 
@@ -91,6 +95,7 @@ func (o *OnDisk) Remove(key string) error {
 	}
 	key = fsutil.CleanFilename(key)
 	fn := filepath.Join(o.dir, key)
+
 	return os.Remove(fn)
 }
 

--- a/internal/cache/disk_test.go
+++ b/internal/cache/disk_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestOnDisk(t *testing.T) {
+func TestOnDisk(t *testing.T) { //nolint:paralleltest
 	td, err := os.MkdirTemp("", "gopass-")
 	require.NoError(t, err)
 
@@ -17,11 +17,7 @@ func TestOnDisk(t *testing.T) {
 		_ = os.RemoveAll(td)
 	}()
 
-	ogh := os.Getenv("GOPASS_HOMEDIR")
-	os.Setenv("GOPASS_HOMEDIR", td)
-	defer func() {
-		os.Setenv("GOPASS_HOMEDIR", ogh)
-	}()
+	t.Setenv("GOPASS_HOMEDIR", td)
 
 	odc, err := NewOnDisk("test", time.Hour)
 	assert.NoError(t, err)

--- a/internal/cache/ghssh/cache.go
+++ b/internal/cache/ghssh/cache.go
@@ -20,6 +20,7 @@ func New() (*Cache, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	return &Cache{
 		disk:    cDir,
 		client:  github.NewClient(nil),

--- a/internal/cache/inmem.go
+++ b/internal/cache/inmem.go
@@ -16,9 +16,11 @@ func (ce *cacheEntry[V]) isExpired() bool {
 	if time.Now().After(ce.maxExpire) {
 		return true
 	}
+
 	if time.Now().After(ce.expire) {
 		return true
 	}
+
 	return false
 }
 
@@ -60,6 +62,7 @@ func (c *InMemTTL[K, V]) Get(key K) (V, bool) {
 
 	ce.expire = time.Now().Add(c.ttl)
 	c.entries[key] = ce
+
 	return ce.value, true
 }
 

--- a/internal/cache/inmem_test.go
+++ b/internal/cache/inmem_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func TestTTL(t *testing.T) {
+	t.Parallel()
+
 	testFactor := time.Duration(1)
 
 	if value, ok := os.LookupEnv("SLOW_TEST_FACTOR"); ok {
@@ -64,4 +66,23 @@ func TestTTL(t *testing.T) {
 	val, found = c.Get("bar")
 	assert.Equal(t, "", val)
 	assert.False(t, found)
+}
+
+func TestPar(t *testing.T) {
+	t.Parallel()
+
+	c := NewInMemTTL[int, int](time.Minute, time.Minute)
+
+	for i := 0; i < 32; i++ {
+		for j := 0; j < 32; j++ {
+			t.Run("set"+strconv.Itoa(i), func(t *testing.T) {
+				t.Parallel()
+				c.Set(i, i)
+				time.Sleep(time.Millisecond)
+				iv, found := c.Get(i)
+				assert.True(t, found)
+				assert.Equal(t, i, iv)
+			})
+		}
+	}
 }

--- a/internal/completion/fish/completion_test.go
+++ b/internal/completion/fish/completion_test.go
@@ -32,6 +32,8 @@ func (u *unknownFlag) Names() []string {
 }
 
 func TestFormatFlag(t *testing.T) {
+	t.Parallel()
+
 	for _, tc := range []struct {
 		Name  string
 		Usage string
@@ -45,11 +47,18 @@ func TestFormatFlag(t *testing.T) {
 		{"", "Print", "long", ""},
 		{"print, p", "Print", "foo", ""},
 	} {
-		assert.Equal(t, tc.Out, formatFlag(tc.Name, tc.Usage, tc.Typ))
+		tc := tc
+
+		t.Run(tc.Name, func(t *testing.T) {
+			assert.Equal(t, tc.Out, formatFlag(tc.Name, tc.Usage, tc.Typ))
+			t.Parallel()
+		})
 	}
 }
 
 func TestGetCompletion(t *testing.T) {
+	t.Parallel()
+
 	app := cli.NewApp()
 	sv, err := GetCompletion(app)
 	require.NoError(t, err)
@@ -67,6 +76,8 @@ func TestGetCompletion(t *testing.T) {
 }
 
 func TestFormatflagFunc(t *testing.T) {
+	t.Parallel()
+
 	for _, flag := range []cli.Flag{
 		&cli.BoolFlag{Name: "foo", Usage: "bar"},
 		&cli.Float64Flag{Name: "foo", Usage: "bar"},

--- a/internal/completion/zsh/completion.go
+++ b/internal/completion/zsh/completion.go
@@ -9,6 +9,9 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
+// ErrUnknownType is returned when an unknown type is encountered.
+var ErrUnknownType = fmt.Errorf("unknown type")
+
 func longName(name string) string {
 	// "If s does not contain sep and sep is not empty, Split returns a slice of length 1 whose only element is s."
 	// from https://golang.org/pkg/strings/#Split
@@ -45,7 +48,7 @@ func formatFlagFunc() func(cli.Flag) (string, error) {
 		case *cli.UintFlag:
 			return formatFlag(ft.Name, ft.Usage), nil
 		default:
-			return "", fmt.Errorf("unknown type: '%T'", f)
+			return "", fmt.Errorf("error '%T': %w", f, ErrUnknownType)
 		}
 	}
 }
@@ -55,13 +58,16 @@ func GetCompletion(a *cli.App) (string, error) {
 	tplFuncs := template.FuncMap{
 		"formatFlag": formatFlagFunc(),
 	}
+
 	tpl, err := template.New("zsh").Funcs(tplFuncs).Parse(zshTemplate)
 	if err != nil {
 		return "", err
 	}
+
 	buf := &bytes.Buffer{}
 	if err := tpl.Execute(buf, a); err != nil {
 		return "", err
 	}
+
 	return buf.String(), nil
 }

--- a/internal/completion/zsh/completion_test.go
+++ b/internal/completion/zsh/completion_test.go
@@ -32,6 +32,8 @@ func (u *unknownFlag) Names() []string {
 }
 
 func TestFormatFlag(t *testing.T) {
+	t.Parallel()
+
 	for _, tc := range []struct {
 		name  string
 		usage string
@@ -39,11 +41,17 @@ func TestFormatFlag(t *testing.T) {
 	}{
 		{"print, p", "Print", "--print[Print]"},
 	} {
-		assert.Equal(t, tc.out, formatFlag(tc.name, tc.usage))
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.out, formatFlag(tc.name, tc.usage))
+		})
 	}
 }
 
 func TestGetCompletion(t *testing.T) {
+	t.Parallel()
+
 	app := cli.NewApp()
 	sv, err := GetCompletion(app)
 	require.NoError(t, err)
@@ -61,6 +69,8 @@ func TestGetCompletion(t *testing.T) {
 }
 
 func TestFormatflagFunc(t *testing.T) {
+	t.Parallel()
+
 	ff := formatFlagFunc()
 	for _, flag := range []cli.Flag{
 		&cli.BoolFlag{Name: "foo", Usage: "bar"},
@@ -79,6 +89,7 @@ func TestFormatflagFunc(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "--foo[bar]", sv)
 	}
+
 	sv, err := ff(&unknownFlag{})
 	assert.Error(t, err)
 	assert.Equal(t, "", sv)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -64,6 +64,7 @@ func (c *Config) SetConfigValue(key, value string) error {
 	if err := c.setConfigValue(key, value); err != nil {
 		return err
 	}
+
 	return c.Save()
 }
 
@@ -80,17 +81,20 @@ func (c *Config) setConfigValue(key, value string) error {
 			continue
 		}
 		f := o.Field(i)
-		switch f.Kind() {
+		switch f.Kind() { //nolint:exhaustive
 		case reflect.String:
 			f.SetString(value)
+
 			return nil
 		case reflect.Bool:
 			switch {
 			case value == "true" || value == "on":
 				f.SetBool(true)
+
 				return nil
 			case value == "false" || value == "off":
 				f.SetBool(false)
+
 				return nil
 			default:
 				return fmt.Errorf("not a bool: %s", value)
@@ -101,11 +105,13 @@ func (c *Config) setConfigValue(key, value string) error {
 				return fmt.Errorf("failed to convert %q to integer: %w", value, err)
 			}
 			f.SetInt(int64(iv))
+
 			return nil
 		default:
 			continue
 		}
 	}
+
 	return fmt.Errorf("unknown config option %q", key)
 }
 
@@ -129,7 +135,7 @@ func (c *Config) ConfigMap() map[string]string {
 		}
 		f := o.Field(i)
 		var strVal string
-		switch f.Kind() {
+		switch f.Kind() { //nolint:exhaustive
 		case reflect.String:
 			strVal = f.String()
 		case reflect.Bool:
@@ -141,5 +147,6 @@ func (c *Config) ConfigMap() map[string]string {
 		}
 		m[jsonArg] = strVal
 	}
+
 	return m
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -11,11 +11,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestHomedir(t *testing.T) {
+func TestHomedir(t *testing.T) { //nolint:paralleltest
 	assert.NotEqual(t, config.Homedir(), "")
 }
 
-func TestNewConfig(t *testing.T) {
+func TestNewConfig(t *testing.T) { //nolint:paralleltest
 	assert.NoError(t, os.Setenv("GOPASS_CONFIG", filepath.Join(os.TempDir(), ".gopass.yml")))
 
 	cfg := config.New()
@@ -34,7 +34,7 @@ func TestNewConfig(t *testing.T) {
 	assert.Contains(t, cs, `SafeContent:false, Mounts:map[string]string{"bar":"", "foo":""},`)
 }
 
-func TestSetConfigValue(t *testing.T) {
+func TestSetConfigValue(t *testing.T) { //nolint:paralleltest
 	assert.NoError(t, os.Setenv("GOPASS_CONFIG", filepath.Join(os.TempDir(), ".gopass.yml")))
 
 	cfg := config.New()

--- a/internal/config/context.go
+++ b/internal/config/context.go
@@ -12,20 +12,26 @@ func (c *Config) WithContext(ctx context.Context) context.Context {
 	if !c.AutoImport {
 		ctx = ctxutil.WithImportFunc(ctx, nil)
 	}
+
 	if !ctxutil.HasExportKeys(ctx) {
 		ctx = ctxutil.WithExportKeys(ctx, c.ExportKeys)
 	}
+
 	if !ctxutil.HasNoPager(ctx) {
 		ctx = ctxutil.WithNoPager(ctx, c.NoPager)
 	}
+
 	if !ctxutil.HasNotifications(ctx) {
 		ctx = ctxutil.WithNotifications(ctx, c.Notifications)
 	}
+
 	if !ctxutil.HasShowSafeContent(ctx) {
 		ctx = ctxutil.WithShowSafeContent(ctx, c.SafeContent)
 	}
+
 	if !ctxutil.HasShowParsing(ctx) {
 		ctx = ctxutil.WithShowParsing(ctx, c.Parsing)
 	}
+
 	return ctx
 }

--- a/internal/config/io_test.go
+++ b/internal/config/io_test.go
@@ -16,6 +16,8 @@ import (
 )
 
 func TestConfigs(t *testing.T) {
+	t.Parallel()
+
 	for _, tc := range []struct {
 		name string
 		cfg  string
@@ -331,7 +333,10 @@ version: "1.0.0"`,
 			},
 		},
 	} {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
 			got, err := decode([]byte(tc.cfg), true)
 			require.NoError(t, err)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
@@ -371,7 +376,7 @@ mounts:
     safecontent: false
 version: 1.4.0`
 
-func TestLoad(t *testing.T) {
+func TestLoad(t *testing.T) { //nolint:paralleltest
 	td := os.TempDir()
 	gcfg := filepath.Join(td, ".gopass.yml")
 	_ = os.Remove(gcfg)
@@ -384,7 +389,7 @@ func TestLoad(t *testing.T) {
 	assert.True(t, cfg.SafeContent)
 }
 
-func TestLoadError(t *testing.T) {
+func TestLoadError(t *testing.T) { //nolint:paralleltest
 	gcfg := filepath.Join(os.TempDir(), ".gopass-err.yml")
 	assert.NoError(t, os.Setenv("GOPASS_CONFIG", gcfg))
 
@@ -395,6 +400,7 @@ func TestLoadError(t *testing.T) {
 		if err == nil {
 			return fmt.Errorf("should fail")
 		}
+
 		return nil
 	})
 
@@ -404,15 +410,17 @@ func TestLoadError(t *testing.T) {
 
 	td, err := os.MkdirTemp("", "gopass-")
 	require.NoError(t, err)
+
 	defer func() {
-		os.RemoveAll(td)
+		_ = os.RemoveAll(td)
 	}()
+
 	gcfg = filepath.Join(td, "foo", ".gopass.yml")
 	assert.NoError(t, os.Setenv("GOPASS_CONFIG", gcfg))
 	assert.NoError(t, cfg.Save())
 }
 
-func TestDecodeError(t *testing.T) {
+func TestDecodeError(t *testing.T) { //nolint:paralleltest
 	gcfg := filepath.Join(os.TempDir(), ".gopass-err2.yml")
 	assert.NoError(t, os.Setenv("GOPASS_CONFIG", gcfg))
 
@@ -424,12 +432,14 @@ func TestDecodeError(t *testing.T) {
 		if err == nil {
 			return fmt.Errorf("should fail")
 		}
+
 		return nil
 	})
 }
 
 func capture(t *testing.T, fn func() error) string {
 	t.Helper()
+
 	old := os.Stdout
 
 	oldcol := color.NoColor
@@ -453,5 +463,6 @@ func capture(t *testing.T, fn func() error) string {
 	color.NoColor = oldcol
 	assert.NoError(t, err)
 	out := <-done
+
 	return strings.TrimSpace(out)
 }

--- a/internal/config/legacy.go
+++ b/internal/config/legacy.go
@@ -39,9 +39,11 @@ func (c *Pre1127) Config() *Config {
 		SafeContent:   c.SafeContent,
 		Mounts:        make(map[string]string, len(c.Mounts)),
 	}
+
 	for k, v := range c.Mounts {
 		cfg.Mounts[k] = v
 	}
+
 	return cfg
 }
 
@@ -87,9 +89,11 @@ func (c *Pre1102) Config() *Config {
 		SafeContent:   c.SafeContent,
 		Mounts:        make(map[string]string, len(c.Mounts)),
 	}
+
 	for k, v := range c.Mounts {
 		cfg.Mounts[k] = v
 	}
+
 	return cfg
 }
 
@@ -142,9 +146,11 @@ func (c *Pre193) Config() *Config {
 		SafeContent:   c.Root.SafeContent,
 		Mounts:        make(map[string]string, len(c.Mounts)),
 	}
+
 	if p, err := pathFromURL(c.Root.Path); err == nil {
 		cfg.Path = p
 	}
+
 	for k, v := range c.Mounts {
 		p, err := pathFromURL(v.Path)
 		if err != nil {
@@ -152,6 +158,7 @@ func (c *Pre193) Config() *Config {
 		}
 		cfg.Mounts[k] = p
 	}
+
 	return cfg
 }
 
@@ -205,9 +212,11 @@ func (c *Pre182) Config() *Config {
 		SafeContent:   c.Root.SafeContent,
 		Mounts:        make(map[string]string, len(c.Mounts)),
 	}
+
 	if p, err := pathFromURL(c.Root.Path); err == nil {
 		cfg.Path = p
 	}
+
 	for k, v := range c.Mounts {
 		p, err := pathFromURL(v.Path)
 		if err != nil {
@@ -215,6 +224,7 @@ func (c *Pre182) Config() *Config {
 		}
 		cfg.Mounts[k] = p
 	}
+
 	return cfg
 }
 
@@ -250,9 +260,11 @@ func (c *Pre140) Config() *Config {
 		SafeContent: c.SafeContent,
 		Mounts:      make(map[string]string, len(c.Mounts)),
 	}
+
 	for k, v := range c.Mounts {
 		cfg.Mounts[k] = v
 	}
+
 	return cfg
 }
 
@@ -295,9 +307,11 @@ func (c *Pre130) Config() *Config {
 		SafeContent: c.SafeContent,
 		Mounts:      make(map[string]string, len(c.Mounts)),
 	}
+
 	for k, v := range c.Mounts {
 		cfg.Mounts[k] = v
 	}
+
 	return cfg
 }
 
@@ -310,5 +324,6 @@ func pathFromURL(u string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+
 	return up.Path, nil
 }

--- a/internal/config/location.go
+++ b/internal/config/location.go
@@ -19,8 +19,10 @@ func Homedir() string {
 	hd, err := homedir.Dir()
 	if err != nil {
 		debug.Log("Failed to get homedir: %s\n", err)
+
 		return ""
 	}
+
 	return hd
 }
 
@@ -48,6 +50,7 @@ func configLocations() []string {
 	l = append(l, filepath.Join(appdir.UserConfig(), "config.yml"))
 	l = append(l, filepath.Join(Homedir(), ".config", "gopass", "config.yml"))
 	l = append(l, filepath.Join(Homedir(), ".gopass.yml"))
+
 	return l
 }
 
@@ -56,16 +59,22 @@ func configLocations() []string {
 func PwStoreDir(mount string) string {
 	if mount != "" {
 		cleanName := strings.ReplaceAll(mount, string(filepath.Separator), "-")
+
 		return fsutil.CleanPath(filepath.Join(appdir.UserData(), "stores", cleanName))
 	}
 	// PASSWORD_STORE_DIR support is discouraged.
 	if d := os.Getenv("PASSWORD_STORE_DIR"); d != "" {
+		debug.Log("using value of PASSWORD_STORE_DIR: %s", d)
+
 		return fsutil.CleanPath(d)
 	}
+
 	if ld := filepath.Join(appdir.UserHome(), ".password-store"); fsutil.IsDir(ld) {
 		debug.Log("re-using existing legacy dir for root store: %s", ld)
+
 		return ld
 	}
+
 	return fsutil.CleanPath(filepath.Join(appdir.UserData(), "stores", "root"))
 }
 

--- a/internal/config/location_test.go
+++ b/internal/config/location_test.go
@@ -2,22 +2,29 @@ package config
 
 import (
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
-func TestPwStoreDirNoEnv(t *testing.T) {
+func TestPwStoreDirNoEnv(t *testing.T) { //nolint:paralleltest
+	if runtime.GOOS != "windows" {
+		t.Setenv("GOPASS_HOMEDIR", "/tmp")
+	}
+
 	for in, out := range map[string]string{
 		"":                          filepath.Join(Homedir(), ".local", "share", "gopass", "stores", "root"),
 		"work":                      filepath.Join(Homedir(), ".local", "share", "gopass", "stores", "work"),
 		filepath.Join("foo", "bar"): filepath.Join(Homedir(), ".local", "share", "gopass", "stores", "foo-bar"),
 	} {
-		assert.Equal(t, out, PwStoreDir(in))
+		assert.Equal(t, out, PwStoreDir(in), in)
 	}
 }
 
 func TestDirectory(t *testing.T) {
+	t.Parallel()
+
 	loc := configLocation()
 	dir := filepath.Dir(loc)
 	assert.Equal(t, dir, Directory())

--- a/internal/config/location_xdg_test.go
+++ b/internal/config/location_xdg_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestPwStoreDir(t *testing.T) {
+func TestPwStoreDir(t *testing.T) { //nolint:paralleltest
 	gph := filepath.Join(os.TempDir(), "home")
 	require.NoError(t, os.Setenv("GOPASS_HOMEDIR", gph))
 
@@ -39,7 +39,7 @@ func TestPwStoreDir(t *testing.T) {
 	assert.NoError(t, os.Unsetenv("XDG_DATA_HOME"))
 }
 
-func TestConfigLocation(t *testing.T) {
+func TestConfigLocation(t *testing.T) { //nolint:paralleltest
 	evs := map[string]struct {
 		ev  string
 		loc string
@@ -60,7 +60,7 @@ func TestConfigLocation(t *testing.T) {
 	}
 }
 
-func TestConfigLocations(t *testing.T) {
+func TestConfigLocations(t *testing.T) { //nolint:paralleltest
 	gpcfg := filepath.Join(os.TempDir(), "config", ".gopass.yml")
 	xdghome := filepath.Join(os.TempDir(), "xdg")
 	gphome := filepath.Join(os.TempDir(), "home")

--- a/internal/create/helpers.go
+++ b/internal/create/helpers.go
@@ -16,6 +16,7 @@ func fmtfn(d int, n string, t string) string {
 	// indent - [N] - text (trailing spaces)
 	fmtStr := "%" + strconv.Itoa(d) + "s%s %-" + strconv.Itoa(strlen) + "s"
 	debug.Log("d: %d, n: %q, t: %q, strlen: %d, fmtStr: %q", d, n, t, strlen, fmtStr)
+
 	return fmt.Sprintf(fmtStr, "", color.GreenString("["+n+"]"), t)
 }
 
@@ -31,11 +32,13 @@ func extractHostname(in string) string {
 	if !strings.Contains(urlStr, "://") {
 		urlStr = "http://" + urlStr
 	}
+
 	u, err := url.Parse(urlStr)
 	if err == nil {
 		if ch := fsutil.CleanFilename(u.Hostname()); ch != "" {
 			return ch
 		}
 	}
+
 	return fsutil.CleanFilename(in)
 }

--- a/internal/create/wizard_test.go
+++ b/internal/create/wizard_test.go
@@ -6,12 +6,15 @@ import (
 
 	"github.com/gopasspw/gopass/internal/store/mockstore/inmem"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNew(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	s := inmem.New()
-	s.Set(ctx, ".create/pin.yml", []byte(`---
+	_ = s.Set(ctx, ".create/pin.yml", []byte(`---
 priority: 1
 name: "PIN Code (numerical)"
 prefix: "pin"
@@ -38,51 +41,26 @@ attributes:
     type: "string"
 `))
 	w, err := New(ctx, s)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if w.Templates == nil {
-		t.Fatal("no templates")
-	}
-	if len(w.Templates) != 3 {
-		t.Fatal("wrong number of templates")
-	}
-	if w.Templates[0].Prefix != "websites" {
-		t.Fatal("wrong prefix")
-	}
-	if w.Templates[0].Welcome != "🧪 Creating Website login" {
-		t.Fatal("wrong welcome")
-	}
-	if l := len(w.Templates[0].Attributes); l != 3 {
-		t.Fatalf("wrong number of attributes. want(%d), got(%d)", 3, l)
-	}
-	if w.Templates[0].Attributes[0].Type != "hostname" {
-		t.Fatal("wrong type")
-	}
-	if w.Templates[0].Attributes[0].Prompt != "Website URL" {
-		t.Fatal("wrong prompt:", w.Templates[0].Attributes[0].Prompt, "want:", "Website URL")
-	}
-	if w.Templates[0].Attributes[0].Min != 1 {
-		t.Fatal("wrong min")
-	}
-	if w.Templates[0].Attributes[0].Max != 255 {
-		t.Fatal("wrong max")
-	}
-	if w.Templates[0].Attributes[1].Type != "string" {
-		t.Fatal("wrong type", w.Templates[0].Attributes[1].Type, "want:", "string")
-	}
-	if w.Templates[0].Attributes[1].Prompt != "Login" {
-		t.Fatal("wrong prompt")
-	}
-	if w.Templates[0].Attributes[1].Min != 1 {
-		t.Fatal("wrong min")
-	}
-	if w.Templates[0].Attributes[2].Type != "password" {
-		t.Fatal("wrong type", w.Templates[0].Attributes[2].Type, "want:", "password")
-	}
+	require.NoError(t, err)
+	require.NotNil(t, w.Templates, "no templates")
+	require.Len(t, w.Templates, 3, "wrong number of templates")
+
+	assert.Equal(t, "websites", w.Templates[0].Prefix, "wrong prefix")
+	assert.Equal(t, "🧪 Creating Website login", w.Templates[0].Welcome, "wrong welcome")
+	assert.Equal(t, 3, len(w.Templates[0].Attributes), "wrong number of attributes")
+	assert.Equal(t, "hostname", w.Templates[0].Attributes[0].Type, "wrong type")
+	assert.Equal(t, "Website URL", w.Templates[0].Attributes[0].Prompt, "wrong prompt")
+	assert.Equal(t, 1, w.Templates[0].Attributes[0].Min, "wrong min")
+	assert.Equal(t, 255, w.Templates[0].Attributes[0].Max, "wrong max")
+	assert.Equal(t, "string", w.Templates[0].Attributes[1].Type, "wrong type")
+	assert.Equal(t, "Login", w.Templates[0].Attributes[1].Prompt, "wrong prompt")
+	assert.Equal(t, 1, w.Templates[0].Attributes[1].Min, "wrong min")
+	assert.Equal(t, "password", w.Templates[0].Attributes[2].Type, "wrong type")
 }
 
 func TestExtractHostname(t *testing.T) {
+	t.Parallel()
+
 	for in, out := range map[string]string{
 		"":                                     "",
 		"http://www.example.org/":              "www.example.org",

--- a/internal/cui/actions.go
+++ b/internal/cui/actions.go
@@ -22,6 +22,7 @@ func (ca Actions) Selection() []string {
 	for _, a := range ca {
 		keys = append(keys, a.Name)
 	}
+
 	return keys
 }
 
@@ -33,5 +34,6 @@ func (ca Actions) Run(ctx context.Context, c *cli.Context, i int) error {
 	if ca[i].Fn == nil {
 		return errors.New("action invalid")
 	}
+
 	return ca[i].Fn(ctx, c)
 }

--- a/internal/cui/actions_test.go
+++ b/internal/cui/actions_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestCreateActions(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	cas := Actions{
 		{

--- a/internal/cui/cui.go
+++ b/internal/cui/cui.go
@@ -37,5 +37,6 @@ func GetSelection(ctx context.Context, prompt string, choices []string) (string,
 		}
 	}
 	fmt.Println(i)
+
 	return "default", i
 }

--- a/internal/cui/cui_test.go
+++ b/internal/cui/cui_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestGetSelection(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	ctx = ctxutil.WithInteractive(ctx, false)
 

--- a/internal/cui/recipients.go
+++ b/internal/cui/recipients.go
@@ -32,6 +32,7 @@ func AskForPrivateKey(ctx context.Context, crypto backend.Crypto, prompt string)
 	if !ctxutil.IsInteractive(ctx) {
 		return "", fmt.Errorf("can not select private key without terminal")
 	}
+
 	if crypto == nil {
 		return "", fmt.Errorf("can not select private key without valid crypto backend")
 	}
@@ -40,15 +41,17 @@ func AskForPrivateKey(ctx context.Context, crypto backend.Crypto, prompt string)
 	if err != nil {
 		return "", err
 	}
+
 	if len(kl) < 1 {
 		return "", fmt.Errorf("no useable private keys found. make sure you have valid private keys with sufficient trust")
 	}
-	// shortcut: I there is only one key, use it
+
+	// shortcut: If there is only one key, use it
 	if len(kl) == 1 {
 		return kl[0], nil
 	}
 
-	fmtStr := "[%" + strconv.Itoa(int(len(kl)/10)+1) + "d] %s - %s\n"
+	fmtStr := "[%" + strconv.Itoa((len(kl)/10)+1) + "d] %s - %s\n"
 	for i := 0; i < maxTries; i++ {
 		if !ctxutil.IsTerminal(ctx) {
 			return kl[0], nil
@@ -64,6 +67,7 @@ func AskForPrivateKey(ctx context.Context, crypto backend.Crypto, prompt string)
 		for i, k := range kl {
 			fmt.Fprintf(Stdout, fmtStr, i, crypto.Name(), crypto.FormatKey(ctx, k, ""))
 		}
+
 		iv, err := termio.AskForInt(ctx, fmt.Sprintf("Please enter the number of a key (0-%d, [q]uit)", len(kl)-1), 0)
 		if err != nil {
 			if err.Error() == "user aborted" {
@@ -72,10 +76,12 @@ func AskForPrivateKey(ctx context.Context, crypto backend.Crypto, prompt string)
 
 			continue
 		}
+
 		if iv >= 0 && iv < len(kl) {
 			return kl[iv], nil
 		}
 	}
+
 	return "", fmt.Errorf("no valid user input")
 }
 
@@ -92,8 +98,10 @@ func AskForGitConfigUser(ctx context.Context, crypto backend.Crypto) (string, st
 	if crypto == nil {
 		return "", "", fmt.Errorf("crypto not available")
 	}
+
 	if crypto.Name() == "age" {
 		debug.Log("skipping git config user prompt for non-gpg backend %s", crypto.Name())
+
 		return "", "", nil
 	}
 
@@ -101,6 +109,7 @@ func AskForGitConfigUser(ctx context.Context, crypto backend.Crypto) (string, st
 	if err != nil {
 		return "", "", err
 	}
+
 	if len(keyList) < 1 {
 		return "", "", fmt.Errorf("no usable private keys found")
 	}
@@ -114,7 +123,7 @@ func AskForGitConfigUser(ctx context.Context, crypto backend.Crypto) (string, st
 		}
 
 		name := crypto.FormatKey(ctx, key, "{{ .Identity.Name }}")
-		email := crypto.FormatKey(ctx, key, "{{ .Identity.Email }}")
+		email := crypto.FormatKey(ctx, key, "{{ .Identity.Email }}")
 
 		if name == "" && email == "" {
 			continue
@@ -125,9 +134,11 @@ func AskForGitConfigUser(ctx context.Context, crypto backend.Crypto) (string, st
 			fmt.Sprintf("Use %s (%s) for password store git config?", name, email),
 			true,
 		)
+
 		if err != nil {
 			return "", "", err
 		}
+
 		if useCurrent {
 			return name, email, nil
 		}
@@ -142,6 +153,7 @@ type mountPointer interface {
 
 func sorted(s []string) []string {
 	sort.Strings(s)
+
 	return s
 }
 
@@ -166,6 +178,7 @@ func AskForStore(ctx context.Context, s mountPointer) string {
 		if store == "<root>" {
 			store = ""
 		}
+
 		return store
 	default:
 		return "" // root store

--- a/internal/cui/recipients_test.go
+++ b/internal/cui/recipients_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestAskForPrivateKey(t *testing.T) {
+func TestAskForPrivateKey(t *testing.T) { //nolint:paralleltest
 	buf := &bytes.Buffer{}
 	Stdout = buf
 	defer func() {
@@ -29,7 +29,7 @@ func TestAskForPrivateKey(t *testing.T) {
 	buf.Reset()
 }
 
-func TestAskForGitConfigUser(t *testing.T) {
+func TestAskForGitConfigUser(t *testing.T) { //nolint:paralleltest
 	u := gptest.NewUnitTester(t)
 	defer u.Remove()
 
@@ -47,7 +47,7 @@ func (f fakeMountPointer) MountPoints() []string {
 	return f
 }
 
-func TestAskForStore(t *testing.T) {
+func TestAskForStore(t *testing.T) { //nolint:paralleltest
 	ctx := context.Background()
 
 	// test non-interactive
@@ -70,5 +70,7 @@ func TestAskForStore(t *testing.T) {
 }
 
 func TestSorted(t *testing.T) {
+	t.Parallel()
+
 	assert.Equal(t, []string{"a", "b", "c"}, sorted([]string{"c", "a", "b"}))
 }

--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -4,6 +4,7 @@ package diff
 // the second list.
 func Stat[K comparable](l, r []K) (int, int) {
 	added, removed := List(l, r)
+
 	return len(added), len(removed)
 }
 
@@ -14,12 +15,15 @@ func List[K comparable](l, r []K) ([]K, []K) {
 	mr := listToMap(r)
 
 	var added []K
+
 	for k := range mr {
 		if _, found := ml[k]; !found {
 			added = append(added, k)
 		}
 	}
+
 	var removed []K
+
 	for k := range ml {
 		if _, found := mr[k]; !found {
 			removed = append(removed, k)
@@ -34,5 +38,6 @@ func listToMap[K comparable](l []K) map[K]struct{} {
 	for _, e := range l {
 		m[e] = struct{}{}
 	}
+
 	return m
 }

--- a/internal/diff/diff_test.go
+++ b/internal/diff/diff_test.go
@@ -7,36 +7,50 @@ import (
 )
 
 func TestStat(t *testing.T) {
+	t.Parallel()
+
 	for _, tc := range []struct {
+		name    string
 		old     []string
 		new     []string
 		added   int
 		removed int
 	}{
 		{
+			name:  "added",
 			old:   []string{"foo", "bar"},
 			new:   []string{"foo", "bar", "baz"},
 			added: 1,
 		},
 		{
+			name:    "removed",
 			old:     []string{"foo", "bar", "baz"},
 			new:     []string{"foo", "bar"},
 			removed: 1,
 		},
 		{
+			name:    "added and removed",
 			old:     []string{"foo", "baz"},
 			new:     []string{"foo", "bar"},
 			added:   1,
 			removed: 1,
 		},
 	} {
-		a, r := Stat(tc.old, tc.new)
-		assert.Equal(t, tc.added, a)
-		assert.Equal(t, tc.removed, r)
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			a, r := Stat(tc.old, tc.new)
+			assert.Equal(t, tc.added, a)
+			assert.Equal(t, tc.removed, r)
+		})
 	}
 }
 
 func TestList(t *testing.T) {
+	t.Parallel()
+
 	for _, tc := range []struct {
 		old     []string
 		new     []string
@@ -69,6 +83,8 @@ func TestList(t *testing.T) {
 }
 
 func TestListToMap(t *testing.T) {
+	t.Parallel()
+
 	for _, tc := range []struct {
 		l []string
 		m map[string]struct{}

--- a/internal/editor/edit_others_test.go
+++ b/internal/editor/edit_others_test.go
@@ -18,6 +18,8 @@ import (
 )
 
 func TestEditor(t *testing.T) {
+	t.Parallel()
+
 	u := gptest.NewUnitTester(t)
 	defer u.Remove()
 
@@ -34,6 +36,7 @@ func TestEditor(t *testing.T) {
 }
 
 func TestGetEditor(t *testing.T) {
+	t.Parallel()
 	app := cli.NewApp()
 
 	// --editor=fooed

--- a/internal/editor/edit_test.go
+++ b/internal/editor/edit_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestEdit(t *testing.T) {
+func TestEdit(t *testing.T) { //nolint:paralleltest
 	ctx := context.Background()
 	ctx = ctxutil.WithAlwaysYes(ctx, true)
 	ctx = ctxutil.WithTerminal(ctx, false)

--- a/internal/editor/editor.go
+++ b/internal/editor/editor.go
@@ -36,27 +36,35 @@ func Check(ctx context.Context, editor string) error {
 	if !strings.Contains(editor, "vi") {
 		return nil
 	}
+
 	uhd, err := os.UserHomeDir()
 	if err != nil {
 		return err
 	}
+
 	vrc := filepath.Join(uhd, ".vimrc")
 	if runtime.GOOS == "windows" {
 		vrc = filepath.Join(uhd, "_vimrc")
 	}
+
 	if !fsutil.IsFile(vrc) {
 		return nil
 	}
+
 	buf, err := os.ReadFile(vrc)
 	if err != nil {
 		return err
 	}
+
 	if vimOptsRe.Match(buf) {
 		debug.Log("Recommended settings found in %s", vrc)
+
 		return nil
 	}
+
 	debug.Log("%s did not match %s", string(buf), vimOptsRe)
 	out.Warningf(ctx, "Vim might leak credentials. Check your setup.\nhttps://github.com/gopasspw/gopass/blob/master/docs/setup.md#securing-your-editor")
+
 	return nil
 }
 
@@ -70,6 +78,7 @@ func Invoke(ctx context.Context, editor string, content []byte) ([]byte, error) 
 	if err != nil {
 		return []byte{}, fmt.Errorf("failed to create tmpfile %s: %w", editor, err)
 	}
+
 	defer func() {
 		if err := tmpfile.Remove(ctx); err != nil {
 			color.Red("Failed to remove tempfile at %s: %s", tmpfile.Name(), err)
@@ -79,6 +88,7 @@ func Invoke(ctx context.Context, editor string, content []byte) ([]byte, error) 
 	if _, err := tmpfile.Write(content); err != nil {
 		return []byte{}, fmt.Errorf("failed to write tmpfile to start with %s %v: %w", editor, tmpfile.Name(), err)
 	}
+
 	if err := tmpfile.Close(); err != nil {
 		return []byte{}, fmt.Errorf("failed to close tmpfile to start with %s %v: %w", editor, tmpfile.Name(), err)
 	}
@@ -103,6 +113,7 @@ func Invoke(ctx context.Context, editor string, content []byte) ([]byte, error) 
 
 	if err := cmd.Run(); err != nil {
 		debug.Log("cmd: %s %+v - error: %+v", cmd.Path, cmd.Args, err)
+
 		return []byte{}, fmt.Errorf("failed to run %s with %s file: %w", editor, tmpfile.Name(), err)
 	}
 

--- a/internal/notify/icon.go
+++ b/internal/notify/icon.go
@@ -32,6 +32,7 @@ func iconURI() string {
 		if err = bindataWrite(assetLogoSmallPng(), fh); err != nil {
 			return ""
 		}
+
 		if err = fh.Close(); err != nil {
 			return ""
 		}
@@ -40,6 +41,7 @@ func iconURI() string {
 	if fsutil.IsFile(iconFN) {
 		return "file://" + iconFN
 	}
+
 	return ""
 }
 
@@ -53,6 +55,7 @@ func bindataWrite(in []byte, out io.Writer) error {
 	}()
 
 	_, err = io.Copy(out, gz)
+
 	return err
 }
 

--- a/internal/notify/notify_dbus.go
+++ b/internal/notify/notify_dbus.go
@@ -16,11 +16,13 @@ import (
 func Notify(ctx context.Context, subj, msg string) error {
 	if os.Getenv("GOPASS_NO_NOTIFY") != "" || !ctxutil.IsNotifications(ctx) {
 		debug.Log("Notifications disabled")
+
 		return nil
 	}
 	conn, err := dbus.SessionBus()
 	if err != nil {
 		debug.Log("DBus failure: %s", err)
+
 		return err
 	}
 
@@ -28,6 +30,7 @@ func Notify(ctx context.Context, subj, msg string) error {
 	call := obj.Call("org.freedesktop.Notifications.Notify", 0, "gopass", uint32(0), iconURI(), subj, msg, []string{}, map[string]dbus.Variant{}, int32(5000))
 	if call.Err != nil {
 		debug.Log("DBus notification failure: %s", call.Err)
+
 		return err
 	}
 

--- a/internal/notify/notify_test.go
+++ b/internal/notify/notify_test.go
@@ -11,21 +11,26 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestNotify(t *testing.T) {
+func TestNotify(t *testing.T) { //nolint:paralleltest
 	ctx := context.Background()
-	_ = os.Setenv("GOPASS_NO_NOTIFY", "true")
+
+	t.Setenv("GOPASS_NO_NOTIFY", "true")
 	assert.NoError(t, Notify(ctx, "foo", "bar"))
 }
 
 func TestIcon(t *testing.T) {
+	t.Parallel()
+
 	fn := strings.TrimPrefix(iconURI(), "file://")
-	_ = os.Remove(fn)
+	require.NoError(t, os.Remove(fn))
 	_ = iconURI()
 	fh, err := os.Open(fn)
 	require.NoError(t, err)
+
 	defer func() {
 		assert.NoError(t, fh.Close())
 	}()
+
 	require.NotNil(t, fh)
 	_, err = png.Decode(fh)
 	assert.NoError(t, err)

--- a/internal/out/context.go
+++ b/internal/out/context.go
@@ -20,10 +20,12 @@ func AddPrefix(ctx context.Context, prefix string) context.Context {
 	if prefix == "" {
 		return ctx
 	}
+
 	pfx := Prefix(ctx)
 	if pfx == "" {
 		return WithPrefix(ctx, prefix)
 	}
+
 	return WithPrefix(ctx, pfx+prefix)
 }
 
@@ -33,6 +35,7 @@ func Prefix(ctx context.Context) string {
 	if !ok {
 		return ""
 	}
+
 	return sv
 }
 
@@ -47,5 +50,6 @@ func HasNewline(ctx context.Context) bool {
 	if !ok {
 		return true
 	}
+
 	return bv
 }

--- a/internal/out/context_test.go
+++ b/internal/out/context_test.go
@@ -8,6 +8,8 @@ import (
 )
 
 func TestPrefix(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 
 	assert.Equal(t, "", Prefix(ctx))
@@ -23,6 +25,8 @@ func TestPrefix(t *testing.T) {
 }
 
 func TestNewline(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 
 	assert.True(t, HasNewline(ctx))

--- a/internal/out/print.go
+++ b/internal/out/print.go
@@ -30,6 +30,7 @@ func (s Secret) SafeStr() string {
 // OutputIsRedirected returns true if the current os.Stdout is a pipe instead of a terminal.
 func OutputIsRedirected() bool {
 	o, _ := os.Stdout.Stat()
+
 	return (o.Mode() & os.ModeCharDevice) != os.ModeCharDevice
 }
 
@@ -37,6 +38,7 @@ func newline(ctx context.Context) string {
 	if HasNewline(ctx) {
 		return "\n"
 	}
+
 	return ""
 }
 

--- a/internal/out/print_test.go
+++ b/internal/out/print_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestPrint(t *testing.T) {
+func TestPrint(t *testing.T) { //nolint:paralleltest
 	ctx := context.Background()
 	buf := &bytes.Buffer{}
 	Stdout = buf

--- a/internal/pwschemes/argon2i/argon2i.go
+++ b/internal/pwschemes/argon2i/argon2i.go
@@ -65,7 +65,7 @@ func Generate(password string, saltLen uint32) (string, error) {
 
 	salt := make([]byte, params.SaltLen)
 	if _, err := rand.Read(salt); err != nil {
-		return "", err
+		return "", fmt.Errorf("failed to read rand: %w", err)
 	}
 
 	hash := argon2.Key([]byte(password), salt, params.Iterations, params.Memory, params.Parallelism, params.KeyLen)
@@ -111,9 +111,10 @@ func unpackHash(hash string) (*Params, []byte, []byte, error) {
 	}
 
 	var version int
+
 	_, err := fmt.Sscanf(p[2], "v=%d", &version)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, fmt.Errorf("failed to decode version %s: %w", p[2], err)
 	}
 
 	if version != argon2.Version {
@@ -121,21 +122,24 @@ func unpackHash(hash string) (*Params, []byte, []byte, error) {
 	}
 
 	params := &Params{}
+
 	_, err = fmt.Sscanf(p[3], "m=%d,t=%d,p=%d", &params.Memory, &params.Iterations, &params.Parallelism)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, fmt.Errorf("failed to decode header %s: %w", p[3], err)
 	}
 
 	salt, err := base64.RawStdEncoding.DecodeString(p[4])
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, fmt.Errorf("failed to decode salt %s: %w", p[4], err)
 	}
+
 	params.SaltLen = uint32(len(salt))
 
 	key, err := base64.RawStdEncoding.DecodeString(p[5])
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, fmt.Errorf("failed to decode hash %s: %w", p[5], err)
 	}
+
 	params.KeyLen = uint32(len(key))
 
 	return params, salt, key, nil

--- a/internal/pwschemes/argon2i/argon2i_test.go
+++ b/internal/pwschemes/argon2i/argon2i_test.go
@@ -8,6 +8,8 @@ import (
 )
 
 func TestArgon2I(t *testing.T) {
+	t.Parallel()
+
 	pw := "foobar"
 	hash, err := Generate(pw, 0)
 	require.NoError(t, err)

--- a/internal/pwschemes/argon2id/argon2id_test.go
+++ b/internal/pwschemes/argon2id/argon2id_test.go
@@ -8,6 +8,8 @@ import (
 )
 
 func TestArgon2ID(t *testing.T) {
+	t.Parallel()
+
 	pw := "foobar"
 	hash, err := Generate(pw, 0)
 	require.NoError(t, err)

--- a/internal/pwschemes/bcrypt/bcrypt.go
+++ b/internal/pwschemes/bcrypt/bcrypt.go
@@ -1,6 +1,7 @@
 package bcrypt
 
 import (
+	"fmt"
 	"strings"
 
 	"golang.org/x/crypto/bcrypt"
@@ -18,7 +19,7 @@ var Prefix = "{BLF-CRYPT}"
 func Generate(password string) (string, error) {
 	h, err := bcrypt.GenerateFromPassword([]byte(password), cost)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("failed to generate password hash: %w", err)
 	}
 
 	return Prefix + string(h), nil
@@ -27,5 +28,10 @@ func Generate(password string) (string, error) {
 // Validate validates the password against the given hash.
 func Validate(password, hash string) error {
 	hash = strings.TrimPrefix(hash, Prefix)
-	return bcrypt.CompareHashAndPassword([]byte(hash), []byte(password))
+
+	if err := bcrypt.CompareHashAndPassword([]byte(hash), []byte(password)); err != nil {
+		return fmt.Errorf("failed to validate password hash %s: %w", hash, err)
+	}
+
+	return nil
 }

--- a/internal/pwschemes/bcrypt/bcrypt_test.go
+++ b/internal/pwschemes/bcrypt/bcrypt_test.go
@@ -8,6 +8,8 @@ import (
 )
 
 func TestBcrypt(t *testing.T) {
+	t.Parallel()
+
 	pw := "foobar"
 
 	hash, err := Generate(pw)

--- a/internal/queue/background.go
+++ b/internal/queue/background.go
@@ -40,6 +40,7 @@ func GetQueue(ctx context.Context) Queuer {
 	if q, ok := ctx.Value(ctxKeyQueue).(*Queue); ok {
 		return q
 	}
+
 	return &noop{}
 }
 
@@ -76,6 +77,7 @@ func New(ctx context.Context) *Queue {
 		done: make(chan struct{}, 1),
 	}
 	go q.run(ctx)
+
 	return q
 }
 
@@ -94,12 +96,14 @@ func (q *Queue) run(ctx context.Context) {
 func (q *Queue) Add(t Task) Task {
 	q.work <- t
 	debug.Log("enqueued task")
+
 	return func(_ context.Context) error { return nil }
 }
 
 // Idle returns nil the next time the queue is empty.
 func (q *Queue) Idle(maxWait time.Duration) error {
 	done := make(chan struct{})
+
 	go func() {
 		for {
 			if len(q.work) < 1 {
@@ -113,6 +117,7 @@ func (q *Queue) Idle(maxWait time.Duration) error {
 			time.Sleep(20 * time.Millisecond)
 		}
 	}()
+
 	select {
 	case <-done:
 		return nil
@@ -130,6 +135,7 @@ func (q *Queue) Close(ctx context.Context) error {
 		return nil
 	case <-ctx.Done():
 		debug.Log("context canceled")
+
 		return ctx.Err()
 	}
 }

--- a/internal/recipients/recipients_test.go
+++ b/internal/recipients/recipients_test.go
@@ -3,5 +3,7 @@ package recipients
 import "testing"
 
 func TestMarshal(t *testing.T) {
+	t.Parallel()
+
 	t.Skip("implement this")
 }

--- a/internal/reminder/reminder.go
+++ b/internal/reminder/reminder.go
@@ -34,16 +34,20 @@ func (s *Store) lastSeen(key string) time.Time {
 	res, err := s.cache.Get(key)
 	if err != nil {
 		debug.Log("failed to read %q from cache: %s", key, err)
+
 		return t
 	}
+
 	if len(res) < 1 {
 		debug.Log("cache result is empty")
+
 		return t
 	}
 
 	ts, err := time.Parse(time.RFC3339, res[0])
 	if err != nil {
 		debug.Log("failed to parse stored time %q: %s", err)
+
 		return t
 	}
 
@@ -69,6 +73,8 @@ func (s *Store) Overdue(key string) bool {
 	if time.Since(s.lastSeen("overdue")) < 24*time.Hour {
 		return false
 	}
-	s.Reset("overdue")
+
+	_ = s.Reset("overdue")
+
 	return time.Since(s.lastSeen(key)) > 90*24*time.Hour
 }

--- a/internal/set/filter.go
+++ b/internal/set/filter.go
@@ -4,10 +4,12 @@ package set
 func Filter[K comparable](in []K, r ...K) []K {
 	rs := Map(r)
 	var out []K
+
 	for _, i := range in {
 		if !rs[i] {
 			out = append(out, i)
 		}
 	}
+
 	return out
 }

--- a/internal/set/map.go
+++ b/internal/set/map.go
@@ -7,5 +7,6 @@ func Map[K comparable](in []K) map[K]bool {
 	for _, i := range in {
 		m[i] = true
 	}
+
 	return m
 }

--- a/internal/set/sorted_test.go
+++ b/internal/set/sorted_test.go
@@ -8,6 +8,8 @@ import (
 )
 
 func TestSorted(t *testing.T) {
+	t.Parallel()
+
 	want := []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
 	in := append(want, want...)
 	rand.Shuffle(len(in), func(i, j int) {
@@ -17,6 +19,8 @@ func TestSorted(t *testing.T) {
 }
 
 func TestSortedFiltered(t *testing.T) {
+	t.Parallel()
+
 	in := []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
 	in = append(in, in...)
 	rand.Shuffle(len(in), func(i, j int) {

--- a/internal/store/leaf/context.go
+++ b/internal/store/leaf/context.go
@@ -34,6 +34,7 @@ func IsFsckCheck(ctx context.Context) bool {
 	if !ok {
 		return false
 	}
+
 	return bv
 }
 
@@ -54,6 +55,7 @@ func IsFsckForce(ctx context.Context) bool {
 	if !ok {
 		return false
 	}
+
 	return bv
 }
 
@@ -65,6 +67,7 @@ func WithFsckFunc(ctx context.Context, imf store.FsckCallback) context.Context {
 // HasFsckFunc returns true if a fsck func has been set in this context.
 func HasFsckFunc(ctx context.Context) bool {
 	imf, ok := ctx.Value(ctxKeyFsckFunc).(store.FsckCallback)
+
 	return ok && imf != nil
 }
 
@@ -78,6 +81,7 @@ func GetFsckFunc(ctx context.Context) store.FsckCallback {
 			return true
 		}
 	}
+
 	return imf
 }
 
@@ -100,6 +104,7 @@ func IsCheckRecipients(ctx context.Context) bool {
 	if !ok {
 		return false
 	}
+
 	return bv
 }
 
@@ -131,6 +136,7 @@ func IsNoGitOps(ctx context.Context) bool {
 // the provided context.
 func hasBool(ctx context.Context, key contextKey) bool {
 	_, ok := ctx.Value(key).(bool)
+
 	return ok
 }
 
@@ -141,5 +147,6 @@ func is(ctx context.Context, key contextKey, def bool) bool {
 	if !ok {
 		return def
 	}
+
 	return bv
 }

--- a/internal/store/leaf/context_test.go
+++ b/internal/store/leaf/context_test.go
@@ -8,6 +8,8 @@ import (
 )
 
 func TestFsckCheck(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 
 	assert.False(t, IsFsckCheck(ctx))
@@ -17,6 +19,8 @@ func TestFsckCheck(t *testing.T) {
 }
 
 func TestFsckForce(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 
 	assert.False(t, IsFsckForce(ctx))
@@ -26,6 +30,8 @@ func TestFsckForce(t *testing.T) {
 }
 
 func TestFsckFunc(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 
 	ffunc := func(context.Context, string) bool {
@@ -38,6 +44,8 @@ func TestFsckFunc(t *testing.T) {
 }
 
 func TestCheckRecipients(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 
 	assert.False(t, IsCheckRecipients(ctx))

--- a/internal/store/leaf/convert.go
+++ b/internal/store/leaf/convert.go
@@ -26,6 +26,7 @@ func (s *Store) Convert(ctx context.Context, cryptoBe backend.CryptoBackend, sto
 	if err := os.MkdirAll(tmpPath, 0o700); err != nil {
 		return err
 	}
+
 	debug.Log("create temporary store path for conversion: %s", tmpPath)
 
 	// init new store at temp path
@@ -33,14 +34,17 @@ func (s *Store) Convert(ctx context.Context, cryptoBe backend.CryptoBackend, sto
 	if err != nil {
 		return err
 	}
+
 	debug.Log("initialized storage %s at %s", st, tmpPath)
 
 	crypto, err := backend.NewCrypto(ctx, cryptoBe)
 	if err != nil {
 		return err
 	}
+
 	debug.Log("initialized Crypto %s", crypto)
-	// TODO need to initialize recipients
+
+	// TODO(gh-2170) need to initialize recipients
 
 	tmpStore := &Store{
 		alias:   s.alias,
@@ -54,6 +58,7 @@ func (s *Store) Convert(ctx context.Context, cryptoBe backend.CryptoBackend, sto
 	if err != nil {
 		return err
 	}
+
 	if err := tmpStore.Init(ctx, tmpPath, key); err != nil {
 		return err
 	}
@@ -87,18 +92,23 @@ func (s *Store) Convert(ctx context.Context, cryptoBe backend.CryptoBackend, sto
 			if err != nil {
 				return err
 			}
+
 			if err := tmpStore.Set(ctx, e, sec); err != nil {
 				return err
 			}
+
 			continue
 		}
+
 		sort.Sort(sort.Reverse(backend.Revisions(revs)))
+
 		for _, r := range revs {
 			debug.Log("converting %s@%s", e, r.Hash)
 			sec, err := s.GetRevision(ctx, e, r.Hash)
 			if err != nil {
 				return err
 			}
+
 			msg := fmt.Sprintf("%s\n%s\nCommitted as: %s\nDate: %s\nAuthor: %s <%s>",
 				r.Subject,
 				r.Body,

--- a/internal/store/leaf/crypto_test.go
+++ b/internal/store/leaf/crypto_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestGPG(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 
 	tempdir, err := os.MkdirTemp("", "gopass-")

--- a/internal/store/leaf/fsck.go
+++ b/internal/store/leaf/fsck.go
@@ -51,6 +51,7 @@ func (s *Store) Fsck(ctx context.Context, path string) error {
 		}
 		ctx := ctxutil.WithNoNetwork(ctx, true)
 		debug.Log("[%s] Checking %s", path, name)
+
 		if err := s.fsckCheckEntry(ctx, name); err != nil {
 			return fmt.Errorf("failed to check %q: %w", name, err)
 		}
@@ -118,12 +119,14 @@ func (s *Store) fsckCheckRecipients(ctx context.Context, name string) error {
 	if err != nil {
 		return fmt.Errorf("failed to read recipient IDs from raw secret: %w", err)
 	}
+
 	itemRecps = fingerprints(ctx, s.crypto, itemRecps)
 
 	perItemStoreRecps, err := s.GetRecipients(ctx, name)
 	if err != nil {
 		return fmt.Errorf("failed to get recipients from store: %w", err)
 	}
+
 	perItemStoreRecps = fingerprints(ctx, s.crypto, perItemStoreRecps)
 
 	// check itemRecps matches storeRecps
@@ -135,6 +138,7 @@ func (s *Store) fsckCheckRecipients(ctx context.Context, name string) error {
 	if len(extra) > 0 {
 		out.Errorf(ctx, "Extra recipients on %s: %+v\nRun fsck with the --decrypt flag to re-encrypt it automatically, or edit this secret yourself.", name, extra)
 	}
+
 	return nil
 }
 
@@ -143,6 +147,7 @@ func fingerprints(ctx context.Context, crypto backend.Crypto, in []string) []str
 	for _, r := range in {
 		out = append(out, crypto.Fingerprint(ctx, r))
 	}
+
 	return out
 }
 
@@ -156,6 +161,7 @@ func compareStringSlices(want, have []string) ([]string, []string) {
 	for _, w := range want {
 		wantMap[w] = struct{}{}
 	}
+
 	for _, h := range have {
 		haveMap[h] = struct{}{}
 	}
@@ -165,6 +171,7 @@ func compareStringSlices(want, have []string) ([]string, []string) {
 			missing = append(missing, k)
 		}
 	}
+
 	for k := range haveMap {
 		if _, found := wantMap[k]; !found {
 			extra = append(extra, k)

--- a/internal/store/leaf/fsck_test.go
+++ b/internal/store/leaf/fsck_test.go
@@ -16,6 +16,8 @@ import (
 )
 
 func TestFsck(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	ctx = ctxutil.WithExportKeys(ctx, false)
 
@@ -51,10 +53,37 @@ func TestFsck(t *testing.T) {
 }
 
 func TestCompareStringSlices(t *testing.T) {
-	want := []string{"foo", "bar"}
-	have := []string{"baz", "bar"}
+	t.Parallel()
 
-	missing, extra := compareStringSlices(want, have)
-	assert.Equal(t, []string{"foo"}, missing)
-	assert.Equal(t, []string{"baz"}, extra)
+	for _, tc := range []struct {
+		name    string
+		from    []string
+		to      []string
+		missing []string
+		extra   []string
+	}{
+		{
+			name:    "Add foo, remove baz",
+			from:    []string{"foo", "bar"},
+			to:      []string{"baz", "bar"},
+			missing: []string{"foo"},
+			extra:   []string{"baz"},
+		},
+		{
+			name:    "Add foo, bar, baz, zab",
+			from:    []string{"foo", "bar"},
+			to:      []string{"foo", "bar", "bar", "baz", "zab"},
+			missing: []string{},
+			extra:   []string{"baz", "zab"},
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			missing, extra := compareStringSlices(tc.from, tc.to)
+			assert.Equal(t, tc.missing, missing)
+			assert.Equal(t, tc.extra, extra)
+		})
+	}
 }

--- a/internal/store/leaf/init.go
+++ b/internal/store/leaf/init.go
@@ -14,8 +14,10 @@ func (s *Store) IsInitialized(ctx context.Context) bool {
 	if s == nil || s.storage == nil {
 		return false
 	}
+
 	ok := s.storage.Exists(ctx, s.idFile(ctx, ""))
 	debug.Log("store %q is initialized: %t", s.path, ok)
+
 	return ok
 }
 
@@ -37,11 +39,13 @@ You can add secondary stores with 'gopass init --path <path to secondary store> 
 		if err != nil {
 			debug.Log("no useable key for %q: %s. Ignoring.", id, err)
 			out.Errorf(ctx, "Failed to fetch public key for %q: %s", id, err)
+
 			continue
 		}
 		if len(kl) < 1 {
 			debug.Log("no useable key for %q. Ignoring.", id)
 			out.Errorf(ctx, "No useable keys for %q", id)
+
 			continue
 		}
 		recipients = append(recipients, kl[0])

--- a/internal/store/leaf/init_test.go
+++ b/internal/store/leaf/init_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func TestInit(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 
 	tempdir, err := os.MkdirTemp("", "gopass-")

--- a/internal/store/leaf/link.go
+++ b/internal/store/leaf/link.go
@@ -15,6 +15,7 @@ func (s *Store) Link(ctx context.Context, from, to string) error {
 	if !s.Exists(ctx, from) {
 		return fmt.Errorf("source %q does not exists", from)
 	}
+
 	if s.Exists(ctx, to) {
 		return fmt.Errorf("destination %q already exists", to)
 	}
@@ -22,12 +23,14 @@ func (s *Store) Link(ctx context.Context, from, to string) error {
 	if err := s.storage.Link(ctx, s.passfile(from), s.passfile(to)); err != nil {
 		return fmt.Errorf("failed to create symlink from %q to %q: %w", from, to, err)
 	}
+
 	debug.Log("created symlink from %q to %q", from, to)
 
 	if err := s.storage.Add(ctx, s.passfile(to)); err != nil {
 		if errors.Is(err, store.ErrGitNotInit) {
 			return nil
 		}
+
 		return fmt.Errorf("failed to add %q to git: %w", to, err)
 	}
 
@@ -36,5 +39,6 @@ func (s *Store) Link(ctx context.Context, from, to string) error {
 	t := queue.GetQueue(ctx).Add(func(ctx context.Context) error {
 		return s.gitCommitAndPush(ctx, to)
 	})
+
 	return t(ctx)
 }

--- a/internal/store/leaf/link_test.go
+++ b/internal/store/leaf/link_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestLink(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 
 	tempdir, err := os.MkdirTemp("", "gopass-")
@@ -18,6 +20,7 @@ func TestLink(t *testing.T) {
 	defer func() {
 		_ = os.RemoveAll(tempdir)
 	}()
+
 	t.Logf(tempdir)
 
 	s, err := createSubStore(tempdir)

--- a/internal/store/leaf/list.go
+++ b/internal/store/leaf/list.go
@@ -20,6 +20,7 @@ func (s *Store) List(ctx context.Context, prefix string) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	debug.Log("Listing %s: %+v\n", prefix, lst)
 	out := make([]string, 0, len(lst))
 	cExt := "." + s.crypto.Ext()
@@ -33,5 +34,6 @@ func (s *Store) List(ctx context.Context, prefix string) ([]string, error) {
 		}
 		out = append(out, path)
 	}
+
 	return out, nil
 }

--- a/internal/store/leaf/move.go
+++ b/internal/store/leaf/move.go
@@ -25,9 +25,11 @@ func (s *Store) Copy(ctx context.Context, from, to string) error {
 	if err != nil {
 		return fmt.Errorf("failed to get %q from store: %w", from, err)
 	}
+
 	if err := s.Set(ctxutil.WithCommitMessage(ctx, fmt.Sprintf("Copied from %s to %s", from, to)), to, content); err != nil {
 		return fmt.Errorf("failed to save %q to store: %w", to, err)
 	}
+
 	return nil
 }
 
@@ -45,12 +47,15 @@ func (s *Store) Move(ctx context.Context, from, to string) error {
 	if err != nil {
 		return fmt.Errorf("failed to decrypt %q: %w", from, err)
 	}
+
 	if err := s.Set(ctxutil.WithCommitMessage(ctx, fmt.Sprintf("Move from %s to %s", from, to)), to, content); err != nil {
 		return fmt.Errorf("failed to write %q: %w", to, err)
 	}
+
 	if err := s.Delete(ctx, from); err != nil {
 		return fmt.Errorf("failed to delete %q: %w", from, err)
 	}
+
 	return nil
 }
 
@@ -101,6 +106,7 @@ func (s *Store) delete(ctx context.Context, name string, recurse bool) error {
 		if errors.Is(err, store.ErrGitNotInit) || errors.Is(err, store.ErrGitNoRemote) {
 			return nil
 		}
+
 		return fmt.Errorf("failed to push change to git remote: %w", err)
 	}
 
@@ -117,6 +123,7 @@ func (s *Store) deleteRecurse(ctx context.Context, name, path string) error {
 	debug.Log("Pruning %s", name)
 	if err := s.storage.Prune(ctx, name); err != nil {
 		debug.Log("storage.Prune(%v) failed", name)
+
 		return err
 	}
 
@@ -124,9 +131,11 @@ func (s *Store) deleteRecurse(ctx context.Context, name, path string) error {
 		if errors.Is(err, store.ErrGitNotInit) {
 			return nil
 		}
+
 		return fmt.Errorf("failed to add %q to git: %w", path, err)
 	}
 	debug.Log("pruned")
+
 	return nil
 }
 
@@ -144,7 +153,9 @@ func (s *Store) deleteSingle(ctx context.Context, path string) error {
 		if errors.Is(err, store.ErrGitNotInit) {
 			return nil
 		}
+
 		return fmt.Errorf("failed to add %q to git: %w", path, err)
 	}
+
 	return nil
 }

--- a/internal/store/leaf/rcs.go
+++ b/internal/store/leaf/rcs.go
@@ -19,12 +19,14 @@ func (s *Store) GitInit(ctx context.Context) error {
 		return err
 	}
 	s.storage = storage
+
 	return nil
 }
 
 // ListRevisions will list all revisions for a secret.
 func (s *Store) ListRevisions(ctx context.Context, name string) ([]backend.Revision, error) {
 	p := s.passfile(name)
+
 	return s.storage.Revisions(ctx, p)
 }
 
@@ -39,6 +41,7 @@ func (s *Store) GetRevision(ctx context.Context, name, revision string) (gopass.
 	content, err := s.crypto.Decrypt(ctx, ciphertext)
 	if err != nil {
 		debug.Log("Decryption failed: %s", err)
+
 		return nil, store.ErrDecrypt
 	}
 
@@ -46,6 +49,7 @@ func (s *Store) GetRevision(ctx context.Context, name, revision string) (gopass.
 	if err != nil {
 		debug.Log("Failed to parse YAML: %s", err)
 	}
+
 	return sec, nil
 }
 
@@ -55,8 +59,11 @@ func (s *Store) GitStatus(ctx context.Context, _ string) error {
 	buf, err := s.storage.Status(ctx)
 	if err != nil {
 		debug.Log("RCS status failed for %s: %s", s.path, err)
+
 		return fmt.Errorf("failed to get RCS status for %s: %w", s.path, err)
 	}
+
 	out.Printf(ctx, string(buf))
+
 	return nil
 }

--- a/internal/store/leaf/rcs_test.go
+++ b/internal/store/leaf/rcs_test.go
@@ -13,10 +13,13 @@ import (
 )
 
 func TestGit(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 
 	tempdir, err := os.MkdirTemp("", "gopass-")
 	require.NoError(t, err)
+
 	defer func() {
 		_ = os.RemoveAll(tempdir)
 	}()
@@ -43,6 +46,8 @@ func TestGit(t *testing.T) {
 }
 
 func TestGitRevisions(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 
 	tempdir, err := os.MkdirTemp("", "gopass-")

--- a/internal/store/leaf/read.go
+++ b/internal/store/leaf/read.go
@@ -19,12 +19,14 @@ func (s *Store) Get(ctx context.Context, name string) (gopass.Secret, error) {
 	ciphertext, err := s.storage.Get(ctx, p)
 	if err != nil {
 		debug.Log("File %s not found: %s", p, err)
+
 		return nil, store.ErrNotFound
 	}
 
 	content, err := s.crypto.Decrypt(ctx, ciphertext)
 	if err != nil {
 		out.Errorf(ctx, "Decryption failed: %s\n%s", err, string(content))
+
 		return nil, store.ErrDecrypt
 	}
 

--- a/internal/store/leaf/recipients_test.go
+++ b/internal/store/leaf/recipients_test.go
@@ -20,16 +20,20 @@ import (
 )
 
 func TestGetRecipientsDefault(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 
 	tempdir, err := os.MkdirTemp("", "gopass-")
 	require.NoError(t, err)
+
 	defer func() {
 		_ = os.RemoveAll(tempdir)
 	}()
 
 	obuf := &bytes.Buffer{}
 	out.Stdout = obuf
+
 	defer func() {
 		out.Stdout = os.Stdout
 	}()
@@ -51,16 +55,20 @@ func TestGetRecipientsDefault(t *testing.T) {
 }
 
 func TestGetRecipientsSubID(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 
 	tempdir, err := os.MkdirTemp("", "gopass-")
 	require.NoError(t, err)
+
 	defer func() {
 		_ = os.RemoveAll(tempdir)
 	}()
 
 	obuf := &bytes.Buffer{}
 	out.Stdout = obuf
+
 	defer func() {
 		out.Stdout = os.Stdout
 	}()
@@ -88,19 +96,24 @@ func TestGetRecipientsSubID(t *testing.T) {
 }
 
 func TestSaveRecipients(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	ctx = ctxutil.WithExportKeys(ctx, true)
 
 	tempdir, err := os.MkdirTemp("", "gopass-")
 	require.NoError(t, err)
+
 	defer func() {
 		_ = os.RemoveAll(tempdir)
 	}()
+
 	_, _, err = createStore(tempdir, nil, nil)
 	assert.NoError(t, err)
 
 	obuf := &bytes.Buffer{}
 	out.Stdout = obuf
+
 	defer func() {
 		out.Stdout = os.Stdout
 	}()
@@ -124,16 +137,20 @@ func TestSaveRecipients(t *testing.T) {
 
 	foundRecs := []string{}
 	scanner := bufio.NewScanner(bytes.NewReader(buf))
+
 	for scanner.Scan() {
 		foundRecs = append(foundRecs, strings.TrimSpace(scanner.Text()))
 	}
+
 	sort.Strings(foundRecs)
 
 	for i := 0; i < len(recp); i++ {
 		if i >= len(foundRecs) {
 			t.Errorf("Read too few recipients")
+
 			break
 		}
+
 		if recp[i] != foundRecs[i] {
 			t.Errorf("Mismatch at %d: %s vs %s", i, recp[i], foundRecs[i])
 		}
@@ -141,11 +158,14 @@ func TestSaveRecipients(t *testing.T) {
 }
 
 func TestAddRecipient(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	ctx = ctxutil.WithHidden(ctx, true)
 
 	tempdir, err := os.MkdirTemp("", "gopass-")
 	require.NoError(t, err)
+
 	defer func() {
 		_ = os.RemoveAll(tempdir)
 	}()
@@ -155,6 +175,7 @@ func TestAddRecipient(t *testing.T) {
 
 	obuf := &bytes.Buffer{}
 	out.Stdout = obuf
+
 	defer func() {
 		out.Stdout = os.Stdout
 	}()
@@ -180,19 +201,24 @@ func TestAddRecipient(t *testing.T) {
 }
 
 func TestRemoveRecipient(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	ctx = ctxutil.WithHidden(ctx, true)
 
 	tempdir, err := os.MkdirTemp("", "gopass-")
 	require.NoError(t, err)
+
 	defer func() {
 		_ = os.RemoveAll(tempdir)
 	}()
+
 	_, _, err = createStore(tempdir, nil, nil)
 	assert.NoError(t, err)
 
 	obuf := &bytes.Buffer{}
 	out.Stdout = obuf
+
 	defer func() {
 		out.Stdout = os.Stdout
 	}()
@@ -213,10 +239,13 @@ func TestRemoveRecipient(t *testing.T) {
 }
 
 func TestListRecipients(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 
 	tempdir, err := os.MkdirTemp("", "gopass-")
 	require.NoError(t, err)
+
 	defer func() {
 		_ = os.RemoveAll(tempdir)
 	}()
@@ -226,6 +255,7 @@ func TestListRecipients(t *testing.T) {
 
 	obuf := &bytes.Buffer{}
 	out.Stdout = obuf
+
 	defer func() {
 		out.Stdout = os.Stdout
 	}()

--- a/internal/store/leaf/reencrypt.go
+++ b/internal/store/leaf/reencrypt.go
@@ -51,16 +51,19 @@ func (s *Store) reencrypt(ctx context.Context) error {
 					content, err := s.Get(ctx, e)
 					if err != nil {
 						logger.Printf("Worker %d: Failed to get current value for %s: %s\n", workerId, e, err)
+
 						continue
 					}
 					if err := s.Set(WithNoGitOps(ctx, conc > 1), e, content); err != nil {
 						logger.Printf("Worker %d: Failed to write %s: %s\n", workerId, e, err)
+
 						continue
 					}
 				}
 				wg.Done() // report the job as finished
 			}(i)
 		}
+
 		for _, e := range entries {
 			// check for context cancelation
 			select {
@@ -69,6 +72,7 @@ func (s *Store) reencrypt(ctx context.Context) error {
 				close(jobs)
 				// we wait for all workers to have finished
 				wg.Wait()
+
 				return fmt.Errorf("context canceled")
 			default:
 			}
@@ -95,10 +99,13 @@ func (s *Store) reencrypt(ctx context.Context) error {
 			if err := s.storage.Add(ctx, p); err != nil {
 				if errors.Is(err, store.ErrGitNotInit) {
 					debug.Log("skipping git add - git not initialized")
+
 					continue
 				}
+
 				return fmt.Errorf("failed to add %q to git: %w", p, err)
 			}
+
 			debug.Log("added %s to git", p)
 		}
 	}
@@ -123,15 +130,20 @@ func (s *Store) reencryptGitPush(ctx context.Context) error {
 			msg := "Warning: git is not initialized for this.storage. Ignoring auto-push option\n" +
 				"Run: gopass git init"
 			debug.Log(msg)
+
 			return nil
 		}
+
 		if errors.Is(err, store.ErrGitNoRemote) {
 			msg := "Warning: git has no remote. Ignoring auto-push option\n" +
 				"Run: gopass git remote add origin ..."
 			debug.Log(msg)
+
 			return nil
 		}
+
 		return fmt.Errorf("failed to push change to git remote: %w", err)
 	}
+
 	return nil
 }

--- a/internal/store/leaf/storage.go
+++ b/internal/store/leaf/storage.go
@@ -10,10 +10,13 @@ import (
 
 func (s *Store) initStorageBackend(ctx context.Context) error {
 	ctx = ctxutil.WithAlias(ctx, s.alias)
+
 	store, err := backend.DetectStorage(ctx, s.path)
 	if err != nil {
 		return fmt.Errorf("unknown storage backend: %w", err)
 	}
+
 	s.storage = store
+
 	return nil
 }

--- a/internal/store/leaf/store.go
+++ b/internal/store/leaf/store.go
@@ -22,6 +22,7 @@ type Store struct {
 // Init initializes this sub store.
 func Init(ctx context.Context, alias, path string) (*Store, error) {
 	debug.Log("Initializing %s at %s", alias, path)
+
 	s := &Store{
 		alias: alias,
 		path:  path,
@@ -31,6 +32,7 @@ func Init(ctx context.Context, alias, path string) (*Store, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize storage for %s at %s: %w", alias, path, err)
 	}
+
 	s.storage = st
 	debug.Log("Storage for %s => %s initialized as %s", alias, path, st.Name())
 
@@ -38,15 +40,16 @@ func Init(ctx context.Context, alias, path string) (*Store, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize crypto for %s at %s: %w", alias, path, err)
 	}
+
 	s.crypto = crypto
-	debug.Log("Crypto for %s => %s initialized as %s", alias, path, crypto.Name())
+	debug.Log("Crypto for %q => %q initialized as %s", alias, path, crypto.Name())
 
 	return s, nil
 }
 
 // New creates a new store.
 func New(ctx context.Context, alias, path string) (*Store, error) {
-	debug.Log("Instantiating %s at %s", alias, path)
+	debug.Log("Instantiating %q at %q", alias, path)
 
 	s := &Store{
 		alias: alias,
@@ -57,12 +60,14 @@ func New(ctx context.Context, alias, path string) (*Store, error) {
 	if err := s.initStorageBackend(ctx); err != nil {
 		return nil, fmt.Errorf("failed to init storage backend: %w", err)
 	}
+
 	debug.Log("Storage for %s => %s initialized as %v", alias, path, s.storage)
 
 	// init crypto backend
 	if err := s.initCryptoBackend(ctx); err != nil {
 		return nil, fmt.Errorf("failed to init crypto backend: %w", err)
 	}
+
 	debug.Log("Crypto for %s => %s initialized as %v", alias, path, s.crypto)
 
 	return s, nil
@@ -75,22 +80,29 @@ func (s *Store) idFile(ctx context.Context, name string) string {
 	if s.crypto == nil {
 		return ""
 	}
+
 	fn := name
+
 	var cnt uint8
+
 	for {
 		cnt++
 		if cnt > 100 {
 			break
 		}
+
 		if fn == "" || fn == Sep {
 			break
 		}
+
 		gfn := filepath.Join(fn, s.crypto.IDFile())
 		if s.storage.Exists(ctx, gfn) {
 			return gfn
 		}
+
 		fn = filepath.Dir(fn)
 	}
+
 	return s.crypto.IDFile()
 }
 
@@ -108,10 +120,12 @@ func (s *Store) idFiles(ctx context.Context) []string {
 	// we need to transform the list of files into a list of id files so we can't use
 	// set.SortedFiltered as it doesn't support transformations
 	idfs := make([]string, 0, len(files))
+
 	for _, f := range files {
 		if strings.HasPrefix(filepath.Base(f), ".") {
 			continue
 		}
+
 		idf := s.idFile(ctx, f)
 		if s.storage.Exists(ctx, idf) {
 			idfs = append(idfs, idf)
@@ -119,6 +133,7 @@ func (s *Store) idFiles(ctx context.Context) []string {
 	}
 
 	debug.Log("idFiles: %q", idfs)
+
 	return set.Sorted(idfs)
 }
 
@@ -127,6 +142,7 @@ func (s *Store) Equals(other *Store) bool {
 	if other == nil {
 		return false
 	}
+
 	return s.Path() == other.Path()
 }
 

--- a/internal/store/leaf/templates.go
+++ b/internal/store/leaf/templates.go
@@ -28,17 +28,22 @@ func (s *Store) LookupTemplate(ctx context.Context, name string) (string, []byte
 	for {
 		l1 := len(name)
 		name = filepath.Dir(name)
+
 		if len(name) == l1 {
 			break
 		}
+
 		tpl := filepath.Join(name, TemplateFile)
+
 		if s.storage.Exists(ctx, tpl) {
 			if content, err := s.storage.Get(ctx, tpl); err == nil {
 				debug.Log("Found template %q for %q", tpl, oName)
+
 				return tpl, content, true
 			}
 		}
 	}
+
 	return "", []byte{}, false
 }
 
@@ -47,30 +52,41 @@ func (s *Store) ListTemplates(ctx context.Context, prefix string) []string {
 	lst, err := s.storage.List(ctx, "")
 	if err != nil {
 		debug.Log("failed to list templates: %s", err)
+
 		return nil
 	}
+
 	tpls := make(map[string]struct{}, len(lst))
+
 	for _, path := range lst {
 		if !strings.HasSuffix(path, TemplateFile) {
 			continue
 		}
+
 		path = strings.TrimSuffix(path, Sep+TemplateFile)
+
 		if prefix != "" {
 			path = prefix + Sep + path
 		}
+
 		tpls[path] = struct{}{}
 	}
+
 	out := make([]string, 0, len(tpls))
+
 	for k := range tpls {
 		out = append(out, k)
 	}
+
 	sort.Strings(out)
+
 	return out
 }
 
 // TemplateTree returns a tree of all templates.
 func (s *Store) TemplateTree(ctx context.Context) *tree.Root {
 	root := tree.New("gopass")
+
 	for _, t := range s.ListTemplates(ctx, "") {
 		if err := root.AddFile(t, "gopass/template"); err != nil {
 			out.Errorf(ctx, "Failed to add template: %s", err)
@@ -107,6 +123,7 @@ func (s *Store) SetTemplate(ctx context.Context, name string, content []byte) er
 		if errors.Is(err, store.ErrGitNotInit) {
 			return nil
 		}
+
 		return fmt.Errorf("failed to add %q to git: %w", p, err)
 	}
 
@@ -129,6 +146,7 @@ func (s *Store) RemoveTemplate(ctx context.Context, name string) error {
 		if errors.Is(err, store.ErrGitNotInit) {
 			return nil
 		}
+
 		return fmt.Errorf("failed to add %q to git: %w", p, err)
 	}
 

--- a/internal/store/leaf/templates_test.go
+++ b/internal/store/leaf/templates_test.go
@@ -12,10 +12,13 @@ import (
 )
 
 func TestTemplates(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 
 	tempdir, err := os.MkdirTemp("", "gopass-")
 	require.NoError(t, err)
+
 	defer func() {
 		_ = os.RemoveAll(tempdir)
 	}()

--- a/internal/store/leaf/write.go
+++ b/internal/store/leaf/write.go
@@ -33,6 +33,7 @@ func (s *Store) Set(ctx context.Context, name string, sec gopass.Byter) error {
 	ciphertext, err := s.crypto.Encrypt(ctx, sec.Bytes(), recipients)
 	if err != nil {
 		debug.Log("Failed encrypt secret: %s", err)
+
 		return store.ErrEncrypt
 	}
 
@@ -45,6 +46,7 @@ func (s *Store) Set(ctx context.Context, name string, sec gopass.Byter) error {
 	// at the end of the batch processing.
 	if IsNoGitOps(ctx) {
 		debug.Log("sub.Set(%s) - skipping git ops (disabled)")
+
 		return nil
 	}
 
@@ -52,6 +54,7 @@ func (s *Store) Set(ctx context.Context, name string, sec gopass.Byter) error {
 		if errors.Is(err, store.ErrGitNotInit) {
 			return nil
 		}
+
 		return fmt.Errorf("failed to add %q to git: %w", p, err)
 	}
 
@@ -64,6 +67,7 @@ func (s *Store) Set(ctx context.Context, name string, sec gopass.Byter) error {
 	t := queue.GetQueue(ctx).Add(func(ctx context.Context) error {
 		return s.gitCommitAndPush(ctx, name)
 	})
+
 	return t(ctx)
 }
 
@@ -80,21 +84,28 @@ func (s *Store) gitCommitAndPush(ctx context.Context, name string) error {
 	}
 
 	debug.Log("syncing with remote ...")
+
 	if err := s.storage.Push(ctx, "", ""); err != nil {
 		if errors.Is(err, store.ErrGitNotInit) {
 			msg := "Warning: git is not initialized for this.storage. Ignoring auto-push option\n" +
 				"Run: gopass git init"
 			out.Errorf(ctx, msg)
+
 			return nil
 		}
+
 		if errors.Is(err, store.ErrGitNoRemote) {
 			msg := "Warning: git has no remote. Ignoring auto-push option\n" +
 				"Run: gopass git remote add origin ..."
 			debug.Log(msg)
+
 			return nil
 		}
+
 		return fmt.Errorf("failed to push to git remote: %w", err)
 	}
+
 	debug.Log("synced with remote")
+
 	return nil
 }

--- a/internal/store/leaf/write_test.go
+++ b/internal/store/leaf/write_test.go
@@ -12,10 +12,13 @@ import (
 )
 
 func TestSet(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 
 	tempdir, err := os.MkdirTemp("", "gopass-")
 	require.NoError(t, err)
+
 	defer func() {
 		_ = os.RemoveAll(tempdir)
 	}()
@@ -27,10 +30,12 @@ func TestSet(t *testing.T) {
 	sec.SetPassword("foo")
 	sec.WriteString("bar")
 	require.NoError(t, s.Set(ctx, "zab/zab", sec))
+
 	if runtime.GOOS != "windows" {
 		assert.Error(t, s.Set(ctx, "../../../../../etc/passwd", sec))
 	} else {
 		assert.NoError(t, s.Set(ctx, "../../../../../etc/passwd", sec))
 	}
+
 	assert.NoError(t, s.Set(ctx, "zab", sec))
 }

--- a/internal/store/mockstore/inmem/store.go
+++ b/internal/store/mockstore/inmem/store.go
@@ -52,6 +52,7 @@ func (m *InMem) Set(ctx context.Context, name string, value []byte) error {
 	defer m.Unlock()
 
 	m.data[name] = value
+
 	return nil
 }
 
@@ -61,6 +62,7 @@ func (m *InMem) Delete(ctx context.Context, name string) error {
 	defer m.Unlock()
 
 	delete(m.data, name)
+
 	return nil
 }
 
@@ -70,6 +72,7 @@ func (m *InMem) Exists(ctx context.Context, name string) bool {
 	defer m.Unlock()
 
 	_, found := m.data[name]
+
 	return found
 }
 
@@ -80,6 +83,7 @@ func (m *InMem) List(ctx context.Context, prefix string) ([]string, error) {
 
 	keys := maps.Keys(m.data)
 	sort.Strings(keys)
+
 	return keys, nil
 }
 
@@ -93,6 +97,7 @@ func (m *InMem) IsDir(ctx context.Context, name string) bool {
 			return true
 		}
 	}
+
 	return false
 }
 
@@ -102,15 +107,18 @@ func (m *InMem) Prune(ctx context.Context, prefix string) error {
 	defer m.Unlock()
 
 	deleted := 0
+
 	for k := range m.data {
 		if strings.HasPrefix(k, prefix+"/") {
 			delete(m.data, k)
 			deleted++
 		}
 	}
+
 	if deleted < 1 {
 		return fmt.Errorf("not found")
 	}
+
 	return nil
 }
 

--- a/internal/store/mockstore/store.go
+++ b/internal/store/mockstore/store.go
@@ -63,7 +63,7 @@ func (m *MockStore) SetTemplate(context.Context, string, []byte) error {
 
 // TemplateTree does nothing.
 func (m *MockStore) TemplateTree(context.Context) (*tree.Root, error) {
-	return nil, nil
+	return nil, fmt.Errorf("not supported")
 }
 
 // AddRecipient does nothing.
@@ -73,7 +73,7 @@ func (m *MockStore) AddRecipient(context.Context, string) error {
 
 // GetRecipients does nothing.
 func (m *MockStore) GetRecipients(context.Context, string) ([]string, error) {
-	return nil, nil
+	return nil, fmt.Errorf("not supported")
 }
 
 // RemoveRecipient does nothing.
@@ -142,6 +142,7 @@ func (m *MockStore) Copy(ctx context.Context, from string, to string) error {
 	if err != nil {
 		return err
 	}
+
 	return m.storage.Set(ctx, to, content)
 }
 
@@ -166,6 +167,7 @@ func (m *MockStore) Get(ctx context.Context, name string) (gopass.Secret, error)
 	if err != nil {
 		return nil, err
 	}
+
 	return secparse.Parse(content)
 }
 
@@ -202,7 +204,8 @@ func (m *MockStore) ListRevisions(context.Context, string) ([]backend.Revision, 
 // Move does nothing.
 func (m *MockStore) Move(ctx context.Context, from string, to string) error {
 	content, _ := m.storage.Get(ctx, from)
-	m.storage.Set(ctx, to, content)
+	_ = m.storage.Set(ctx, to, content)
+
 	return m.storage.Delete(ctx, from)
 }
 

--- a/internal/store/root/convert.go
+++ b/internal/store/root/convert.go
@@ -16,9 +16,11 @@ func (r *Store) Convert(ctx context.Context, name string, cryptoBe backend.Crypt
 	}
 
 	debug.Log("converting %s to crypto: %s, rcs: %s, storage: %s", name, cryptoBe, storageBe)
+
 	if err := sub.Convert(ctx, cryptoBe, storageBe, move); err != nil {
 		return err
 	}
+
 	if name == "" {
 		debug.Log("success. updating root path to %s", sub.Path())
 		r.cfg.Path = sub.Path()

--- a/internal/store/root/crypto.go
+++ b/internal/store/root/crypto.go
@@ -12,7 +12,9 @@ func (r *Store) Crypto(ctx context.Context, name string) backend.Crypto {
 	sub, _ := r.getStore(name)
 	if !sub.Valid() {
 		debug.Log("Sub-Store not found for %s. Returning nil crypto backend", name)
+
 		return nil
 	}
+
 	return sub.Crypto()
 }

--- a/internal/store/root/crypto_test.go
+++ b/internal/store/root/crypto_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestCrypto(t *testing.T) {
+	t.Parallel()
+
 	u := gptest.NewUnitTester(t)
 	defer u.Remove()
 

--- a/internal/store/root/fsck.go
+++ b/internal/store/root/fsck.go
@@ -17,13 +17,16 @@ func (s *Store) Fsck(ctx context.Context, path string) error {
 		if sub == nil {
 			continue
 		}
+
 		if path != "" && !strings.HasPrefix(path, alias+"/") {
 			continue
 		}
+
 		path = strings.TrimPrefix(path, alias+"/")
 
 		// check sub store
 		debug.Log("Checking %s", alias)
+
 		if err := sub.Fsck(ctx, path); err != nil {
 			out.Errorf(ctx, "fsck failed on sub store %s: %s", alias, err)
 			result = multierror.Append(result, err)

--- a/internal/store/root/fsck_test.go
+++ b/internal/store/root/fsck_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestFsck(t *testing.T) {
+	t.Parallel()
+
 	u := gptest.NewUnitTester(t)
 	defer u.Remove()
 

--- a/internal/store/root/init.go
+++ b/internal/store/root/init.go
@@ -15,21 +15,25 @@ import (
 func (r *Store) IsInitialized(ctx context.Context) (bool, error) {
 	if r.store == nil {
 		debug.Log("initializing store and possible sub-stores")
+
 		if err := r.initialize(ctx); err != nil {
 			return false, fmt.Errorf("failed to initialize stores: %w", err)
 		}
 	}
 
 	debug.Log("root store is initialized")
+
 	return r.store.IsInitialized(ctx), nil
 }
 
 // Init tries to initialize a new password store location matching the object.
 func (r *Store) Init(ctx context.Context, alias, path string, ids ...string) error {
 	debug.Log("Instantiating new sub store %s at %s for %+v", alias, path, ids)
+
 	if !backend.HasCryptoBackend(ctx) {
 		ctx = backend.WithCryptoBackend(ctx, backend.GPGCLI)
 	}
+
 	if !backend.HasStorageBackend(ctx) {
 		ctx = backend.WithStorageBackend(ctx, backend.GitFS)
 	}
@@ -38,11 +42,13 @@ func (r *Store) Init(ctx context.Context, alias, path string, ids ...string) err
 	if err != nil {
 		return fmt.Errorf("failed to instantiate new sub store: %w", err)
 	}
+
 	if !r.store.IsInitialized(ctx) && alias == "" {
 		r.store = sub
 	}
 
 	debug.Log("Initializing sub store at %s for %+v", path, ids)
+
 	if err := sub.Init(ctx, path, ids...); err != nil {
 		return fmt.Errorf("failed to initialize new sub store: %w", err)
 	}
@@ -67,11 +73,14 @@ func (r *Store) initialize(ctx context.Context) error {
 	// create the base store
 	path := fsutil.CleanPath(r.cfg.Path)
 	debug.Log("initialize - %s", path)
+
 	s, err := leaf.New(ctx, "", path)
 	if err != nil {
 		return fmt.Errorf("failed to initialize the root store at %q: %w", r.cfg.Path, err)
 	}
+
 	debug.Log("Root Store initialized at %s", path)
+
 	r.store = s
 
 	// initialize all mounts
@@ -79,8 +88,10 @@ func (r *Store) initialize(ctx context.Context) error {
 		path := fsutil.CleanPath(path)
 		if err := r.addMount(ctx, alias, path); err != nil {
 			out.Errorf(ctx, "Failed to initialize mount %s (%s). Ignoring: %s", alias, path, err)
+
 			continue
 		}
+
 		debug.Log("Sub-Store mounted at %s from %s", alias, path)
 	}
 

--- a/internal/store/root/init_test.go
+++ b/internal/store/root/init_test.go
@@ -13,6 +13,8 @@ import (
 )
 
 func TestInit(t *testing.T) {
+	t.Parallel()
+
 	u := gptest.NewUnitTester(t)
 	defer u.Remove()
 

--- a/internal/store/root/list.go
+++ b/internal/store/root/list.go
@@ -17,6 +17,7 @@ func (r *Store) List(ctx context.Context, maxDepth int) ([]string, error) {
 	if err != nil {
 		return []string{}, err
 	}
+
 	return t.List(maxDepth), nil
 }
 
@@ -26,6 +27,7 @@ func (r *Store) Tree(ctx context.Context) (*tree.Root, error) {
 	addFileFunc := func(in ...string) {
 		for _, f := range in {
 			var ct string
+
 			switch {
 			case strings.HasSuffix(f, ".b64"):
 				ct = "application/octet-stream"
@@ -36,8 +38,10 @@ func (r *Store) Tree(ctx context.Context) (*tree.Root, error) {
 			default:
 				ct = "text/plain"
 			}
+
 			if err := root.AddFile(f, ct); err != nil {
 				out.Errorf(ctx, "Failed to add file %s to tree: %s", f, err)
+
 				continue
 			}
 		}
@@ -46,6 +50,7 @@ func (r *Store) Tree(ctx context.Context) (*tree.Root, error) {
 		for _, f := range in {
 			if err := root.AddTemplate(f); err != nil {
 				out.Errorf(ctx, "Failed to add template %s to tree: %s", f, err)
+
 				continue
 			}
 		}
@@ -55,23 +60,28 @@ func (r *Store) Tree(ctx context.Context) (*tree.Root, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	addFileFunc(sf...)
 	addTplFunc(r.store.ListTemplates(ctx, "")...)
 
 	mps := r.MountPoints()
 	sort.Sort(store.ByPathLen(mps))
+
 	for _, alias := range mps {
 		substore := r.mounts[alias]
 		if substore == nil {
 			continue
 		}
+
 		if err := root.AddMount(alias, substore.Path()); err != nil {
 			return nil, fmt.Errorf("failed to add mount: %w", err)
 		}
+
 		sf, err := substore.List(ctx, "")
 		if err != nil {
 			return nil, fmt.Errorf("failed to add file: %w", err)
 		}
+
 		addFileFunc(sf...)
 		addTplFunc(substore.ListTemplates(ctx, alias)...)
 	}
@@ -82,15 +92,18 @@ func (r *Store) Tree(ctx context.Context) (*tree.Root, error) {
 // HasSubDirs returns true if the named entity has subdirectories.
 func (r *Store) HasSubDirs(ctx context.Context, name string) (bool, error) {
 	sub, prefix := r.getStore(name)
+
 	entries, err := sub.List(ctx, prefix)
 	if err != nil {
 		return false, err
 	}
+
 	for _, e := range entries {
 		if sub.IsDir(ctx, e) {
 			return true, nil
 		}
 	}
+
 	return false, nil
 }
 
@@ -100,5 +113,6 @@ func (r *Store) Format(ctx context.Context, maxDepth int) (string, error) {
 	if err != nil {
 		return "", err
 	}
+
 	return t.Format(maxDepth), nil
 }

--- a/internal/store/root/list_test.go
+++ b/internal/store/root/list_test.go
@@ -13,6 +13,8 @@ import (
 )
 
 func TestList(t *testing.T) {
+	t.Parallel()
+
 	u := gptest.NewUnitTester(t)
 	defer u.Remove()
 

--- a/internal/store/root/mount.go
+++ b/internal/store/root/mount.go
@@ -27,9 +27,11 @@ func (r *Store) addMount(ctx context.Context, alias, path string, keys ...string
 	if alias == "" {
 		return fmt.Errorf("alias must not be empty")
 	}
+
 	if r.mounts == nil {
 		r.mounts = make(map[string]*leaf.Store, 1)
 	}
+
 	if _, found := r.mounts[alias]; found {
 		return AlreadyMountedError(alias)
 	}
@@ -47,9 +49,11 @@ func (r *Store) addMount(ctx context.Context, alias, path string, keys ...string
 	if r.cfg.Mounts == nil {
 		r.cfg.Mounts = make(map[string]string, 1)
 	}
+
 	r.cfg.Mounts[alias] = path
 
 	debug.Log("Added mount %s -> %s (%s)", alias, path, fullPath)
+
 	return nil
 }
 
@@ -65,17 +69,21 @@ func (r *Store) initSub(ctx context.Context, alias, path string, keys []string) 
 	}
 
 	debug.Log("[%s] Mount %s is not initialized", alias, path)
+
 	if len(keys) < 1 {
 		debug.Log("[%s] No keys available", alias)
+
 		return s, NotInitializedError{alias, path}
 	}
 
 	debug.Log("[%s] Trying to initialize at %s for %+v", alias, path, keys)
+
 	if err := s.Init(ctx, path, keys...); err != nil {
 		return s, fmt.Errorf("failed to initialize store %q at %q: %w", alias, path, err)
 	}
 
 	out.Printf(ctx, "Password store %s initialized for:", path)
+
 	for _, r := range s.Recipients(ctx) {
 		out.Noticef(ctx, "  %s", r)
 	}
@@ -88,11 +96,14 @@ func (r *Store) RemoveMount(ctx context.Context, alias string) error {
 	if _, found := r.mounts[alias]; !found {
 		out.Warningf(ctx, "%s is not mounted", alias)
 	}
+
 	if _, found := r.mounts[alias]; !found {
 		out.Warningf(ctx, "%s is not initialized", alias)
 	}
+
 	delete(r.mounts, alias)
 	delete(r.cfg.Mounts, alias)
+
 	return nil
 }
 
@@ -102,6 +113,7 @@ func (r *Store) Mounts() map[string]string {
 	for alias, sub := range r.mounts {
 		m[alias] = sub.Path()
 	}
+
 	return m
 }
 
@@ -113,7 +125,9 @@ func (r *Store) MountPoints() []string {
 	for k := range r.mounts {
 		mps = append(mps, k)
 	}
+
 	sort.Sort(sort.Reverse(store.ByPathLen(mps)))
+
 	return mps
 }
 
@@ -124,6 +138,7 @@ func (r *Store) MountPoint(name string) string {
 			return mp
 		}
 	}
+
 	return ""
 }
 
@@ -135,6 +150,7 @@ func (r *Store) Lock() error {
 			return err
 		}
 	}
+
 	return r.store.Lock()
 }
 
@@ -143,9 +159,11 @@ func (r *Store) Lock() error {
 func (r *Store) getStore(name string) (*leaf.Store, string) {
 	name = strings.TrimSuffix(name, "/")
 	mp := r.MountPoint(name)
+
 	if sub, found := r.mounts[mp]; found {
 		return sub, strings.TrimPrefix(name, sub.Alias())
 	}
+
 	return r.store, name
 }
 
@@ -155,11 +173,13 @@ func (r *Store) GetSubStore(name string) (*leaf.Store, error) {
 	if name == "" {
 		return r.store, nil
 	}
+
 	if sub, found := r.mounts[name]; found {
 		return sub, nil
 	}
 
 	debug.Log("mounts available: %+v", r.mounts)
+
 	return nil, fmt.Errorf("no such mount point %q", name)
 }
 
@@ -171,7 +191,9 @@ func (r *Store) checkMounts() error {
 		if _, found := paths[v.Path()]; found {
 			return fmt.Errorf("doubly mounted path at %s: %s", v.Path(), k)
 		}
+
 		paths[v.Path()] = k
 	}
+
 	return nil
 }

--- a/internal/store/root/mount_test.go
+++ b/internal/store/root/mount_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestMount(t *testing.T) {
+	t.Parallel()
+
 	u := gptest.NewUnitTester(t)
 	defer u.Remove()
 

--- a/internal/store/root/move_test.go
+++ b/internal/store/root/move_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestMoveShadow(t *testing.T) {
+	t.Parallel()
+
 	u := gptest.NewUnitTester(t)
 	u.Entries = []string{
 		"old/www/foo",
@@ -19,6 +21,7 @@ func TestMoveShadow(t *testing.T) {
 	}
 
 	require.NoError(t, u.InitStore(""))
+
 	defer u.Remove()
 
 	ctx := context.Background()
@@ -49,6 +52,8 @@ func TestMoveShadow(t *testing.T) {
 }
 
 func TestMove(t *testing.T) {
+	t.Parallel()
+
 	u := gptest.NewUnitTester(t)
 	u.Entries = []string{
 		"foo/bar",
@@ -56,6 +61,7 @@ func TestMove(t *testing.T) {
 		"misc/zab",
 	}
 	require.NoError(t, u.InitStore(""))
+
 	defer u.Remove()
 
 	ctx := context.Background()
@@ -145,6 +151,8 @@ func TestMove(t *testing.T) {
 }
 
 func TestUnixMvSemantics(t *testing.T) {
+	t.Parallel()
+
 	u := gptest.NewUnitTester(t)
 	u.Entries = []string{
 		"a/f1",
@@ -152,6 +160,7 @@ func TestUnixMvSemantics(t *testing.T) {
 		"b/f3",
 	}
 	require.NoError(t, u.InitStore(""))
+
 	defer u.Remove()
 
 	ctx := context.Background()
@@ -183,6 +192,8 @@ func TestUnixMvSemantics(t *testing.T) {
 }
 
 func TestRegression2079(t *testing.T) {
+	t.Parallel()
+
 	u := gptest.NewUnitTester(t)
 	u.Entries = []string{
 		"comm/test",
@@ -190,6 +201,7 @@ func TestRegression2079(t *testing.T) {
 		"communication/t1",
 	}
 	require.NoError(t, u.InitStore(""))
+
 	defer u.Remove()
 
 	ctx := context.Background()
@@ -221,6 +233,8 @@ func TestRegression2079(t *testing.T) {
 }
 
 func TestCopy(t *testing.T) {
+	t.Parallel()
+
 	u := gptest.NewUnitTester(t)
 	u.Entries = []string{
 		"foo/bar",
@@ -228,6 +242,7 @@ func TestCopy(t *testing.T) {
 		"misc/zab",
 	}
 	require.NoError(t, u.InitStore(""))
+
 	defer u.Remove()
 
 	ctx := context.Background()
@@ -239,7 +254,7 @@ func TestCopy(t *testing.T) {
 	assert.NoError(t, rs.Delete(ctx, "foo"))
 
 	// Initial state:
-	t.Run("initial state", func(t *testing.T) {
+	t.Run("initial state", func(t *testing.T) { //nolint:paralleltest
 		entries, err := rs.List(ctx, tree.INF)
 		require.NoError(t, err)
 		assert.Equal(t, []string{
@@ -255,7 +270,7 @@ func TestCopy(t *testing.T) {
 	assert.Error(t, rs.Copy(ctx, "foo", "misc/zab"))
 
 	// -> copy foo/ misc => OK
-	t.Run("copy foo misc", func(t *testing.T) {
+	t.Run("copy foo misc", func(t *testing.T) { //nolint:paralleltest
 		assert.NoError(t, rs.Copy(ctx, "foo", "misc"))
 		entries, err := rs.List(ctx, tree.INF)
 		require.NoError(t, err)
@@ -269,7 +284,7 @@ func TestCopy(t *testing.T) {
 	})
 
 	// -> copy misc/foo/ bar/ => OK
-	t.Run("copy misc/foo/ bar/", func(t *testing.T) {
+	t.Run("copy misc/foo/ bar/", func(t *testing.T) { //nolint:paralleltest
 		assert.NoError(t, rs.Copy(ctx, "misc/foo/", "bar/"))
 		entries, err := rs.List(ctx, tree.INF)
 		require.NoError(t, err)
@@ -285,7 +300,7 @@ func TestCopy(t *testing.T) {
 	})
 
 	// -> copy misc/zab bar/foo/zab => OK
-	t.Run("copy misc/zab bar/foo/zab", func(t *testing.T) {
+	t.Run("copy misc/zab bar/foo/zab", func(t *testing.T) { //nolint:paralleltest
 		assert.NoError(t, rs.Copy(ctx, "misc/zab", "bar/foo/zab"))
 		entries, err := rs.List(ctx, tree.INF)
 		require.NoError(t, err)
@@ -303,6 +318,8 @@ func TestCopy(t *testing.T) {
 }
 
 func TestComputeMoveDestination(t *testing.T) {
+	t.Parallel()
+
 	for _, tc := range []struct {
 		name     string
 		src      string
@@ -365,8 +382,10 @@ func TestComputeMoveDestination(t *testing.T) {
 		},
 	} {
 		tc := tc
+
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
+
 			dst := computeMoveDestination(tc.src, tc.from, tc.to, tc.srcIsDir, tc.dstIsDir)
 			assert.Equal(t, tc.dst, dst, tc.name)
 		})

--- a/internal/store/root/rcs.go
+++ b/internal/store/root/rcs.go
@@ -14,42 +14,49 @@ func (r *Store) RCSInit(ctx context.Context, name, userName, userEmail string) e
 	store, _ := r.getStore(name)
 	ctx = ctxutil.WithUsername(ctx, userName)
 	ctx = ctxutil.WithEmail(ctx, userEmail)
+
 	return store.GitInit(ctx)
 }
 
 // RCSInitConfig initializes the git repos local config.
 func (r *Store) RCSInitConfig(ctx context.Context, name, userName, userEmail string) error {
 	store, _ := r.getStore(name)
+
 	return store.Storage().InitConfig(ctx, userName, userEmail)
 }
 
 // RCSAddRemote adds a git remote.
 func (r *Store) RCSAddRemote(ctx context.Context, name, remote, url string) error {
 	store, _ := r.getStore(name)
+
 	return store.Storage().AddRemote(ctx, remote, url)
 }
 
 // RCSRemoveRemote removes a git remote.
 func (r *Store) RCSRemoveRemote(ctx context.Context, name, remote string) error {
 	store, _ := r.getStore(name)
+
 	return store.Storage().RemoveRemote(ctx, remote)
 }
 
 // RCSPull performs a git pull.
 func (r *Store) RCSPull(ctx context.Context, name, origin, remote string) error {
 	store, _ := r.getStore(name)
+
 	return store.Storage().Pull(ctx, origin, remote)
 }
 
 // RCSPush performs a git push.
 func (r *Store) RCSPush(ctx context.Context, name, origin, remote string) error {
 	store, _ := r.getStore(name)
+
 	return store.Storage().Push(ctx, origin, remote)
 }
 
 // ListRevisions will list all revisions for the named entity.
 func (r *Store) ListRevisions(ctx context.Context, name string) ([]backend.Revision, error) {
 	store, name := r.getStore(name)
+
 	return store.ListRevisions(ctx, name)
 }
 
@@ -57,6 +64,7 @@ func (r *Store) ListRevisions(ctx context.Context, name string) ([]backend.Revis
 func (r *Store) GetRevision(ctx context.Context, name, revision string) (context.Context, gopass.Secret, error) {
 	store, name := r.getStore(name)
 	sec, err := store.GetRevision(ctx, name, revision)
+
 	return ctx, sec, err
 }
 
@@ -65,5 +73,6 @@ func (r *Store) GetRevision(ctx context.Context, name, revision string) (context
 func (r *Store) RCSStatus(ctx context.Context, name string) error {
 	store, name := r.getStore(name)
 	out.Printf(ctx, "Store: %s", store.Path())
+
 	return store.GitStatus(ctx, name)
 }

--- a/internal/store/root/rcs_test.go
+++ b/internal/store/root/rcs_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestRCS(t *testing.T) {
+	t.Parallel()
+
 	u := gptest.NewUnitTester(t)
 	defer u.Remove()
 

--- a/internal/store/root/read.go
+++ b/internal/store/root/read.go
@@ -9,5 +9,6 @@ import (
 // Get returns the plaintext of a single key.
 func (r *Store) Get(ctx context.Context, name string) (gopass.Secret, error) {
 	store, name := r.getStore(name)
+
 	return store.Get(ctx, name)
 }

--- a/internal/store/root/read_test.go
+++ b/internal/store/root/read_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestGet(t *testing.T) {
+	t.Parallel()
+
 	u := gptest.NewUnitTester(t)
 	defer u.Remove()
 

--- a/internal/store/root/recipients.go
+++ b/internal/store/root/recipients.go
@@ -16,27 +16,32 @@ import (
 // ListRecipients lists all recipients for the given store.
 func (r *Store) ListRecipients(ctx context.Context, store string) []string {
 	sub, _ := r.getStore(store)
+
 	return sub.Recipients(ctx)
 }
 
 // AddRecipient adds a single recipient to the given store.
 func (r *Store) AddRecipient(ctx context.Context, store, rec string) error {
 	sub, _ := r.getStore(store)
+
 	return sub.AddRecipient(ctx, rec)
 }
 
 // RemoveRecipient removes a single recipient from the given store.
 func (r *Store) RemoveRecipient(ctx context.Context, store, rec string) error {
 	sub, _ := r.getStore(store)
+
 	return sub.RemoveRecipient(ctx, rec)
 }
 
 func (r *Store) addRecipient(ctx context.Context, prefix string, root *tree.Root, recp string, pretty bool) error {
 	sub, _ := r.getStore(prefix)
 	key := fmt.Sprintf("%s (missing public key)", recp)
+
 	if v := sub.Crypto().FormatKey(ctx, recp, ""); v != "" {
 		key = v
 	}
+
 	kl, err := sub.Crypto().FindRecipients(ctx, recp)
 	if err == nil {
 		if len(kl) > 0 {
@@ -87,6 +92,7 @@ func (r *Store) RecipientsTree(ctx context.Context, pretty bool) (*tree.Root, er
 		if name != "" {
 			name += "/"
 		}
+
 		for _, recp := range recps {
 			if err := r.addRecipient(ctx, name, root, recp, pretty); err != nil {
 				color.Yellow("Failed to add recipient to tree %s: %s", recp, err)
@@ -96,6 +102,7 @@ func (r *Store) RecipientsTree(ctx context.Context, pretty bool) (*tree.Root, er
 
 	mps := r.MountPoints()
 	sort.Sort(store.ByPathLen(mps))
+
 	for _, alias := range mps {
 		substore := r.mounts[alias]
 
@@ -103,13 +110,16 @@ func (r *Store) RecipientsTree(ctx context.Context, pretty bool) (*tree.Root, er
 		if substore == nil {
 			continue
 		}
+
 		if err := root.AddMount(alias, substore.Path()); err != nil {
 			return nil, fmt.Errorf("failed to add mount: %w", err)
 		}
+
 		for name, recps := range substore.RecipientsTree(ctx) {
 			if name != "" {
 				name += "/"
 			}
+
 			for _, recp := range recps {
 				if err := r.addRecipient(ctx, alias+"/"+name, root, recp, pretty); err != nil {
 					debug.Log("Failed to add recipient to tree %s: %s", recp, err)

--- a/internal/store/root/recipients_test.go
+++ b/internal/store/root/recipients_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestRecipients(t *testing.T) {
+	t.Parallel()
+
 	u := gptest.NewUnitTester(t)
 	defer u.Remove()
 

--- a/internal/store/root/store.go
+++ b/internal/store/root/store.go
@@ -26,12 +26,14 @@ func New(cfg *config.Config) *Store {
 	if cfg == nil {
 		cfg = &config.Config{}
 	}
+
 	r := &Store{
 		cfg:    cfg,
 		mounts: make(map[string]*leaf.Store, len(cfg.Mounts)),
 	}
 
 	debug.Log("created store %s", r)
+
 	return r
 }
 
@@ -43,12 +45,14 @@ func (r *Store) WithContext(ctx context.Context) context.Context {
 // Exists checks the existence of a single entry.
 func (r *Store) Exists(ctx context.Context, name string) bool {
 	store, name := r.getStore(name)
+
 	return store.Exists(ctx, name)
 }
 
 // IsDir checks if a given key is actually a folder.
 func (r *Store) IsDir(ctx context.Context, name string) bool {
 	store, name := r.getStore(name)
+
 	return store.IsDir(ctx, name)
 }
 
@@ -57,10 +61,12 @@ func (r *Store) String() string {
 	for alias, sub := range r.mounts {
 		ms = append(ms, alias+"="+sub.String())
 	}
+
 	path := ""
 	if r.store != nil {
 		path = r.store.Path()
 	}
+
 	return fmt.Sprintf("Store(Path: %s, Mounts: %+v)", path, strings.Join(ms, ","))
 }
 
@@ -69,6 +75,7 @@ func (r *Store) Path() string {
 	if r.store == nil {
 		return ""
 	}
+
 	return r.store.Path()
 }
 
@@ -83,6 +90,7 @@ func (r *Store) Storage(ctx context.Context, name string) backend.Storage {
 	if sub == nil || !sub.Valid() {
 		return nil
 	}
+
 	return sub.Storage()
 }
 
@@ -95,8 +103,10 @@ func (r *Store) Concurrency() int {
 			min = sub.Concurrency()
 		}
 	}
+
 	if nc := runtime.NumCPU(); nc < min {
 		min = nc
 	}
+
 	return min
 }

--- a/internal/store/root/store_test.go
+++ b/internal/store/root/store_test.go
@@ -17,6 +17,8 @@ import (
 )
 
 func TestSimpleList(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 
 	u := gptest.NewUnitTester(t)
@@ -31,6 +33,8 @@ func TestSimpleList(t *testing.T) {
 }
 
 func TestListMulti(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	ctx = backend.WithCryptoBackend(ctx, backend.Plain)
 
@@ -46,12 +50,14 @@ func TestListMulti(t *testing.T) {
 
 	// sub1 store
 	assert.NoError(t, u.InitStore("sub1"))
+
 	for _, k := range u.Entries {
 		ents = append(ents, path.Join("sub1", k))
 	}
 
 	// sub2 store
 	assert.NoError(t, u.InitStore("sub2"))
+
 	for _, k := range u.Entries {
 		ents = append(ents, path.Join("sub2", k))
 	}
@@ -63,7 +69,9 @@ func TestListMulti(t *testing.T) {
 	require.NoError(t, err)
 
 	sort.Strings(ents)
+
 	lst := st.List(tree.INF)
+
 	sort.Strings(lst)
 	assert.Equal(t, ents, lst)
 
@@ -71,6 +79,8 @@ func TestListMulti(t *testing.T) {
 }
 
 func TestListNested(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	ctx = backend.WithCryptoBackend(ctx, backend.Plain)
 
@@ -86,18 +96,21 @@ func TestListNested(t *testing.T) {
 
 	// sub1 store
 	assert.NoError(t, u.InitStore("sub1"))
+
 	for _, k := range u.Entries {
 		ents = append(ents, path.Join("sub1", k))
 	}
 
 	// sub2 store
 	assert.NoError(t, u.InitStore("sub2"))
+
 	for _, k := range u.Entries {
 		ents = append(ents, path.Join("sub2", k))
 	}
 
 	// sub3 store
 	assert.NoError(t, u.InitStore("sub3"))
+
 	for _, k := range u.Entries {
 		ents = append(ents, path.Join("sub2", "sub3", k))
 	}
@@ -110,7 +123,9 @@ func TestListNested(t *testing.T) {
 	assert.NoError(t, err)
 
 	sort.Strings(ents)
+
 	lst := st.List(tree.INF)
+
 	sort.Strings(lst)
 	assert.Equal(t, ents, lst)
 
@@ -127,8 +142,10 @@ func createRootStore(ctx context.Context, u *gptest.Unit) (*Store, error) {
 			Path: u.StoreDir(""),
 		},
 	)
+
 	if _, err := s.IsInitialized(ctx); err != nil {
 		return nil, err
 	}
+
 	return s, nil
 }

--- a/internal/store/root/templates.go
+++ b/internal/store/root/templates.go
@@ -18,6 +18,7 @@ func (r *Store) LookupTemplate(ctx context.Context, name string) (string, []byte
 	store, name := r.getStore(name)
 	tName, content, found := store.LookupTemplate(ctx, name)
 	tName = filepath.Join(r.MountPoint(oName), tName)
+
 	return tName, content, found
 }
 
@@ -27,6 +28,7 @@ func (r *Store) TemplateTree(ctx context.Context) (*tree.Root, error) {
 
 	for _, t := range r.store.ListTemplates(ctx, "") {
 		debug.Log("[<root>] Adding template %s", t)
+
 		if err := root.AddFile(t, "gopass/template"); err != nil {
 			out.Errorf(ctx, "Failed to add file to tree: %s", err)
 		}
@@ -34,16 +36,20 @@ func (r *Store) TemplateTree(ctx context.Context) (*tree.Root, error) {
 
 	mps := r.MountPoints()
 	sort.Sort(store.ByPathLen(mps))
+
 	for _, alias := range mps {
 		substore := r.mounts[alias]
 		if substore == nil {
 			continue
 		}
+
 		if err := root.AddMount(alias, substore.Path()); err != nil {
 			return nil, fmt.Errorf("failed to add mount: %w", err)
 		}
+
 		for _, t := range substore.ListTemplates(ctx, alias) {
 			debug.Log("[%s] Adding template %s", alias, t)
+
 			if err := root.AddFile(t, "gopass/template"); err != nil {
 				out.Errorf(ctx, "Failed to add file to tree: %s", err)
 			}
@@ -56,23 +62,27 @@ func (r *Store) TemplateTree(ctx context.Context) (*tree.Root, error) {
 // HasTemplate returns true if the template exists.
 func (r *Store) HasTemplate(ctx context.Context, name string) bool {
 	store, name := r.getStore(name)
+
 	return store.HasTemplate(ctx, name)
 }
 
 // GetTemplate will return the content of the named template.
 func (r *Store) GetTemplate(ctx context.Context, name string) ([]byte, error) {
 	store, name := r.getStore(name)
+
 	return store.GetTemplate(ctx, name)
 }
 
 // SetTemplate will (over)write the content to the template file.
 func (r *Store) SetTemplate(ctx context.Context, name string, content []byte) error {
 	store, name := r.getStore(name)
+
 	return store.SetTemplate(ctx, name, content)
 }
 
 // RemoveTemplate will delete the named template if it exists.
 func (r *Store) RemoveTemplate(ctx context.Context, name string) error {
 	store, name := r.getStore(name)
+
 	return store.RemoveTemplate(ctx, name)
 }

--- a/internal/store/root/templates_test.go
+++ b/internal/store/root/templates_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestTemplate(t *testing.T) {
+	t.Parallel()
+
 	u := gptest.NewUnitTester(t)
 	defer u.Remove()
 

--- a/internal/store/root/write.go
+++ b/internal/store/root/write.go
@@ -9,5 +9,6 @@ import (
 // Set encodes and write the ciphertext of one entry to disk.
 func (r *Store) Set(ctx context.Context, name string, sec gopass.Byter) error {
 	store, name := r.getStore(name)
+
 	return store.Set(ctx, name, sec)
 }

--- a/internal/store/root/write_test.go
+++ b/internal/store/root/write_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestSet(t *testing.T) {
+	t.Parallel()
+
 	u := gptest.NewUnitTester(t)
 	defer u.Remove()
 

--- a/internal/store/sort_test.go
+++ b/internal/store/sort_test.go
@@ -6,18 +6,23 @@ import (
 )
 
 func TestMountPointSort(t *testing.T) {
+	t.Parallel()
+
 	mps := []string{
 		"sub2",
 		"sub1isveryverylong",
 		"sub2/sub3",
 	}
+
 	sort.Sort(ByPathLen(mps))
+
 	for i, v := range []string{
 		"sub2",
 		"sub1isveryverylong",
 		"sub2/sub3",
 	} {
 		t.Logf("[%d] %s - Want: %s", i, mps[i], v)
+
 		if mps[i] != v {
 			t.Errorf("Mismatch at %d: %s vs. %s", i, v, mps[i])
 		}
@@ -25,18 +30,23 @@ func TestMountPointSort(t *testing.T) {
 }
 
 func TestMountPointReverseSort(t *testing.T) {
+	t.Parallel()
+
 	mps := []string{
 		"sub2",
 		"sub1isveryverylong",
 		"sub2/sub3",
 	}
+
 	sort.Sort(sort.Reverse(ByPathLen(mps)))
+
 	for i, v := range []string{
 		"sub2/sub3",
 		"sub2",
 		"sub1isveryverylong",
 	} {
 		t.Logf("[%d] %s - Want: %s", i, mps[i], v)
+
 		if mps[i] != v {
 			t.Errorf("Mismatch at %d: %s vs. %s", i, v, mps[i])
 		}
@@ -44,6 +54,8 @@ func TestMountPointReverseSort(t *testing.T) {
 }
 
 func TestSortByLen(t *testing.T) {
+	t.Parallel()
+
 	in := []string{
 		"a",
 		"bb",
@@ -56,7 +68,9 @@ func TestSortByLen(t *testing.T) {
 		"bb",
 		"a",
 	}
+
 	sort.Sort(ByLen(in))
+
 	for i, s := range in {
 		if out[i] != s {
 			t.Errorf("Mismatch at pos %d (%s - %s)", i, out[i], s)

--- a/internal/tpl/template.go
+++ b/internal/tpl/template.go
@@ -3,6 +3,7 @@ package tpl
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"path/filepath"
 	"text/template"
 
@@ -32,12 +33,12 @@ func Execute(ctx context.Context, tpl, name string, content []byte, s kvstore) (
 
 	tmpl, err := template.New(tpl).Funcs(funcs).Parse(tpl)
 	if err != nil {
-		return []byte{}, err
+		return []byte{}, fmt.Errorf("failed to parse template: %w", err)
 	}
 
 	buff := &bytes.Buffer{}
 	if err := tmpl.Execute(buff, pl); err != nil {
-		return []byte{}, err
+		return []byte{}, fmt.Errorf("failed to execute template: %w", err)
 	}
 
 	return buff.Bytes(), nil

--- a/internal/tpl/template_test.go
+++ b/internal/tpl/template_test.go
@@ -45,13 +45,16 @@ Bcrypt of the new password: {{ .Content | bcrypt }}
 type kvMock struct{}
 
 func (k kvMock) Get(ctx context.Context, key string) (gopass.Secret, error) {
-	return secparse.Parse([]byte("barfoo\n---\nbarkey: barvalue\n"))
+	return secparse.Parse([]byte("barfoo\n---\nbarkey: barvalue\n")) //nolint:wrapcheck
 }
 
+//nolint:gocognit
 func TestVars(t *testing.T) {
-	ctx := context.Background()
+	t.Parallel()
 
+	ctx := context.Background()
 	kv := kvMock{}
+
 	for _, tc := range []struct {
 		Template   string
 		Name       string
@@ -154,13 +157,16 @@ func TestVars(t *testing.T) {
 				if !strings.HasPrefix(s, "{SSHA}") {
 					return fmt.Errorf("wrong prefix")
 				}
+
 				ok, err := ssha.Validate("foobar", s)
 				if err != nil {
 					return fmt.Errorf("can't validate: %w", err)
 				}
+
 				if !ok {
 					return fmt.Errorf("hash mismatch")
 				}
+
 				return nil
 			},
 		},
@@ -172,13 +178,16 @@ func TestVars(t *testing.T) {
 				if !strings.HasPrefix(s, "{SSHA256}") {
 					return fmt.Errorf("wrong prefix: %s", s)
 				}
+
 				ok, err := ssha256.Validate("foobar", s)
 				if err != nil {
 					return fmt.Errorf("can't validate: %w", err)
 				}
+
 				if !ok {
 					return fmt.Errorf("hash mismatch")
 				}
+
 				return nil
 			},
 		},
@@ -190,13 +199,16 @@ func TestVars(t *testing.T) {
 				if !strings.HasPrefix(s, "{SSHA512}") {
 					return fmt.Errorf("wrong prefix: %s", s)
 				}
+
 				ok, err := ssha512.Validate("foobar", s)
 				if err != nil {
 					return fmt.Errorf("can't validate: %w", err)
 				}
+
 				if !ok {
 					return fmt.Errorf("hash mismatch")
 				}
+
 				return nil
 			},
 		},
@@ -208,13 +220,16 @@ func TestVars(t *testing.T) {
 				if !strings.HasPrefix(s, "{SSHA512}") {
 					return fmt.Errorf("wrong prefix: %s", s)
 				}
+
 				ok, err := ssha512.Validate("foobar", s)
 				if err != nil {
 					return fmt.Errorf("can't validate: %w", err)
 				}
+
 				if !ok {
 					return fmt.Errorf("hash mismatch")
 				}
+
 				return nil
 			},
 		},
@@ -226,13 +241,16 @@ func TestVars(t *testing.T) {
 				if !strings.HasPrefix(s, "{MD5-CRYPT}") {
 					return fmt.Errorf("wrong prefix: %s", s)
 				}
+
 				ok, err := md5crypt.Validate("foobar", s)
 				if err != nil {
 					return fmt.Errorf("can't validate: %w", err)
 				}
+
 				if !ok {
 					return fmt.Errorf("hash mismatch")
 				}
+
 				return nil
 			},
 		},
@@ -244,13 +262,16 @@ func TestVars(t *testing.T) {
 				if !strings.HasPrefix(s, "{MD5-CRYPT}") {
 					return fmt.Errorf("wrong prefix: %s", s)
 				}
+
 				ok, err := md5crypt.Validate("foobar", s)
 				if err != nil {
 					return fmt.Errorf("can't validate: %w", err)
 				}
+
 				if !ok {
 					return fmt.Errorf("hash mismatch")
 				}
+
 				return nil
 			},
 		},
@@ -262,13 +283,16 @@ func TestVars(t *testing.T) {
 				if !strings.HasPrefix(s, "{ARGON2I}") {
 					return fmt.Errorf("wrong prefix: %s", s)
 				}
+
 				ok, err := argon2i.Validate("foobar", s)
 				if err != nil {
 					return fmt.Errorf("can't validate: %w", err)
 				}
+
 				if !ok {
 					return fmt.Errorf("hash mismatch")
 				}
+
 				return nil
 			},
 		},
@@ -280,13 +304,16 @@ func TestVars(t *testing.T) {
 				if !strings.HasPrefix(s, "{ARGON2ID}") {
 					return fmt.Errorf("wrong prefix: %s", s)
 				}
+
 				ok, err := argon2id.Validate("foobar", s)
 				if err != nil {
 					return fmt.Errorf("can't validate: %w", err)
 				}
+
 				if !ok {
 					return fmt.Errorf("hash mismatch")
 				}
+
 				return nil
 			},
 		},
@@ -300,6 +327,7 @@ func TestVars(t *testing.T) {
 		tc := tc
 		t.Run(tc.Template, func(t *testing.T) {
 			t.Parallel()
+
 			buf, err := Execute(ctx, tc.Template, tc.Name, tc.Content, kv)
 			if tc.ShouldFail {
 				assert.Error(t, err)

--- a/internal/tree/node.go
+++ b/internal/tree/node.go
@@ -39,19 +39,23 @@ func (n Node) Equals(other Node) bool {
 	if n.Name != other.Name {
 		return false
 	}
+
 	if n.Type != other.Type {
 		return false
 	}
+
 	if n.Subtree != nil {
 		if other.Subtree == nil {
 			return false
 		}
+
 		if !n.Subtree.Equals(other.Subtree) {
 			return false
 		}
 	} else if other.Subtree != nil {
 		return false
 	}
+
 	return true
 }
 
@@ -103,6 +107,7 @@ func (n *Node) format(prefix string, last bool, maxDepth, curDepth int) string {
 		last := i == len(n.Subtree.Nodes)-1
 		_, _ = out.WriteString(node.format(prefix, last, maxDepth, curDepth+1))
 	}
+
 	return out.String()
 }
 
@@ -111,10 +116,13 @@ func (n *Node) Len() int {
 	if n.Type == "file" {
 		return 1
 	}
+
 	var l int
+
 	for _, t := range n.Subtree.Nodes {
 		l += t.Len()
 	}
+
 	return l
 }
 
@@ -126,6 +134,7 @@ func (n *Node) list(prefix string, maxDepth, curDepth int, files bool) []string 
 	if prefix != "" {
 		prefix += sep
 	}
+
 	prefix += n.Name
 
 	// if it's a file and we are looking for files
@@ -154,5 +163,6 @@ func (n *Node) list(prefix string, maxDepth, curDepth int, files bool) []string 
 	for _, t := range n.Subtree.Nodes {
 		out = append(out, t.list(prefix, maxDepth, curDepth+1, files)...)
 	}
+
 	return out
 }

--- a/internal/tree/root_test.go
+++ b/internal/tree/root_test.go
@@ -8,15 +8,17 @@ import (
 )
 
 func TestRoot(t *testing.T) {
+	t.Parallel()
+
 	color.NoColor = true
 
 	r := New("gopass")
-	r.AddTemplate("foo")
-	r.AddFile("foo/bar/baz", "")
-	r.AddFile("foo/bar/zab", "")
-	r.AddMount("mnt/m1", "/tmp/m1")
-	r.AddFile("mnt/m1/foo", "")
-	r.AddFile("mnt/m1/foo/bar", "")
+	assert.NoError(t, r.AddTemplate("foo"))
+	assert.NoError(t, r.AddFile("foo/bar/baz", ""))
+	assert.NoError(t, r.AddFile("foo/bar/zab", ""))
+	assert.NoError(t, r.AddMount("mnt/m1", "/tmp/m1"))
+	assert.NoError(t, r.AddFile("mnt/m1/foo", ""))
+	assert.NoError(t, r.AddFile("mnt/m1/foo/bar", ""))
 	t.Logf("%+#v", r)
 	assert.Equal(t, `gopass
 ├── foo/ (template)
@@ -41,6 +43,7 @@ func TestRoot(t *testing.T) {
 		"mnt/m1/",
 		"mnt/m1/foo/",
 	}, r.ListFolders(INF))
+
 	f, err := r.FindFolder("mnt/m1")
 	assert.NoError(t, err)
 	assert.Equal(t, `gopass
@@ -50,15 +53,17 @@ func TestRoot(t *testing.T) {
 }
 
 func TestMountShadow(t *testing.T) {
+	t.Parallel()
+
 	color.NoColor = true
 
 	r := New("gopass")
-	r.AddTemplate("foo")
-	r.AddFile("foo/bar/baz", "")
-	r.AddFile("foo/bar/zab", "")
-	r.AddMount("foo", "/tmp/m1")
-	r.AddFile("foo/zab", "")
-	r.AddFile("foo/baz", "")
+	assert.NoError(t, r.AddTemplate("foo"))
+	assert.NoError(t, r.AddFile("foo/bar/baz", ""))
+	assert.NoError(t, r.AddFile("foo/bar/zab", ""))
+	assert.NoError(t, r.AddMount("foo", "/tmp/m1"))
+	assert.NoError(t, r.AddFile("foo/zab", ""))
+	assert.NoError(t, r.AddFile("foo/baz", ""))
 	t.Logf("%+#v", r)
 	assert.Equal(t, `gopass
 └── foo (/tmp/m1)
@@ -73,6 +78,7 @@ func TestMountShadow(t *testing.T) {
 	assert.Equal(t, []string{
 		"foo/",
 	}, r.ListFolders(INF))
+
 	_, err := r.FindFolder("mnt/m1")
 	assert.Error(t, err)
 }

--- a/internal/tree/tree.go
+++ b/internal/tree/tree.go
@@ -8,6 +8,9 @@ import (
 	"sort"
 )
 
+// ErrNodePresent is returned when a node with the same name is already present.
+var ErrNodePresent = fmt.Errorf("node already present")
+
 // Tree is a tree.
 type Tree struct {
 	Nodes []*Node
@@ -46,9 +49,11 @@ func (t *Tree) Insert(node *Node) (*Node, error) {
 	if found != nil {
 		if node.Mount {
 			t.Nodes[pos] = node
+
 			return node, nil
 		}
-		return t.Nodes[pos], fmt.Errorf("node %q already preset", node.Name)
+
+		return t.Nodes[pos], fmt.Errorf("error at %q: %w", node.Name, ErrNodePresent)
 	}
 
 	// insert at the right position, see

--- a/internal/tree/tree_test.go
+++ b/internal/tree/tree_test.go
@@ -7,13 +7,18 @@ import (
 )
 
 func TestTree(t *testing.T) {
+	t.Parallel()
+
 	t1 := NewTree()
 	t2 := NewTree()
 
 	assert.True(t, t1.Equals(t2))
 
-	t1.Insert(&Node{Name: "foo"})
+	_, err := t1.Insert(&Node{Name: "foo"})
+	assert.NoError(t, err)
 	assert.False(t, t1.Equals(t2))
-	t2.Insert(&Node{Name: "foo"})
+
+	_, err = t2.Insert(&Node{Name: "foo"})
+	assert.NoError(t, err)
 	assert.True(t, t1.Equals(t2))
 }

--- a/internal/updater/access_others.go
+++ b/internal/updater/access_others.go
@@ -6,5 +6,5 @@ package updater
 import "golang.org/x/sys/unix"
 
 func canWrite(path string) error {
-	return unix.Access(path, unix.W_OK)
+	return unix.Access(path, unix.W_OK) //nolint:wrapcheck
 }

--- a/internal/updater/update.go
+++ b/internal/updater/update.go
@@ -17,9 +17,11 @@ import (
 var UpdateMoveAfterQuit = true
 
 // Update will start th interactive update assistant.
+//nolint:goerr113
 func Update(ctx context.Context, currentVersion semver.Version) error {
 	if err := IsUpdateable(ctx); err != nil {
 		out.Errorf(ctx, "Your gopass binary is externally managed. Can not update: %q", err)
+
 		return err
 	}
 
@@ -37,31 +39,37 @@ func Update(ctx context.Context, currentVersion semver.Version) error {
 	// binary is newer or equal to the latest release -> nothing to do
 	if currentVersion.GTE(rel.Version) {
 		out.Printf(ctx, "gopass is up to date (%s)", currentVersion.String())
+
 		if gfu := os.Getenv("GOPASS_FORCE_UPDATE"); gfu == "" {
 			return nil
 		}
 	}
 
 	debug.Log("downloading SHA256SUMS ...")
+
 	_, sha256sums, err := downloadAsset(ctx, rel.Assets, "SHA256SUMS")
 	if err != nil {
 		return err
 	}
 
 	debug.Log("downloading SHA256SUMS.sig ...")
+
 	_, sig, err := downloadAsset(ctx, rel.Assets, "SHA256SUMS.sig")
 	if err != nil {
 		return err
 	}
 
 	debug.Log("verifying GPG signature ...")
+
 	ok, err := gpgVerify(sha256sums, sig)
 	if err != nil {
 		return fmt.Errorf("signature verification failed: %w", err)
 	}
+
 	if !ok {
 		return fmt.Errorf("GPG signature verification for SHA256SUMS failed")
 	}
+
 	debug.Log("GPG signature OK!")
 
 	ext := "tar.gz"
@@ -71,30 +79,35 @@ func Update(ctx context.Context, currentVersion semver.Version) error {
 
 	suffix := fmt.Sprintf("%s-%s.%s", runtime.GOOS, runtime.GOARCH, ext)
 	debug.Log("downloading tarball %q ...", suffix)
+
 	dlFilename, buf, err := downloadAsset(ctx, rel.Assets, suffix)
 	if err != nil {
 		return err
 	}
 
 	debug.Log("finding hashsum entry for %q", dlFilename)
+
 	wantHash, err := findHashForFile(sha256sums, dlFilename)
 	if err != nil {
 		return err
 	}
 
 	debug.Log("calculating hashsum of downloaded archive ...")
+
 	gotHash := sha256.Sum256(buf)
 	if !bytes.Equal(wantHash, gotHash[:]) {
 		return fmt.Errorf("SHA256 hash mismatch, want %02x, got %02x", wantHash, gotHash)
 	}
-	debug.Log("hashsums match!")
 
+	debug.Log("hashsums match!")
 	debug.Log("extracting binary from tarball ...")
+
 	if err := extractFile(buf, dlFilename, dest); err != nil {
 		return err
 	}
-	debug.Log("extracted %q to %q", dlFilename, dest)
 
+	debug.Log("extracted %q to %q", dlFilename, dest)
 	debug.Log("success!")
+
 	return nil
 }

--- a/internal/updater/update_test.go
+++ b/internal/updater/update_test.go
@@ -14,15 +14,18 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestIsUpdateable(t *testing.T) {
+//nolint:wrapcheck
+func TestIsUpdateable(t *testing.T) { //nolint:paralleltest
 	ctx := context.Background()
 	oldExec := executable
+
 	defer func() {
 		executable = oldExec
 	}()
 
 	td, err := os.MkdirTemp("", "gopass-")
 	require.NoError(t, err)
+
 	defer func() {
 		_ = os.RemoveAll(td)
 	}()
@@ -37,7 +40,7 @@ func TestIsUpdateable(t *testing.T) {
 		{
 			name: "executable error",
 			exec: func(context.Context) (string, error) {
-				return "", fmt.Errorf("failed")
+				return "", fmt.Errorf("failed") //nolint:goerr113
 			},
 		},
 		{
@@ -94,6 +97,7 @@ func TestIsUpdateable(t *testing.T) {
 			name: "no write access to dir",
 			pre: func() error {
 				dir := filepath.Join(td, "bin")
+
 				return os.Mkdir(dir, 0o555)
 			},
 			exec: func(context.Context) (string, error) {
@@ -104,13 +108,16 @@ func TestIsUpdateable(t *testing.T) {
 		if tc.pre != nil {
 			require.NoError(t, tc.pre(), tc.name)
 		}
+
 		executable = tc.exec
+
 		err := IsUpdateable(ctx)
 		if tc.ok {
 			assert.NoError(t, err, tc.name)
 		} else {
 			assert.Error(t, err, tc.name)
 		}
+
 		if tc.post != nil {
 			assert.NoError(t, tc.post(), tc.name)
 		}

--- a/internal/updater/updateable.go
+++ b/internal/updater/updateable.go
@@ -11,6 +11,7 @@ import (
 )
 
 // IsUpdateable returns an error if this binary is not updateable.
+//nolint:goerr113
 func IsUpdateable(ctx context.Context) error {
 	fn, err := executable(ctx)
 	if err != nil {
@@ -26,6 +27,7 @@ func IsUpdateable(ctx context.Context) error {
 	// check if we want to force updateability
 	if uf := os.Getenv("GOPASS_FORCE_UPDATE"); uf != "" {
 		debug.Log("updateable due to force flag")
+
 		return nil
 	}
 
@@ -37,11 +39,13 @@ func IsUpdateable(ctx context.Context) error {
 	// check file
 	fi, err := os.Stat(fn)
 	if err != nil {
-		return err
+		return err //nolint:wrapcheck
 	}
+
 	if !fi.Mode().IsRegular() {
 		return fmt.Errorf("not a regular file")
 	}
+
 	if err := canWrite(fn); err != nil {
 		return fmt.Errorf("can not write %q: %w", fn, err)
 	}
@@ -50,11 +54,13 @@ func IsUpdateable(ctx context.Context) error {
 	return nil
 }
 
+//nolint:wrapcheck
 var executable = func(ctx context.Context) (string, error) {
 	path, err := os.Executable()
 	if err != nil {
 		return path, err
 	}
 	path, err = filepath.EvalSymlinks(path)
+
 	return path, err
 }

--- a/internal/updater/verify_test.go
+++ b/internal/updater/verify_test.go
@@ -29,6 +29,8 @@ var testData = []byte(`gopass-sign-test
 `)
 
 func TestGPGVerify(t *testing.T) {
+	t.Parallel()
+
 	ok, err := gpgVerify(testData, testSignature)
 	assert.NoError(t, err)
 	assert.True(t, ok)

--- a/main_test.go
+++ b/main_test.go
@@ -44,6 +44,8 @@ func TestGetVersion(t *testing.T) {
 }
 
 func TestSetupApp(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	_, app := setupApp(ctx, semver.Version{})
 	assert.NotNil(t, app)
@@ -98,13 +100,14 @@ var commandsWithError = set.Map([]string{
 	".unclip",
 })
 
-func TestGetCommands(t *testing.T) {
+func TestGetCommands(t *testing.T) { //nolint:paralleltest
 	u := gptest.NewUnitTester(t)
 	defer u.Remove()
 
 	buf := &bytes.Buffer{}
-	out.Stdout = buf
 	color.NoColor = true
+
+	out.Stdout = buf
 	defer func() {
 		out.Stdout = os.Stdout
 	}()
@@ -137,33 +140,43 @@ func TestGetCommands(t *testing.T) {
 }
 
 func testCommands(t *testing.T, c *cli.Context, commands []*cli.Command, prefix string) {
+	t.Helper()
+
 	for _, cmd := range commands {
 		if cmd.Name == "update" {
 			continue
 		}
+
 		if len(cmd.Subcommands) > 0 {
 			testCommands(t, c, cmd.Subcommands, prefix+"."+cmd.Name)
 		}
+
 		if cmd.Before != nil {
 			if err := cmd.Before(c); err != nil {
 				continue
 			}
 		}
+
 		if cmd.BashComplete != nil {
 			cmd.BashComplete(c)
 		}
+
 		if cmd.Action != nil {
 			fullName := prefix + "." + cmd.Name
 			if _, found := commandsWithError[fullName]; found {
 				assert.Error(t, cmd.Action(c), fullName)
+
 				continue
 			}
+
 			assert.NoError(t, cmd.Action(c), fullName)
 		}
 	}
 }
 
 func TestInitContext(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	cfg := config.New()
 

--- a/pkg/appdir/appdir.go
+++ b/pkg/appdir/appdir.go
@@ -21,7 +21,9 @@ func UserHome() string {
 	uhd, err := os.UserHomeDir()
 	if err != nil {
 		debug.Log("failed to detect user home dir: %s", err)
+
 		return ""
 	}
+
 	return uhd
 }

--- a/pkg/appdir/appdir_xdg_test.go
+++ b/pkg/appdir/appdir_xdg_test.go
@@ -12,69 +12,69 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestUserConfig(t *testing.T) {
+func TestUserConfig(t *testing.T) { //nolint:paralleltest
 	ov := gptest.UnsetVars("GOPASS_HOMEDIR", "XDG_CONFIG_HOME", "HOME")
 	defer ov()
 
-	t.Run("gopass homedir", func(t *testing.T) {
+	t.Run("gopass homedir", func(t *testing.T) { //nolint:paralleltest
 		require.NoError(t, os.Setenv("GOPASS_HOMEDIR", "/foo/bar"))
 		assert.Equal(t, "/foo/bar/.config/gopass", UserConfig())
 		require.NoError(t, os.Unsetenv("GOPASS_HOMEDIR"))
 	})
 
-	t.Run("xdg_config_home", func(t *testing.T) {
+	t.Run("xdg_config_home", func(t *testing.T) { //nolint:paralleltest
 		require.NoError(t, os.Setenv("XDG_CONFIG_HOME", "/foo/baz/myconfig"))
 		assert.Equal(t, "/foo/baz/myconfig/gopass", UserConfig())
 		require.NoError(t, os.Unsetenv("XDG_CONFIG_HOME"))
 	})
 
-	t.Run("default", func(t *testing.T) {
+	t.Run("default", func(t *testing.T) { //nolint:paralleltest
 		require.NoError(t, os.Setenv("HOME", "/home/gopass"))
 		assert.Equal(t, "/home/gopass/.config/gopass", UserConfig())
 		require.NoError(t, os.Unsetenv("HOME"))
 	})
 }
 
-func TestUserCache(t *testing.T) {
+func TestUserCache(t *testing.T) { //nolint:paralleltest
 	ov := gptest.UnsetVars("GOPASS_HOMEDIR", "XDG_CACHE_HOME", "HOME")
 	defer ov()
 
-	t.Run("gopass homedir", func(t *testing.T) {
+	t.Run("gopass homedir", func(t *testing.T) { //nolint:paralleltest
 		require.NoError(t, os.Setenv("GOPASS_HOMEDIR", "/foo/bar"))
 		assert.Equal(t, "/foo/bar/.cache/gopass", UserCache())
 		require.NoError(t, os.Unsetenv("GOPASS_HOMEDIR"))
 	})
 
-	t.Run("xdg_cache_home", func(t *testing.T) {
+	t.Run("xdg_cache_home", func(t *testing.T) { //nolint:paralleltest
 		require.NoError(t, os.Setenv("XDG_CACHE_HOME", "/foo/baz/mycache"))
 		assert.Equal(t, "/foo/baz/mycache/gopass", UserCache())
 		require.NoError(t, os.Unsetenv("XDG_CACHE_HOME"))
 	})
 
-	t.Run("default", func(t *testing.T) {
+	t.Run("default", func(t *testing.T) { //nolint:paralleltest
 		require.NoError(t, os.Setenv("HOME", "/home/gopass"))
 		assert.Equal(t, "/home/gopass/.cache/gopass", UserCache())
 		require.NoError(t, os.Unsetenv("HOME"))
 	})
 }
 
-func TestUserData(t *testing.T) {
+func TestUserData(t *testing.T) { //nolint:paralleltest
 	ov := gptest.UnsetVars("GOPASS_HOMEDIR", "XDG_DATA_HOME", "HOME")
 	defer ov()
 
-	t.Run("gopass homedir", func(t *testing.T) {
+	t.Run("gopass homedir", func(t *testing.T) { //nolint:paralleltest
 		require.NoError(t, os.Setenv("GOPASS_HOMEDIR", "/foo/bar"))
 		assert.Equal(t, "/foo/bar/.local/share/gopass", UserData())
 		require.NoError(t, os.Unsetenv("GOPASS_HOMEDIR"))
 	})
 
-	t.Run("xdg_data_home", func(t *testing.T) {
+	t.Run("xdg_data_home", func(t *testing.T) { //nolint:paralleltest
 		require.NoError(t, os.Setenv("XDG_DATA_HOME", "/foo/baz/mydata"))
 		assert.Equal(t, "/foo/baz/mydata/gopass", UserData())
 		require.NoError(t, os.Unsetenv("XDG_DATA_HOME"))
 	})
 
-	t.Run("default", func(t *testing.T) {
+	t.Run("default", func(t *testing.T) { //nolint:paralleltest
 		require.NoError(t, os.Setenv("HOME", "/home/gopass"))
 		assert.Equal(t, "/home/gopass/.local/share/gopass", UserData())
 		require.NoError(t, os.Unsetenv("HOME"))

--- a/pkg/clipboard/clipboard_test.go
+++ b/pkg/clipboard/clipboard_test.go
@@ -12,17 +12,14 @@ import (
 
 	"github.com/atotto/clipboard"
 	"github.com/gopasspw/gopass/internal/out"
-	"github.com/gopasspw/gopass/tests/gptest"
 	ps "github.com/mitchellh/go-ps"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestNotExistingClipboardCopyCommand(t *testing.T) {
-	r1 := gptest.UnsetVars("GOPASS_NO_NOTIFY", "GOPASS_CLIPBOARD_COPY_CMD")
-	defer r1()
+func TestNotExistingClipboardCopyCommand(t *testing.T) { //nolint:paralleltest
+	t.Setenv("GOPASS_NO_NOTIFY", "true")
+	t.Setenv("GOPASS_CLIPBOARD_COPY_CMD", "not_existing_command")
 
-	_ = os.Setenv("GOPASS_NO_NOTIFY", "true")
-	_ = os.Setenv("GOPASS_CLIPBOARD_COPY_CMD", "not_existing_command")
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -31,22 +28,22 @@ func TestNotExistingClipboardCopyCommand(t *testing.T) {
 	assert.Contains(t, maybeErr.Error(), "\"not_existing_command\": executable file not found")
 }
 
-func TestUnsupportedCopyToClipboard(t *testing.T) {
-	r1 := gptest.UnsetVars("GOPASS_NO_NOTIFY")
-	defer r1()
+func TestUnsupportedCopyToClipboard(t *testing.T) { //nolint:paralleltest
+	t.Setenv("GOPASS_NO_NOTIFY", "true")
 
-	_ = os.Setenv("GOPASS_NO_NOTIFY", "true")
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+
 	clipboard.Unsupported = true
 
 	buf := &bytes.Buffer{}
 	out.Stderr = buf
+
 	assert.NoError(t, CopyTo(ctx, "foo", []byte("bar"), 1))
 	assert.Contains(t, buf.String(), "WARNING")
 }
 
-func TestClearClipboard(t *testing.T) {
+func TestClearClipboard(t *testing.T) { //nolint:paralleltest
 	ctx, cancel := context.WithCancel(context.Background())
 	assert.NoError(t, clear(ctx, "foo", []byte("bar"), 0))
 	cancel()
@@ -70,6 +67,7 @@ func BenchmarkWalkProc(b *testing.B) {
 				return nil
 			}
 			walkFn(pid, func(int) {})
+
 			return nil
 		})
 	}
@@ -81,6 +79,7 @@ func BenchmarkListProc(b *testing.B) {
 		if err != nil {
 			b.Fatalf("err: %s", err)
 		}
+
 		for _, proc := range procs {
 			walkFn(proc.Pid(), func(int) {})
 		}

--- a/pkg/clipboard/copy_others.go
+++ b/pkg/clipboard/copy_others.go
@@ -5,10 +5,15 @@ package clipboard
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/atotto/clipboard"
 )
 
 func copyToClipboard(ctx context.Context, content []byte) error {
-	return clipboard.WriteAll(string(content))
+	if err := clipboard.WriteAll(string(content)); err != nil {
+		return fmt.Errorf("failed to write to clipboard: %w", err)
+	}
+
+	return nil
 }

--- a/pkg/clipboard/kill_ps.go
+++ b/pkg/clipboard/kill_ps.go
@@ -4,6 +4,8 @@
 package clipboard
 
 import (
+	"fmt"
+
 	ps "github.com/mitchellh/go-ps"
 )
 
@@ -13,10 +15,12 @@ import (
 func killPrecedessors() error {
 	procs, err := ps.Processes()
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to list processes: %w", err)
 	}
+
 	for _, proc := range procs {
 		walkFn(proc.Pid(), killProc)
 	}
+
 	return nil
 }

--- a/pkg/clipboard/unclip.go
+++ b/pkg/clipboard/unclip.go
@@ -17,9 +17,12 @@ func Clear(ctx context.Context, name string, checksum string, force bool) error 
 	if clipboardClearCMD != "" {
 		if err := callCommand(ctx, clipboardClearCMD, name, []byte(checksum)); err != nil {
 			_ = notify.Notify(ctx, "gopass - clipboard", "failed to call clipboard clear command")
+
 			return fmt.Errorf("failed to call clipboard clear command: %w", err)
 		}
+
 		debug.Log("clipboard cleared (%s)", checksum)
+
 		return nil
 	}
 
@@ -35,19 +38,23 @@ func Clear(ctx context.Context, name string, checksum string, force bool) error 
 	match, err := argon2id.Validate(cur, checksum)
 	if err != nil {
 		debug.Log("failed to validate checksum %s: %s", checksum, err)
+
 		return nil
 	}
+
 	if !match && !force {
 		return nil
 	}
 
 	if err := clipboard.WriteAll(""); err != nil {
 		_ = notify.Notify(ctx, "gopass - clipboard", "Failed to clear clipboard")
+
 		return fmt.Errorf("failed to write clipboard: %w", err)
 	}
 
 	if err := clearClipboardHistory(ctx); err != nil {
 		_ = notify.Notify(ctx, "gopass - clipboard", "Failed to clear clipboard history")
+
 		return fmt.Errorf("failed to clear clipboard history: %w", err)
 	}
 
@@ -56,5 +63,6 @@ func Clear(ctx context.Context, name string, checksum string, force bool) error 
 	}
 
 	debug.Log("clipboard cleared (%s)", checksum)
+
 	return nil
 }

--- a/pkg/clipboard/unclip_linux.go
+++ b/pkg/clipboard/unclip_linux.go
@@ -5,6 +5,7 @@ package clipboard
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/godbus/dbus"
@@ -13,18 +14,21 @@ import (
 func clearClipboardHistory(ctx context.Context) error {
 	conn, err := dbus.SessionBus()
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to connect to session bus: %w", err)
 	}
 
 	obj := conn.Object("org.kde.klipper", "/klipper")
 	call := obj.Call("org.kde.klipper.klipper.clearClipboardHistory", 0)
+
 	if call.Err != nil {
 		if strings.HasPrefix(call.Err.Error(), "The name org.kde.klipper was not provided") {
 			return nil
 		}
+
 		if strings.HasPrefix(call.Err.Error(), "The name is not activatable") {
 			return nil
 		}
+
 		return call.Err
 	}
 

--- a/pkg/clipboard/unclip_test.go
+++ b/pkg/clipboard/unclip_test.go
@@ -8,18 +8,14 @@ import (
 
 	"github.com/gopasspw/gopass/internal/out"
 	"github.com/gopasspw/gopass/pkg/ctxutil"
-	"github.com/gopasspw/gopass/tests/gptest"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestNotExistingClipboardClearCommand(t *testing.T) {
-	r1 := gptest.UnsetVars("GOPASS_CLIPBOARD_CLEAR_CMD")
-	defer r1()
-
+func TestNotExistingClipboardClearCommand(t *testing.T) { //nolint:paralleltest
 	ctx := context.Background()
 	ctx = ctxutil.WithAlwaysYes(ctx, true)
 
-	_ = os.Setenv("GOPASS_CLIPBOARD_CLEAR_CMD", "not_existing_command")
+	t.Setenv("GOPASS_CLIPBOARD_CLEAR_CMD", "not_existing_command")
 
 	maybeErr := Clear(ctx, "", "", false)
 	assert.Error(t, maybeErr)
@@ -27,11 +23,14 @@ func TestNotExistingClipboardClearCommand(t *testing.T) {
 }
 
 func TestUnclip(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	ctx = ctxutil.WithAlwaysYes(ctx, true)
 
 	buf := &bytes.Buffer{}
 	out.Stdout = buf
+
 	defer func() {
 		out.Stdout = os.Stdout
 	}()

--- a/pkg/ctxutil/ctxutil.go
+++ b/pkg/ctxutil/ctxutil.go
@@ -37,12 +37,16 @@ const (
 	ctxKeyHidden
 )
 
+// ErrNoCallback is returned when no callback is set in the context.
+var ErrNoCallback = fmt.Errorf("no callback")
+
 // WithGlobalFlags parses any global flags from the cli context and returns
 // a regular context.
 func WithGlobalFlags(c *cli.Context) context.Context {
 	if c.Bool("yes") {
 		return WithAlwaysYes(c.Context, true)
 	}
+
 	return c.Context
 }
 
@@ -57,6 +61,7 @@ func WithTerminal(ctx context.Context, isTerm bool) context.Context {
 // HasTerminal returns true if a value for Terminal has been set in this context.
 func HasTerminal(ctx context.Context) bool {
 	_, ok := ctx.Value(ctxKeyTerminal).(bool)
+
 	return ok
 }
 
@@ -66,6 +71,7 @@ func IsTerminal(ctx context.Context) bool {
 	if !ok {
 		return true
 	}
+
 	return bv
 }
 
@@ -77,6 +83,7 @@ func WithInteractive(ctx context.Context, isInteractive bool) context.Context {
 // HasInteractive returns true if a value for Interactive has been set in this context.
 func HasInteractive(ctx context.Context) bool {
 	_, ok := ctx.Value(ctxKeyInteractive).(bool)
+
 	return ok
 }
 
@@ -86,6 +93,7 @@ func IsInteractive(ctx context.Context) bool {
 	if !ok {
 		return true
 	}
+
 	return bv
 }
 
@@ -98,6 +106,7 @@ func WithStdin(ctx context.Context, isStdin bool) context.Context {
 // HasStdin returns true if a value for Stdin has been set in this context.
 func HasStdin(ctx context.Context) bool {
 	_, ok := ctx.Value(ctxKeyStdin).(bool)
+
 	return ok
 }
 
@@ -108,6 +117,7 @@ func IsStdin(ctx context.Context) bool {
 	if !ok {
 		return false
 	}
+
 	return bv
 }
 
@@ -119,6 +129,7 @@ func WithNoPager(ctx context.Context, bv bool) context.Context {
 // HasNoPager returns true if a value for NoPager has been set in this context.
 func HasNoPager(ctx context.Context) bool {
 	_, ok := ctx.Value(ctxKeyNoPager).(bool)
+
 	return ok
 }
 
@@ -128,6 +139,7 @@ func IsNoPager(ctx context.Context) bool {
 	if !ok {
 		return false
 	}
+
 	return bv
 }
 
@@ -139,6 +151,7 @@ func WithShowSafeContent(ctx context.Context, bv bool) context.Context {
 // HasShowSafeContent returns true if a value for ShowSafeContent has been set in this context.
 func HasShowSafeContent(ctx context.Context) bool {
 	_, ok := ctx.Value(ctxKeyShowSafeContent).(bool)
+
 	return ok
 }
 
@@ -148,6 +161,7 @@ func IsShowSafeContent(ctx context.Context) bool {
 	if !ok {
 		return false
 	}
+
 	return bv
 }
 
@@ -159,6 +173,7 @@ func WithShowParsing(ctx context.Context, bv bool) context.Context {
 // HasShowParsing returns true if a value for ShowParsing has been set in this context.
 func HasShowParsing(ctx context.Context) bool {
 	_, ok := ctx.Value(ctxKeyShowParsing).(bool)
+
 	return ok
 }
 
@@ -168,6 +183,7 @@ func IsShowParsing(ctx context.Context) bool {
 	if !ok {
 		return true
 	}
+
 	return bv
 }
 
@@ -179,6 +195,7 @@ func WithGitCommit(ctx context.Context, bv bool) context.Context {
 // HasGitCommit returns true if a value for GitCommit has been set in this context.
 func HasGitCommit(ctx context.Context) bool {
 	_, ok := ctx.Value(ctxKeyGitCommit).(bool)
+
 	return ok
 }
 
@@ -195,6 +212,7 @@ func WithAlwaysYes(ctx context.Context, bv bool) context.Context {
 // HasAlwaysYes returns true if a value for AlwaysYes has been set in this context.
 func HasAlwaysYes(ctx context.Context) bool {
 	_, ok := ctx.Value(ctxKeyAlwaysYes).(bool)
+
 	return ok
 }
 
@@ -204,6 +222,7 @@ func IsAlwaysYes(ctx context.Context) bool {
 	if !ok {
 		return false
 	}
+
 	return bv
 }
 
@@ -215,6 +234,7 @@ func WithVerbose(ctx context.Context, verbose bool) context.Context {
 // HasVerbose returns true if a value for Verbose has been set in this context.
 func HasVerbose(ctx context.Context) bool {
 	_, ok := ctx.Value(ctxKeyVerbose).(bool)
+
 	return ok
 }
 
@@ -246,6 +266,7 @@ func WithProgressCallback(ctx context.Context, cb ProgressCallback) context.Cont
 // HasProgressCallback returns true if a ProgressCallback has been set.
 func HasProgressCallback(ctx context.Context) bool {
 	_, ok := ctx.Value(ctxKeyProgressCallback).(ProgressCallback)
+
 	return ok
 }
 
@@ -256,6 +277,7 @@ func GetProgressCallback(ctx context.Context) ProgressCallback {
 	if !ok || cb == nil {
 		return func() {}
 	}
+
 	return cb
 }
 
@@ -275,6 +297,7 @@ func GetAlias(ctx context.Context) string {
 	if !ok {
 		return ""
 	}
+
 	return a
 }
 
@@ -324,6 +347,7 @@ func GetCommitMessage(ctx context.Context) string {
 	if !ok {
 		return ""
 	}
+
 	return sv
 }
 
@@ -353,6 +377,7 @@ func GetUsername(ctx context.Context) string {
 	if !ok {
 		return ""
 	}
+
 	return sv
 }
 
@@ -367,6 +392,7 @@ func GetEmail(ctx context.Context) string {
 	if !ok {
 		return ""
 	}
+
 	return sv
 }
 
@@ -379,6 +405,7 @@ func WithImportFunc(ctx context.Context, imf store.ImportCallback) context.Conte
 // context.
 func HasImportFunc(ctx context.Context) bool {
 	imf, ok := ctx.Value(ctxKeyImportFunc).(store.ImportCallback)
+
 	return ok && imf != nil
 }
 
@@ -391,6 +418,7 @@ func GetImportFunc(ctx context.Context) store.ImportCallback {
 			return true
 		}
 	}
+
 	return imf
 }
 
@@ -420,6 +448,7 @@ func WithPasswordCallback(ctx context.Context, cb PasswordCallback) context.Cont
 // HasPasswordCallback returns true if a password callback was set in the context.
 func HasPasswordCallback(ctx context.Context) bool {
 	_, ok := ctx.Value(ctxKeyPasswordCallback).(PasswordCallback)
+
 	return ok
 }
 
@@ -428,9 +457,10 @@ func GetPasswordCallback(ctx context.Context) PasswordCallback {
 	pwcb, ok := ctx.Value(ctxKeyPasswordCallback).(PasswordCallback)
 	if !ok || pwcb == nil {
 		return func(string, bool) ([]byte, error) {
-			return nil, fmt.Errorf("no callback")
+			return nil, ErrNoCallback
 		}
 	}
+
 	return pwcb
 }
 
@@ -444,6 +474,7 @@ func WithCommitTimestamp(ctx context.Context, ts time.Time) context.Context {
 // was set in the context.
 func HasCommitTimestamp(ctx context.Context) bool {
 	_, ok := ctx.Value(ctxKeyCommitTimestamp).(time.Time)
+
 	return ok
 }
 
@@ -453,6 +484,7 @@ func GetCommitTimestamp(ctx context.Context) time.Time {
 	if ts, ok := ctx.Value(ctxKeyCommitTimestamp).(time.Time); ok {
 		return ts
 	}
+
 	return time.Now()
 }
 
@@ -467,5 +499,6 @@ func IsHidden(ctx context.Context) bool {
 	if !ok {
 		return false
 	}
+
 	return bv
 }

--- a/pkg/ctxutil/ctxutil_test.go
+++ b/pkg/ctxutil/ctxutil_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func TestTerminal(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 
 	assert.Equal(t, true, IsTerminal(ctx))
@@ -18,6 +20,8 @@ func TestTerminal(t *testing.T) {
 }
 
 func TestInteractive(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 
 	assert.Equal(t, true, IsInteractive(ctx))
@@ -26,6 +30,8 @@ func TestInteractive(t *testing.T) {
 }
 
 func TestStdin(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 
 	assert.Equal(t, false, IsStdin(ctx))
@@ -34,6 +40,8 @@ func TestStdin(t *testing.T) {
 }
 
 func TestNoPager(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 
 	assert.Equal(t, false, IsNoPager(ctx))
@@ -42,6 +50,8 @@ func TestNoPager(t *testing.T) {
 }
 
 func TestShowSafeContent(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 
 	assert.Equal(t, false, IsShowSafeContent(ctx))
@@ -50,6 +60,8 @@ func TestShowSafeContent(t *testing.T) {
 }
 
 func TestGitCommit(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 
 	assert.Equal(t, true, IsGitCommit(ctx))
@@ -58,6 +70,8 @@ func TestGitCommit(t *testing.T) {
 }
 
 func TestAlwaysYes(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 
 	assert.Equal(t, false, IsAlwaysYes(ctx))
@@ -66,6 +80,8 @@ func TestAlwaysYes(t *testing.T) {
 }
 
 func TestVerbose(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 
 	assert.Equal(t, false, IsVerbose(ctx))
@@ -74,6 +90,8 @@ func TestVerbose(t *testing.T) {
 }
 
 func TestNotifications(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 
 	assert.Equal(t, true, IsNotifications(ctx))
@@ -82,15 +100,21 @@ func TestNotifications(t *testing.T) {
 }
 
 func TestProgressCallback(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 
 	var foo bool
+
 	pc := func() { foo = true }
+
 	GetProgressCallback(WithProgressCallback(ctx, pc))()
 	assert.Equal(t, true, foo)
 }
 
 func TestAlias(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 
 	assert.Equal(t, "", GetAlias(ctx))
@@ -98,6 +122,8 @@ func TestAlias(t *testing.T) {
 }
 
 func TestGitInit(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 
 	assert.Equal(t, true, IsGitInit(ctx))
@@ -106,6 +132,8 @@ func TestGitInit(t *testing.T) {
 }
 
 func TestForce(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 
 	assert.Equal(t, false, IsForce(ctx))
@@ -114,6 +142,8 @@ func TestForce(t *testing.T) {
 }
 
 func TestCommitMessage(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 
 	assert.Equal(t, "", GetCommitMessage(ctx))
@@ -122,6 +152,8 @@ func TestCommitMessage(t *testing.T) {
 }
 
 func TestComposite(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	ctx = WithTerminal(ctx, false)
 	ctx = WithInteractive(ctx, false)
@@ -187,6 +219,8 @@ func TestComposite(t *testing.T) {
 }
 
 func TestGlobalFlags(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	app := cli.NewApp()
 
@@ -204,11 +238,14 @@ func TestGlobalFlags(t *testing.T) {
 }
 
 func TestImportFunc(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 
 	ifunc := func(context.Context, string, []string) bool {
 		return true
 	}
+
 	assert.NotNil(t, GetImportFunc(ctx))
 	assert.Equal(t, true, GetImportFunc(WithImportFunc(ctx, ifunc))(ctx, "", nil))
 	assert.Equal(t, true, HasImportFunc(WithImportFunc(ctx, ifunc)))
@@ -216,6 +253,8 @@ func TestImportFunc(t *testing.T) {
 }
 
 func TestHidden(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 
 	assert.False(t, IsHidden(ctx))

--- a/pkg/ctxutil/helper.go
+++ b/pkg/ctxutil/helper.go
@@ -6,6 +6,7 @@ import "context"
 // the provided context.
 func hasString(ctx context.Context, key contextKey) bool {
 	_, ok := ctx.Value(key).(string)
+
 	return ok
 }
 
@@ -13,6 +14,7 @@ func hasString(ctx context.Context, key contextKey) bool {
 // the provided context.
 func hasBool(ctx context.Context, key contextKey) bool {
 	_, ok := ctx.Value(key).(bool)
+
 	return ok
 }
 
@@ -23,5 +25,6 @@ func is(ctx context.Context, key contextKey, def bool) bool {
 	if !ok {
 		return def
 	}
+
 	return bv
 }

--- a/pkg/debug/debug.go
+++ b/pkg/debug/debug.go
@@ -33,6 +33,7 @@ var enabled = initDebug()
 func initDebug() bool {
 	if os.Getenv("GOPASS_DEBUG") == "" && os.Getenv("GOPASS_DEBUG_LOG") == "" {
 		logFn = doNotLog
+
 		return false
 	}
 
@@ -42,6 +43,7 @@ func initDebug() bool {
 
 	initDebugLogger()
 	initDebugTags()
+
 	logFn = doLog
 
 	return true
@@ -62,6 +64,7 @@ func initDebugLogger() {
 			os.Exit(3)
 		}
 	}
+
 	if err != nil && os.IsNotExist(err) {
 		f, err = os.OpenFile(debugfile, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
 	}
@@ -85,6 +88,7 @@ func parseFilter(envname string, pad func(string) string) map[string]bool {
 	for _, fn := range strings.Split(env, ",") {
 		t := pad(strings.TrimSpace(fn))
 		val := true
+
 		if t[0] == '-' {
 			val = false
 			t = t[1:]
@@ -145,6 +149,7 @@ func getPosition(offset int) (fn, dir, file string, line int) {
 	filename := filepath.Base(file)
 
 	f := runtime.FuncForPC(pc)
+
 	return path.Base(f.Name()), dirname, filename, line
 }
 
@@ -186,6 +191,7 @@ func doNotLog(offset int, f string, args ...any) {}
 
 func doLog(offset int, f string, args ...any) {
 	fn, dir, file, line := getPosition(offset)
+
 	if len(f) == 0 || f[len(f)-1] != '\n' {
 		f += "\n"
 	}
@@ -203,8 +209,10 @@ func doLog(offset int, f string, args ...any) {
 		argsi[i] = item
 		if secreter, ok := item.(Safer); ok && !logSecrets {
 			argsi[i] = secreter.SafeStr()
+
 			continue
 		}
+
 		if shortener, ok := item.(Shortener); ok {
 			argsi[i] = shortener.Str()
 		}
@@ -225,6 +233,7 @@ func doLog(offset int, f string, args ...any) {
 	filename := fmt.Sprintf("%s/%s:%d", dir, file, line)
 	if checkFilter(opts.files, filename) {
 		dbgprint()
+
 		return
 	}
 

--- a/pkg/debug/debug_test.go
+++ b/pkg/debug/debug_test.go
@@ -6,8 +6,8 @@ import (
 )
 
 func BenchmarkLogging(b *testing.B) {
-	os.Setenv("GOPASS_DEBUG", "true")
-	defer func() { os.Unsetenv("GOPASS_DEBUG") }()
+	b.Setenv("GOPASS_DEBUG", "true")
+
 	initDebug()
 
 	for i := 0; i < b.N; i++ {
@@ -16,7 +16,8 @@ func BenchmarkLogging(b *testing.B) {
 }
 
 func BenchmarkNoLogging(b *testing.B) {
-	os.Unsetenv("GOPASS_DEBUG")
+	_ = os.Unsetenv("GOPASS_DEBUG")
+
 	initDebug()
 
 	for i := 0; i < b.N; i++ {

--- a/pkg/debug/version.go
+++ b/pkg/debug/version.go
@@ -12,6 +12,7 @@ func ModuleVersion(m string) semver.Version {
 	bi, ok := rdebug.ReadBuildInfo()
 	if !ok || bi == nil {
 		Log("Failed to read build info")
+
 		return semver.Version{}
 	}
 
@@ -19,13 +20,18 @@ func ModuleVersion(m string) semver.Version {
 		if dep.Path != m {
 			continue
 		}
+
 		sv, err := semver.Parse(strings.TrimPrefix(dep.Version, "v"))
 		if err != nil {
 			Log("Failed to parse version %s: %s", dep.Version, err)
+
 			return semver.Version{}
 		}
+
 		return sv
 	}
+
 	Log("no module %s found", m)
+
 	return semver.Version{}
 }

--- a/pkg/fsutil/fsutil_test.go
+++ b/pkg/fsutil/fsutil_test.go
@@ -12,21 +12,23 @@ import (
 )
 
 func TestCleanFilename(t *testing.T) {
+	t.Parallel()
+
 	m := map[string]string{
 		`"§$%&aÜÄ*&b%§"'Ä"c%$"'"`: "a____b______c",
 	}
 	for k, v := range m {
 		out := CleanFilename(k)
 		t.Logf("%s -> %s / %s", k, v, out)
-		if out != v {
-			t.Errorf("%q != %q", out, v)
-		}
+
+		assert.Equal(t, v, out)
 	}
 }
 
-func TestCleanPath(t *testing.T) {
+func TestCleanPath(t *testing.T) { //nolint:paralleltest
 	tempdir, err := os.MkdirTemp("", "gopass-")
 	require.NoError(t, err)
+
 	defer func() {
 		_ = os.RemoveAll(tempdir)
 	}()
@@ -44,6 +46,7 @@ func TestCleanPath(t *testing.T) {
 		if gph := os.Getenv("GOPASS_HOMEDIR"); gph != "" {
 			hd = gph
 		}
+
 		m["~/.password-store"] = hd + "/.password-store"
 	}
 
@@ -58,8 +61,11 @@ func TestCleanPath(t *testing.T) {
 }
 
 func TestIsDir(t *testing.T) {
+	t.Parallel()
+
 	tempdir, err := os.MkdirTemp("", "gopass-")
 	require.NoError(t, err)
+
 	defer func() {
 		_ = os.RemoveAll(tempdir)
 	}()
@@ -72,8 +78,11 @@ func TestIsDir(t *testing.T) {
 }
 
 func TestIsFile(t *testing.T) {
+	t.Parallel()
+
 	tempdir, err := os.MkdirTemp("", "gopass-")
 	require.NoError(t, err)
+
 	defer func() {
 		_ = os.RemoveAll(tempdir)
 	}()
@@ -85,8 +94,11 @@ func TestIsFile(t *testing.T) {
 }
 
 func TestShred(t *testing.T) {
+	t.Parallel()
+
 	tempdir, err := os.MkdirTemp("", "gopass-")
 	require.NoError(t, err)
+
 	defer func() {
 		_ = os.RemoveAll(tempdir)
 	}()
@@ -101,7 +113,8 @@ func TestShred(t *testing.T) {
 		_, _ = rand.Read(buf)
 		_, _ = fh.Write(buf)
 	}
-	_ = fh.Close()
+
+	require.NoError(t, fh.Close())
 	assert.NoError(t, Shred(fn, 8))
 	assert.Equal(t, false, IsFile(fn))
 
@@ -114,14 +127,18 @@ func TestShred(t *testing.T) {
 		_, _ = rand.Read(buf)
 		_, _ = fh.Write(buf)
 	}
-	_ = fh.Close()
+
+	require.NoError(t, fh.Close())
 	assert.Error(t, Shred(fn, 8))
 	assert.Equal(t, true, IsFile(fn))
 }
 
 func TestIsEmptyDir(t *testing.T) {
+	t.Parallel()
+
 	tempdir, err := os.MkdirTemp("", "gopass-")
 	require.NoError(t, err)
+
 	defer func() {
 		_ = os.RemoveAll(tempdir)
 	}()

--- a/pkg/fsutil/umask.go
+++ b/pkg/fsutil/umask.go
@@ -8,11 +8,20 @@ import (
 // Umask extracts the umask from env.
 func Umask() int {
 	for _, en := range []string{"GOPASS_UMASK", "PASSWORD_STORE_UMASK"} {
-		if um := os.Getenv(en); um != "" {
-			if iv, err := strconv.ParseInt(um, 8, 32); err == nil && iv >= 0 && iv <= 0o777 {
-				return int(iv)
-			}
+		um := os.Getenv(en)
+		if um == "" {
+			continue
+		}
+
+		iv, err := strconv.ParseInt(um, 8, 32)
+		if err != nil {
+			continue
+		}
+
+		if iv >= 0 && iv <= 0o777 {
+			return int(iv)
 		}
 	}
+
 	return 0o77
 }

--- a/pkg/fsutil/umask_test.go
+++ b/pkg/fsutil/umask_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestUmask(t *testing.T) {
+func TestUmask(t *testing.T) { //nolint:paralleltest
 	for _, vn := range []string{"GOPASS_UMASK", "PASSWORD_STORE_UMASK"} {
 		for in, out := range map[string]int{
 			"002":      0o2,

--- a/pkg/gopass/api/api.go
+++ b/pkg/gopass/api/api.go
@@ -23,18 +23,27 @@ type Gopass struct {
 // make sure that *Gopass implements Store.
 var _ gopass.Store = &Gopass{}
 
+// ErrNotImplemented is returned when a method is not implemented.
+var ErrNotImplemented = fmt.Errorf("not yet implemented")
+
+// ErrNotInitialized is returned when the store is not initialized.
+var ErrNotInitialized = fmt.Errorf("password store not initialized. run 'gopass setup' first")
+
 // New creates a new secret store.
 // WARNING: This will need to change to accommodate for runtime configuration.
 func New(ctx context.Context) (*Gopass, error) {
 	cfg := config.LoadWithFallbackRelaxed()
 	store := root.New(cfg)
+
 	initialized, err := store.IsInitialized(ctx)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to check initialization: %w", err)
 	}
+
 	if !initialized {
-		return nil, fmt.Errorf("store not initialized. run gopass init first")
+		return nil, ErrNotInitialized
 	}
+
 	return &Gopass{
 		rs: store,
 	}, nil
@@ -42,42 +51,42 @@ func New(ctx context.Context) (*Gopass, error) {
 
 // List returns a list of all secrets.
 func (g *Gopass) List(ctx context.Context) ([]string, error) {
-	return g.rs.List(ctx, tree.INF)
+	return g.rs.List(ctx, tree.INF) //nolint:wrapcheck
 }
 
 // Get returns a single, encrypted secret. It must be unwrapped before use.
 func (g *Gopass) Get(ctx context.Context, name, revision string) (gopass.Secret, error) {
-	return g.rs.Get(ctx, name)
+	return g.rs.Get(ctx, name) //nolint:wrapcheck
 }
 
 // Set adds a new revision to an existing secret or creates a new one.
 func (g *Gopass) Set(ctx context.Context, name string, sec gopass.Byter) error {
-	return g.rs.Set(ctx, name, sec)
+	return g.rs.Set(ctx, name, sec) //nolint:wrapcheck
 }
 
 // Remove removes a single secret.
 func (g *Gopass) Remove(ctx context.Context, name string) error {
-	return g.rs.Delete(ctx, name)
+	return g.rs.Delete(ctx, name) //nolint:wrapcheck
 }
 
 // RemoveAll removes all secrets with a given prefix.
 func (g *Gopass) RemoveAll(ctx context.Context, prefix string) error {
-	return g.rs.Prune(ctx, prefix)
+	return g.rs.Prune(ctx, prefix) //nolint:wrapcheck
 }
 
 // Rename move a prefix to another.
 func (g *Gopass) Rename(ctx context.Context, src, dest string) error {
-	return g.rs.Move(ctx, src, dest)
+	return g.rs.Move(ctx, src, dest) //nolint:wrapcheck
 }
 
 // Sync synchronizes a secret with a remote.
 func (g *Gopass) Sync(ctx context.Context) error {
-	return fmt.Errorf("not yet implemented")
+	return ErrNotImplemented
 }
 
 // Revisions lists all revisions of this secret.
 func (g *Gopass) Revisions(ctx context.Context, name string) ([]string, error) {
-	return nil, fmt.Errorf("not yet implemented")
+	return nil, ErrNotImplemented
 }
 
 func (g *Gopass) String() string {
@@ -86,7 +95,11 @@ func (g *Gopass) String() string {
 
 // Close shuts down all background processes.
 func (g *Gopass) Close(ctx context.Context) error {
-	return queue.GetQueue(ctx).Close(ctx)
+	if err := queue.GetQueue(ctx).Close(ctx); err != nil {
+		return fmt.Errorf("failed to close queue: %w", err)
+	}
+
+	return nil
 }
 
 // ConfigDir returns gopass' configuration directory.

--- a/pkg/gopass/apimock/mock.go
+++ b/pkg/gopass/apimock/mock.go
@@ -8,6 +8,9 @@ import (
 	"github.com/gopasspw/gopass/pkg/gopass"
 )
 
+// ErrNotImplemented is returned when a method is not implemented.
+var ErrNotImplemented = fmt.Errorf("not yet implemented")
+
 // Secret is a mock secret for writing.
 type Secret struct {
 	Buf []byte
@@ -37,50 +40,52 @@ func (a *MockAPI) String() string {
 
 // List does nothing.
 func (a *MockAPI) List(ctx context.Context) ([]string, error) {
-	return a.store.List(ctx, "")
+	return a.store.List(ctx, "") //nolint:wrapcheck
 }
 
 // Get does nothing.
 func (a *MockAPI) Get(ctx context.Context, name, _ string) (gopass.Secret, error) {
-	return a.store.Get(ctx, name)
+	return a.store.Get(ctx, name) //nolint:wrapcheck
 }
 
 // Revisions does nothing.
 func (a *MockAPI) Revisions(ctx context.Context, name string) ([]string, error) {
 	rs, err := a.store.ListRevisions(ctx, name)
 	if err != nil {
-		return nil, err
+		return nil, err //nolint:wrapcheck
 	}
+
 	revs := make([]string, 0, len(rs))
 	for _, r := range rs {
 		revs = append(revs, r.Hash)
 	}
+
 	return revs, nil
 }
 
 // Set does nothing.
 func (a *MockAPI) Set(ctx context.Context, name string, sec gopass.Byter) error {
-	return a.store.Set(ctx, name, sec)
+	return a.store.Set(ctx, name, sec) //nolint:wrapcheck
 }
 
 // Remove does nothing.
 func (a *MockAPI) Remove(ctx context.Context, name string) error {
-	return a.store.Delete(ctx, name)
+	return a.store.Delete(ctx, name) //nolint:wrapcheck
 }
 
 // RemoveAll does nothing.
 func (a *MockAPI) RemoveAll(ctx context.Context, prefix string) error {
-	return a.store.Prune(ctx, prefix)
+	return a.store.Prune(ctx, prefix) //nolint:wrapcheck
 }
 
 // Rename does nothing.
 func (a *MockAPI) Rename(ctx context.Context, src, dest string) error {
-	return a.store.Move(ctx, src, dest)
+	return a.store.Move(ctx, src, dest) //nolint:wrapcheck
 }
 
 // Sync does nothing.
 func (a *MockAPI) Sync(ctx context.Context) error {
-	return fmt.Errorf("not yet implemented")
+	return ErrNotImplemented
 }
 
 // Close does nothing.

--- a/pkg/gopass/secrets/kv_test.go
+++ b/pkg/gopass/secrets/kv_test.go
@@ -8,7 +8,10 @@ import (
 )
 
 func TestKV(t *testing.T) {
+	t.Parallel()
+
 	t.Logf("Retrieve content from invalid YAML (#375)")
+
 	mlValue := `somepasswd
 Test / test.com
 username: myuser@test.com
@@ -31,15 +34,22 @@ url: http://www.test.com/
 username: myuser@test.com
 Test / test.com
 `
+
 	t.Run("read back the secret", func(t *testing.T) {
+		t.Parallel()
+
 		assert.Equal(t, mlOut, string(s.Bytes()))
 	})
 
 	t.Run("no_duplicate_keys", func(t *testing.T) {
+		t.Parallel()
+
 		assert.Equal(t, []string{"password", "url", "username"}, s.Keys())
 	})
 
 	t.Run("read some keys", func(t *testing.T) {
+		t.Parallel()
+
 		for k, v := range map[string]string{
 			"password": "bar",
 			"url":      "http://www.test.com/",
@@ -53,10 +63,13 @@ Test / test.com
 	})
 
 	t.Run("remove a key", func(t *testing.T) {
-		s.Set("foobar", "baz")
+		t.Parallel()
+
+		assert.NoError(t, s.Set("foobar", "baz"))
 		v, ok := s.Get("foobar")
 		assert.True(t, ok)
 		assert.Equal(t, "baz", v)
+
 		s.Del("foobar")
 		v, ok = s.Get("foobar")
 		assert.False(t, ok)
@@ -64,6 +77,8 @@ Test / test.com
 	})
 
 	t.Run("read the body", func(t *testing.T) {
+		t.Parallel()
+
 		body := "Test / test.com\n"
 		assert.Equal(t, body, s.Body())
 		assert.Equal(t, body, s.Body())
@@ -72,6 +87,8 @@ Test / test.com
 }
 
 func TestKVNoNewLine(t *testing.T) {
+	t.Parallel()
+
 	mlValue := `foobar
 ab: cd`
 	s, err := ParseKV([]byte(mlValue))
@@ -82,6 +99,8 @@ ab: cd`
 }
 
 func TestMultiKeyKVMIME(t *testing.T) {
+	t.Parallel()
+
 	in := `passw0rd
 foo: baz
 foo: bar

--- a/pkg/gopass/secrets/new.go
+++ b/pkg/gopass/secrets/new.go
@@ -5,6 +5,6 @@ import (
 )
 
 // New creates a new secret.
-func New() gopass.Secret {
+func New() gopass.Secret { //nolint:ireturn
 	return NewKV()
 }

--- a/pkg/gopass/secrets/plain.go
+++ b/pkg/gopass/secrets/plain.go
@@ -31,6 +31,7 @@ func ParsePlain(in []byte) *Plain {
 		buf: make([]byte, len(in)),
 	}
 	copy(p.buf, in)
+
 	return p
 }
 
@@ -43,8 +44,10 @@ func (p *Plain) Bytes() []byte {
 func (p *Plain) Body() string {
 	br := bufio.NewReader(bytes.NewReader(p.buf))
 	_, _ = br.ReadString('\n')
+
 	body := &bytes.Buffer{}
-	io.Copy(body, br)
+	_, _ = io.Copy(body, br)
+
 	return body.String()
 }
 
@@ -56,12 +59,14 @@ func (p *Plain) Keys() []string {
 // Get returns the empty string for Plain secrets.
 func (p *Plain) Get(key string) (string, bool) {
 	debug.Log("Trying to access key %q on a Plain secret", key)
+
 	return "", false
 }
 
 // Values returns the empty string for Plain secrets.
 func (p *Plain) Values(key string) ([]string, bool) {
 	debug.Log("Trying to access key %q on a Plain secret", key)
+
 	return []string{""}, false
 }
 
@@ -69,17 +74,18 @@ func (p *Plain) Values(key string) ([]string, bool) {
 func (p *Plain) Password() string {
 	br := bufio.NewReader(bytes.NewReader(p.buf))
 	pw, _ := br.ReadString('\n')
+
 	return strings.TrimSuffix(pw, "\n")
 }
 
 // Set does nothing.
 func (p *Plain) Set(_ string, _ any) error {
-	return fmt.Errorf("not supported for PLAIN")
+	return fmt.Errorf("Set not supported for PLAIN: %w", ErrNotSupported)
 }
 
 // Add does nothing.
 func (p *Plain) Add(_ string, _ any) error {
-	return fmt.Errorf("not supported for PLAIN")
+	return fmt.Errorf("Add not supported for PLAIN: %w", ErrNotSupported)
 }
 
 // SetPassword updates the first line.
@@ -87,14 +93,17 @@ func (p *Plain) SetPassword(value string) {
 	buf := &bytes.Buffer{}
 	fmt.Fprintln(buf, value)
 	br := bufio.NewReader(bytes.NewReader(p.buf))
+
 	_, err := br.ReadString('\n')
 	if err != nil {
 		debug.Log("failed to discard password line: %s", err)
 	}
+
 	_, err = io.Copy(buf, br)
 	if err != nil {
 		debug.Log("failed to copy buffer: %s", err)
 	}
+
 	p.buf = buf.Bytes()
 }
 
@@ -108,22 +117,26 @@ func (p *Plain) Getbuf() string {
 	br := bufio.NewReader(bytes.NewReader(p.buf))
 	if _, err := br.ReadString('\n'); err != nil {
 		debug.Log("failed to discard password line: %s", err)
+
 		return ""
 	}
+
 	buf := &bytes.Buffer{}
-	io.Copy(buf, br)
+	_, _ = io.Copy(buf, br)
+
 	return buf.String()
 }
 
 // Write appends to the internal buffer.
 func (p *Plain) Write(buf []byte) (int, error) {
 	p.buf = append(p.buf, buf...)
+
 	return len(buf), nil
 }
 
 // WriteString append a string to the internal buffer.
 func (p *Plain) WriteString(in string) {
-	p.Write([]byte(in))
+	_, _ = p.Write([]byte(in))
 }
 
 // SafeStr always returnes "(elided)".

--- a/pkg/gopass/secrets/plain_test.go
+++ b/pkg/gopass/secrets/plain_test.go
@@ -8,6 +8,8 @@ import (
 )
 
 func TestParsePlain(t *testing.T) {
+	t.Parallel()
+
 	for _, tc := range []struct {
 		desc string
 		in   string
@@ -27,8 +29,11 @@ func TestParsePlain(t *testing.T) {
 			body: "",
 		},
 	} {
+		tc := tc
+
 		t.Run(tc.desc, func(t *testing.T) {
 			t.Parallel()
+
 			sec := ParsePlain([]byte(tc.in))
 			t.Logf("Secret: %+v", sec)
 			assert.Equal(t, tc.pw, sec.Password())
@@ -38,16 +43,22 @@ func TestParsePlain(t *testing.T) {
 }
 
 func TestPlainModify(t *testing.T) {
+	t.Parallel()
+
 	in := "foobar\nhello world\nhow are you?"
 	sec := ParsePlain([]byte(in))
+
 	require.NotNil(t, sec)
 	assert.Equal(t, in, string(sec.Bytes()))
 	assert.Equal(t, 0, len(sec.Keys()))
-	sec.Set("foozen", "zab")
+	assert.Error(t, sec.Set("foozen", "zab"))
+
 	v, ok := sec.Get("foozen")
 	assert.False(t, ok)
+
 	assert.Equal(t, "", v)
 	assert.Equal(t, "foobar", sec.Password())
+
 	sec.SetPassword("zab")
 	assert.Equal(t, "zab", sec.Password())
 }

--- a/pkg/gopass/secrets/secparse/mime.go
+++ b/pkg/gopass/secrets/secparse/mime.go
@@ -3,6 +3,7 @@ package secparse
 import (
 	"bufio"
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"net/textproto"
@@ -11,32 +12,42 @@ import (
 	"github.com/gopasspw/gopass/pkg/gopass/secrets"
 )
 
+// ErrUnknown is returned when the secret is not recognized.
+var ErrUnknown = fmt.Errorf("unknown secrets type")
+
 // parseLegacyMIME is a fallback parser for the transient MIME format.
 func parseLegacyMIME(buf []byte) (*secrets.KV, error) {
 	var hdr textproto.MIMEHeader
+
 	body := &bytes.Buffer{}
+
 	var pw string
 
 	r := bufio.NewReader(bytes.NewReader(buf))
+
 	line, err := r.ReadString('\n')
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to read line: %w", err)
 	}
+
 	if strings.TrimSpace(line) != secrets.Ident {
-		return nil, fmt.Errorf("unknown secrets type: %s", line)
+		return nil, fmt.Errorf("%s: %w", line, ErrUnknown)
 	}
+
 	tpr := textproto.NewReader(r)
 	hdr, err = tpr.ReadMIMEHeader()
 	// we can reach EOF is there are no new line at the end of the secret file after the MIME header.
-	if err != nil && err != io.EOF {
+	if err != nil && !errors.Is(err, io.EOF) {
 		return nil, &secrets.PermanentError{Err: err}
 	}
+
 	if _, err := io.Copy(body, r); err != nil {
 		return nil, &secrets.PermanentError{Err: err}
 	}
 
 	if sv := hdr.Get("Password"); sv != "" {
 		pw = sv
+
 		hdr.Del("Password")
 	}
 

--- a/pkg/gopass/secrets/secparse/parse.go
+++ b/pkg/gopass/secrets/secparse/parse.go
@@ -1,6 +1,8 @@
 package secparse
 
 import (
+	"errors"
+
 	"github.com/gopasspw/gopass/internal/out"
 	"github.com/gopasspw/gopass/pkg/debug"
 	"github.com/gopasspw/gopass/pkg/gopass"
@@ -9,34 +11,46 @@ import (
 
 // Parse tries to parse a secret. It will start with the most specific
 // secrets type.
+//nolint:ireturn
 func Parse(in []byte) (gopass.Secret, error) {
 	var s gopass.Secret
+
 	var err error
+
 	s, err = parseLegacyMIME(in)
 	if err == nil {
 		debug.Log("parsed as MIME: %+v", s)
+
 		return s, nil
 	}
+
 	debug.Log("failed to parse as MIME: %s", out.Secret(err.Error()))
 
-	if _, ok := err.(*secrets.PermanentError); ok {
+	var permError *secrets.PermanentError
+	if errors.As(err, &permError) {
 		return secrets.ParsePlain(in), err
 	}
+
 	s, err = secrets.ParseYAML(in)
 	if err == nil {
 		debug.Log("parsed as YAML: %+v", s)
+
 		return s, nil
 	}
+
 	debug.Log("failed to parse as YAML: %s\n%s", err, out.Secret(string(in)))
 
 	s, err = secrets.ParseKV(in)
 	if err == nil {
 		debug.Log("parsed as KV: %+v", s)
+
 		return s, nil
 	}
+
 	debug.Log("failed to parse as KV: %s", err)
 
 	s = secrets.ParsePlain(in)
 	debug.Log("parsed as plain: %s", out.Secret(s.Bytes()))
+
 	return s, nil
 }

--- a/pkg/gopass/secrets/secparse/parse_test.go
+++ b/pkg/gopass/secrets/secparse/parse_test.go
@@ -1,7 +1,6 @@
 package secparse
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/gopasspw/gopass/pkg/gopass/secrets"
@@ -10,6 +9,8 @@ import (
 )
 
 func TestParse(t *testing.T) {
+	t.Parallel()
+
 	for _, tc := range []string{
 		"foo\n",                                  // Plain
 		"foo\nbar\n",                             // Plain
@@ -24,6 +25,8 @@ func TestParse(t *testing.T) {
 }
 
 func TestParsedIsSerialized(t *testing.T) {
+	t.Parallel()
+
 	for _, tc := range []string{
 		"foo",                     // Plain
 		"foo\nbar",                // Plain
@@ -33,7 +36,6 @@ func TestParsedIsSerialized(t *testing.T) {
 	} {
 		sec, err := Parse([]byte(tc))
 		require.NoError(t, err)
-		fmt.Println()
 		assert.Equal(t, tc, string(sec.Bytes()))
 	}
 }
@@ -49,11 +51,13 @@ func FuzzParse(f *testing.F) {
 	} {
 		f.Add(tc)
 	}
-	f.Fuzz(func(t *testing.T, in string) {
+
+	f.Fuzz(func(t *testing.T, in string) { //nolint:thelper
 		sec, err := Parse([]byte(in))
 		if err != nil {
 			t.Fatalf("Parse failed to decode a valid secret %q: %v", in, err)
 		}
+
 		if sec == nil {
 			t.Errorf("secret should not be nil")
 		}

--- a/pkg/gopass/secrets/yaml_test.go
+++ b/pkg/gopass/secrets/yaml_test.go
@@ -17,7 +17,10 @@ const (
 )
 
 func TestYAMLFromHereDoc(t *testing.T) {
+	t.Parallel()
+
 	t.Logf("Parse K/V w/ HereDoc as YAML, not K/V")
+
 	mlValue := `somepw
 ---
 foo:  |
@@ -34,8 +37,12 @@ key: value
 }
 
 func TestYAMLKeyFromEmptySecret(t *testing.T) {
+	t.Parallel()
+
 	t.Logf("Get Key from empty Secret")
+
 	s := &YAML{}
+
 	v, ok := s.Get(yamlKey)
 	assert.False(t, ok)
 	assert.Equal(t, "", v)
@@ -51,6 +58,8 @@ type inlineC struct {
 }
 
 func TestYAMLEncodingError(t *testing.T) {
+	t.Parallel()
+
 	s := &YAML{
 		data: map[string]any{
 			"foo": &struct {
@@ -63,10 +72,13 @@ func TestYAMLEncodingError(t *testing.T) {
 }
 
 func TestYAMLKeyToEmptySecret(t *testing.T) {
+	t.Parallel()
+
 	t.Logf("Set Key to empty Secret")
+
 	s := &YAML{}
 	// write key
-	s.Set(yamlKey, yamlValue)
+	assert.NoError(t, s.Set(yamlKey, yamlValue))
 
 	// read back key
 	v, ok := s.Get(yamlKey)
@@ -79,26 +91,41 @@ func TestYAMLKeyToEmptySecret(t *testing.T) {
 }
 
 func TestYAMLKeyFromPWOnlySecret(t *testing.T) {
+	t.Parallel()
+
 	t.Logf("Get key from password-only secret")
+
 	_, err := ParseYAML([]byte(yamlPassword))
+
 	require.Error(t, err)
 }
 
 func TestYAMLKeyToPWOnlySecret(t *testing.T) {
+	t.Parallel()
+
 	t.Logf("Set key to password-only secret")
+
 	_, err := ParseYAML([]byte(yamlPassword))
+
 	require.Error(t, err)
 }
 
 func TestBareYAMLReadKey(t *testing.T) {
+	t.Parallel()
+
 	t.Logf("Bare YAML - no document marker - read key")
+
 	in := "\nbar: baz\nzab: 123\n"
+
 	_, err := ParseYAML([]byte(in))
 	require.Error(t, err)
 }
 
 func TestYAMLSetMultipleKeys(t *testing.T) {
+	t.Parallel()
+
 	t.Logf("Set multiple keys to a secret")
+
 	s := &YAML{
 		password: yamlPassword,
 	}
@@ -108,14 +135,18 @@ func TestYAMLSetMultipleKeys(t *testing.T) {
 	_, _ = b.WriteString("\n")
 	numKey := 100
 	keys := make([]string, 0, numKey)
+
 	for i := 0; i < numKey; i++ {
 		// set key
 		key := fmt.Sprintf("%s-%04d", yamlKey, i)
-		s.Set(key, yamlValue)
+		assert.NoError(t, s.Set(key, yamlValue))
 		keys = append(keys, key)
 	}
+
 	_, _ = b.WriteString("---\n")
+
 	sort.Strings(keys)
+
 	for _, key := range keys {
 		_, _ = b.WriteString(key)
 		_, _ = b.WriteString(": ")
@@ -138,7 +169,10 @@ func TestYAMLSetMultipleKeys(t *testing.T) {
 }
 
 func TestYAMLMultilineWithDashes(t *testing.T) {
+	t.Parallel()
+
 	t.Logf("Get Multi-Line Value containing three dashes")
+
 	mlValue := `-----BEGIN PGP PRIVATE KEY BLOCK-----
 aaa
 bbb
@@ -146,7 +180,7 @@ ccc
 -----END PGP PRIVATE KEY BLOCK-----`
 	s := &YAML{}
 	// write key
-	s.Set(yamlKey, mlValue)
+	assert.NoError(t, s.Set(yamlKey, mlValue))
 
 	// read back key
 	v, ok := s.Get(yamlKey)
@@ -155,18 +189,26 @@ ccc
 }
 
 func TestYAMLDocMarkerAsPW(t *testing.T) {
+	t.Parallel()
+
 	t.Logf("Document Marker as Password (#398)")
+
 	mlValue := `---`
+
 	_, err := ParseYAML([]byte(mlValue))
 	require.Error(t, err)
 }
 
 func TestYAMLBodyWithoutPW(t *testing.T) {
+	t.Parallel()
+
 	t.Logf("YAML Body without Password (#398)")
+
 	mlValue := `---
 username: myuser@test.com
 password: somepasswd
 url: http://www.test.com/`
+
 	s, err := ParseYAML([]byte(mlValue))
 	require.NoError(t, err)
 	assert.NotNil(t, s)
@@ -180,12 +222,16 @@ url: http://www.test.com/`
 }
 
 func TestYAMLBodyWithPW(t *testing.T) {
+	t.Parallel()
+
 	t.Logf("YAML Body with Password (#1607)")
+
 	mlValue := `password
 ---
 username: myuser@test.com
 password: somepasswd
 url: http://www.test.com/`
+
 	s, err := ParseYAML([]byte(mlValue))
 	require.NoError(t, err)
 	assert.NotNil(t, s)
@@ -197,6 +243,8 @@ url: http://www.test.com/`
 }
 
 func TestYAMLValues(t *testing.T) {
+	t.Parallel()
+
 	s := &YAML{
 		data: map[string]any{
 			"string": "string",
@@ -209,6 +257,7 @@ func TestYAMLValues(t *testing.T) {
 
 	get := func(k string) string {
 		v, _ := s.Get(k)
+
 		return v
 	}
 
@@ -220,6 +269,8 @@ func TestYAMLValues(t *testing.T) {
 }
 
 func TestYAMLComplex(t *testing.T) {
+	t.Parallel()
+
 	in := `20
 ---
 login: hallo
@@ -233,6 +284,7 @@ sub:
 
 	get := func(k string) string {
 		v, _ := s.Get(k)
+
 		return v
 	}
 
@@ -240,4 +292,16 @@ sub:
 	assert.Equal(t, "42", get("number"))
 	assert.Equal(t, "map[subentry:123]", get("sub"))
 	assert.Equal(t, []string{"login", "number", "sub"}, s.Keys())
+}
+
+func TestYAMLInvalid(t *testing.T) {
+	t.Parallel()
+
+	in := `password
+---
+otpauth://totp/example-otp.com?secret=2m32moqkjmzochgb&issuer=authenticator&digits=6
+`
+	s, err := ParseYAML([]byte(in))
+	require.Error(t, err)
+	assert.Nil(t, s)
 }

--- a/pkg/otp/otp.go
+++ b/pkg/otp/otp.go
@@ -6,10 +6,13 @@ import (
 	"strings"
 
 	"github.com/gokyle/twofactor"
+	"github.com/gopasspw/gopass/internal/out"
+	"github.com/gopasspw/gopass/pkg/debug"
 	"github.com/gopasspw/gopass/pkg/gopass"
 )
 
 // Calculate will compute a OTP code from a given secret.
+//nolint:ireturn
 func Calculate(name string, sec gopass.Secret) (twofactor.OTP, string, error) {
 	otpURL, found := sec.Get("otpauth")
 	if found && strings.HasPrefix(otpURL, "//") {
@@ -19,13 +22,16 @@ func Calculate(name string, sec gopass.Secret) (twofactor.OTP, string, error) {
 		for _, line := range strings.Split(sec.Body(), "\n") {
 			if strings.HasPrefix(line, "otpauth://") {
 				otpURL = line
+
 				break
 			}
 		}
 	}
 
 	if otpURL != "" {
-		return twofactor.FromURL(otpURL)
+		debug.Log("found otpauth url: %s", out.Secret(otpURL))
+
+		return twofactor.FromURL(otpURL) //nolint:wrapcheck
 	}
 
 	// check yaml entry and fall back to password if we don't have one
@@ -33,37 +39,48 @@ func Calculate(name string, sec gopass.Secret) (twofactor.OTP, string, error) {
 
 	secKey, found := sec.Get("totp")
 	if !found {
+		debug.Log("no totp secret found, falling back to password")
+
 		secKey = sec.Password()
 	}
 
 	if strings.HasPrefix(secKey, "otpauth://") {
-		return twofactor.FromURL(secKey)
+		return twofactor.FromURL(secKey) //nolint:wrapcheck
 	}
 
 	otp, err := twofactor.NewGoogleTOTP(twofactor.Pad(secKey))
-	return otp, label, err
+	if err != nil {
+		return otp, label, fmt.Errorf("invalid OTP secret %q: %w", secKey, err)
+	}
+
+	return otp, label, nil
 }
 
 // WriteQRFile writes the given OTP code as a QR image to disk.
 func WriteQRFile(otp twofactor.OTP, label, file string) error {
 	var qr []byte
+
 	var err error
+
 	switch otp.Type() {
 	case twofactor.OATH_HOTP:
 		hotp, ok := otp.(*twofactor.HOTP)
 		if !ok {
-			return fmt.Errorf("Type assertion failed on twofactor.HOTP")
+			return fmt.Errorf("Type assertion failed on twofactor.HOTP: %w", ErrType)
 		}
+
 		qr, err = hotp.QR(label)
 	case twofactor.OATH_TOTP:
 		totp, ok := otp.(*twofactor.TOTP)
 		if !ok {
-			return fmt.Errorf("Type assertion failed on twofactor.TOTP")
+			return fmt.Errorf("Type assertion failed on twofactor.TOTP: %w", ErrType)
 		}
+
 		qr, err = totp.QR(label)
 	default:
-		err = fmt.Errorf("QR codes can only be generated for OATH OTPs")
+		err = ErrOathOTP
 	}
+
 	if err != nil {
 		return fmt.Errorf("failed to write qr file: %w", err)
 	}
@@ -71,5 +88,13 @@ func WriteQRFile(otp twofactor.OTP, label, file string) error {
 	if err := os.WriteFile(file, qr, 0o600); err != nil {
 		return fmt.Errorf("failed to write QR code: %w", err)
 	}
+
 	return nil
 }
+
+var (
+	// ErrOathOTP is returned when the secret is not a valid OATH secret.
+	ErrOathOTP = fmt.Errorf("QR codes can only be generated for OATH OTPs")
+	// ErrType is returned when the secret is not a valid OTP type.
+	ErrType = fmt.Errorf("type assertion failed")
+)

--- a/pkg/otp/otp_test.go
+++ b/pkg/otp/otp_test.go
@@ -19,6 +19,8 @@ const (
 )
 
 func TestCalculate(t *testing.T) {
+	t.Parallel()
+
 	testCases := [][]byte{
 		[]byte(totpSecret),
 		[]byte(fmt.Sprintf("%s\ntotp: %s", pw, totpSecret)),
@@ -27,21 +29,31 @@ func TestCalculate(t *testing.T) {
 		[]byte(fmt.Sprintf("%s\n---\n%s", pw, totpURL)),
 	}
 
-	for _, tc := range testCases {
-		s, err := secparse.Parse(tc)
-		require.NoError(t, err)
-		otp, _, err := Calculate("test", s)
-		assert.NoError(t, err, string(tc))
-		assert.NotNil(t, otp, string(tc))
+	for _, tc := range testCases { //nolint:paralleltest
+		tc := tc
+
+		t.Run(fmt.Sprintf("%s", tc), func(t *testing.T) {
+			t.Parallel()
+
+			s, err := secparse.Parse(tc)
+			require.NoError(t, err)
+			otp, _, err := Calculate("test", s)
+			assert.NoError(t, err, string(tc))
+			assert.NotNil(t, otp, string(tc))
+		})
 	}
 }
 
 func TestWrite(t *testing.T) {
+	t.Parallel()
+
 	td, err := os.MkdirTemp("", "gopass-")
 	assert.NoError(t, err)
+
 	defer func() {
-		os.RemoveAll(td)
+		_ = os.RemoveAll(td)
 	}()
+
 	tf := filepath.Join(td, "qr.png")
 
 	otp, label, err := twofactor.FromURL(totpURL)

--- a/pkg/pinentry/cli/fallback.go
+++ b/pkg/pinentry/cli/fallback.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/gopasspw/gopass/pkg/termio"
 )
@@ -21,6 +22,7 @@ func (c *Client) Set(key string) error {
 	if key == "REPEAT" {
 		c.repeat = true
 	}
+
 	return nil
 }
 
@@ -33,7 +35,8 @@ func (c *Client) Option(string) error {
 func (c *Client) GetPIN() (string, error) {
 	pw, err := termio.AskForPassword(context.TODO(), "your PIN", c.repeat)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("failed to ask for PIN: %w", err)
 	}
+
 	return pw, nil
 }

--- a/pkg/protect/protect_test.go
+++ b/pkg/protect/protect_test.go
@@ -7,5 +7,7 @@ import (
 )
 
 func TestProtect(t *testing.T) {
+	t.Parallel()
+
 	assert.NoError(t, Pledge(""))
 }

--- a/pkg/pwgen/cryptic.go
+++ b/pkg/pwgen/cryptic.go
@@ -11,6 +11,9 @@ import (
 	"github.com/muesli/crunchy"
 )
 
+// ErrCrypticInvalid is returned when a password is invalid.
+var ErrCrypticInvalid = fmt.Errorf("password does not satisfy all validators")
+
 // Cryptic is a generator for hard-to-remember passwords as required by (too)
 // many sites. Prefer memorable or xkcd-style passwords, if possible.
 type Cryptic struct {
@@ -25,10 +28,13 @@ func NewCryptic(length int, symbols bool) *Cryptic {
 	if length < 1 {
 		length = 16
 	}
+
 	chars := Digits + Upper + Lower
+
 	if symbols {
 		chars += Syms
 	}
+
 	return &Cryptic{
 		Chars:    chars,
 		Length:   length,
@@ -41,25 +47,33 @@ func NewCryptic(length int, symbols bool) *Cryptic {
 func NewCrypticForDomain(length int, domain string) *Cryptic {
 	c := NewCryptic(length, true)
 	r, found := pwrules.LookupRule(domain)
+
 	debug.Log("found rules for %s: %t", domain, found)
+
 	if !found {
 		return c
 	}
+
 	if r.Maxlen > 0 && c.Length > r.Maxlen {
 		c.Length = r.Maxlen
 	}
+
 	if c.Length < r.Minlen {
 		c.Length = r.Minlen
 	}
+
 	if chars := charsFromRule(append(r.Required, r.Allowed...)...); chars != "" {
 		c.Chars = chars
 	}
+
 	for _, req := range r.Required {
 		chars := charsFromRule(req)
 		if req == "" || strings.TrimSpace(chars) == "" {
 			continue
 		}
+
 		debug.Log("Adding validator for %s: Requires %q -> %q", domain, req, chars)
+
 		c.Validators = append(c.Validators, func(pw string) error {
 			wantChars := charsFromRule(req)
 			if wantChars == "" {
@@ -68,23 +82,29 @@ func NewCrypticForDomain(length int, domain string) *Cryptic {
 			if containsAllClasses(pw, wantChars) {
 				return nil
 			}
-			return fmt.Errorf("password %s does not contain any of %s", pw, chars)
+
+			return fmt.Errorf("password %s does not contain any of %s: %w", pw, chars, ErrCrypticInvalid)
 		})
 	}
+
 	if r.Maxconsec > 0 {
 		c.Validators = append(c.Validators, func(pw string) error {
 			if containsMaxConsecutive(pw, r.Maxconsec) {
 				return nil
 			}
-			return fmt.Errorf("password %s contains more than %d consecutive characters", pw, r.Maxconsec)
+
+			return fmt.Errorf("password %s contains more than %d consecutive characters: %w", pw, r.Maxconsec, ErrCrypticInvalid)
 		})
 	}
+
 	debug.Log("initialized generator: %+v", c)
+
 	return c
 }
 
 func charsFromRule(rules ...string) string {
 	chars := ""
+
 	for _, req := range rules {
 		switch req {
 		case "lower":
@@ -101,6 +121,7 @@ func charsFromRule(rules ...string) string {
 			}
 		}
 	}
+
 	return uniqueChars(chars)
 }
 
@@ -110,11 +131,14 @@ func uniqueChars(in string) string {
 	for _, c := range in {
 		charSet[c] = struct{}{}
 	}
+
 	charSlice := make([]string, 0, len(charSet))
 	for k := range charSet {
 		charSlice = append(charSlice, string(k))
 	}
+
 	sort.Strings(charSlice)
+
 	return strings.Join(charSlice, "")
 }
 
@@ -126,8 +150,10 @@ func NewCrypticWithAllClasses(length int, symbols bool) *Cryptic {
 		if containsAllClasses(pw, c.Chars) {
 			return nil
 		}
-		return fmt.Errorf("password does not contain all character classes")
+
+		return fmt.Errorf("password does not contain all classes: %w", ErrCrypticInvalid)
 	})
+
 	return c
 }
 
@@ -138,6 +164,7 @@ func NewCrypticWithCrunchy(length int, symbols bool) *Cryptic {
 	c.MaxTries = 3
 	validator := crunchy.NewValidator()
 	c.Validators = append(c.Validators, validator.Check)
+
 	return c
 }
 
@@ -146,22 +173,29 @@ func (c *Cryptic) Password() string {
 	round := 0
 	maxFn := func() bool {
 		round++
+
 		if c.MaxTries < 1 {
 			return false
 		}
+
 		if c.MaxTries == 0 && round >= 64 {
 			return true
 		}
+
 		if round > c.MaxTries {
 			return true
 		}
+
 		return false
 	}
+
 	for {
 		if maxFn() {
 			debug.Log("failed to generate password after %d rounds", round)
+
 			return ""
 		}
+
 		if pw := c.randomString(); c.isValid(pw) {
 			return pw
 		}
@@ -172,9 +206,11 @@ func (c *Cryptic) isValid(pw string) bool {
 	for _, v := range c.Validators {
 		if err := v(pw); err != nil {
 			debug.Log("failed to validate: %s", err)
+
 			return false
 		}
 	}
+
 	return true
 }
 
@@ -183,5 +219,6 @@ func (c *Cryptic) randomString() string {
 	for pw.Len() < c.Length {
 		_ = pw.WriteByte(c.Chars[randomInteger(len(c.Chars))])
 	}
+
 	return pw.String()
 }

--- a/pkg/pwgen/cryptic_test.go
+++ b/pkg/pwgen/cryptic_test.go
@@ -11,19 +11,29 @@ import (
 )
 
 func TestCrypticForDomain(t *testing.T) {
+	t.Parallel()
+
 	rules := pwrules.AllRules()
 	keys := make([]string, 0, len(rules))
+
 	for k := range rules {
 		keys = append(keys, k)
 	}
+
 	sort.Strings(keys)
-	for _, domain := range keys {
+
+	for _, domain := range keys { //nolint:paralleltest
 		t.Run(domain, func(t *testing.T) {
+			t.Parallel()
+
 			for _, length := range []int{1, 4, 8, 100} {
 				tcName := fmt.Sprintf("%s - %d", domain, length)
 				c := NewCrypticForDomain(length, domain)
+
 				require.NotNil(t, c, tcName)
+
 				pw := c.Password()
+
 				assert.NotEqual(t, "", pw, tcName)
 				t.Logf("%s -> %s (%d)", tcName, pw, len(pw))
 			}
@@ -32,6 +42,8 @@ func TestCrypticForDomain(t *testing.T) {
 }
 
 func TestUniqueChars(t *testing.T) {
+	t.Parallel()
+
 	for in, out := range map[string]string{
 		"foobar": "abfor",
 		"abced":  "abcde",

--- a/pkg/pwgen/external.go
+++ b/pkg/pwgen/external.go
@@ -10,29 +10,43 @@ import (
 	shellquote "github.com/kballard/go-shellquote"
 )
 
+var (
+	// ErrNoExternal is returned when no external generator is set.
+	ErrNoExternal = fmt.Errorf("no external generator")
+	// ErrNoCommand is returned when no command is set.
+	ErrNoCommand = fmt.Errorf("no command")
+)
+
 // GenerateExternal will invoke an external password generator,
 // if set, and return it's output.
 func GenerateExternal(pwlen int) (string, error) {
 	c := os.Getenv("GOPASS_EXTERNAL_PWGEN")
 	if c == "" {
-		return "", fmt.Errorf("no external generator")
+		return "", ErrNoExternal
 	}
+
 	cmdArgs, err := shellquote.Split(c)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("failed to split %s: %w", c, err)
 	}
+
 	if len(cmdArgs) < 1 {
-		return "", fmt.Errorf("no command")
+		return "", ErrNoCommand
 	}
+
 	exe := cmdArgs[0]
 	args := []string{}
+
 	if len(cmdArgs) > 1 {
 		args = cmdArgs[1:]
 	}
+
 	args = append(args, strconv.Itoa(pwlen))
+
 	out, err := exec.Command(exe, args...).Output()
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("failed to execute %s %v: %w", exe, args, err)
 	}
+
 	return strings.TrimSpace(string(out)), nil
 }

--- a/pkg/pwgen/memorable.go
+++ b/pkg/pwgen/memorable.go
@@ -6,26 +6,34 @@ import "strings"
 // with a minimum length.
 func GenerateMemorablePassword(minLength int, symbols bool, capitals bool) string {
 	var sb strings.Builder
+
 	upper := false
+
 	for sb.Len() < minLength {
 		// when requesting uppercase, we randomly uppercase words
 		if capitals && randomInteger(2) == 0 {
 			sb.WriteString(strings.Title(randomWord()))
+
 			upper = true
 		} else {
 			sb.WriteString(randomWord())
 		}
+
 		sb.WriteByte(Digits[randomInteger(len(Digits))])
+
 		if !symbols {
 			continue
 		}
+
 		sb.WriteByte(Syms[randomInteger(len(Syms))])
 	}
 	// If there isn't already a capitalized word, capitalize the first letter
 	if capitals && !upper {
 		str := sb.String()
+
 		return strings.Title(string(str[0])) + str[1:]
 	}
+
 	return sb.String()
 }
 

--- a/pkg/pwgen/pwgen_others_test.go
+++ b/pkg/pwgen/pwgen_others_test.go
@@ -4,16 +4,16 @@
 package pwgen
 
 import (
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
-func TestPwgenExternal(t *testing.T) {
-	_ = os.Setenv("GOPASS_EXTERNAL_PWGEN", "echo foobar")
-	defer os.Unsetenv("GOPASS_EXTERNAL_PWGEN")
+func TestPwgenExternal(t *testing.T) { //nolint:paralleltest
+	t.Setenv("GOPASS_EXTERNAL_PWGEN", "echo foobar")
+
 	pw, err := GenerateExternal(4)
+
 	assert.NoError(t, err)
 	assert.Equal(t, "foobar 4", pw)
 }

--- a/pkg/pwgen/pwgen_test.go
+++ b/pkg/pwgen/pwgen_test.go
@@ -18,49 +18,63 @@ func ExampleGenerateMemorablePassword() {
 }
 
 func TestPwgen(t *testing.T) {
+	t.Parallel()
+
 	for _, sym := range []bool{true, false} {
 		for i := 1; i < 50; i++ {
 			Syms := CharAlphaNum
 			if sym {
 				Syms = CharAll
 			}
+
 			assert.Equal(t, i, len(GeneratePasswordCharset(i, Syms)))
 		}
 	}
 }
 
-func TestPwgenCharset(t *testing.T) {
-	_ = os.Setenv("GOPASS_CHARACTER_SET", "a")
+func TestPwgenCharset(t *testing.T) { //nolint:paralleltest
+	t.Setenv("GOPASS_CHARACTER_SET", "a")
+
 	assert.Equal(t, "aaaa", GeneratePassword(4, true))
 	assert.Equal(t, "", GeneratePasswordCharsetCheck(4, "a"))
 }
 
-func TestPwgenNoCrand(t *testing.T) {
+func TestPwgenNoCrand(t *testing.T) { //nolint:paralleltest
 	old := rand.Reader
 	rand.Reader = strings.NewReader("")
+
 	defer func() {
 		rand.Reader = old
 	}()
+
 	oldOut := os.Stdout
 	r, w, _ := os.Pipe()
 	os.Stdout = w
 	os.Stderr = w
 	done := make(chan string)
+
 	go func() {
 		buf := &bytes.Buffer{}
 		_, _ = io.Copy(buf, r)
 		done <- buf.String()
 	}()
+
 	// if we seed math/rand with 1789, the first "random number" will be 42
 	mrand.Seed(1789)
+
 	n := randomInteger(1024)
+
 	assert.NoError(t, w.Close())
+
 	os.Stdout = oldOut
+
 	assert.Equal(t, 42, n)
 	assert.Equal(t, "WARNING: No crypto/rand available. Falling back to PRNG\n", <-done)
 }
 
 func TestContainsAllClasses(t *testing.T) {
+	t.Parallel()
+
 	for _, tc := range []struct {
 		pw      string
 		classes []string
@@ -82,29 +96,42 @@ func TestContainsAllClasses(t *testing.T) {
 			ok:      false,
 		},
 	} {
-		assert.Equal(t, tc.ok, containsAllClasses(tc.pw, tc.classes...))
+		tc := tc
+		t.Run(tc.pw, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tc.ok, containsAllClasses(tc.pw, tc.classes...))
+		})
 	}
 }
 
 func TestGeneratePasswordWithAllClasses(t *testing.T) {
+	t.Parallel()
+
 	pw, err := GeneratePasswordWithAllClasses(50, true)
 	assert.NoError(t, err)
 	assert.Equal(t, 50, len(pw))
 }
 
 func TestGenerateMemorablePassword(t *testing.T) {
+	t.Parallel()
+
 	pw := GenerateMemorablePassword(20, false, false)
 	assert.GreaterOrEqual(t, len(pw), 20)
 	assert.Equal(t, pw, strings.ToLower(pw))
 }
 
 func TestGenerateMemorablePasswordCapital(t *testing.T) {
+	t.Parallel()
+
 	pw := GenerateMemorablePassword(20, false, true)
 	assert.GreaterOrEqual(t, len(pw), 20)
 	assert.NotEqual(t, pw, strings.ToLower(pw))
 }
 
 func TestPrune(t *testing.T) {
+	t.Parallel()
+
 	for _, tc := range []struct {
 		In     string
 		Cutset string

--- a/pkg/pwgen/pwrules/change.go
+++ b/pkg/pwgen/pwrules/change.go
@@ -8,6 +8,7 @@ func init() {
 		if v == "" {
 			continue
 		}
+
 		changeURLs[k] = v
 	}
 }
@@ -18,10 +19,12 @@ func LookupChangeURL(domain string) string {
 	if u, found := changeURLs[domain]; found {
 		return u
 	}
+
 	for _, alias := range LookupAliases(domain) {
 		if u, found := changeURLs[alias]; found {
 			return u
 		}
 	}
+
 	return ""
 }

--- a/pkg/pwgen/pwrules/pwrules.go
+++ b/pkg/pwgen/pwrules/pwrules.go
@@ -25,11 +25,13 @@ func LookupRule(domain string) (Rule, bool) {
 	if found {
 		return r, true
 	}
+
 	for _, alias := range LookupAliases(domain) {
 		if r, found := genRules[alias]; found {
 			return r, true
 		}
 	}
+
 	return Rule{}, false
 }
 
@@ -47,10 +49,12 @@ type Rule struct {
 // NOTE: This is not a complete parser.
 func ParseRule(in string) Rule {
 	r := Rule{}
+
 	if reChars.MatchString(in) {
 		m := reChars.FindStringSubmatch(in)
 		if len(m) > 2 {
 			re := "[" + m[2] + "]"
+
 			switch m[1] {
 			case "required":
 				r.Required = append(r.Required, re)
@@ -59,18 +63,23 @@ func ParseRule(in string) Rule {
 			}
 		}
 	}
+
 	for _, part := range strings.Split(strings.TrimSuffix(in, ";"), ";") {
 		p := strings.Split(part, ": ")
 		if len(p) < 2 {
 			continue
 		}
+
 		var err error
+
 		key := strings.TrimSpace(p[0])
 		strVal := strings.TrimSpace(p[1])
 		max := len(strVal)
+
 		if i := strings.Index(strVal, "["); i > 0 {
 			max = i
 		}
+
 		switch key {
 		case "minlength":
 			r.Minlen, err = strconv.Atoi(strVal)
@@ -83,24 +92,31 @@ func ParseRule(in string) Rule {
 		case "allowed":
 			r.Allowed = append(r.Allowed, strings.Split(strVal[0:max], ",")...)
 		}
+
 		if err != nil {
 			debug.Log("failed to parse %s for %s: %s", strVal, key, err)
 		}
 	}
+
 	r.Required = sanitize(r.Required)
 	r.Allowed = sanitize(r.Allowed)
+
 	return r
 }
 
 func sanitize(in []string) []string {
 	out := make([]string, 0, len(in))
+
 	for _, v := range in {
 		v := strings.TrimSpace(v)
 		if strings.HasPrefix(v, "[") && !strings.HasSuffix(v, "]") {
 			continue
 		}
+
 		out = append(out, v)
 	}
+
 	sort.Strings(out)
+
 	return out
 }

--- a/pkg/pwgen/pwrules/pwrules_test.go
+++ b/pkg/pwgen/pwrules/pwrules_test.go
@@ -7,6 +7,8 @@ import (
 )
 
 func TestParseRule(t *testing.T) {
+	t.Parallel()
+
 	for _, tc := range []struct {
 		in  string
 		out Rule
@@ -53,6 +55,8 @@ func TestParseRule(t *testing.T) {
 	} {
 		tc := tc
 		t.Run(tc.in, func(t *testing.T) {
+			t.Parallel()
+
 			assert.Equal(t, tc.out, ParseRule(tc.in))
 		})
 	}

--- a/pkg/pwgen/rand.go
+++ b/pkg/pwgen/rand.go
@@ -19,6 +19,8 @@ func randomInteger(max int) int {
 	if err == nil {
 		return int(i.Int64())
 	}
+
 	fmt.Fprintln(os.Stderr, "WARNING: No crypto/rand available. Falling back to PRNG")
+
 	return rand.Intn(max)
 }

--- a/pkg/pwgen/validate.go
+++ b/pkg/pwgen/validate.go
@@ -14,8 +14,10 @@ CLASSES:
 				continue CLASSES
 			}
 		}
+
 		return false
 	}
+
 	return true
 }
 
@@ -29,12 +31,14 @@ func containsOnlyClasses(pw string, classes ...string) bool {
 			}
 		}
 	}
+
 	return true
 }
 
 func containsMaxConsecutive(pw string, n int) bool {
 	last := ""
 	repCnt := 1
+
 	for _, r := range pw {
 		if last == string(r) {
 			repCnt++
@@ -44,7 +48,9 @@ func containsMaxConsecutive(pw string, n int) bool {
 		} else {
 			repCnt = 1
 		}
+
 		last = string(r)
 	}
+
 	return true
 }

--- a/pkg/pwgen/validate_test.go
+++ b/pkg/pwgen/validate_test.go
@@ -7,6 +7,8 @@ import (
 )
 
 func TestMaxConsec(t *testing.T) {
+	t.Parallel()
+
 	// good
 	for _, tc := range []string{
 		"abcd",
@@ -29,6 +31,8 @@ func TestMaxConsec(t *testing.T) {
 }
 
 func TestContainsOnly(t *testing.T) {
+	t.Parallel()
+
 	// good
 	for _, tc := range []string{
 		"aBcDeF",

--- a/pkg/pwgen/xkcdgen/pwgen.go
+++ b/pkg/pwgen/xkcdgen/pwgen.go
@@ -1,10 +1,15 @@
 package xkcdgen
 
-import "github.com/martinhoefling/goxkcdpwgen/xkcdpwgen"
+import (
+	"fmt"
+
+	"github.com/martinhoefling/goxkcdpwgen/xkcdpwgen"
+)
 
 // Random returns a random passphrase combined from four words.
 func Random() string {
 	password, _ := RandomLength(4, "en")
+
 	return password
 }
 
@@ -21,8 +26,10 @@ func RandomLengthDelim(length int, delim, lang string) (string, error) {
 	g.SetNumWords(length)
 	g.SetDelimiter(delim)
 	g.SetCapitalize(delim == "")
+
 	if err := g.UseLangWordlist(lang); err != nil {
-		return "", err
+		return "", fmt.Errorf("failed to use wordlist for lang %s: %w", lang, err)
 	}
+
 	return string(g.GeneratePassword()), nil
 }

--- a/pkg/pwgen/xkcdgen/pwgen_test.go
+++ b/pkg/pwgen/xkcdgen/pwgen_test.go
@@ -8,16 +8,21 @@ import (
 )
 
 func TestRandom(t *testing.T) {
+	t.Parallel()
+
 	pw := Random()
 	if len(pw) < 4 {
 		t.Errorf("too short")
 	}
+
 	if len(strings.Fields(pw)) < 4 {
 		t.Errorf("too few words")
 	}
 }
 
 func TestRandomLengthDelim(t *testing.T) {
+	t.Parallel()
+
 	_, err := RandomLengthDelim(10, " ", "cn_ZH")
 	assert.Error(t, err)
 }

--- a/pkg/qrcon/qrcon.go
+++ b/pkg/qrcon/qrcon.go
@@ -15,39 +15,49 @@ const (
 	white = "\033[47m  \033[0m"
 )
 
+// ErrUnknowColor is returned when the color is unknown.
+var ErrUnknowColor = fmt.Errorf("unknown color")
+
 // QRCode returns a string containing an ANSI encoded
 // QR Code.
 func QRCode(content string) (string, error) {
 	q, err := qrcode.New(content, qrcode.Medium)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("failed to create qr code: %w", err)
 	}
 
 	var sb strings.Builder
+
 	i := q.Image(0)
 	b := i.Bounds()
+
 	for x := b.Min.X; x < b.Max.X; x++ {
 		for y := b.Min.Y; y < b.Max.Y; y++ {
 			col := i.At(x, y)
+
 			switch {
 			case sameColor(col, q.ForegroundColor):
 				_, _ = sb.WriteString(black)
 			case sameColor(col, q.BackgroundColor):
 				_, _ = sb.WriteString(white)
 			default:
-				return "", fmt.Errorf("unexpected color at (%d,%d): %+v", x, y, col)
+				return "", fmt.Errorf("error at (%d,%d): %+v: %w", x, y, col, ErrUnknowColor)
 			}
 		}
+
 		_, _ = sb.WriteString("\n")
 	}
+
 	return sb.String(), nil
 }
 
 func sameColor(a color.Color, b color.Color) bool {
 	r1, g1, b1, a1 := a.RGBA()
 	r2, g2, b2, a2 := b.RGBA()
+
 	if r1 == r2 && g1 == g2 && b1 == b2 && a1 == a2 {
 		return true
 	}
+
 	return false
 }

--- a/pkg/qrcon/qrcon_test.go
+++ b/pkg/qrcon/qrcon_test.go
@@ -12,10 +12,13 @@ func ExampleQRCode() {
 	if err != nil {
 		panic(err)
 	}
+
 	fmt.Println(code)
 }
 
 func TestQRCode(t *testing.T) {
+	t.Parallel()
+
 	_, err := QRCode("https://www.gopass.pw/")
 	assert.NoError(t, err)
 }

--- a/pkg/tempfile/mount_linux.go
+++ b/pkg/tempfile/mount_linux.go
@@ -23,11 +23,11 @@ func tempdirBase() string {
 			}
 		}
 	}
+
 	return ""
 }
 
 func (t *File) mount(context.Context) error {
-	_ = t.dev // to trick megacheck
 	return nil
 }
 

--- a/pkg/termio/ask_test.go
+++ b/pkg/termio/ask_test.go
@@ -12,10 +12,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestAskForString(t *testing.T) {
+func TestAskForString(t *testing.T) { //nolint:paralleltest
 	buf := &bytes.Buffer{}
 	out.Stderr = buf
 	Stderr = buf
+
 	defer func() {
 		out.Stderr = os.Stderr
 		Stderr = os.Stderr
@@ -45,21 +46,24 @@ bar
 	sv, err = AskForString(ctx, "test", "foobar")
 	assert.NoError(t, err)
 	assert.Equal(t, "bar", sv)
+
 	Stdin = os.Stdin
 
 	sv, err = AskForString(ctx, "test", "foobar")
 	assert.NoError(t, err)
 	assert.Equal(t, "foobar", sv)
+
 	Stdin = os.Stdin
 
 	t.Logf("Stderr: %s", buf.String())
 	buf.Reset()
 }
 
-func TestAskForBool(t *testing.T) {
+func TestAskForBool(t *testing.T) { //nolint:paralleltest
 	buf := &bytes.Buffer{}
 	out.Stderr = buf
 	Stderr = buf
+
 	defer func() {
 		out.Stderr = os.Stderr
 		Stderr = os.Stderr
@@ -112,10 +116,11 @@ z
 	assert.False(t, bv)
 }
 
-func TestAskForInt(t *testing.T) {
+func TestAskForInt(t *testing.T) { //nolint:paralleltest
 	buf := &bytes.Buffer{}
 	out.Stderr = buf
 	Stderr = buf
+
 	defer func() {
 		out.Stderr = os.Stderr
 		Stderr = os.Stderr
@@ -144,10 +149,11 @@ func TestAskForInt(t *testing.T) {
 	assert.Equal(t, 23, iv)
 }
 
-func TestAskForConfirmation(t *testing.T) {
+func TestAskForConfirmation(t *testing.T) { //nolint:paralleltest
 	buf := &bytes.Buffer{}
 	out.Stderr = buf
 	Stderr = buf
+
 	defer func() {
 		out.Stderr = os.Stderr
 		Stderr = os.Stderr
@@ -173,10 +179,11 @@ n
 	assert.False(t, AskForConfirmation(ctx, "test"))
 }
 
-func TestAskForKeyImport(t *testing.T) {
+func TestAskForKeyImport(t *testing.T) { //nolint:paralleltest
 	buf := &bytes.Buffer{}
 	out.Stderr = buf
 	Stderr = buf
+
 	defer func() {
 		out.Stderr = os.Stderr
 		Stderr = os.Stderr
@@ -201,10 +208,11 @@ z
 	assert.False(t, AskForKeyImport(ctx, "", nil))
 }
 
-func TestAskForPasswordNonInteractive(t *testing.T) {
+func TestAskForPasswordNonInteractive(t *testing.T) { //nolint:paralleltest
 	buf := &bytes.Buffer{}
 	out.Stderr = buf
 	Stderr = buf
+
 	defer func() {
 		out.Stderr = os.Stderr
 		Stderr = os.Stderr
@@ -241,10 +249,11 @@ foobat
 	assert.Equal(t, "", sv)
 }
 
-func TestAskForPasswordInteractive(t *testing.T) {
+func TestAskForPasswordInteractive(t *testing.T) { //nolint:paralleltest
 	buf := &bytes.Buffer{}
 	out.Stderr = buf
 	Stderr = buf
+
 	defer func() {
 		out.Stderr = os.Stderr
 		Stderr = os.Stderr

--- a/pkg/termio/context.go
+++ b/pkg/termio/context.go
@@ -20,6 +20,7 @@ func WithPassPromptFunc(ctx context.Context, ppf PassPromptFunc) context.Context
 // set in this context.
 func HasPassPromptFunc(ctx context.Context) bool {
 	ppf, ok := ctx.Value(ctxKeyPassPromptFunc).(PassPromptFunc)
+
 	return ok && ppf != nil
 }
 
@@ -30,5 +31,6 @@ func GetPassPromptFunc(ctx context.Context) PassPromptFunc {
 	if !ok || ppf == nil {
 		return promptPass
 	}
+
 	return ppf
 }

--- a/pkg/termio/context_test.go
+++ b/pkg/termio/context_test.go
@@ -8,6 +8,8 @@ import (
 )
 
 func TestPassPromptFunc(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 
 	assert.False(t, HasPassPromptFunc(ctx))

--- a/pkg/termio/identity.go
+++ b/pkg/termio/identity.go
@@ -27,17 +27,21 @@ var (
 func DetectName(ctx context.Context, c *cli.Context) string {
 	cand := make([]string, 0, 5)
 	cand = append(cand, ctxutil.GetUsername(ctx))
+
 	if c != nil {
 		cand = append(cand, c.String("name"))
 	}
+
 	for _, k := range NameVars {
 		cand = append(cand, os.Getenv(k))
 	}
+
 	for _, e := range cand {
 		if e != "" {
 			return e
 		}
 	}
+
 	return ""
 }
 
@@ -45,16 +49,20 @@ func DetectName(ctx context.Context, c *cli.Context) string {
 func DetectEmail(ctx context.Context, c *cli.Context) string {
 	cand := make([]string, 0, 5)
 	cand = append(cand, ctxutil.GetEmail(ctx))
+
 	if c != nil {
 		cand = append(cand, c.String("email"))
 	}
+
 	for _, k := range EmailVars {
 		cand = append(cand, os.Getenv(k))
 	}
+
 	for _, e := range cand {
 		if e != "" {
 			return e
 		}
 	}
+
 	return ""
 }

--- a/pkg/termio/identity_test.go
+++ b/pkg/termio/identity_test.go
@@ -8,40 +8,46 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestDetectName(t *testing.T) {
+func TestDetectName(t *testing.T) { //nolint:paralleltest
 	ctx := context.Background()
 
 	oga := os.Getenv("GIT_AUTHOR_NAME")
 	odf := os.Getenv("DEBFULLNAME")
 	ous := os.Getenv("USER")
+
 	defer func() {
-		os.Setenv("GIT_AUTHOR_NAME", oga)
-		os.Setenv("DEBFULLNAME", odf)
-		os.Setenv("USER", ous)
+		_ = os.Setenv("GIT_AUTHOR_NAME", oga)
+		_ = os.Setenv("DEBFULLNAME", odf)
+		_ = os.Setenv("USER", ous)
 	}()
 
-	os.Unsetenv("GIT_AUTHOR_NAME")
-	os.Unsetenv("DEBFULLNAME")
-	os.Unsetenv("USER")
+	_ = os.Unsetenv("GIT_AUTHOR_NAME")
+	_ = os.Unsetenv("DEBFULLNAME")
+	_ = os.Unsetenv("USER")
+
 	assert.Equal(t, "", DetectName(ctx, nil))
-	os.Setenv("USER", "foo")
+
+	t.Setenv("USER", "foo")
+
 	assert.Equal(t, "foo", DetectName(ctx, nil))
 }
 
-func TestDetectEmail(t *testing.T) {
+func TestDetectEmail(t *testing.T) { //nolint:paralleltest
 	ctx := context.Background()
 
 	oga := os.Getenv("GIT_AUTHOR_EMAIL")
 	odf := os.Getenv("DEBEMAIL")
 	ous := os.Getenv("EMAIL")
+
 	defer func() {
-		os.Setenv("GIT_AUTHOR_EMAIL", oga)
-		os.Setenv("DEBEMAIL", odf)
-		os.Setenv("EMAIL", ous)
+		_ = os.Setenv("GIT_AUTHOR_EMAIL", oga)
+		_ = os.Setenv("DEBEMAIL", odf)
+		_ = os.Setenv("EMAIL", ous)
 	}()
 
-	os.Unsetenv("GIT_AUTHOR_EMAIL")
-	os.Unsetenv("DEBEMAIL")
-	os.Unsetenv("EMAIL")
+	_ = os.Unsetenv("GIT_AUTHOR_EMAIL")
+	_ = os.Unsetenv("DEBEMAIL")
+	_ = os.Unsetenv("EMAIL")
+
 	assert.Equal(t, "", DetectEmail(ctx, nil))
 }

--- a/pkg/termio/progress_test.go
+++ b/pkg/termio/progress_test.go
@@ -10,17 +10,19 @@ import (
 func ExampleProgressBar() {
 	max := 100
 	pb := NewProgressBar(int64(max))
+
 	for i := 0; i < max+20; i++ {
 		pb.Inc()
 		pb.Add(23)
 		pb.Set(42)
 		time.Sleep(150 * time.Millisecond)
 	}
+
 	time.Sleep(5 * time.Second)
 	pb.Done()
 }
 
-func TestProgress(t *testing.T) {
+func TestProgress(t *testing.T) { //nolint:paralleltest
 	max := 2
 	pb := NewProgressBar(int64(max))
 	pb.Hidden = true
@@ -28,14 +30,16 @@ func TestProgress(t *testing.T) {
 	assert.Equal(t, int64(1), pb.current)
 }
 
-func TestProgressBytes(t *testing.T) {
+func TestProgressBytes(t *testing.T) { //nolint:paralleltest
 	max := 2 << 24
 	pb := NewProgressBar(int64(max))
 	pb.Hidden = true
 	pb.Bytes = true
+
 	for i := 0; i < 24; i++ {
 		pb.Set(2 << (i + 1))
 	}
+
 	assert.Equal(t, int64(max), pb.current)
 	pb.Done()
 }

--- a/pkg/termio/promptpass_test.go
+++ b/pkg/termio/promptpass_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestPromptPass(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	ctx = ctxutil.WithTerminal(ctx, false)
 	ctx = ctxutil.WithAlwaysYes(ctx, true)

--- a/pkg/termio/reader_test.go
+++ b/pkg/termio/reader_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestReadLines(t *testing.T) {
+	t.Parallel()
+
 	for _, tc := range [][]string{
 		{"foo", "bar"},
 		{"foo", "bar", "", "baz"},
@@ -25,6 +27,8 @@ func TestReadLines(t *testing.T) {
 }
 
 func TestReadLineError(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	stdin := strings.NewReader("fo")
 	lr := NewReader(ctx, iotest.TimeoutReader(stdin))
@@ -35,6 +39,8 @@ func TestReadLineError(t *testing.T) {
 }
 
 func TestRead(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	stdin := strings.NewReader(`foobarbazzabzabzab`)
 	lr := NewReader(ctx, stdin)
@@ -48,9 +54,11 @@ func TestRead(t *testing.T) {
 
 func mustReadLine(r io.Reader) string {
 	ctx := context.Background()
+
 	line, err := NewReader(ctx, r).ReadLine()
 	if err != nil {
 		panic(err)
 	}
+
 	return line
 }

--- a/tests/audit_test.go
+++ b/tests/audit_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestAudit(t *testing.T) {
+func TestAudit(t *testing.T) { //nolint:paralleltest
 	ts := newTester(t)
 	defer ts.teardown()
 

--- a/tests/binary_test.go
+++ b/tests/binary_test.go
@@ -9,18 +9,18 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestBinaryCopy(t *testing.T) {
+func TestBinaryCopy(t *testing.T) { //nolint:paralleltest
 	ts := newTester(t)
 	defer ts.teardown()
 
-	t.Run("empty store", func(t *testing.T) {
+	t.Run("empty store", func(t *testing.T) { //nolint:paralleltest
 		_, err := ts.run("fscopy")
 		assert.Error(t, err)
 	})
 
 	ts.initStore()
 
-	t.Run("no args", func(t *testing.T) {
+	t.Run("no args", func(t *testing.T) { //nolint:paralleltest
 		out, err := ts.run("fscopy")
 		assert.Error(t, err)
 		assert.Equal(t, "\nError: usage: gopass fscopy from to\n", out)
@@ -30,13 +30,13 @@ func TestBinaryCopy(t *testing.T) {
 	dat := []byte("foobar")
 	require.NoError(t, os.WriteFile(fn, dat, 0o644))
 
-	t.Run("copy file to store", func(t *testing.T) {
+	t.Run("copy file to store", func(t *testing.T) { //nolint:paralleltest
 		_, err := ts.run("fscopy " + fn + " foo/bar")
 		require.NoError(t, err)
 		assert.NoError(t, os.Remove(fn))
 	})
 
-	t.Run("copy store to file", func(t *testing.T) {
+	t.Run("copy store to file", func(t *testing.T) { //nolint:paralleltest
 		_, err := ts.run("fscopy foo/bar " + fn)
 		assert.NoError(t, err)
 
@@ -46,24 +46,24 @@ func TestBinaryCopy(t *testing.T) {
 		assert.Equal(t, buf, dat)
 	})
 
-	t.Run("cat from store", func(t *testing.T) {
+	t.Run("cat from store", func(t *testing.T) { //nolint:paralleltest
 		_, err := ts.run("cat foo/bar")
 		assert.NoError(t, err)
 	})
 }
 
-func TestBinaryMove(t *testing.T) {
+func TestBinaryMove(t *testing.T) { //nolint:paralleltest
 	ts := newTester(t)
 	defer ts.teardown()
 
-	t.Run("empty store", func(t *testing.T) {
+	t.Run("empty store", func(t *testing.T) { //nolint:paralleltest
 		_, err := ts.run("fsmove")
 		assert.Error(t, err)
 	})
 
 	ts.initStore()
 
-	t.Run("no args", func(t *testing.T) {
+	t.Run("no args", func(t *testing.T) { //nolint:paralleltest
 		out, err := ts.run("fsmove")
 		assert.Error(t, err)
 		assert.Equal(t, "\nError: usage: gopass fsmove from to\n", out)
@@ -73,13 +73,13 @@ func TestBinaryMove(t *testing.T) {
 	dat := []byte("foobar")
 	require.NoError(t, os.WriteFile(fn, dat, 0o644))
 
-	t.Run("move fs to store", func(t *testing.T) {
+	t.Run("move fs to store", func(t *testing.T) { //nolint:paralleltest
 		_, err := ts.run("fsmove " + fn + " foo/bar")
 		assert.NoError(t, err)
 		assert.Error(t, os.Remove(fn))
 	})
 
-	t.Run("move store to fs", func(t *testing.T) {
+	t.Run("move store to fs", func(t *testing.T) { //nolint:paralleltest
 		_, err := ts.run("fsmove foo/bar " + fn)
 		assert.NoError(t, err)
 
@@ -89,30 +89,30 @@ func TestBinaryMove(t *testing.T) {
 		assert.Equal(t, buf, dat)
 	})
 
-	t.Run("cat secret", func(t *testing.T) {
+	t.Run("cat secret", func(t *testing.T) { //nolint:paralleltest
 		_, err := ts.run("cat foo/bar")
 		assert.Error(t, err)
 	})
 }
 
-func TestBinaryShasum(t *testing.T) {
+func TestBinaryShasum(t *testing.T) { //nolint:paralleltest
 	ts := newTester(t)
 	defer ts.teardown()
 
-	t.Run("shasum on empty store", func(t *testing.T) {
+	t.Run("shasum on empty store", func(t *testing.T) { //nolint:paralleltest
 		_, err := ts.run("sha256")
 		assert.Error(t, err)
 	})
 
 	ts.initStore()
 
-	t.Run("shasum w/o args", func(t *testing.T) {
+	t.Run("shasum w/o args", func(t *testing.T) { //nolint:paralleltest
 		out, err := ts.run("sha256")
 		assert.Error(t, err)
 		assert.Equal(t, "\nError: Usage: gopass sha256 name\n", out)
 	})
 
-	t.Run("populate store", func(t *testing.T) {
+	t.Run("populate store", func(t *testing.T) { //nolint:paralleltest
 		fn := filepath.Join(ts.tempDir, "shasum")
 		dat := []byte("foobar")
 		require.NoError(t, os.WriteFile(fn, dat, 0o644))
@@ -121,7 +121,7 @@ func TestBinaryShasum(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	t.Run("shasum on binary secret", func(t *testing.T) {
+	t.Run("shasum on binary secret", func(t *testing.T) { //nolint:paralleltest
 		out, err := ts.run("sha256 foo/bar")
 		assert.NoError(t, err)
 		assert.Equal(t, "c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2", out)

--- a/tests/completion_test.go
+++ b/tests/completion_test.go
@@ -1,28 +1,28 @@
 package tests
 
 import (
-	"os"
 	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
-func TestCompletion(t *testing.T) {
+func TestCompletion(t *testing.T) { //nolint:paralleltest
 	if runtime.GOOS == "windows" {
 		t.Skip("skipping test on windows.")
 	}
+
 	ts := newTester(t)
 	defer ts.teardown()
 
-	t.Run("completion help", func(t *testing.T) {
+	t.Run("completion help", func(t *testing.T) { //nolint:paralleltest
 		out, err := ts.run("completion")
 		assert.NoError(t, err)
 		assert.Contains(t, out, "Source for auto completion in bash")
 		assert.Contains(t, out, "Source for auto completion in zsh")
 	})
 
-	t.Run("bash completion", func(t *testing.T) {
+	t.Run("bash completion", func(t *testing.T) { //nolint:paralleltest
 		bash := `_gopass_bash_autocomplete() {
      local cur opts base
      COMPREPLY=()
@@ -40,28 +40,24 @@ complete -F _gopass_bash_autocomplete gopass`
 		assert.Equal(t, bash, out)
 	})
 
-	t.Run("zsh completion", func(t *testing.T) {
+	t.Run("zsh completion", func(t *testing.T) { //nolint:paralleltest
 		out, err := ts.run("completion zsh")
 		assert.NoError(t, err)
 		assert.Contains(t, out, "compdef gopass")
 	})
 
-	t.Run("fish completion", func(t *testing.T) {
+	t.Run("fish completion", func(t *testing.T) { //nolint:paralleltest
 		out, err := ts.run("completion fish")
 		assert.NoError(t, err)
 		assert.Contains(t, out, "complete")
 	})
 }
 
-func TestCompletionNoPath(t *testing.T) {
+func TestCompletionNoPath(t *testing.T) { //nolint:paralleltest
 	ts := newTester(t)
 	defer ts.teardown()
 
-	ov := os.Getenv("PATH")
-	assert.NoError(t, os.Setenv("PATH", "/tmp/foobar"))
-	defer func() {
-		_ = os.Setenv("PATH", ov)
-	}()
+	t.Setenv("PATH", "/tmp/foobar")
 
 	t.Run("generate bash", func(t *testing.T) {
 		_, err := ts.run("--generate-bash-completion")

--- a/tests/config_test.go
+++ b/tests/config_test.go
@@ -8,12 +8,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestBaseConfig(t *testing.T) {
+func TestBaseConfig(t *testing.T) { //nolint:paralleltest
 	ts := newTester(t)
 	defer ts.teardown()
 
 	out, err := ts.run("config")
 	assert.NoError(t, err)
+
 	wanted := `autoclip: false
 autoimport: true
 cliptimeout: 45
@@ -33,7 +34,7 @@ parsing: true
 		"parsing",
 	}
 
-	for _, invert := range invertables {
+	for _, invert := range invertables { //nolint:paralleltest
 		t.Run("invert "+invert, func(t *testing.T) {
 			out, err = ts.run("config " + invert + " false")
 			assert.NoError(t, err)
@@ -56,7 +57,7 @@ parsing: true
 	})
 }
 
-func TestMountConfig(t *testing.T) {
+func TestMountConfig(t *testing.T) { //nolint:paralleltest
 	ts := newTester(t)
 	defer ts.teardown()
 

--- a/tests/copy_test.go
+++ b/tests/copy_test.go
@@ -8,30 +8,30 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestCopy(t *testing.T) {
+func TestCopy(t *testing.T) { //nolint:paralleltest
 	ts := newTester(t)
 	defer ts.teardown()
 
-	t.Run("copy w/ empty store", func(t *testing.T) {
+	t.Run("copy w/ empty store", func(t *testing.T) { //nolint:paralleltest
 		_, err := ts.run("copy")
 		assert.Error(t, err)
 	})
 
 	ts.initStore()
 
-	t.Run("copy usage", func(t *testing.T) {
+	t.Run("copy usage", func(t *testing.T) { //nolint:paralleltest
 		out, err := ts.run("copy")
 		assert.Error(t, err)
 		assert.Equal(t, "\nError: Usage: "+filepath.Base(ts.Binary)+" cp <FROM> <TO>\n", out)
 	})
 
-	t.Run("copy w/o destination", func(t *testing.T) {
+	t.Run("copy w/o destination", func(t *testing.T) { //nolint:paralleltest
 		out, err := ts.run("copy foo")
 		assert.Error(t, err)
 		assert.Equal(t, "\nError: Usage: "+filepath.Base(ts.Binary)+" cp <FROM> <TO>\n", out)
 	})
 
-	t.Run("copy non existing source", func(t *testing.T) {
+	t.Run("copy non existing source", func(t *testing.T) { //nolint:paralleltest
 		out, err := ts.run("copy foo bar")
 		assert.Error(t, err)
 		assert.Equal(t, "\nError: foo does not exist\n", out)
@@ -39,12 +39,12 @@ func TestCopy(t *testing.T) {
 
 	ts.initSecrets("")
 
-	t.Run("recursive copy", func(t *testing.T) {
+	t.Run("recursive copy", func(t *testing.T) { //nolint:paralleltest
 		_, err := ts.run("copy foo/ bar")
 		require.NoError(t, err)
 	})
 
-	t.Run("copy existing secret to non-existing destination", func(t *testing.T) {
+	t.Run("copy existing secret to non-existing destination", func(t *testing.T) { //nolint:paralleltest
 		out, err := ts.run("copy foo/bar foo/baz")
 		require.NoError(t, err)
 		assert.Equal(t, "", out)

--- a/tests/delete_test.go
+++ b/tests/delete_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestDelete(t *testing.T) {
+func TestDelete(t *testing.T) { //nolint:paralleltest
 	ts := newTester(t)
 	defer ts.teardown()
 

--- a/tests/find_test.go
+++ b/tests/find_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestFind(t *testing.T) {
+func TestFind(t *testing.T) { //nolint:paralleltest
 	ts := newTester(t)
 	defer ts.teardown()
 

--- a/tests/generate_test.go
+++ b/tests/generate_test.go
@@ -1,7 +1,6 @@
 package tests
 
 import (
-	"os"
 	"strings"
 	"testing"
 
@@ -9,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestGenerate(t *testing.T) {
+func TestGenerate(t *testing.T) { //nolint:paralleltest
 	ts := newTester(t)
 	defer ts.teardown()
 
@@ -25,15 +24,20 @@ func TestGenerate(t *testing.T) {
 
 	out, err = ts.run("generate -p baz 42")
 	assert.NoError(t, err)
+
 	lines := strings.Split(out, "\n")
+
 	require.Greater(t, len(lines), 2)
 	assert.Contains(t, out, "The generated password is:")
 	assert.Len(t, lines[3], 42)
 
-	_ = os.Setenv("GOPASS_CHARACTER_SET", "a")
+	t.Setenv("GOPASS_CHARACTER_SET", "a")
+
 	out, err = ts.run("generate -p zab 4")
 	assert.NoError(t, err)
+
 	lines = strings.Split(out, "\n")
+
 	require.Greater(t, len(lines), 2)
 	assert.Contains(t, out, "The generated password is:")
 	assert.Equal(t, lines[3], "aaaa")

--- a/tests/grep_test.go
+++ b/tests/grep_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestGrep(t *testing.T) {
+func TestGrep(t *testing.T) { //nolint:paralleltest
 	ts := newTester(t)
 	defer ts.teardown()
 

--- a/tests/init_test.go
+++ b/tests/init_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestInit(t *testing.T) {
+func TestInit(t *testing.T) { //nolint:paralleltest
 	ts := newTester(t)
 	defer ts.teardown()
 

--- a/tests/insert_test.go
+++ b/tests/insert_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestInsert(t *testing.T) {
+func TestInsert(t *testing.T) { //nolint:paralleltest
 	ts := newTester(t)
 	defer ts.teardown()
 
@@ -23,7 +23,7 @@ func TestInsert(t *testing.T) {
 	_, err = ts.runCmd([]string{ts.Binary, "insert", "some/newsecret"}, []byte("and\nmoar"))
 	assert.NoError(t, err)
 
-	t.Run("Regression test for #1573 without actual pipes", func(t *testing.T) {
+	t.Run("Regression test for #1573 without actual pipes", func(t *testing.T) { //nolint:paralleltest
 		out, err = ts.run("show -f some/secret")
 		assert.NoError(t, err)
 		assert.Equal(t, "moar", out)
@@ -41,7 +41,7 @@ func TestInsert(t *testing.T) {
 		assert.Equal(t, "and\nmoar", out)
 	})
 
-	t.Run("Regression test for #1595", func(t *testing.T) {
+	t.Run("Regression test for #1595", func(t *testing.T) { //nolint:paralleltest
 		t.Skip("TODO")
 
 		_, err = ts.runCmd([]string{ts.Binary, "insert", "some/other"}, []byte("nope"))
@@ -100,7 +100,7 @@ func TestInsert(t *testing.T) {
 		assert.Equal(t, "inline2", out)
 	})
 
-	t.Run("Regression test for #1650 with JSON", func(t *testing.T) {
+	t.Run("Regression test for #1650 with JSON", func(t *testing.T) { //nolint:paralleltest
 		json := `Password: SECRET
 --
 glossary": {
@@ -132,7 +132,7 @@ glossary": {
 		assert.Equal(t, json, out)
 	})
 
-	t.Run("Regression test for #1600", func(t *testing.T) {
+	t.Run("Regression test for #1600", func(t *testing.T) { //nolint:paralleltest
 		input := `test1
 test2
 {
@@ -147,7 +147,7 @@ test2
 		assert.Equal(t, input, out)
 	})
 
-	t.Run("Regression test for #1601", func(t *testing.T) {
+	t.Run("Regression test for #1601", func(t *testing.T) { //nolint:paralleltest
 		input := `thepassword
 user: a user
 web: test.com
@@ -162,7 +162,7 @@ user: second user`
 		assert.Equal(t, input, out)
 	})
 
-	t.Run("Regression test full support for #1601", func(t *testing.T) {
+	t.Run("Regression test full support for #1601", func(t *testing.T) { //nolint:paralleltest
 		t.Skip("Skipping until we support actual key-valueS for KV")
 
 		input := `thepassword
@@ -184,7 +184,7 @@ user: second user`
 		assert.Equal(t, output, out)
 	})
 
-	t.Run("Regression test for #1614", func(t *testing.T) {
+	t.Run("Regression test for #1614", func(t *testing.T) { //nolint:paralleltest
 		input := `yamltest
 ---
 user: 0123`
@@ -207,7 +207,7 @@ user: 83`
 		assert.Equal(t, input, out)
 	})
 
-	t.Run("Regression test for #1594", func(t *testing.T) {
+	t.Run("Regression test for #1594", func(t *testing.T) { //nolint:paralleltest
 		input := `somepasswd
 ---
 Test / test.com

--- a/tests/list_test.go
+++ b/tests/list_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestList(t *testing.T) {
+func TestList(t *testing.T) { //nolint:paralleltest
 	ts := newTester(t)
 	defer ts.teardown()
 
@@ -54,6 +54,8 @@ foo/
 
 // regression test for #1628.
 func TestListRegressions1628(t *testing.T) {
+	t.Parallel()
+
 	ts := newTester(t)
 	defer ts.teardown()
 
@@ -70,6 +72,7 @@ func TestListRegressions1628(t *testing.T) {
 
 	out, err = ts.run("list")
 	assert.NoError(t, err)
+
 	exp := `gopass
 └── misc/
     ├── file1

--- a/tests/mount_test.go
+++ b/tests/mount_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestSingleMount(t *testing.T) {
+func TestSingleMount(t *testing.T) { //nolint:paralleltest
 	ts := newTester(t)
 	defer ts.teardown()
 
@@ -22,6 +22,7 @@ func TestSingleMount(t *testing.T) {
 
 	out, err = ts.run("mounts")
 	assert.NoError(t, err)
+
 	want := "gopass (" + ts.storeDir("root") + ")\n"
 	want += "└── mnt/\n    └── m1 (" + ts.storeDir("m1") + ")"
 	assert.Equal(t, strings.TrimSpace(want), out)
@@ -56,7 +57,7 @@ gopass
 	assert.Equal(t, strings.TrimSpace(list), out)
 }
 
-func TestMountShadowing(t *testing.T) {
+func TestMountShadowing(t *testing.T) { //nolint:paralleltest
 	ts := newTester(t)
 	defer ts.teardown()
 
@@ -78,6 +79,7 @@ func TestMountShadowing(t *testing.T) {
 	// check the mount is there
 	out, err = ts.run("mounts")
 	assert.NoError(t, err)
+
 	want := "gopass (" + ts.storeDir("root") + ")\n"
 	want += "└── mnt/\n    └── m1 (" + ts.storeDir("m1") + ")"
 	assert.Equal(t, strings.TrimSpace(want), out)
@@ -150,7 +152,7 @@ gopass
 	assert.Equal(t, "moar", out)
 }
 
-func TestMultiMount(t *testing.T) {
+func TestMultiMount(t *testing.T) { //nolint:paralleltest
 	ts := newTester(t)
 	defer ts.teardown()
 

--- a/tests/move_test.go
+++ b/tests/move_test.go
@@ -7,38 +7,56 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestMove(t *testing.T) {
+func TestMove(t *testing.T) { //nolint:paralleltest
 	ts := newTester(t)
 	defer ts.teardown()
 
-	_, err := ts.run("move")
-	assert.Error(t, err)
+	t.Run("move before init", func(t *testing.T) { //nolint:paralleltest
+		_, err := ts.run("move")
+		assert.Error(t, err)
+	})
 
+	// init store so it does exist, but empty so far
 	ts.initStore()
 
-	out, err := ts.run("move")
-	assert.Error(t, err)
-	assert.Equal(t, "\nError: Usage: "+filepath.Base(ts.Binary)+" mv old-path new-path\n", out)
+	t.Run("move w/o args", func(t *testing.T) { //nolint:paralleltest
+		out, err := ts.run("move")
+		assert.Error(t, err)
+		assert.Equal(t, "\nError: Usage: "+filepath.Base(ts.Binary)+" mv old-path new-path\n", out)
+	})
 
-	out, err = ts.run("move foo")
-	assert.Error(t, err)
-	assert.Equal(t, "\nError: Usage: "+filepath.Base(ts.Binary)+" mv old-path new-path\n", out)
+	t.Run("move w/o destination", func(t *testing.T) { //nolint:paralleltest
+		out, err := ts.run("move foo")
+		assert.Error(t, err)
+		assert.Equal(t, "\nError: Usage: "+filepath.Base(ts.Binary)+" mv old-path new-path\n", out)
+	})
 
-	out, err = ts.run("move foo bar")
-	assert.Error(t, err)
-	assert.Equal(t, "\nError: source foo does not exist in source store : entry is not in the password store\n", out)
+	t.Run("move non existing source", func(t *testing.T) { //nolint:paralleltest
+		out, err := ts.run("move foo bar")
+		assert.Error(t, err)
+		assert.Equal(t, "\nError: source foo does not exist in source store : entry is not in the password store\n", out)
+	})
 
+	// populate store with secrets
 	ts.initSecrets("")
 
-	_, err = ts.run("move foo bar")
-	assert.NoError(t, err)
+	t.Run("move a secret", func(t *testing.T) { //nolint:paralleltest
+		_, err := ts.run("move foo bar")
+		assert.NoError(t, err)
+	})
 
-	out, _ = ts.run("move foo/bar foo/baz")
-	assert.Equal(t, "\nError: source foo/bar does not exist in source store : entry is not in the password store\n", out)
+	t.Run("move existing secret from non-existing destination", func(t *testing.T) { //nolint:paralleltest
+		out, _ := ts.run("move foo/bar foo/baz")
+		assert.Equal(t, "\nError: source foo/bar does not exist in source store : entry is not in the password store\n", out)
+	})
 
-	_, err = ts.run("show -f bar/bar")
-	assert.NoError(t, err)
+	t.Run("show source secret", func(t *testing.T) { //nolint:paralleltest
+		_, err := ts.run("show -f bar/bar")
+		assert.NoError(t, err)
+	})
 
-	_, err = ts.run("show -f baz")
-	assert.NoError(t, err)
+	t.Run("show secret", func(t *testing.T) { //nolint:paralleltest
+		_, err := ts.run("show -f baz")
+		assert.NoError(t, err)
+	})
 }

--- a/tests/show_test.go
+++ b/tests/show_test.go
@@ -9,7 +9,7 @@ import (
 
 var goldenQr = "\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\n\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\n\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\n\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\n\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\n\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\n\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\n\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\n\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\n\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\n\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\n\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\n\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\n\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\n\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\n\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\n\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\n\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\n\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\n\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\n\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\n\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\n\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\n\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\n\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[40m  \x1b[0m\x1b[40m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\n\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\n\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\n\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\n\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m\x1b[47m  \x1b[0m"
 
-func TestShow(t *testing.T) {
+func TestShow(t *testing.T) { //nolint:paralleltest
 	ts := newTester(t)
 	defer ts.teardown()
 
@@ -18,13 +18,13 @@ func TestShow(t *testing.T) {
 
 	ts.initStore()
 
-	t.Run("test usage", func(t *testing.T) {
+	t.Run("test usage", func(t *testing.T) { //nolint:paralleltest
 		out, err := ts.run("show")
 		assert.Error(t, err)
 		assert.Equal(t, "\nError: Usage: "+filepath.Base(ts.Binary)+" show [name]\n", out)
 	})
 
-	t.Run("test show with non-existing secret", func(t *testing.T) {
+	t.Run("test show with non-existing secret", func(t *testing.T) { //nolint:paralleltest
 		out, err := ts.run("show foo")
 		assert.Error(t, err)
 		assert.Contains(t, out, "entry is not in the password store", out)
@@ -32,7 +32,7 @@ func TestShow(t *testing.T) {
 
 	ts.initSecrets("")
 
-	t.Run("show folder foo", func(t *testing.T) {
+	t.Run("show folder foo", func(t *testing.T) { //nolint:paralleltest
 		_, err = ts.run("show foo")
 		assert.NoError(t, err)
 		_, err = ts.run("show -u foo")
@@ -41,7 +41,7 @@ func TestShow(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	t.Run("show w/o safecontent", func(t *testing.T) {
+	t.Run("show w/o safecontent", func(t *testing.T) { //nolint:paralleltest
 		_, err = ts.run("config safecontent false")
 		assert.NoError(t, err)
 
@@ -58,14 +58,14 @@ func TestShow(t *testing.T) {
 		assert.Equal(t, goldenQr, out)
 	})
 
-	t.Run("show w/o autoclip", func(t *testing.T) {
+	t.Run("show w/o autoclip", func(t *testing.T) { //nolint:paralleltest
 		_, err = ts.run("config autoclip false")
 		assert.NoError(t, err)
 		_, err = ts.run("show fixed/secret")
 		assert.NoError(t, err)
 	})
 
-	t.Run("show with safecontent", func(t *testing.T) {
+	t.Run("show with safecontent", func(t *testing.T) { //nolint:paralleltest
 		_, err = ts.run("config safecontent true")
 		assert.NoError(t, err)
 
@@ -80,7 +80,7 @@ func TestShow(t *testing.T) {
 		assert.NotContains(t, out, "first line")
 	})
 
-	t.Run("force showing full secret", func(t *testing.T) {
+	t.Run("force showing full secret", func(t *testing.T) { //nolint:paralleltest
 		_, err = ts.run("config safecontent true")
 		assert.NoError(t, err)
 
@@ -113,7 +113,9 @@ func TestShow(t *testing.T) {
 		assert.NotContains(t, out, "first line")
 	})
 
-	t.Run("Regression test for #1574 and #1575", func(t *testing.T) {
+	t.Run("Regression test for #1574 and #1575", func(t *testing.T) { //nolint:paralleltest
+		t.Setenv("GOPASS_CHARACTER_SET", "a")
+
 		_, err = ts.run("config safecontent true")
 		assert.NoError(t, err)
 
@@ -128,7 +130,7 @@ func TestShow(t *testing.T) {
 
 		out, err = ts.run("show -u fo2")
 		assert.NoError(t, err)
-		assert.Equal(t, out, "aaaaa")
+		assert.Equal(t, "aaaaa", out)
 
 		_, err = ts.run("generate fo6 5")
 		assert.NoError(t, err)

--- a/tests/tester.go
+++ b/tests/tester.go
@@ -24,6 +24,9 @@ exportkeys: false
 	keyID = "BE73F104"
 )
 
+// ErrNoCommand is returned when the command is missing.
+var ErrNoCommand = fmt.Errorf("no command")
+
 type tester struct {
 	t *testing.T
 
@@ -36,6 +39,7 @@ type tester struct {
 
 func newTester(t *testing.T) *tester {
 	t.Helper()
+
 	sourceDir := "."
 	if d := os.Getenv("GOPASS_TEST_DIR"); d != "" {
 		sourceDir = d
@@ -45,13 +49,16 @@ func newTester(t *testing.T) *tester {
 	if b := os.Getenv("GOPASS_BINARY"); b != "" {
 		gopassBin = b
 	}
+
 	fi, err := os.Stat(gopassBin)
 	if err != nil {
 		t.Skipf("Failed to stat GOPASS_BINARY %s: %s", gopassBin, err)
 	}
+
 	if !strings.HasSuffix(gopassBin, ".exe") && fi.Mode()&0o111 == 0 {
 		t.Fatalf("GOPASS_BINARY is not executeable")
 	}
+
 	t.Logf("Using gopass binary: %s", gopassBin)
 
 	ts := &tester{
@@ -121,16 +128,18 @@ func (ts tester) workDir() string {
 
 func (ts tester) teardown() {
 	ts.resetFn() // restore env vars
+
 	if ts.tempDir == "" {
 		return
 	}
+
 	err := os.RemoveAll(ts.tempDir)
 	require.NoError(ts.t, err)
 }
 
 func (ts tester) runCmd(args []string, in []byte) (string, error) {
 	if len(args) < 1 {
-		return "", fmt.Errorf("no command")
+		return "", fmt.Errorf("invalid args %v: %w", args, ErrNoCommand)
 	}
 
 	cmd := exec.CommandContext(context.Background(), args[0], args[1:]...)
@@ -151,9 +160,10 @@ func (ts tester) run(arg string) (string, error) {
 	if runtime.GOOS == "windows" {
 		arg = strings.ReplaceAll(arg, "\\", "\\\\")
 	}
+
 	args, err := shellquote.Split(arg)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("failed to split args %v: %w", arg, err)
 	}
 
 	cmd := exec.CommandContext(context.Background(), ts.Binary, args...)
@@ -171,13 +181,14 @@ func (ts tester) run(arg string) (string, error) {
 
 func (ts tester) runWithInput(arg, input string) ([]byte, error) {
 	reader := strings.NewReader(input)
+
 	return ts.runWithInputReader(arg, reader)
 }
 
 func (ts tester) runWithInputReader(arg string, input io.Reader) ([]byte, error) {
 	args, err := shellquote.Split(arg)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to split args %v: %w", arg, err)
 	}
 
 	cmd := exec.Command(ts.Binary, args...)
@@ -186,7 +197,12 @@ func (ts tester) runWithInputReader(arg string, input io.Reader) ([]byte, error)
 
 	ts.t.Logf("%+v", cmd.Args)
 
-	return cmd.CombinedOutput()
+	buf, err := cmd.CombinedOutput()
+	if err != nil {
+		return buf, fmt.Errorf("%s %v failed: %w", ts.Binary, args, err)
+	}
+
+	return buf, nil
 }
 
 func (ts *tester) initStore() {

--- a/tests/uninitialized_test.go
+++ b/tests/uninitialized_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestUninitialized(t *testing.T) {
+func TestUninitialized(t *testing.T) { //nolint:paralleltest
 	ts := newTester(t)
 	defer ts.teardown()
 
@@ -30,7 +30,7 @@ func TestUninitialized(t *testing.T) {
 		"show",
 	}
 
-	for _, command := range commands {
+	for _, command := range commands { //nolint:paralleltest
 		t.Run(command, func(t *testing.T) {
 			out, err := ts.run(command)
 			assert.Error(t, err)

--- a/tests/yaml_test.go
+++ b/tests/yaml_test.go
@@ -7,52 +7,52 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestYAMLAndSecret(t *testing.T) {
+func TestYAMLAndSecret(t *testing.T) { //nolint:paralleltest
 	ts := newTester(t)
 	defer ts.teardown()
 
-	t.Run("show key from uninitialized store", func(t *testing.T) {
+	t.Run("show key from uninitialized store", func(t *testing.T) { //nolint:paralleltest
 		_, err := ts.run("show foo/bar baz")
 		assert.Error(t, err)
 	})
 
 	ts.initStore()
 
-	t.Run("default action (show) from initialized store", func(t *testing.T) {
+	t.Run("default action (show) from initialized store", func(t *testing.T) { //nolint:paralleltest
 		out, err := ts.run("foo/bar baz")
 		assert.Error(t, err)
 		assert.Contains(t, out, "entry is not in the password store")
 	})
 
-	t.Run("insert key", func(t *testing.T) {
+	t.Run("insert key", func(t *testing.T) { //nolint:paralleltest
 		_, err := ts.runCmd([]string{ts.Binary, "insert", "foo/bar", "password"}, []byte("moar"))
 		require.NoError(t, err)
 	})
 
-	t.Run("insert another key", func(t *testing.T) {
+	t.Run("insert another key", func(t *testing.T) { //nolint:paralleltest
 		_, err := ts.runCmd([]string{ts.Binary, "insert", "foo/bar", "baz"}, []byte("moar"))
 		require.NoError(t, err)
 	})
 
-	t.Run("insert into the body", func(t *testing.T) {
+	t.Run("insert into the body", func(t *testing.T) { //nolint:paralleltest
 		out, err := ts.runCmd([]string{ts.Binary, "insert", "-a", "foo/bar"}, []byte("body"))
 		assert.NoError(t, err, out)
 	})
 
-	t.Run("show a key", func(t *testing.T) {
+	t.Run("show a key", func(t *testing.T) { //nolint:paralleltest
 		out, err := ts.run("show foo/bar baz")
 		assert.NoError(t, err)
 		assert.Equal(t, "moar", out)
 	})
 
-	t.Run("show the whole secret", func(t *testing.T) {
+	t.Run("show the whole secret", func(t *testing.T) { //nolint:paralleltest
 		out, err := ts.run("show foo/bar")
 		assert.NoError(t, err)
 		assert.Equal(t, "baz: moar\npassword: moar\nbody", out)
 	})
 }
 
-func TestInvalidYAML(t *testing.T) {
+func TestInvalidYAML(t *testing.T) { //nolint:paralleltest
 	testBody := `somepasswd
 ---
 Test / test.com
@@ -63,25 +63,25 @@ url: http://www.test.com/`
 	ts := newTester(t)
 	defer ts.teardown()
 
-	t.Run("show secret from uninitialized store", func(t *testing.T) {
+	t.Run("show secret from uninitialized store", func(t *testing.T) { //nolint:paralleltest
 		_, err := ts.run("show foo/bar")
 		assert.Error(t, err)
 	})
 
 	ts.initStore()
 
-	t.Run("show non-existing secret", func(t *testing.T) {
+	t.Run("show non-existing secret", func(t *testing.T) { //nolint:paralleltest
 		out, err := ts.run("foo/bar")
 		assert.Error(t, err)
 		assert.Contains(t, out, "entry is not in the password store")
 	})
 
-	t.Run("insert new secret", func(t *testing.T) {
+	t.Run("insert new secret", func(t *testing.T) { //nolint:paralleltest
 		_, err := ts.runCmd([]string{ts.Binary, "insert", "foo/bar"}, []byte(testBody))
 		assert.NoError(t, err)
 	})
 
-	t.Run("show newly inserted secret", func(t *testing.T) {
+	t.Run("show newly inserted secret", func(t *testing.T) { //nolint:paralleltest
 		_, err := ts.run("show foo/bar")
 		assert.NoError(t, err)
 	})

--- a/version.go
+++ b/version.go
@@ -11,6 +11,7 @@ func getVersion() semver.Version {
 	if err == nil {
 		return sv
 	}
+
 	return semver.Version{
 		Major: 1,
 		Minor: 14,


### PR DESCRIPTION
Be more strict and bring back codequality checks for the repo.

Depends on https://github.com/golangci/golangci-lint/pull/2438 being fixed and released first.

RELEASE_NOTES=n/a