### PR TITLE
Automatically export creators key to the store

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,3 +62,4 @@ If any of the above don't work check out the [troubleshooting section](#troubles
 ## Releasing
 
 See [docs/releases.md](docs/releases.md).
+

--- a/docs/hacking.md
+++ b/docs/hacking.md
@@ -1,0 +1,39 @@
+# Hacking on gopass
+
+Note: See [CONTRIBUTING.md](../CONTRIBUTING.md) for an overview.
+
+This document provides an overview on how to develop on gopass.
+
+## Setting up an isolated development environment
+
+### With GPG
+
+`gopass` should fully respect `GOPASS_HOMEDIR` overriding all gopass internal paths.
+However it will still use your normal GPG keyring and configuration. To override this
+you will need to set `GNUPGHOME` as well and possibly generate a new keyring.
+
+```bash
+$ export GOPASS_DEBUG_LOG=/tmp/gp1.log
+$ export GOPASS_HOMEDIR=/tmp/gp1
+$ mkdir -p $GOPASS_HOMEDIR
+$ export GNUPGHOME=$GOPASS_HOMEDIR/.gnupg
+# Make sure that you're using the correct keyring.
+$ gpg -K
+gpg: directory '/tmp/gp1/.gnupg' created
+gpg: keybox '/tmp/gp1/.gnupg/pubring.kbx' created
+gpg: /tmp/gp1/.gnupg/trustdb.gpg: trustdb created
+$ gpg --gen-key
+$ go build && ./gopass setup --crypto gpg --storage gitfs
+```
+
+### With age
+
+Using `age` is recommended for development since it's easier to set up. Setting
+`GOPASS_HOMEDIR` should be sufficient to ensure an isolated environment.
+
+```bash
+$ export GOPASS_DEBUG_LOG=/tmp/gp1.log
+$ export GOPASS_HOMEDIR=/tmp/gp1
+$ mkdir -p $GOPASS_HOMEDIR
+$ go build && ./gopass setup --crypto age --storage gitfs
+```

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -37,7 +37,7 @@ type Config struct {
 // New creates a new config with sane default values.
 func New() *Config {
 	return &Config{
-		AutoImport:    true,
+		AutoImport:    false,
 		ClipTimeout:   45,
 		ExportKeys:    true,
 		Mounts:        make(map[string]string),

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -20,7 +20,7 @@ func TestNewConfig(t *testing.T) {
 
 	cfg := config.New()
 	cs := cfg.String()
-	assert.Contains(t, cs, `&config.Config{AutoClip:false, AutoImport:true, ClipTimeout:45, ExportKeys:true, NoPager:false, Notifications:true,`)
+	assert.Contains(t, cs, `&config.Config{AutoClip:false, AutoImport:false, ClipTimeout:45, ExportKeys:true, NoPager:false, Notifications:true,`)
 	assert.Contains(t, cs, `SafeContent:false, Mounts:map[string]string{},`)
 
 	cfg = &config.Config{

--- a/internal/store/leaf/crypto.go
+++ b/internal/store/leaf/crypto.go
@@ -28,7 +28,7 @@ func (s *Store) Crypto() backend.Crypto {
 
 // ImportMissingPublicKeys will try to import any missing public keys from the
 // .public-keys folder in the password store.
-func (s *Store) ImportMissingPublicKeys(ctx context.Context) error {
+func (s *Store) ImportMissingPublicKeys(ctx context.Context, newrs ...string) error {
 	// do not import any keys for age, where public key == key id
 	// TODO: do not hard code exceptions, ask the backend if it supports it
 	if _, ok := s.crypto.(*age.Age); ok {
@@ -39,6 +39,7 @@ func (s *Store) ImportMissingPublicKeys(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to get recipients: %w", err)
 	}
+	rs = append(rs, newrs...)
 	for _, r := range rs {
 		debug.Log("Checking recipients %s ...", r)
 		// check if this recipient is missing


### PR DESCRIPTION
Fixes #1919

This will also automatically try to import a public key from the store if none is found. This makes it very convenient to add new recipients, but on the other hand this is might open a small attack vector if someone manages to inject their public key into the git repo and getting an existing member to add it to the recipients. But then on the other hand I wonder how carefully people examine imported GPG keys anyway.

RELEASE_NOTES=[ENHANCEMENT] Automatically export creators key to the
store. Change default for AutoImport to false.

Signed-off-by: Dominik Schulz <dominik.schulz@gauner.org>