### PR TITLE
Handle Unix, Windows and Mac line endings in recipients parsing

### DIFF
--- a/internal/recipients/recipients.go
+++ b/internal/recipients/recipients.go
@@ -22,9 +22,13 @@ func Marshal(r []string) []byte {
 	return out.Bytes()
 }
 
-// Unmarshal Recipients line by line from a io.Reader.
+// Unmarshal Recipients line by line from a io.Reader. Handles Unix, Windows and Mac line endings.
 func Unmarshal(buf []byte) []string {
-	return set.SortedFiltered(strings.Split(string(buf), "\n"), func(k string) bool {
+	in := strings.ReplaceAll(string(buf), "\r", "\n")
+
+	return set.Apply(set.SortedFiltered(strings.Split(in, "\n"), func(k string) bool {
 		return k != ""
+	}), func(k string) string {
+		return strings.TrimSpace(k)
 	})
 }

--- a/internal/recipients/recipients_test.go
+++ b/internal/recipients/recipients_test.go
@@ -1,9 +1,49 @@
 package recipients
 
-import "testing"
+import (
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
 
 func TestMarshal(t *testing.T) {
 	t.Parallel()
 
 	t.Skip("implement this")
+}
+
+func TestUnmarshal(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		in   string
+		want []string
+	}{
+		{
+			in:   "foo@bar.com",
+			want: []string{"foo@bar.com"},
+		},
+		{
+			in:   "foo@bar.com\nbaz@bar.com\n",
+			want: []string{"baz@bar.com", "foo@bar.com"},
+		},
+		{
+			in:   "foo@bar.com\r\nbaz@bar.com\r\n",
+			want: []string{"baz@bar.com", "foo@bar.com"},
+		},
+		{
+			in:   "foo@bar.com\rbaz@bar.com\r",
+			want: []string{"baz@bar.com", "foo@bar.com"},
+		},
+	} {
+		tc := tc
+		t.Run(tc.in, func(t *testing.T) {
+			t.Parallel()
+
+			got := Unmarshal([]byte(tc.in))
+			sort.Strings(got)
+			assert.Equal(t, tc.want, got, tc.in)
+		})
+	}
 }

--- a/internal/set/map.go
+++ b/internal/set/map.go
@@ -10,3 +10,13 @@ func Map[K comparable](in []K) map[K]bool {
 
 	return m
 }
+
+// Apply applies the given function to every element of the slice.
+func Apply[K comparable](in []K, f func(K) K) []K {
+	out := make([]K, len(in))
+	for i, v := range in {
+		out[i] = f(v)
+	}
+
+	return out
+}


### PR DESCRIPTION
Fixes #2220

RELEASE_NOTES=[BUGFIX] Handle different line breaks in recipient
handling.

Signed-off-by: Dominik Schulz <dominik.schulz@gauner.org>