### PR TITLE
Determine password length from env variable, if set

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -24,6 +24,7 @@ Some configuration options are only available through setting environment variab
 | `GOPASS_CLIPBOARD_COPY_CMD`  | `string` | Use an external command to copy a password to the clipboard. See [GPaste](usecases/gpaste.md) for an example     |
 | `GOPASS_CLIPBOARD_CLEAR_CMD` | `string` | Use an external command to remove a password from the clipboard. See [GPaste](usecases/gpaste.md) for an example |
 | `GOPASS_GPG_BINARY` | `string` | Set this to the absolute path to the GPG binary if you need to override the value returned by `gpgconf`, e.g. [QubesOS](https://www.qubes-os.org/doc/split-gpg/). |
+| `GOPASS_PW_DEFAULT_LENGTH`   | `int`    | Set to any integer value larger than zero to define a different default length in the `generate` command. By default the length is 24 characters. |
 
 Variables not exclusively used by gopass
 

--- a/internal/action/edit.go
+++ b/internal/action/edit.go
@@ -95,7 +95,7 @@ func (s *Action) editGetContent(ctx context.Context, name string, create bool) (
 	}
 
 	// load template if it exists.
-	if content, found := s.renderTemplate(ctx, name, []byte(pwgen.GeneratePassword(defaultLength, false))); found {
+	if content, found := s.renderTemplate(ctx, name, []byte(pwgen.GeneratePassword(defaultLengthFromEnv(), false))); found {
 		return name, content, true, nil
 	}
 

--- a/internal/action/edit.go
+++ b/internal/action/edit.go
@@ -95,7 +95,8 @@ func (s *Action) editGetContent(ctx context.Context, name string, create bool) (
 	}
 
 	// load template if it exists.
-	if content, found := s.renderTemplate(ctx, name, []byte(pwgen.GeneratePassword(defaultLengthFromEnv(), false))); found {
+	pwLength, _ := defaultLengthFromEnv()
+	if content, found := s.renderTemplate(ctx, name, []byte(pwgen.GeneratePassword(pwLength, false))); found {
 		return name, content, true, nil
 	}
 

--- a/internal/action/generate.go
+++ b/internal/action/generate.go
@@ -30,7 +30,7 @@ const (
 	defaultXKCDLength = 4
 )
 
-// defaultLengthFromEnv will determine the password length from the env varibale
+// defaultLengthFromEnv will determine the password length from the env variable
 // GOPASS_PW_DEFAULT_LENGTH or fallback to the hard-coded default length.
 // If the env variable is set by the user and is valid, the boolean return value
 // will be true, otherwise it will be false.
@@ -46,6 +46,7 @@ func defaultLengthFromEnv() (int, bool) {
 	if length < 1 {
 		return defaultLength, false
 	}
+
 	return length, true
 }
 

--- a/internal/action/generate.go
+++ b/internal/action/generate.go
@@ -3,6 +3,7 @@ package action
 import (
 	"context"
 	"fmt"
+	"os"
 	"path"
 	"regexp"
 	"sort"
@@ -28,6 +29,23 @@ const (
 	defaultLength     = 24
 	defaultXKCDLength = 4
 )
+
+// defaultLengthFromEnv will determine the password length from the env varibale
+// GOPASS_PW_DEFAULT_LENGTH or fallback to the hardcoded default length
+func defaultLengthFromEnv() int {
+	lengthStr, isSet := os.LookupEnv("GOPASS_PW_DEFAULT_LENGTH")
+	if !isSet {
+		return defaultLength
+	}
+	length, err := strconv.Atoi(lengthStr)
+	if err != nil {
+		return defaultLength
+	}
+	if length < 1 {
+		return defaultLength
+	}
+	return length
+}
 
 var reNumber = regexp.MustCompile(`^\d+$`)
 
@@ -176,7 +194,7 @@ func (s *Action) generatePassword(ctx context.Context, c *cli.Context, length, n
 
 	var pwlen int
 	if length == "" {
-		candidateLength := defaultLength
+		candidateLength := defaultLengthFromEnv()
 		question := "How long should the password be?"
 		iv, err := termio.AskForInt(ctx, question, candidateLength)
 		if err != nil {

--- a/internal/action/generate_test.go
+++ b/internal/action/generate_test.go
@@ -178,6 +178,35 @@ func TestGenerate(t *testing.T) { //nolint:paralleltest
 		assert.Contains(t, buf.String(), "Copied to clipboard")
 		buf.Reset()
 	})
+
+	// generate --force foobar w/ pw length set via env variable (42 chars)
+	t.Run("generate --force foobar", func(t *testing.T) { //nolint:paralleltest
+		t.Setenv("GOPASS_PW_DEFAULT_LENGTH", "42")
+
+		if testing.Short() {
+			t.Skip("skipping test in short mode.")
+		}
+
+		assert.NoError(t, act.Generate(gptest.CliCtxWithFlags(ctx, t, map[string]string{"force": "true", "print": "true", "symbols": "false"}, "foobar")))
+		lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+		assert.Len(t, lines[3], 42)
+		buf.Reset()
+	})
+
+	// generate --force foobar w/ pw length set via env variable to invalid value, fallback mechanism
+	t.Run("generate --force foobar", func(t *testing.T) { //nolint:paralleltest
+		t.Setenv("GOPASS_PW_DEFAULT_LENGTH", "0")
+
+		if testing.Short() {
+			t.Skip("skipping test in short mode.")
+		}
+
+		assert.NoError(t, act.Generate(gptest.CliCtxWithFlags(ctx, t, map[string]string{"force": "true", "print": "true", "symbols": "false"}, "foobar")))
+		lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+		assert.Len(t, lines[3], 24) // 24 = default value used as fallback
+		buf.Reset()
+	})
+
 }
 
 func passIsAlphaNum(t *testing.T, buf string, want bool) {

--- a/internal/action/generate_test.go
+++ b/internal/action/generate_test.go
@@ -368,18 +368,20 @@ func TestFilterPrefix(t *testing.T) {
 	}
 }
 
-func TestDefaultLengthFromEnv(t *testing.T) {
+// NOTE: Do not use t.Parallel because environment variables are being used
+// which can leak into other tests that run in parallel.
+func TestDefaultLengthFromEnv(t *testing.T) { //nolint:paralleltest
 	const pwLengthEnvName = "GOPASS_PW_DEFAULT_LENGTH"
 
-	t.Run("use default value if no environment variable is set", func(t *testing.T) {
+	t.Run("use default value if no environment variable is set", func(t *testing.T) { //nolint:paralleltest
 		actual, isCustom := defaultLengthFromEnv()
 		expected := defaultLength
 		assert.Equal(t, actual, expected)
 		assert.False(t, isCustom)
 	})
 
-	t.Run("interpretetion of various inputs for environment variable", func(t *testing.T) {
-		for _, tc := range []struct { //nolint:paralleltest
+	t.Run("interpretetion of various inputs for environment variable", func(t *testing.T) { //nolint:paralleltest
+		for _, tc := range []struct {
 			in       string
 			expected int
 			custom   bool

--- a/internal/action/generate_test.go
+++ b/internal/action/generate_test.go
@@ -202,7 +202,6 @@ func TestGenerate(t *testing.T) { //nolint:paralleltest
 		assert.Len(t, lines[3], 24) // 24 = default value used as fallback
 		buf.Reset()
 	})
-
 }
 
 func passIsAlphaNum(t *testing.T, buf string, want bool) {

--- a/internal/action/generate_test.go
+++ b/internal/action/generate_test.go
@@ -371,3 +371,34 @@ func TestFilterPrefix(t *testing.T) {
 		})
 	}
 }
+
+func TestDefaultLengthFromEnv(t *testing.T) {
+	const pwLengthEnvName = "GOPASS_PW_DEFAULT_LENGTH"
+
+	t.Run("use default value if no environment variable is set", func(t *testing.T) {
+		actual, isCustom := defaultLengthFromEnv()
+		expected := defaultLength
+		assert.Equal(t, actual, expected)
+		assert.False(t, isCustom)
+	})
+
+	t.Run("interpretetion of various inputs for environment variable", func(t *testing.T) {
+		for _, tc := range []struct { //nolint:paralleltest
+			in       string
+			expected int
+			custom   bool
+		}{
+			{in: "42", expected: 42, custom: true},
+			{in: "1", expected: 1, custom: true},
+			{in: "0", expected: defaultLength, custom: false},
+			{in: "abc", expected: defaultLength, custom: false},
+			{in: "-1", expected: defaultLength, custom: false},
+		} {
+			tc := tc
+			t.Setenv(pwLengthEnvName, tc.in)
+			actual, isCustom := defaultLengthFromEnv()
+			assert.Equal(t, actual, tc.expected)
+			assert.Equal(t, isCustom, tc.custom)
+		}
+	})
+}

--- a/internal/action/generate_test.go
+++ b/internal/action/generate_test.go
@@ -183,10 +183,6 @@ func TestGenerate(t *testing.T) { //nolint:paralleltest
 	t.Run("generate --force foobar", func(t *testing.T) { //nolint:paralleltest
 		t.Setenv("GOPASS_PW_DEFAULT_LENGTH", "42")
 
-		if testing.Short() {
-			t.Skip("skipping test in short mode.")
-		}
-
 		assert.NoError(t, act.Generate(gptest.CliCtxWithFlags(ctx, t, map[string]string{"force": "true", "print": "true", "symbols": "false"}, "foobar")))
 		lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
 		assert.Len(t, lines[3], 42)


### PR DESCRIPTION
With this change, the variable `GOPASS_PW_DEFAULT_LENGTH` can be used to set a default length for the `generate` cmd.

This PR fixes #2190.