### PR TITLE
Use IsTerminal instead of OutputIsRedirected

### DIFF
--- a/internal/action/otp.go
+++ b/internal/action/otp.go
@@ -95,7 +95,7 @@ func (s *Action) otp(ctx context.Context, name, qrf string, clip, pw, recurse bo
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	skip := ctxutil.IsHidden(ctx) || pw || qrf != "" || !ctxutil.IsTerminal() || !ctxutil.IsInteractive(ctx) || clip
+	skip := ctxutil.IsHidden(ctx) || pw || qrf != "" || !ctxutil.IsTerminal(ctx) || !ctxutil.IsInteractive(ctx) || clip
 	if !skip {
 		// let us monitor key presses for cancellation:.
 		go waitForKeyPress(ctx, cancel)
@@ -128,7 +128,7 @@ func (s *Action) otp(ctx context.Context, name, qrf string, clip, pw, recurse bo
 		}
 
 		// check if we are in "password only" or in "qr code" mode or being redirected to a pipe.
-		if pw || qrf != "" || !ctxutil.IsTerminal() {
+		if pw || qrf != "" || !ctxutil.IsTerminal(ctx) {
 			out.Printf(ctx, "%s", token)
 			cancel()
 		} else { // if not then we want to print a progress bar with the expiry time.

--- a/internal/action/otp.go
+++ b/internal/action/otp.go
@@ -95,7 +95,7 @@ func (s *Action) otp(ctx context.Context, name, qrf string, clip, pw, recurse bo
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	skip := ctxutil.IsHidden(ctx) || pw || qrf != "" || out.OutputIsRedirected() || !ctxutil.IsInteractive(ctx) || clip
+	skip := ctxutil.IsHidden(ctx) || pw || qrf != "" || !ctxutil.IsTerminal() || !ctxutil.IsInteractive(ctx) || clip
 	if !skip {
 		// let us monitor key presses for cancellation:.
 		go waitForKeyPress(ctx, cancel)
@@ -128,7 +128,7 @@ func (s *Action) otp(ctx context.Context, name, qrf string, clip, pw, recurse bo
 		}
 
 		// check if we are in "password only" or in "qr code" mode or being redirected to a pipe.
-		if pw || qrf != "" || out.OutputIsRedirected() {
+		if pw || qrf != "" || !ctxutil.IsTerminal() {
 			out.Printf(ctx, "%s", token)
 			cancel()
 		} else { // if not then we want to print a progress bar with the expiry time.

--- a/internal/out/print.go
+++ b/internal/out/print.go
@@ -27,13 +27,6 @@ func (s Secret) SafeStr() string {
 	return "(elided)"
 }
 
-// OutputIsRedirected returns true if the current os.Stdout is a pipe instead of a terminal.
-func OutputIsRedirected() bool {
-	o, _ := os.Stdout.Stat()
-
-	return (o.Mode() & os.ModeCharDevice) != os.ModeCharDevice
-}
-
 func newline(ctx context.Context) string {
 	if HasNewline(ctx) {
 		return "\n"


### PR DESCRIPTION
Deprecate `out.OutputIsRedirected` in favour of `!ctxutil.IsTerminal`.

Fixes #2025.
