### PR TITLE
Set vim options instead of sniffing the config

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -58,6 +58,7 @@ Alternatively, it can be installed via [chocolatey](https://chocolatey.org/packa
 #### OpenBSD
 
 For OpenBSD -current:
+
 ```
 pkg_add gopass
 ```
@@ -117,6 +118,7 @@ touch foo
 git add foo
 git commit -S -m "test"
 ```
+
 Here the `-S` flag will sign your commit using GPG, allowing you to test your GPG setup with git.
 If you get an error like: "gpg failed to sign the data" try to see if creating a clear text signature works:
 
@@ -131,6 +133,7 @@ If this fails with an error: "Inappropriate ioctl for device" run the following 
 ```
 
 If you are using CSH or TCSH:
+
 ```
 setenv GPG_TTY `tty`
 ```
@@ -141,6 +144,7 @@ If you are presented with a different error please investigate this before conti
 set it in your `.zprofile`, `.bashrc` or simliar.
 
 Also if you have both `gnupg` and `gnupg2` installed, make sure to use the latter in git:
+
 ```bash
 git config --global gpg.program gpg2
 ```
@@ -287,6 +291,9 @@ autocmd BufNewFile,BufRead /dev/shm/gopass* setlocal noswapfile nobackup noundof
 autocmd BufNewFile,BufRead /private/**/gopass** setlocal noswapfile nobackup noundofile viminfo=""
 ```
 
+Note: gopass will attempt to detect the correct hardning flags to be used for the editor. It will pass them on
+invocation.
+
 ### Migrating from pass to gopass
 
 If you are migrating from pass to gopass, you can simply use your existing password store and everything should just work. Furthermore, it may be helpful to link the gopass binary so that you can use it as a drop-in replacement. For example, assuming `$HOME/bin/` exists and is present in your `$PATH`:
@@ -320,11 +327,12 @@ If you use zsh, `make install` or `make install-completion` should install the c
 If zsh autocompletion is still not functional, or if you want to install it manually, you can run the following commands:
 
 ```bash
-$ gopass completion zsh > ~/_gopass 
-$ sudo mv ~/_gopass /usr/share/zsh/site-functions/_gopass
-$ rm -i ${ZDOTDIR:-${HOME:?No ZDOTDIR or HOME}}/.zcompdump && compinit
+gopass completion zsh > ~/_gopass 
+sudo mv ~/_gopass /usr/share/zsh/site-functions/_gopass
+rm -i ${ZDOTDIR:-${HOME:?No ZDOTDIR or HOME}}/.zcompdump && compinit
 
 ```
+
 Then exit and re-run zsh if the last command failed.
 
 Notice that it is important to directly redirect Gopass' output to a file,
@@ -334,17 +342,21 @@ completions directory, as defined by either the standard `/usr/share/zsh/site-fu
 or by a user-specified `fpath` folder. It is not meant to used with `source`.
 
 If zsh completion is still not working, you might want to add the following to your `.zshrc` file:
+
 ```bash
 autoload -U compinit && compinit
 ```
+
 if you don't have it already.
 
 ### Enable fish completion
 
 If you use the [fish](https://fishshell.com/) shell, you can enable experimental shell completion by the following command:
+
 ```fish
-$ mkdir -p ~/.config/fish/completions and; gopass completion fish > ~/.config/fish/completions/gopass.fish
+mkdir -p ~/.config/fish/completions and; gopass completion fish > ~/.config/fish/completions/gopass.fish
 ```
+
 and start a new shell afterwards.
 
 Since writing fish completion scripts is not yet supported by the CLI library we use, this completion script is missing a few features. Feel free to contribute if you want to improve it.
@@ -415,10 +427,10 @@ $ gopass setup --crypto gpg --storage gitfs # used by default
 If you have created a password store with `git`, `gopass` can easily clone it.
 
 ```bash
-$ gopass clone git@gitlab.example.org:john/passwords.git
+gopass clone git@gitlab.example.org:john/passwords.git
 ```
 
-### Storing and Syncing your Password Store with Google Drive / Dropbox / Syncthing / etc.
+### Storing and Syncing your Password Store with Google Drive / Dropbox / Syncthing / etc
 
 The recommended way to use Gopass is to sync your store with a git repository, preferably a private one, since the name and path of your secrets might reveal information that you'd prefer to keep private.
 However, shall you prefer to, you might also use the `noop` storage backend that is meant to store data on a cloud provider instead of a git server.
@@ -471,4 +483,3 @@ It will fail if the remote at `github.com/example/pass.git` is not empty.
 
 The second command will clone the existing (no `--create` flag) remote `github.com/example/pass.git`
 and mount it as the mount point `example`.
-

--- a/internal/action/edit.go
+++ b/internal/action/edit.go
@@ -30,9 +30,6 @@ func (s *Action) Edit(c *cli.Context) error {
 
 func (s *Action) edit(ctx context.Context, c *cli.Context, name string) error {
 	ed := editor.Path(c)
-	if err := editor.Check(ctx, ed); err != nil {
-		out.Warningf(ctx, "Failed to check editor config: %s", err)
-	}
 
 	// get existing content or generate new one from a template.
 	name, content, changed, err := s.editGetContent(ctx, name, c.Bool("create"))

--- a/internal/action/merge.go
+++ b/internal/action/merge.go
@@ -8,7 +8,6 @@ import (
 	"github.com/gopasspw/gopass/internal/action/exit"
 	"github.com/gopasspw/gopass/internal/audit"
 	"github.com/gopasspw/gopass/internal/editor"
-	"github.com/gopasspw/gopass/internal/out"
 	"github.com/gopasspw/gopass/internal/queue"
 	"github.com/gopasspw/gopass/pkg/ctxutil"
 	"github.com/gopasspw/gopass/pkg/debug"
@@ -31,9 +30,6 @@ func (s *Action) Merge(c *cli.Context) error {
 	}
 
 	ed := editor.Path(c)
-	if err := editor.Check(ctx, ed); err != nil {
-		out.Warningf(ctx, "Failed to check editor config: %s", err)
-	}
 
 	content := &bytes.Buffer{}
 	for _, k := range c.Args().Slice() {


### PR DESCRIPTION
Fixes #2317

RELEASE_NOTES=[ENHANCEMENT] Set vim options instead of sniffing

Signed-off-by: Dominik Schulz <dominik.schulz@gauner.org>