### PR TITLE
Fixing Windows releaser

### DIFF
--- a/.github/workflows/autorelease.yml
+++ b/.github/workflows/autorelease.yml
@@ -69,7 +69,7 @@ jobs:
           tag="${GITHUB_REF#refs/tags/}"
           version=${tag#v}
           make msi
-          msi=dist/gopass-${version}-windows-x64.msi
+          msi=dist/gopass-x64-windows-${version}.msi
           gh release upload "${tag}" "${msi}"
         env:
           GITHUB_TOKEN: ${{ secrets.GH_PAT }}


### PR DESCRIPTION
This should correct our issue:
```
✅ Current version is: 1.14.3
✅ Wrote Wix XML config to: /tmp/gopass-880485264/wix.xml
✅ Created MSI package at: dist/gopass-x64-windows-1.14.3.msi

stat dist/gopass-1.14.3-windows-x64.msi: no such file or directory
```

So we need to change the path to the correct `gopass-x64-windows-1.14.3.msi` instead.