### PR TITLE
Do not install gnupg and git on Mac

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,9 +84,6 @@ jobs:
       with:
         go-version: 1.18
 
-    - name: MacOS Dependencies
-      run: brew install git gnupg
-
     - run: git config --global user.name nobody
     - run: git config --global user.email foo.bar@example.org
       


### PR DESCRIPTION
Let's see if removing those removes the build flakes.

RELEASE_NOTES=n/a

Signed-off-by: Dominik Schulz <dominik.schulz@gauner.org>