### PR TITLE
Adding concurrency to GHA

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,8 +6,11 @@ on:
   pull_request:
     branches: [ master ]
 
-jobs:
+concurrency:
+  group: ci-${{ github.ref }}-build
+  cancel-in-progress: true
 
+jobs:
   linux:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -20,6 +20,10 @@ on:
   schedule:
     - cron: '19 21 * * 0'
 
+concurrency:
+  group: ci-${{ github.ref }}-codeql
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze


### PR DESCRIPTION
In order to avoid wasting CI minutes, this makes us cancel our workflows when we push again on the same branch and it's still running.