### PR TITLE
Do not print progress bar on otp --clip

### DIFF
--- a/internal/action/otp.go
+++ b/internal/action/otp.go
@@ -95,7 +95,7 @@ func (s *Action) otp(ctx context.Context, name, qrf string, clip, pw, recurse bo
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	skip := ctxutil.IsHidden(ctx) || pw || qrf != "" || out.OutputIsRedirected() || !ctxutil.IsInteractive(ctx)
+	skip := ctxutil.IsHidden(ctx) || pw || qrf != "" || out.OutputIsRedirected() || !ctxutil.IsInteractive(ctx) || clip
 	if !skip {
 		// let us monitor key presses for cancellation:.
 		go waitForKeyPress(ctx, cancel)
@@ -123,6 +123,8 @@ func (s *Action) otp(ctx context.Context, name, qrf string, clip, pw, recurse bo
 			if err := clipboard.CopyTo(ctx, fmt.Sprintf("token for %s", name), []byte(token), s.cfg.ClipTimeout); err != nil {
 				return exit.Error(exit.IO, err, "failed to copy to clipboard: %s", err)
 			}
+
+			return nil
 		}
 
 		// check if we are in "password only" or in "qr code" mode or being redirected to a pipe.


### PR DESCRIPTION
RELEASE_NOTES=[BUGFIX] Do not print progress bar on otp --clip

See the discussion on https://github.com/gopasspw/gopass/pull/2041

Signed-off-by: Dominik Schulz <dominik.schulz@gauner.org>