### PR TITLE
Allow updating gopass.exe on Windows

### DIFF
--- a/internal/action/update.go
+++ b/internal/action/update.go
@@ -1,9 +1,6 @@
 package action
 
 import (
-	"fmt"
-	"runtime"
-
 	"github.com/gopasspw/gopass/internal/action/exit"
 	"github.com/gopasspw/gopass/internal/out"
 	"github.com/gopasspw/gopass/internal/updater"
@@ -21,10 +18,6 @@ func (s *Action) Update(c *cli.Context) error {
 		out.Errorf(ctx, "Can not check version against HEAD")
 
 		return nil
-	}
-
-	if runtime.GOOS == "windows" {
-		return fmt.Errorf("gopass update is not supported on windows (#1722)")
 	}
 
 	out.Printf(ctx, "⚒ Checking for available updates ...")

--- a/internal/updater/access_others.go
+++ b/internal/updater/access_others.go
@@ -8,3 +8,8 @@ import "golang.org/x/sys/unix"
 func canWrite(path string) error {
 	return unix.Access(path, unix.W_OK) //nolint:wrapcheck
 }
+
+func removeOldBinary(dir, dest string) error {
+	// no need, os.Rename will replace the destination
+	return nil
+}

--- a/internal/updater/access_windows.go
+++ b/internal/updater/access_windows.go
@@ -3,6 +3,33 @@
 
 package updater
 
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
 func canWrite(path string) error {
+	return nil
+}
+
+// Windows won't allow us to remove the binary that's currently being executed.
+// So rename the binary and then the updater should be able to write it's
+// update to the correct location.
+//
+// See https://stackoverflow.com/a/459860
+func removeOldBinary(dir, dest string) error {
+	bakFile := filepath.Join(dir, filepath.Base(dest)+".bak")
+	// check if the bakup file already exists
+	if _, err := os.Stat(bakFile); err == nil {
+		// ... then remove it
+		_ = os.Remove(bakFile)
+	}
+	// we can't remove the currently running binary, but should be able to
+	// rename it.
+	if err := os.Rename(dest, bakFile); err != nil {
+		return fmt.Errorf("unable to rename %s to %s: %w", dest, bakFile, err)
+	}
+
 	return nil
 }


### PR DESCRIPTION
Windows will lock files being executed but we should be able to rename them.

Fixes #2011

RELEASE_NOTES=[BUGFIX] Fix updater on Windows.

Signed-off-by: Dominik Schulz <dominik.schulz@gauner.org>