### PR TITLE
Purge incorrect passwords from age's askpass cache

### DIFF
--- a/internal/backend/crypto/age/decrypt.go
+++ b/internal/backend/crypto/age/decrypt.go
@@ -21,6 +21,7 @@ func (a *Age) Decrypt(ctx context.Context, ciphertext []byte) ([]byte, error) {
 
 			return []byte(pw), err
 		})
+		ctx = ctxutil.WithPasswordPurgeCallback(ctx, a.askPass.Remove)
 	}
 
 	ids, err := a.getAllIds(ctx)
@@ -64,7 +65,12 @@ func (a *Age) decryptFile(ctx context.Context, filename string) ([]byte, error) 
 		return nil, err
 	}
 
-	return a.decrypt(ciphertext, id)
+	plaintext, err := a.decrypt(ciphertext, id)
+	if err != nil {
+		ctxutil.GetPasswordPurgeCallback(ctx)(filename)
+	}
+
+	return plaintext, err
 }
 
 func (a *Age) getAllIds(ctx context.Context) ([]age.Identity, error) {

--- a/internal/backend/crypto/age/identities.go
+++ b/internal/backend/crypto/age/identities.go
@@ -27,6 +27,7 @@ func (a *Age) Identities(ctx context.Context) ([]age.Identity, error) {
 
 			return []byte(pw), err
 		})
+		ctx = ctxutil.WithPasswordPurgeCallback(ctx, a.askPass.Remove)
 	}
 
 	debug.Log("reading native identities from %s", a.identity)
@@ -198,6 +199,7 @@ func (a *Age) saveIdentities(ctx context.Context, ids []string, newFile bool) er
 
 			return []byte(pw), err
 		})
+		ctx = ctxutil.WithPasswordPurgeCallback(ctx, a.askPass.Remove)
 	}
 
 	// ensure directory exists.

--- a/internal/backend/crypto/age/keyring.go
+++ b/internal/backend/crypto/age/keyring.go
@@ -54,6 +54,7 @@ func migrate(ctx context.Context, s backend.Storage) error {
 
 			return []byte(pw), err
 		})
+		ctx = ctxutil.WithPasswordPurgeCallback(ctx, a.askPass.Remove)
 	}
 
 	if fsutil.IsFile(OldKeyring) && fsutil.IsFile(a.identity) {

--- a/pkg/ctxutil/ctxutil.go
+++ b/pkg/ctxutil/ctxutil.go
@@ -32,6 +32,7 @@ const (
 	ctxKeyImportFunc
 	ctxKeyExportKeys
 	ctxKeyPasswordCallback
+	ctxKeyPasswordPurgeCallback
 	ctxKeyCommitTimestamp
 	ctxKeyShowParsing
 	ctxKeyHidden
@@ -462,6 +463,31 @@ func GetPasswordCallback(ctx context.Context) PasswordCallback {
 	}
 
 	return pwcb
+}
+
+// PasswordPurgeCallback is a callback to purge a password cached by PasswordCallback.
+type PasswordPurgeCallback func(string)
+
+// WithPasswordPurgeCallback returns a context with the password purge callback set.
+func WithPasswordPurgeCallback(ctx context.Context, cb PasswordPurgeCallback) context.Context {
+	return context.WithValue(ctx, ctxKeyPasswordPurgeCallback, cb)
+}
+
+// HasPasswordPurgeCallback returns true if a password purge callback was set in the context.
+func HasPasswordPurgeCallback(ctx context.Context) bool {
+	_, ok := ctx.Value(ctxKeyPasswordPurgeCallback).(PasswordPurgeCallback)
+
+	return ok
+}
+
+// GetPasswordPurgeCallback returns the password purge callback or a default (which is a no-op).
+func GetPasswordPurgeCallback(ctx context.Context) PasswordPurgeCallback {
+	ppcb, ok := ctx.Value(ctxKeyPasswordPurgeCallback).(PasswordPurgeCallback)
+	if !ok || ppcb == nil {
+		return func(string) {}
+	}
+
+	return ppcb
 }
 
 // WithCommitTimestamp returns a context with the value for the commit


### PR DESCRIPTION
Currently, if I mistype my store password in the gopass cli using the age backend, I need to close and restart the cli, because it keeps trying to use the cached incorrect password.

Possible other approaches:
- Since the password callback and the password purge callback are closely interrelated, it might make sense to have a single `ctxutil` method that sets both of them together.
- Instead of having a callback that returns a password at all, there could be a callback that attempts to decrypt data using the password, and that callback is responsible for clearing its own cache if it fails to decrypt.