### PR TITLE
Upload released deb packages to our apt host

### DIFF
--- a/.github/workflows/autorelease.yml
+++ b/.github/workflows/autorelease.yml
@@ -74,3 +74,12 @@ jobs:
           echo gh release upload "${tag}" "${msi}"
         env:
           GITHUB_TOKEN: ${{ secrets.GH_PAT }}
+      -
+        name: "Upload deb files to apt hosting"
+        run: |
+          for D in dist/*.deb; do
+            curl -H"X-Filename: ${D}" -H'X-Apikey: ${APIKEY}' -XPOST --data-binary @$D http://packages.gauner.org/repos/gopass/upload
+          done
+        env:
+          APIKEY: ${{ secrets.APT_APIKEY }}
+


### PR DESCRIPTION
I'm working on a new approach to hosting packages for users of deb based distributions.
It's not ready for public consumption, yet. But I do want to test if it works with our release pipeline at the next release.

RELEASE_NOTES=n/a

Signed-off-by: Dominik Schulz <dominik.schulz@gauner.org>