### PR TITLE
Do not display (missing public key) for age identities

### DIFF
--- a/internal/backend/crypto/gpg/cli/identities.go
+++ b/internal/backend/crypto/gpg/cli/identities.go
@@ -33,16 +33,16 @@ func (g *GPG) FindIdentities(ctx context.Context, search ...string) ([]string, e
 	return kl.UseableKeys(gpg.IsAlwaysTrust(ctx)).Recipients(), nil
 }
 
-func (g *GPG) findKey(ctx context.Context, id string) gpg.Key {
+func (g *GPG) findKey(ctx context.Context, id string) (gpg.Key, bool) {
 	kl, _ := g.listKeys(ctx, "secret", id)
 	if len(kl) >= 1 {
-		return kl[0]
+		return kl[0], true
 	}
 	kl, _ = g.listKeys(ctx, "public", id)
 	if len(kl) >= 1 {
-		return kl[0]
+		return kl[0], true
 	}
 	return gpg.Key{
 		Fingerprint: id,
-	}
+	}, false
 }

--- a/internal/store/root/recipients.go
+++ b/internal/store/root/recipients.go
@@ -34,6 +34,9 @@ func (r *Store) RemoveRecipient(ctx context.Context, store, rec string) error {
 func (r *Store) addRecipient(ctx context.Context, prefix string, root *tree.Root, recp string, pretty bool) error {
 	sub, _ := r.getStore(prefix)
 	key := fmt.Sprintf("%s (missing public key)", recp)
+	if v := sub.Crypto().FormatKey(ctx, recp, ""); v != "" {
+		key = v
+	}
 	kl, err := sub.Crypto().FindRecipients(ctx, recp)
 	if err == nil {
 		if len(kl) > 0 {


### PR DESCRIPTION
They are fully defined by the public key.

RELEASE_NOTES=[BUGFIX] Do not print missing public key for age.

Signed-off-by: Dominik Schulz <dominik.schulz@gauner.org>