### PR TITLE
Don't require a minimum username length

### DIFF
--- a/internal/create/wizard.go
+++ b/internal/create/wizard.go
@@ -79,7 +79,6 @@ func New(ctx context.Context, s backend.Storage) (*Wizard, error) {
 						Name:   "username",
 						Type:   "string",
 						Prompt: "Login",
-						Min:    1,
 					},
 					{
 						Name:   "password",


### PR DESCRIPTION
Don't require a minimum username length

In https://github.com/gopasspw/gopass/pull/2293, minimum lengths began being enforced for some fields within the create wizard. One such field was username, however, this field should not be required for a simple password (in practice, email is used by many sites instead of username, so it's more convenient for me to assume my email is the "username" and allow specifying an actual username for cases where that isn't true)

RELEASE_NOTES=n/a

Signed-off-by: Landon Carter <lcarter1239@gmail.com>