### PR TITLE
Suppress setup messages on gopass version

### DIFF
--- a/internal/action/version.go
+++ b/internal/action/version.go
@@ -25,7 +25,12 @@ func (s *Action) Version(c *cli.Context) error {
 	version := make(chan string, 1)
 	go s.checkVersion(ctx, version)
 
-	_ = s.IsInitialized(c)
+	// suppress setup output in version
+	{
+		c2 := c
+		c2.Context = ctxutil.WithHidden(c.Context, true)
+		_ = s.IsInitialized(c2)
+	}
 
 	cli.VersionPrinter(c)
 


### PR DESCRIPTION
gopass version might be run on an uninitialized instance (e.g. during
tests). We want to avoid the setup message there.

RELEASE_NOTES=[BUGFIX] Do not show setup message on version

Fixes #2325

Signed-off-by: Dominik Schulz <dominik.schulz@gauner.org>