### PR TITLE
Add flag '--keep-case' to env subcommend

### DIFF
--- a/internal/action/commands.go
+++ b/internal/action/commands.go
@@ -300,6 +300,13 @@ func (s *Action) GetCommands() []*cli.Command {
 			Action:       s.Env,
 			BashComplete: s.Complete,
 			Hidden:       true,
+			Flags: []cli.Flag{
+				&cli.BoolFlag{
+					Name:  "keep-capitalization",
+					Value: false,
+					Usage: "Do not capitalize the environment variable and instead retain the original capitalization",
+				},
+			},
 		},
 		{
 			Name:      "find",

--- a/internal/action/commands.go
+++ b/internal/action/commands.go
@@ -302,9 +302,10 @@ func (s *Action) GetCommands() []*cli.Command {
 			Hidden:       true,
 			Flags: []cli.Flag{
 				&cli.BoolFlag{
-					Name:  "keep-capitalization",
-					Value: false,
-					Usage: "Do not capitalize the environment variable and instead retain the original capitalization",
+					Name:    "keep-case",
+					Aliases: []string{"kc"},
+					Value:   false,
+					Usage:   "Do not capitalize the environment variable and instead retain the original capitalization",
 				},
 			},
 		},

--- a/internal/action/env.go
+++ b/internal/action/env.go
@@ -21,6 +21,7 @@ func (s *Action) Env(c *cli.Context) error {
 	ctx := ctxutil.WithGlobalFlags(c)
 	name := c.Args().First()
 	args := c.Args().Tail()
+	keepCapitalization := c.Bool("keep-capitalization")
 
 	if len(args) == 0 {
 		return exit.Error(exit.Usage, nil, "Missing subcommand to execute")
@@ -59,7 +60,11 @@ func (s *Action) Env(c *cli.Context) error {
 		if err != nil {
 			return fmt.Errorf("failed to get entry for env prefix %q: %w", name, err)
 		}
-		env = append(env, fmt.Sprintf("%s=%s", strings.ToUpper(path.Base(key)), sec.Password()))
+		envKey := path.Base(key)
+		if !keepCapitalization {
+			envKey = strings.ToUpper(envKey)
+		}
+		env = append(env, fmt.Sprintf("%s=%s", envKey, sec.Password()))
 	}
 
 	cmd := exec.CommandContext(ctx, args[0], args[1:]...)

--- a/internal/action/env.go
+++ b/internal/action/env.go
@@ -21,7 +21,7 @@ func (s *Action) Env(c *cli.Context) error {
 	ctx := ctxutil.WithGlobalFlags(c)
 	name := c.Args().First()
 	args := c.Args().Tail()
-	keepCapitalization := c.Bool("keep-capitalization")
+	keepCase := c.Bool("keep-case")
 
 	if len(args) == 0 {
 		return exit.Error(exit.Usage, nil, "Missing subcommand to execute")
@@ -61,7 +61,7 @@ func (s *Action) Env(c *cli.Context) error {
 			return fmt.Errorf("failed to get entry for env prefix %q: %w", name, err)
 		}
 		envKey := path.Base(key)
-		if !keepCapitalization {
+		if !keepCase {
 			envKey = strings.ToUpper(envKey)
 		}
 		env = append(env, fmt.Sprintf("%s=%s", envKey, sec.Password()))

--- a/internal/action/env_test.go
+++ b/internal/action/env_test.go
@@ -48,7 +48,7 @@ func TestEnvLeafHappyPath(t *testing.T) { //nolint:paralleltest
 	assert.Contains(t, buf.String(), fmt.Sprintf("BAZ=%s\n", pw))
 }
 
-func TestEnvLeafHappyPathKeepCapitalization(t *testing.T) { //nolint:paralleltest
+func TestEnvLeafHappyPathKeepCase(t *testing.T) { //nolint:paralleltest
 	u := gptest.NewUnitTester(t)
 	defer u.Remove()
 
@@ -69,7 +69,7 @@ func TestEnvLeafHappyPathKeepCapitalization(t *testing.T) { //nolint:paralleltes
 		stdout = os.Stdout
 	}()
 
-	// Command-line would be: "gopass env --keep-capitalization BaZ env", where
+	// Command-line would be: "gopass env --keep-case BaZ env", where
 	// "foo" is an existing secret with value "secret". We expect to see the
 	// key/value in the output of the /usr/bin/env utility in the form
 	// "BaZ=secret".
@@ -78,7 +78,7 @@ func TestEnvLeafHappyPathKeepCapitalization(t *testing.T) { //nolint:paralleltes
 	buf.Reset()
 
 	flags := make(map[string]string, 1)
-	flags["keep-capitalization"] = "true"
+	flags["keep-case"] = "true"
 	assert.NoError(t, act.Env(gptest.CliCtxWithFlags(ctx, t, flags, "BaZ", "env")))
 	assert.Contains(t, buf.String(), fmt.Sprintf("BaZ=%s\n", pw))
 }

--- a/internal/action/env_test.go
+++ b/internal/action/env_test.go
@@ -48,6 +48,41 @@ func TestEnvLeafHappyPath(t *testing.T) { //nolint:paralleltest
 	assert.Contains(t, buf.String(), fmt.Sprintf("BAZ=%s\n", pw))
 }
 
+func TestEnvLeafHappyPathKeepCapitalization(t *testing.T) { //nolint:paralleltest
+	u := gptest.NewUnitTester(t)
+	defer u.Remove()
+
+	ctx := context.Background()
+	ctx = ctxutil.WithAlwaysYes(ctx, true)
+	ctx = ctxutil.WithTerminal(ctx, false)
+	act, err := newMock(ctx, u)
+	require.NoError(t, err)
+	require.NotNil(t, act)
+
+	buf := &bytes.Buffer{}
+	out.Stdout = buf
+	out.Stderr = buf
+	stdout = buf
+	defer func() {
+		out.Stdout = os.Stdout
+		out.Stderr = os.Stderr
+		stdout = os.Stdout
+	}()
+
+	// Command-line would be: "gopass env --keep-capitalization BaZ env", where
+	// "foo" is an existing secret with value "secret". We expect to see the
+	// key/value in the output of the /usr/bin/env utility in the form
+	// "BaZ=secret".
+	pw := pwgen.GeneratePassword(24, false)
+	assert.NoError(t, act.insertStdin(ctx, "BaZ", []byte(pw), false))
+	buf.Reset()
+
+	flags := make(map[string]string, 1)
+	flags["keep-capitalization"] = "true"
+	assert.NoError(t, act.Env(gptest.CliCtxWithFlags(ctx, t, flags, "BaZ", "env")))
+	assert.Contains(t, buf.String(), fmt.Sprintf("BaZ=%s\n", pw))
+}
+
 func TestEnvSecretNotFound(t *testing.T) { //nolint:paralleltest
 	u := gptest.NewUnitTester(t)
 	defer u.Remove()


### PR DESCRIPTION
By adding this boolean flag to the `gopass env` cmd, the original capitalization of the secret is maintained. This fixes #2225.

RELEASE_NOTES=[ENHANCEMENT] Add flag to keep env variable capitalization in `gopass env` subcmd

Signed-off-by: dotcs <git@dotcs.me>