### PR TITLE
Do not decrypt secrets when moving or copying them

### DIFF
--- a/internal/backend/storage.go
+++ b/internal/backend/storage.go
@@ -39,7 +39,7 @@ type Storage interface {
 	Set(ctx context.Context, name string, value []byte) error
 	Delete(ctx context.Context, name string) error
 	Exists(ctx context.Context, name string) bool
-	Move(ctx context.Context, from, to string, delete bool) error
+	Move(ctx context.Context, from, to string, del bool) error
 	List(ctx context.Context, prefix string) ([]string, error)
 	IsDir(ctx context.Context, name string) bool
 	Prune(ctx context.Context, prefix string) error

--- a/internal/backend/storage.go
+++ b/internal/backend/storage.go
@@ -39,6 +39,7 @@ type Storage interface {
 	Set(ctx context.Context, name string, value []byte) error
 	Delete(ctx context.Context, name string) error
 	Exists(ctx context.Context, name string) bool
+	Move(ctx context.Context, from, to string, delete bool) error
 	List(ctx context.Context, prefix string) ([]string, error)
 	IsDir(ctx context.Context, name string) bool
 	Prune(ctx context.Context, prefix string) error

--- a/internal/backend/storage/fossilfs/storage.go
+++ b/internal/backend/storage/fossilfs/storage.go
@@ -66,3 +66,8 @@ func (f *Fossil) Fsck(ctx context.Context) error {
 func (f *Fossil) Link(ctx context.Context, from, to string) error {
 	return f.fs.Link(ctx, from, to)
 }
+
+// Move moves from src to dst.
+func (f *Fossil) Move(ctx context.Context, src, dst string, del bool) error {
+	return f.fs.Move(ctx, src, dst, del)
+}

--- a/internal/backend/storage/gitfs/storage.go
+++ b/internal/backend/storage/gitfs/storage.go
@@ -89,3 +89,8 @@ func (g *Git) addUntrackedFiles(ctx context.Context) error {
 func (g *Git) Link(ctx context.Context, from, to string) error {
 	return g.fs.Link(ctx, from, to)
 }
+
+// Move moves from src to dst.
+func (g *Git) Move(ctx context.Context, src, dst string, del bool) error {
+	return g.fs.Move(ctx, src, dst, del)
+}

--- a/internal/store/leaf/fsck.go
+++ b/internal/store/leaf/fsck.go
@@ -110,7 +110,7 @@ func (s *Store) fsckCheckEntry(ctx context.Context, name string) error {
 func (s *Store) fsckCheckRecipients(ctx context.Context, name string) error {
 	// now compare the recipients this secret was encoded for and fix it if
 	// if doesn't match
-	ciphertext, err := s.storage.Get(ctx, s.passfile(name))
+	ciphertext, err := s.storage.Get(ctx, s.Passfile(name))
 	if err != nil {
 		return fmt.Errorf("failed to get raw secret: %w", err)
 	}

--- a/internal/store/leaf/link.go
+++ b/internal/store/leaf/link.go
@@ -20,13 +20,13 @@ func (s *Store) Link(ctx context.Context, from, to string) error {
 		return fmt.Errorf("destination %q already exists", to)
 	}
 
-	if err := s.storage.Link(ctx, s.passfile(from), s.passfile(to)); err != nil {
+	if err := s.storage.Link(ctx, s.Passfile(from), s.Passfile(to)); err != nil {
 		return fmt.Errorf("failed to create symlink from %q to %q: %w", from, to, err)
 	}
 
 	debug.Log("created symlink from %q to %q", from, to)
 
-	if err := s.storage.Add(ctx, s.passfile(to)); err != nil {
+	if err := s.storage.Add(ctx, s.Passfile(to)); err != nil {
 		if errors.Is(err, store.ErrGitNotInit) {
 			return nil
 		}

--- a/internal/store/leaf/move.go
+++ b/internal/store/leaf/move.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/gopasspw/gopass/internal/queue"
 	"github.com/gopasspw/gopass/internal/store"
 	"github.com/gopasspw/gopass/pkg/ctxutil"
 	"github.com/gopasspw/gopass/pkg/debug"
@@ -19,6 +20,11 @@ func (s *Store) Copy(ctx context.Context, from, to string) error {
 	// recursive copy?
 	if s.IsDir(ctx, from) {
 		return fmt.Errorf("recursive operations are not supported")
+	}
+
+	// try direct copy first
+	if err := s.directMove(ctx, from, to, false); err == nil {
+		return nil
 	}
 
 	content, err := s.Get(ctx, from)
@@ -43,6 +49,15 @@ func (s *Store) Move(ctx context.Context, from, to string) error {
 		return fmt.Errorf("recursive operations are not supported")
 	}
 
+	// try direct move first
+	err := s.directMove(ctx, from, to, true)
+	if err == nil {
+		return nil
+	}
+
+	debug.Log("direct move failed: %v", err)
+
+	// fall back to copy and delete
 	content, err := s.Get(ctx, from)
 	if err != nil {
 		return fmt.Errorf("failed to decrypt %q: %w", from, err)
@@ -59,6 +74,47 @@ func (s *Store) Move(ctx context.Context, from, to string) error {
 	return nil
 }
 
+func (s *Store) directMove(ctx context.Context, from, to string, del bool) error {
+	ctx = ctxutil.WithCommitMessage(ctx, fmt.Sprintf("Move from %s to %s", from, to))
+	pFrom := s.Passfile(from)
+	pTo := s.Passfile(to)
+
+	debug.Log("directMove %s (%q) -> %s (%q)", from, to, pFrom, pTo)
+
+	if err := s.storage.Move(ctx, pFrom, pTo, del); err != nil {
+		return fmt.Errorf("failed to move %q to %q: %w", from, to, err)
+	}
+
+	// It is not possible to perform concurrent git add and git commit commands
+	// so we need to skip this step when using concurrency and perform them
+	// at the end of the batch processing.
+	if IsNoGitOps(ctx) {
+		debug.Log("sub.directMove(%q -> %q) - skipping git ops (disabled)", from, to)
+
+		return nil
+	}
+
+	if err := s.storage.Add(ctx, pFrom, pTo); err != nil {
+		if errors.Is(err, store.ErrGitNotInit) {
+			return nil
+		}
+
+		return fmt.Errorf("failed to add %q and %q to git: %w", pFrom, pTo, err)
+	}
+
+	if !ctxutil.IsGitCommit(ctx) {
+		return nil
+	}
+
+	// try to enqueue this task, if the queue is not available
+	// it will return the task and we will execute it inline
+	t := queue.GetQueue(ctx).Add(func(ctx context.Context) error {
+		return s.gitCommitAndPush(ctx, to)
+	})
+
+	return t(ctx)
+}
+
 // Delete will remove an single entry from the store.
 func (s *Store) Delete(ctx context.Context, name string) error {
 	return s.delete(ctx, name, false)
@@ -72,7 +128,7 @@ func (s *Store) Prune(ctx context.Context, tree string) error {
 // delete will either delete one file or an directory tree depending on the
 // recurse flag.
 func (s *Store) delete(ctx context.Context, name string, recurse bool) error {
-	path := s.passfile(name)
+	path := s.Passfile(name)
 
 	if recurse {
 		if err := s.deleteRecurse(ctx, name, path); err != nil {

--- a/internal/store/leaf/move.go
+++ b/internal/store/leaf/move.go
@@ -23,9 +23,14 @@ func (s *Store) Copy(ctx context.Context, from, to string) error {
 	}
 
 	// try direct copy first
-	if err := s.directMove(ctx, from, to, false); err == nil {
+	err := s.directMove(ctx, from, to, false)
+	if err == nil {
+		debug.Log("direct copy %s -> %s successful", from, to)
+
 		return nil
 	}
+
+	debug.Log("direct copy failed: %v", err)
 
 	content, err := s.Get(ctx, from)
 	if err != nil {
@@ -52,6 +57,8 @@ func (s *Store) Move(ctx context.Context, from, to string) error {
 	// try direct move first
 	err := s.directMove(ctx, from, to, true)
 	if err == nil {
+		debug.Log("direct move %s -> %s successful", from, to)
+
 		return nil
 	}
 

--- a/internal/store/leaf/rcs.go
+++ b/internal/store/leaf/rcs.go
@@ -25,14 +25,14 @@ func (s *Store) GitInit(ctx context.Context) error {
 
 // ListRevisions will list all revisions for a secret.
 func (s *Store) ListRevisions(ctx context.Context, name string) ([]backend.Revision, error) {
-	p := s.passfile(name)
+	p := s.Passfile(name)
 
 	return s.storage.Revisions(ctx, p)
 }
 
 // GetRevision will retrieve a single revision from the backend.
 func (s *Store) GetRevision(ctx context.Context, name, revision string) (gopass.Secret, error) {
-	p := s.passfile(name)
+	p := s.Passfile(name)
 	ciphertext, err := s.storage.GetRevision(ctx, p, revision)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get ciphertext of %q@%q: %w", name, revision, err)

--- a/internal/store/leaf/read.go
+++ b/internal/store/leaf/read.go
@@ -14,7 +14,7 @@ import (
 
 // Get returns the plaintext of a single key.
 func (s *Store) Get(ctx context.Context, name string) (gopass.Secret, error) {
-	p := s.passfile(name)
+	p := s.Passfile(name)
 
 	ciphertext, err := s.storage.Get(ctx, p)
 	if err != nil {

--- a/internal/store/leaf/reencrypt.go
+++ b/internal/store/leaf/reencrypt.go
@@ -95,7 +95,7 @@ func (s *Store) reencrypt(ctx context.Context) error {
 	// to avoid a race condition on git .index.lock file, so we do it now.
 	if conc > 1 {
 		for _, name := range entries {
-			p := s.passfile(name)
+			p := s.Passfile(name)
 			if err := s.storage.Add(ctx, p); err != nil {
 				if errors.Is(err, store.ErrGitNotInit) {
 					debug.Log("skipping git add - git not initialized")

--- a/internal/store/leaf/store.go
+++ b/internal/store/leaf/store.go
@@ -153,7 +153,7 @@ func (s *Store) IsDir(ctx context.Context, name string) bool {
 
 // Exists checks the existence of a single entry.
 func (s *Store) Exists(ctx context.Context, name string) bool {
-	return s.storage.Exists(ctx, s.passfile(name))
+	return s.storage.Exists(ctx, s.Passfile(name))
 }
 
 func (s *Store) useableKeys(ctx context.Context, name string) ([]string, error) {
@@ -174,8 +174,8 @@ func (s *Store) useableKeys(ctx context.Context, name string) ([]string, error) 
 	return kl, nil
 }
 
-// passfile returns the name of gpg file on disk, for the given key/name.
-func (s *Store) passfile(name string) string {
+// Passfile returns the name of gpg file on disk, for the given key/name.
+func (s *Store) Passfile(name string) string {
 	return strings.TrimPrefix(name+"."+s.crypto.Ext(), "/")
 }
 

--- a/internal/store/leaf/write.go
+++ b/internal/store/leaf/write.go
@@ -20,7 +20,7 @@ func (s *Store) Set(ctx context.Context, name string, sec gopass.Byter) error {
 		return fmt.Errorf("invalid secret name: %s", name)
 	}
 
-	p := s.passfile(name)
+	p := s.Passfile(name)
 
 	recipients, err := s.useableKeys(ctx, name)
 	if err != nil {

--- a/internal/store/mockstore/inmem/store.go
+++ b/internal/store/mockstore/inmem/store.go
@@ -221,3 +221,8 @@ func (m *InMem) Compact(context.Context) error {
 func (m *InMem) Link(context.Context, string, string) error {
 	return nil
 }
+
+// Move is not implemented.
+func (m *InMem) Move(context.Context, string, string, bool) error {
+	return nil
+}

--- a/pkg/fsutil/fsutil.go
+++ b/pkg/fsutil/fsutil.go
@@ -215,3 +215,46 @@ func min(a, b int64) int64 {
 
 	return b
 }
+
+// CopyFile copies a file from src to dst. Permissions will be preserved. It is expected to
+// fail if the destination does exist but is not writeable.
+func CopyFile(from, to string) error {
+	rdr, err := os.Open(from)
+	if err != nil {
+		return fmt.Errorf("failed to open file %q for reading: %w", from, err)
+	}
+	defer rdr.Close()
+
+	rdrStat, err := rdr.Stat()
+	if err != nil {
+		return fmt.Errorf("failed to stat open file %q: %w", from, err)
+	}
+
+	wrt, err := os.OpenFile(to, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, rdrStat.Mode())
+	if err != nil {
+		return fmt.Errorf("failed to open file %q for writing: %w", to, err)
+	}
+	defer wrt.Close()
+
+	n, err := io.Copy(wrt, rdr)
+	if err != nil {
+		return fmt.Errorf("failed to copy content of %q to %q: %w", from, to, err)
+	}
+
+	debug.Log("copied %d bytes from %q to %q", n, from, to)
+
+	// sync permission, applies in case the destination did exist but had different perms
+	return os.Chmod(to, rdrStat.Mode())
+}
+
+// CopyFileForce copies a file from src to dst. Permissions will be preserved. The destination
+// if removed before copying to avoid permission issues.
+func CopyFileForce(from, to string) error {
+	if IsFile(to) {
+		if err := os.Remove(to); err != nil {
+			return fmt.Errorf("failed to remove %q: %w", to, err)
+		}
+	}
+
+	return CopyFile(from, to)
+}


### PR DESCRIPTION
This PR attempts to avoid decrypting secrets needlessly when they are
only copied or moved. All currently supported backends have a filesystem
backing them so the old workaround of Get and Set shouldn't be necessary
anymore. In case we re-introduce such backends or a direct move fails
for some reason we still fall back to Get and Set if necessary.

Fixes #2181

RELEASE_NOTES=[ENHANCEMENT] Avoid decryption on move or copy

Signed-off-by: Dominik Schulz <dominik.schulz@gauner.org>