### PR TITLE
zsh: fix errors in completions (#2005)

### DIFF
--- a/internal/completion/zsh/completion.go
+++ b/internal/completion/zsh/completion.go
@@ -19,6 +19,10 @@ func longName(name string) string {
 }
 
 func formatFlag(name, usage string) string {
+	// Suare brackets must be escaped in zsh completions
+	usage = strings.ReplaceAll(usage, "[", "\\[")
+	usage = strings.ReplaceAll(usage, "]", "\\]")
+
 	return fmt.Sprintf("--%s[%s]", longName(name), usage)
 }
 

--- a/internal/completion/zsh/template.go
+++ b/internal/completion/zsh/template.go
@@ -18,9 +18,9 @@ _{{ $prog }} () {
 	      subcommands=({{ range .Subcommands }}
 	      "{{ .Name }}:{{ .Usage }}"{{ end }}
 	      )
+	      _describe -t commands "{{ $prog }} {{ .Name }}" subcommands
 	      {{- end }}
 	      {{ if .Flags }}_arguments :{{ range .Flags }} "{{ . | formatFlag }}"{{ end }}{{ end }}
-	      _describe -t commands "{{ $prog }} {{ .Name }}" subcommands
 	      {{ if or (eq .Name "insert") (eq .Name "generate")  (eq .Name "list") }}_{{ $prog }}_complete_folders{{ end }}
 	      {{ if or (eq .Name "copy") (eq .Name "move") (eq .Name "delete") (eq .Name "show") (eq .Name "edit") (eq .Name "insert") (eq .Name "generate") }}_{{ $prog }}_complete_passwords{{ end }}
 	      ;;

--- a/zsh.completion
+++ b/zsh.completion
@@ -13,8 +13,8 @@ _gopass () {
 	      subcommands=(
 	      "identities:List identities"
 	      )
-	      
 	      _describe -t commands "gopass age" subcommands
+	      
 	      
 	      
 	      ;;
@@ -25,26 +25,23 @@ _gopass () {
 	      "remove:Remove an alias from a domain"
 	      "delete:Delete an entire domain"
 	      )
-	      
 	      _describe -t commands "gopass alias" subcommands
+	      
 	      
 	      
 	      ;;
 	  audit)
 	      _arguments : "--expiry[Age in days before a password is considered expired. Setting this will only check expiration.]"
-	      _describe -t commands "gopass audit" subcommands
 	      
 	      
 	      ;;
 	  cat)
 	      
-	      _describe -t commands "gopass cat" subcommands
 	      
 	      
 	      ;;
 	  clone)
-	      _arguments : "--path[Path to clone the repo to]" "--crypto[Select crypto backend [age gpgcli plain]]" "--storage[Select storage backend [fossilfs gitfs]]" "--check-keys[Check for valid decryption keys. Generate new keys if none are found.]"
-	      _describe -t commands "gopass clone" subcommands
+	      _arguments : "--path[Path to clone the repo to]" "--crypto[Select crypto backend \[age gpgcli plain\]]" "--storage[Select storage backend \[fossilfs gitfs\]]" "--check-keys[Check for valid decryption keys. Generate new keys if none are found.]"
 	      
 	      
 	      ;;
@@ -56,129 +53,109 @@ _gopass () {
 	      "fish:Source for auto completion in fish"
 	      "openbsdksh:Source for auto completion in OpenBSD's ksh"
 	      )
-	      
 	      _describe -t commands "gopass completion" subcommands
+	      
 	      
 	      
 	      ;;
 	  config)
 	      
-	      _describe -t commands "gopass config" subcommands
 	      
 	      
 	      ;;
 	  convert)
-	      _arguments : "--store[Specify which store to convert]" "--move[Replace store?]" "--crypto[Which crypto backend? [age gpgcli plain]]" "--storage[Which storage backend? [fossilfs fs gitfs]]"
-	      _describe -t commands "gopass convert" subcommands
+	      _arguments : "--store[Specify which store to convert]" "--move[Replace store?]" "--crypto[Which crypto backend? \[age gpgcli plain\]]" "--storage[Which storage backend? \[fossilfs fs gitfs\]]"
 	      
 	      
 	      ;;
 	  copy|cp)
 	      _arguments : "--force[Force to copy the secret and overwrite existing one]"
-	      _describe -t commands "gopass copy" subcommands
 	      
 	      _gopass_complete_passwords
 	      ;;
 	  create|new)
 	      _arguments : "--store[Which store to use]" "--force[Force path selection]"
-	      _describe -t commands "gopass create" subcommands
 	      
 	      
 	      ;;
 	  delete|remove|rm)
 	      _arguments : "--recursive[Recursive delete files and folders]" "--force[Force to delete the secret]"
-	      _describe -t commands "gopass delete" subcommands
 	      
 	      _gopass_complete_passwords
 	      ;;
 	  edit|set)
 	      _arguments : "--editor[Use this editor binary]" "--create[Create a new secret if none found]"
-	      _describe -t commands "gopass edit" subcommands
 	      
 	      _gopass_complete_passwords
 	      ;;
 	  env)
 	      
-	      _describe -t commands "gopass env" subcommands
 	      
 	      
 	      ;;
 	  find|search)
 	      _arguments : "--clip[Copy the password into the clipboard]" "--unsafe[In the case of an exact match, display the password even if safecontent is enabled]"
-	      _describe -t commands "gopass find" subcommands
 	      
 	      
 	      ;;
 	  fsck)
 	      _arguments : "--decrypt[Decrypt and reencryt during fsck.
 WARNING: This will update the secret content to the latest format. This might be incompatible with other implementations. Use with caution!]"
-	      _describe -t commands "gopass fsck" subcommands
 	      
 	      
 	      ;;
 	  fscopy)
 	      
-	      _describe -t commands "gopass fscopy" subcommands
 	      
 	      
 	      ;;
 	  fsmove)
 	      
-	      _describe -t commands "gopass fsmove" subcommands
 	      
 	      
 	      ;;
 	  generate)
 	      _arguments : "--clip[Copy the generated password to the clipboard]" "--print[Print the generated password to the terminal]" "--force[Force to overwrite existing password]" "--edit[Open secret for editing after generating a password]" "--symbols[Use symbols in the password]" "--generator[Choose a password generator, use one of: cryptic, memorable, xkcd or external. Default: cryptic]" "--strict[Require strict character class rules]" "--sep[Word separator for generated passwords. If no separator is specified, the words are combined without spaces/separator and the first character of words is capitalised.]" "--lang[Language to generate password from, currently de (german) and en (english, default) are supported]"
-	      _describe -t commands "gopass generate" subcommands
 	      _gopass_complete_folders
 	      _gopass_complete_passwords
 	      ;;
 	  git)
 	      _arguments : "--store[Store to operate on]"
-	      _describe -t commands "gopass git" subcommands
 	      
 	      
 	      ;;
 	  grep)
 	      _arguments : "--regexp[Interpret pattern as RE2 regular expression]"
-	      _describe -t commands "gopass grep" subcommands
 	      
 	      
 	      ;;
 	  history|hist)
 	      _arguments : "--password[Include passwords in output]"
-	      _describe -t commands "gopass history" subcommands
 	      
 	      
 	      ;;
 	  init)
-	      _arguments : "--path[Set the sub-store path to operate on]" "--store[Set the name of the sub-store]" "--crypto[Select crypto backend [age gpgcli plain]]" "--storage[Select storage backend [fossilfs fs gitfs]]"
-	      _describe -t commands "gopass init" subcommands
+	      _arguments : "--path[Set the sub-store path to operate on]" "--store[Set the name of the sub-store]" "--crypto[Select crypto backend \[age gpgcli plain\]]" "--storage[Select storage backend \[fossilfs fs gitfs\]]"
 	      
 	      
 	      ;;
 	  insert)
 	      _arguments : "--echo[Display secret while typing]" "--multiline[Insert using $EDITOR]" "--force[Overwrite any existing secret and do not prompt to confirm recipients]" "--append[Append data read from STDIN to existing data]"
-	      _describe -t commands "gopass insert" subcommands
 	      _gopass_complete_folders
 	      _gopass_complete_passwords
 	      ;;
 	  link|ln|symlink)
 	      
-	      _describe -t commands "gopass link" subcommands
 	      
 	      
 	      ;;
 	  list|ls)
 	      _arguments : "--limit[Display no more than this many levels of the tree]" "--flat[Print a flat list]" "--folders[Print a flat list of folders]" "--strip-prefix[Strip this prefix from filtered entries]"
-	      _describe -t commands "gopass list" subcommands
 	      _gopass_complete_folders
 	      
 	      ;;
 	  merge)
 	      _arguments : "--delete[Remove merged entries]" "--force[Skip editor, merge entries unattended]"
-	      _describe -t commands "gopass merge" subcommands
 	      
 	      
 	      ;;
@@ -188,32 +165,28 @@ WARNING: This will update the secret content to the latest format. This might be
 	      "add:Mount a password store"
 	      "remove:Umount an mounted password store"
 	      )
-	      
 	      _describe -t commands "gopass mounts" subcommands
+	      
 	      
 	      
 	      ;;
 	  move|mv)
 	      _arguments : "--force[Force to move the secret and overwrite existing one]"
-	      _describe -t commands "gopass move" subcommands
 	      
 	      _gopass_complete_passwords
 	      ;;
 	  otp|totp|hotp)
 	      _arguments : "--clip[Copy the time-based token into the clipboard]" "--qr[Write QR code to FILE]" "--password[Only display the token]"
-	      _describe -t commands "gopass otp" subcommands
 	      
 	      
 	      ;;
 	  process)
 	      
-	      _describe -t commands "gopass process" subcommands
 	      
 	      
 	      ;;
 	  pwgen)
 	      _arguments : "--no-numerals[Do not include numerals in the generated passwords.]" "--no-capitalize[Do not include capital letter in the generated passwords.]" "--ambiguous[Do not include characters that could be easily confused with each other, like '1' and 'l' or '0' and 'O']" "--symbols[Include at least one symbol in the password.]" "--one-per-line[Print one password per line]" "--xkcd[Use multiple random english words combined to a password. By default, space is used as separator and all words are lowercase]" "--sep[Word separator for generated xkcd style password. If no separator is specified, the words are combined without spaces/separator and the first character of words is capitalised. This flag implies -xkcd]" "--lang[Language to generate password from, currently de (german) and en (english, default) are supported]"
-	      _describe -t commands "gopass pwgen" subcommands
 	      
 	      
 	      ;;
@@ -223,8 +196,8 @@ WARNING: This will update the secret content to the latest format. This might be
 	      "init:Init RCS repo"
 	      "status:RCS status"
 	      )
-	      
 	      _describe -t commands "gopass rcs" subcommands
+	      
 	      
 	      
 	      ;;
@@ -234,32 +207,28 @@ WARNING: This will update the secret content to the latest format. This might be
 	      "add:Add any number of Recipients to any store"
 	      "remove:Remove any number of Recipients from any store"
 	      )
-	      
 	      _describe -t commands "gopass recipients" subcommands
+	      
 	      
 	      
 	      ;;
 	  setup)
-	      _arguments : "--remote[URL to a git remote, will attempt to join this team]" "--alias[Local mount point for the given remote]" "--create[Create a new team (default: false, i.e. join an existing team)]" "--name[Firstname and Lastname for unattended GPG key generation]" "--email[EMail for unattended GPG key generation]" "--crypto[Select crypto backend [age gpgcli plain]]" "--storage[Select storage backend [fossilfs fs gitfs]]"
-	      _describe -t commands "gopass setup" subcommands
+	      _arguments : "--remote[URL to a git remote, will attempt to join this team]" "--alias[Local mount point for the given remote]" "--create[Create a new team (default: false, i.e. join an existing team)]" "--name[Firstname and Lastname for unattended GPG key generation]" "--email[EMail for unattended GPG key generation]" "--crypto[Select crypto backend \[age gpgcli plain\]]" "--storage[Select storage backend \[fossilfs fs gitfs\]]"
 	      
 	      
 	      ;;
 	  show)
 	      _arguments : "--yes[Always answer yes to yes/no questions]" "--clip[Copy the password value into the clipboard]" "--alsoclip[Copy the password and show everything]" "--qr[Print the password as a QR Code]" "--unsafe[Display unsafe content (e.g. the password) even if safecontent is enabled]" "--password[Display only the password. Takes precedence over all other flags.]" "--revision[Show a past revision. Does NOT support RCS specific shortcuts. Use exact revision or -<N> to select the Nth oldest revision of this entry.]" "--noparsing[Do not parse the output.]" "--chars[Print specific characters from the secret]"
-	      _describe -t commands "gopass show" subcommands
 	      
 	      _gopass_complete_passwords
 	      ;;
 	  sum|sha|sha256)
 	      
-	      _describe -t commands "gopass sum" subcommands
 	      
 	      
 	      ;;
 	  sync)
 	      _arguments : "--store[Select the store to sync]"
-	      _describe -t commands "gopass sync" subcommands
 	      
 	      
 	      ;;
@@ -270,32 +239,28 @@ WARNING: This will update the secret content to the latest format. This might be
 	      "edit:Edit secret templates."
 	      "remove:Remove secret templates."
 	      )
-	      
 	      _describe -t commands "gopass templates" subcommands
+	      
 	      
 	      
 	      ;;
 	  unclip)
 	      _arguments : "--timeout[Time to wait]" "--force[Clear clipboard even if checksum mismatches]"
-	      _describe -t commands "gopass unclip" subcommands
 	      
 	      
 	      ;;
 	  update)
 	      
-	      _describe -t commands "gopass update" subcommands
 	      
 	      
 	      ;;
 	  version)
 	      
-	      _describe -t commands "gopass version" subcommands
 	      
 	      
 	      ;;
 	  help|h)
 	      
-	      _describe -t commands "gopass help" subcommands
 	      
 	      
 	      ;;


### PR DESCRIPTION
Fix various errors in zsh completions.
- Escape square brackets
- Don't print '_describe...'' if there are no subcommands

RELEASE_NOTES=[BUGFIX] fix errors in zsh completions

Signed-off-by: Tim Culverhouse <tim@timculverhouse.com>