### PR TITLE
Correcting instructions for apt install

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -181,7 +181,7 @@ When installing on Ubuntu or Debian you can either download the `deb` package,
 [install manually or build from source](#installing-from-source) or use our APT repository.
 
 ```bash
-$ curl http://packages.gopass.pw/repos/gopass/gopass-archive-keyring.gpg | sudo tee /usr/share/keyrings/gopass-archive-keyring.gpg
+$ wget -O- http://packages.gopass.pw/repos/gopass/gopass-archive-keyring.gpg | sudo tee /usr/share/keyrings/gopass-archive-keyring.gpg
 $ cat << EOF | sudo tee /etc/apt/sources.list.d/gopass.sources
 Types: deb
 URIs: https://packages.gopass.pw/repos/gopass

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -181,7 +181,7 @@ When installing on Ubuntu or Debian you can either download the `deb` package,
 [install manually or build from source](#installing-from-source) or use our APT repository.
 
 ```bash
-$ wget -O- http://packages.gopass.pw/repos/gopass/gopass-archive-keyring.gpg | sudo tee /usr/share/keyrings/gopass-archive-keyring.gpg
+$ curl http://packages.gopass.pw/repos/gopass/gopass-archive-keyring.gpg | sudo tee /usr/share/keyrings/gopass-archive-keyring.gpg
 $ cat << EOF | sudo tee /etc/apt/sources.list.d/gopass.sources
 Types: deb
 URIs: https://packages.gopass.pw/repos/gopass

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -181,7 +181,7 @@ When installing on Ubuntu or Debian you can either download the `deb` package,
 [install manually or build from source](#installing-from-source) or use our APT repository.
 
 ```bash
-$ curl http://packages.gopass.pw/repos/gopass/gopass-archive-keyring.gpg | sudo tee /usr/share/keyrings/gopass-archive-keyring.gpg
+$ curl https://packages.gopass.pw/repos/gopass/gopass-archive-keyring.gpg | sudo tee /usr/share/keyrings/gopass-archive-keyring.gpg >/dev/null
 $ cat << EOF | sudo tee /etc/apt/sources.list.d/gopass.sources
 Types: deb
 URIs: https://packages.gopass.pw/repos/gopass


### PR DESCRIPTION
Fixing #2282 

I think the culprit is cloudflare, but not sure.

curl is getting a HTTP/1.1 301 Moved Permanently, but since wget works 🤷🏻‍♂️ 