### PR TITLE
Clean up exported public keys if a recipient is removed

### DIFF
--- a/internal/action/clone.go
+++ b/internal/action/clone.go
@@ -218,7 +218,7 @@ func (s *Action) cloneCheckDecryptionKeys(ctx context.Context, mount string) err
 	var exported bool
 	if sub, err := s.Store.GetSubStore(mount); err == nil {
 		debug.Log("exporting public keys: %v", idSet.Elements())
-		exported, err = sub.ExportMissingPublicKeys(ctx, idSet.Elements())
+		exported, err = sub.UpdateExportedPublicKeys(ctx, idSet.Elements())
 		if err != nil {
 			debug.Log("failed to export missing public keys: %w", err)
 		}

--- a/internal/action/sync.go
+++ b/internal/action/sync.go
@@ -217,7 +217,7 @@ func syncExportKeys(ctx context.Context, sub *leaf.Store, name string) error {
 
 		return err
 	}
-	exported, err := sub.ExportMissingPublicKeys(ctx, rs)
+	exported, err := sub.UpdateExportedPublicKeys(ctx, rs)
 	if err != nil {
 		out.Errorf(ctx, "Failed to export missing public keys for %q: %s", name, err)
 

--- a/internal/backend/storage/fs/store.go
+++ b/internal/backend/storage/fs/store.go
@@ -157,7 +157,7 @@ func (s *Store) List(ctx context.Context, prefix string) ([]string, error) {
 			return err
 		}
 		relPath := strings.TrimPrefix(path, s.path+string(filepath.Separator)) + string(filepath.Separator)
-		if info.IsDir() && strings.HasPrefix(info.Name(), ".") && path != s.path && !strings.HasPrefix(prefix, relPath) {
+		if info.IsDir() && strings.HasPrefix(info.Name(), ".") && path != s.path && !strings.HasPrefix(prefix, relPath) && filepath.Base(path) != filepath.Base(prefix) {
 			debug.Log("skipping dot dir (relPath: %s, prefix: %s)", relPath, prefix)
 
 			return filepath.SkipDir

--- a/internal/store/leaf/crypto.go
+++ b/internal/store/leaf/crypto.go
@@ -133,6 +133,8 @@ func (s *Store) exportPublicKey(ctx context.Context, exp keyExporter, r string) 
 		return "", fmt.Errorf("failed to write exported public key to store: %w", err)
 	}
 
+	debug.Log("exported public keys for %s to %s", r, filename)
+
 	return filename, nil
 }
 


### PR DESCRIPTION
Fixes #2315

RELEASE_NOTES=[BUGFIX] Remove exported public keys of removed
recipients.

Signed-off-by: Dominik Schulz <dominik.schulz@gauner.org>