### PR TITLE
Add Fedora installation instructions

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -198,7 +198,13 @@ layman -a go-overlay
 emerge -av gopass
 ```
 
-### Fedora / Red Hat / CentOS
+### Fedora
+
+```bash
+dnf install gopass
+```
+
+### Red Hat / CentOS
 
 There is an unofficial RPM build maintained by a contributor.
 


### PR DESCRIPTION
gopass is now avaialbe in official Fedora repositories.

See [blog post](https://fale.io/blog/2022/04/25/gopass-in-fedora), [src.fpo](https://src.fedoraproject.org/rpms/gopass/)