### PR TITLE
Remove shadowing warning when password-only

### DIFF
--- a/internal/action/otp.go
+++ b/internal/action/otp.go
@@ -86,6 +86,7 @@ func waitForKeyPress(ctx context.Context, cancel context.CancelFunc) {
 	}
 }
 
+//nolint: cyclop
 func (s *Action) otp(ctx context.Context, name, qrf string, clip, pw, recurse bool) error {
 	sec, err := s.Store.Get(ctx, name)
 	if err != nil {

--- a/internal/action/show.go
+++ b/internal/action/show.go
@@ -100,7 +100,7 @@ func (s *Action) show(ctx context.Context, c *cli.Context, name string, recurse 
 		return s.List(c)
 	}
 
-	if s.Store.IsDir(ctx, name) && ctxutil.IsTerminal(ctx) {
+	if s.Store.IsDir(ctx, name) && ctxutil.IsTerminal(ctx) && !IsPasswordOnly(ctx) {
 		out.Warningf(ctx, "%s is a secret and a folder. Use 'gopass show %s' to display the secret and 'gopass list %s' to show the content of the folder", name, name, name)
 	}
 


### PR DESCRIPTION
RELEASE_NOTES=[BUGFIX] Removing shadowing warning when using -o/--password

Fixes #1961