### PR TITLE
Correct (neo)vim settings

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -271,18 +271,20 @@ If `$GOPATH/bin` is in your `$PATH`, you can now run `gopass` from anywhere on y
 
 ### Securing Your Editor
 
-Various editors may store temporary files outside of the secure working directory when editing secrets. We advise you to check and disable this behavior for your editor of choice.
+Various editors may store temporary files outside of the secure working directory when editing secrets.
+We advise you to check and disable this behavior for your editor of choice.
 
-For `vim` on Linux, the following setting may be helpful:
+Here are a few useuful example settings:
 
-```
-au BufNewFile,BufRead /dev/shm/gopass.* setlocal noswapfile nobackup noundofile
-```
-
-For MacOS consider this setting:
-
-```
-au BufNewFile,BufRead /private/**/gopass** setlocal noswapfile nobackup noundofile
+```vim
+" neovim on Linux
+autocmd BufNewFile,BufRead /dev/shm/gopass* setlocal noswapfile nobackup noundofile shada=""
+" neovim on MacOS
+autocmd BufNewFile,BufRead /private/**/gopass** setlocal noswapfile nobackup noundofile shada=""
+" vim on Linux
+autocmd BufNewFile,BufRead /dev/shm/gopass* setlocal noswapfile nobackup noundofile viminfo=""
+" vim on MacOS
+autocmd BufNewFile,BufRead /private/**/gopass** setlocal noswapfile nobackup noundofile viminfo=""
 ```
 
 ### Migrating from pass to gopass

--- a/internal/editor/editor.go
+++ b/internal/editor/editor.go
@@ -28,7 +28,7 @@ var (
 	Stdout io.Writer = os.Stdout
 	// Stderr is exported for tests.
 	Stderr    io.Writer = os.Stderr
-	vimOptsRe           = regexp.MustCompile(`au\s+BufNewFile,BufRead\s+.*gopass.*setlocal\s+noswapfile\s+nobackup\s+noundofile`)
+	vimOptsRe           = regexp.MustCompile(`au(tocmd)?\s+BufNewFile,BufRead\s+.*gopass.*setlocal\s+noswapfile\s+nobackup\s+noundofile\s+viminfo=`)
 )
 
 // Check will validate the editor config.


### PR DESCRIPTION
The previous recommended vim settings still allowed data to leak into
the .viminfo file
For Linux even the matching path was wrong which means that the
(insufficient) rules were not even used.

RELEASE_NOTES=[DOCUMENTATION] fix in recommended vim setting

Signed-off-by: Stefan Gehr <stefangehr@protonmail.com>