### PR TITLE
test: use `T.TempDir` to create temporary test directory

### DIFF
--- a/internal/action/action_test.go
+++ b/internal/action/action_test.go
@@ -70,17 +70,12 @@ func TestAction(t *testing.T) {
 func TestNew(t *testing.T) {
 	t.Parallel()
 
-	td, err := os.MkdirTemp("", "gopass-")
-	require.NoError(t, err)
-	defer func() {
-		_ = os.RemoveAll(td)
-	}()
-
+	td := t.TempDir()
 	cfg := config.New()
 	sv := semver.Version{}
 
 	t.Run("init a new store", func(t *testing.T) { //nolint:paralleltest
-		_, err = New(cfg, sv)
+		_, err := New(cfg, sv)
 		require.NoError(t, err)
 	})
 
@@ -88,7 +83,7 @@ func TestNew(t *testing.T) {
 		cfg.Path = filepath.Join(td, "store")
 		assert.NoError(t, os.MkdirAll(cfg.Path, 0o700))
 		assert.NoError(t, os.WriteFile(filepath.Join(cfg.Path, plain.IDFile), []byte("foobar"), 0o600))
-		_, err = New(cfg, sv)
+		_, err := New(cfg, sv)
 		assert.NoError(t, err)
 	})
 }

--- a/internal/backend/crypto/plain/backend_test.go
+++ b/internal/backend/crypto/plain/backend_test.go
@@ -2,23 +2,15 @@ package plain
 
 import (
 	"context"
-	"os"
 	"testing"
 
 	"github.com/blang/semver/v4"
 	"github.com/gopasspw/gopass/pkg/ctxutil"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestPlain(t *testing.T) {
 	t.Parallel()
-
-	td, err := os.MkdirTemp("", "gopass-")
-	require.NoError(t, err)
-	defer func() {
-		_ = os.RemoveAll(td)
-	}()
 
 	ctx := context.Background()
 	ctx = ctxutil.WithAlwaysYes(ctx, true)

--- a/internal/backend/crypto_test.go
+++ b/internal/backend/crypto_test.go
@@ -33,13 +33,7 @@ func TestDetectCrypto(t *testing.T) { //nolint:paralleltest
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := context.Background()
 
-			td, err := os.MkdirTemp("", "gopass-")
-			require.NoError(t, err)
-			defer func() {
-				_ = os.RemoveAll(td)
-			}()
-
-			fsDir := filepath.Join(td, "fs")
+			fsDir := filepath.Join(t.TempDir(), "fs")
 			_ = os.RemoveAll(fsDir)
 			assert.NoError(t, os.MkdirAll(fsDir, 0o700))
 			assert.NoError(t, os.WriteFile(filepath.Join(fsDir, tc.file), []byte("foo"), 0o600))

--- a/internal/backend/rcs_test.go
+++ b/internal/backend/rcs_test.go
@@ -18,11 +18,7 @@ func TestClone(t *testing.T) {
 
 	ctx := context.Background()
 
-	td, err := os.MkdirTemp("", "gopass-")
-	require.NoError(t, err)
-	defer func() {
-		_ = os.RemoveAll(td)
-	}()
+	td := t.TempDir()
 
 	repo := filepath.Join(td, "repo")
 	require.NoError(t, os.MkdirAll(repo, 0o700))
@@ -43,11 +39,7 @@ func TestInitRCS(t *testing.T) {
 
 	ctx := context.Background()
 
-	td, err := os.MkdirTemp("", "gopass-")
-	require.NoError(t, err)
-	defer func() {
-		_ = os.RemoveAll(td)
-	}()
+	td := t.TempDir()
 
 	buf := &bytes.Buffer{}
 	out.Stdout = buf

--- a/internal/backend/storage/fs/fsck_test.go
+++ b/internal/backend/storage/fs/fsck_test.go
@@ -16,8 +16,7 @@ func TestFsck(t *testing.T) {
 	ctx := context.Background()
 	ctx = ctxutil.WithHidden(ctx, true)
 
-	path, cleanup := newTempDir(t)
-	defer cleanup()
+	path := t.TempDir()
 
 	l := &loader{}
 	s, err := l.Init(ctx, path)

--- a/internal/backend/storage/fs/rcs_test.go
+++ b/internal/backend/storage/fs/rcs_test.go
@@ -13,8 +13,7 @@ func TestRCS(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	path, cleanup := newTempDir(t)
-	defer cleanup()
+	path := t.TempDir()
 
 	g := New(path)
 	// the fs backend does not support the RCS operations

--- a/internal/backend/storage/fs/store_test.go
+++ b/internal/backend/storage/fs/store_test.go
@@ -16,8 +16,7 @@ func TestSetAndGet(t *testing.T) {
 	otherContent := []byte(`other file content`)
 	ctx := context.Background()
 
-	path, cleanup := newTempDir(t)
-	defer cleanup()
+	path := t.TempDir()
 
 	s := &Store{path}
 
@@ -51,8 +50,7 @@ func TestMove(t *testing.T) {
 	otherContent := []byte(`other file content`)
 	ctx := context.Background()
 
-	path, cleanup := newTempDir(t)
-	defer cleanup()
+	path := t.TempDir()
 
 	s := &Store{path}
 
@@ -143,8 +141,7 @@ func TestRemoveEmptyParentDirectories(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
-			td, cleanup := newTempDir(t)
-			defer cleanup()
+			td := t.TempDir()
 
 			path := filepath.Join(append([]string{td}, test.storeRoot...)...)
 			subdir := filepath.Join(append([]string{path}, test.subdirs...)...)
@@ -227,8 +224,7 @@ func TestDelete(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
-			path, cleanup := newTempDir(t)
-			defer cleanup()
+			path := t.TempDir()
 
 			subdir := filepath.Join(append([]string{path}, test.location...)...)
 			if err := os.MkdirAll(subdir, 0o777); err != nil {
@@ -260,18 +256,5 @@ func TestDelete(t *testing.T) {
 				}
 			}
 		})
-	}
-}
-
-func newTempDir(t *testing.T) (string, func()) {
-	t.Helper()
-
-	td, err := os.MkdirTemp("", "gopass-")
-	if err != nil {
-		t.Error(err)
-	}
-
-	return td, func() {
-		_ = os.RemoveAll(td)
 	}
 }

--- a/internal/backend/storage/gitfs/config_test.go
+++ b/internal/backend/storage/gitfs/config_test.go
@@ -14,13 +14,7 @@ import (
 )
 
 func TestGitConfig(t *testing.T) { //nolint:paralleltest
-	td, err := os.MkdirTemp("", "gopass-")
-	require.NoError(t, err)
-	defer func() {
-		_ = os.RemoveAll(td)
-	}()
-
-	gitdir := filepath.Join(td, "git")
+	gitdir := filepath.Join(t.TempDir(), "git")
 	require.NoError(t, os.Mkdir(gitdir, 0o755))
 
 	ctx := context.Background()

--- a/internal/backend/storage/gitfs/git_test.go
+++ b/internal/backend/storage/gitfs/git_test.go
@@ -14,11 +14,7 @@ import (
 )
 
 func TestGit(t *testing.T) { //nolint:paralleltest
-	td, err := os.MkdirTemp("", "gopass-")
-	require.NoError(t, err)
-	defer func() {
-		_ = os.RemoveAll(td)
-	}()
+	td := t.TempDir()
 
 	gitdir := filepath.Join(td, "git")
 	require.NoError(t, os.Mkdir(gitdir, 0o755))

--- a/internal/backend/storage_test.go
+++ b/internal/backend/storage_test.go
@@ -9,17 +9,12 @@ import (
 	"github.com/gopasspw/gopass/pkg/ctxutil"
 	"github.com/gopasspw/gopass/pkg/debug"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestDetectStorage(t *testing.T) { //nolint:paralleltest
 	ctx := context.Background()
 
-	td, err := os.MkdirTemp("", "gopass-")
-	require.NoError(t, err)
-	defer func() {
-		_ = os.RemoveAll(td)
-	}()
+	td := t.TempDir()
 
 	// all tests involving age should set GOPASS_HOMEDIR
 	t.Setenv("GOPASS_HOMEDIR", td)

--- a/internal/cache/disk_test.go
+++ b/internal/cache/disk_test.go
@@ -1,22 +1,14 @@
 package cache
 
 import (
-	"os"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestOnDisk(t *testing.T) { //nolint:paralleltest
-	td, err := os.MkdirTemp("", "gopass-")
-	require.NoError(t, err)
-
-	defer func() {
-		_ = os.RemoveAll(td)
-	}()
-
+	td := t.TempDir()
 	t.Setenv("GOPASS_HOMEDIR", td)
 
 	odc, err := NewOnDisk("test", time.Hour)

--- a/internal/config/io_test.go
+++ b/internal/config/io_test.go
@@ -408,14 +408,7 @@ func TestLoadError(t *testing.T) { //nolint:paralleltest
 	cfg, err := load(gcfg, false)
 	assert.Error(t, err)
 
-	td, err := os.MkdirTemp("", "gopass-")
-	require.NoError(t, err)
-
-	defer func() {
-		_ = os.RemoveAll(td)
-	}()
-
-	gcfg = filepath.Join(td, "foo", ".gopass.yml")
+	gcfg = filepath.Join(t.TempDir(), "foo", ".gopass.yml")
 	assert.NoError(t, os.Setenv("GOPASS_CONFIG", gcfg))
 	assert.NoError(t, cfg.Save())
 }

--- a/internal/store/leaf/crypto_test.go
+++ b/internal/store/leaf/crypto_test.go
@@ -16,11 +16,7 @@ func TestGPG(t *testing.T) {
 
 	ctx := context.Background()
 
-	tempdir, err := os.MkdirTemp("", "gopass-")
-	require.NoError(t, err)
-	defer func() {
-		_ = os.RemoveAll(tempdir)
-	}()
+	tempdir := t.TempDir()
 
 	obuf := &bytes.Buffer{}
 	out.Stdout = obuf

--- a/internal/store/leaf/fsck_test.go
+++ b/internal/store/leaf/fsck_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/gopasspw/gopass/pkg/ctxutil"
 	"github.com/gopasspw/gopass/pkg/gopass/secrets"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestFsck(t *testing.T) {
@@ -28,8 +27,7 @@ func TestFsck(t *testing.T) {
 	}()
 
 	// common setup
-	tempdir, err := os.MkdirTemp("", "gopass-")
-	require.NoError(t, err)
+	tempdir := t.TempDir()
 
 	s := &Store{
 		alias:   "",
@@ -47,9 +45,6 @@ func TestFsck(t *testing.T) {
 
 	assert.NoError(t, s.Fsck(ctx, ""))
 	obuf.Reset()
-
-	// common tear down
-	_ = os.RemoveAll(tempdir)
 }
 
 func TestCompareStringSlices(t *testing.T) {

--- a/internal/store/leaf/init_test.go
+++ b/internal/store/leaf/init_test.go
@@ -2,11 +2,9 @@ package leaf
 
 import (
 	"context"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestInit(t *testing.T) {
@@ -14,11 +12,7 @@ func TestInit(t *testing.T) {
 
 	ctx := context.Background()
 
-	tempdir, err := os.MkdirTemp("", "gopass-")
-	require.NoError(t, err)
-	defer func() {
-		_ = os.RemoveAll(tempdir)
-	}()
+	tempdir := t.TempDir()
 
 	s, err := createSubStore(tempdir)
 	assert.NoError(t, err)

--- a/internal/store/leaf/link_test.go
+++ b/internal/store/leaf/link_test.go
@@ -2,7 +2,6 @@ package leaf
 
 import (
 	"context"
-	"os"
 	"testing"
 
 	"github.com/gopasspw/gopass/pkg/gopass/secrets"
@@ -15,12 +14,7 @@ func TestLink(t *testing.T) {
 
 	ctx := context.Background()
 
-	tempdir, err := os.MkdirTemp("", "gopass-")
-	require.NoError(t, err)
-	defer func() {
-		_ = os.RemoveAll(tempdir)
-	}()
-
+	tempdir := t.TempDir()
 	t.Logf(tempdir)
 
 	s, err := createSubStore(tempdir)

--- a/internal/store/leaf/list_test.go
+++ b/internal/store/leaf/list_test.go
@@ -82,12 +82,10 @@ func TestList(t *testing.T) {
 
 		t.Run(tc.name, func(t *testing.T) {
 			// common setup
-			tempdir, err := os.MkdirTemp("", "gopass-")
-			require.NoError(t, err)
+			tempdir := t.TempDir()
 
 			defer func() {
 				obuf.Reset()
-				_ = os.RemoveAll(tempdir)
 			}()
 
 			s := &Store{

--- a/internal/store/leaf/move_test.go
+++ b/internal/store/leaf/move_test.go
@@ -77,13 +77,10 @@ func TestCopy(t *testing.T) {
 
 		t.Run(tc.name, func(t *testing.T) {
 			// common setup
-			tempdir, err := os.MkdirTemp("", "gopass-")
-			require.NoError(t, err)
+			tempdir := t.TempDir()
 
 			defer func() {
 				obuf.Reset()
-				// common tear down
-				_ = os.RemoveAll(tempdir)
 			}()
 
 			s := &Store{
@@ -163,13 +160,10 @@ func TestMove(t *testing.T) {
 
 		t.Run(tc.name, func(t *testing.T) {
 			// common setup
-			tempdir, err := os.MkdirTemp("", "gopass-")
-			require.NoError(t, err)
+			tempdir := t.TempDir()
 
 			defer func() {
 				obuf.Reset()
-				// common tear down
-				_ = os.RemoveAll(tempdir)
 			}()
 
 			s := &Store{
@@ -179,7 +173,7 @@ func TestMove(t *testing.T) {
 				storage: fs.New(tempdir),
 			}
 
-			err = s.saveRecipients(ctx, []string{"john.doe"}, "test")
+			err := s.saveRecipients(ctx, []string{"john.doe"}, "test")
 			require.NoError(t, err)
 
 			// run test case
@@ -232,13 +226,10 @@ func TestDelete(t *testing.T) {
 
 		t.Run(tc.name, func(t *testing.T) {
 			// common setup
-			tempdir, err := os.MkdirTemp("", "gopass-")
-			require.NoError(t, err)
+			tempdir := t.TempDir()
 
 			defer func() {
 				obuf.Reset()
-				// common tear down
-				_ = os.RemoveAll(tempdir)
 			}()
 
 			s := &Store{
@@ -248,7 +239,7 @@ func TestDelete(t *testing.T) {
 				storage: fs.New(tempdir),
 			}
 
-			err = s.saveRecipients(ctx, []string{"john.doe"}, "test")
+			err := s.saveRecipients(ctx, []string{"john.doe"}, "test")
 			require.NoError(t, err)
 
 			// run test case
@@ -324,13 +315,10 @@ func TestPrune(t *testing.T) {
 
 		t.Run(tc.name, func(t *testing.T) {
 			// common setup
-			tempdir, err := os.MkdirTemp("", "gopass-")
-			require.NoError(t, err)
+			tempdir := t.TempDir()
 
 			defer func() {
 				obuf.Reset()
-				// common tear down
-				_ = os.RemoveAll(tempdir)
 			}()
 
 			s := &Store{
@@ -340,7 +328,7 @@ func TestPrune(t *testing.T) {
 				storage: fs.New(tempdir),
 			}
 
-			err = s.saveRecipients(ctx, []string{"john.doe"}, "test")
+			err := s.saveRecipients(ctx, []string{"john.doe"}, "test")
 			assert.NoError(t, err)
 
 			// run test case

--- a/internal/store/leaf/rcs_test.go
+++ b/internal/store/leaf/rcs_test.go
@@ -2,7 +2,6 @@ package leaf
 
 import (
 	"context"
-	"os"
 	"testing"
 
 	"github.com/blang/semver/v4"
@@ -17,12 +16,7 @@ func TestGit(t *testing.T) {
 
 	ctx := context.Background()
 
-	tempdir, err := os.MkdirTemp("", "gopass-")
-	require.NoError(t, err)
-
-	defer func() {
-		_ = os.RemoveAll(tempdir)
-	}()
+	tempdir := t.TempDir()
 
 	s, err := createSubStore(tempdir)
 	require.NoError(t, err)
@@ -50,11 +44,7 @@ func TestGitRevisions(t *testing.T) {
 
 	ctx := context.Background()
 
-	tempdir, err := os.MkdirTemp("", "gopass-")
-	require.NoError(t, err)
-	defer func() {
-		_ = os.RemoveAll(tempdir)
-	}()
+	tempdir := t.TempDir()
 
 	s, err := createSubStore(tempdir)
 	require.NoError(t, err)

--- a/internal/store/leaf/recipients.go
+++ b/internal/store/leaf/recipients.go
@@ -14,7 +14,6 @@ import (
 	"github.com/gopasspw/gopass/internal/store"
 	"github.com/gopasspw/gopass/pkg/ctxutil"
 	"github.com/gopasspw/gopass/pkg/debug"
-
 	"github.com/gopasspw/gopass/pkg/termio"
 )
 

--- a/internal/store/leaf/recipients_test.go
+++ b/internal/store/leaf/recipients_test.go
@@ -24,12 +24,7 @@ func TestGetRecipientsDefault(t *testing.T) {
 
 	ctx := context.Background()
 
-	tempdir, err := os.MkdirTemp("", "gopass-")
-	require.NoError(t, err)
-
-	defer func() {
-		_ = os.RemoveAll(tempdir)
-	}()
+	tempdir := t.TempDir()
 
 	obuf := &bytes.Buffer{}
 	out.Stdout = obuf
@@ -59,12 +54,7 @@ func TestGetRecipientsSubID(t *testing.T) {
 
 	ctx := context.Background()
 
-	tempdir, err := os.MkdirTemp("", "gopass-")
-	require.NoError(t, err)
-
-	defer func() {
-		_ = os.RemoveAll(tempdir)
-	}()
+	tempdir := t.TempDir()
 
 	obuf := &bytes.Buffer{}
 	out.Stdout = obuf
@@ -101,14 +91,9 @@ func TestSaveRecipients(t *testing.T) {
 	ctx := context.Background()
 	ctx = ctxutil.WithExportKeys(ctx, true)
 
-	tempdir, err := os.MkdirTemp("", "gopass-")
-	require.NoError(t, err)
+	tempdir := t.TempDir()
 
-	defer func() {
-		_ = os.RemoveAll(tempdir)
-	}()
-
-	_, _, err = createStore(tempdir, nil, nil)
+	_, _, err := createStore(tempdir, nil, nil)
 	assert.NoError(t, err)
 
 	obuf := &bytes.Buffer{}
@@ -163,12 +148,7 @@ func TestAddRecipient(t *testing.T) {
 	ctx := context.Background()
 	ctx = ctxutil.WithHidden(ctx, true)
 
-	tempdir, err := os.MkdirTemp("", "gopass-")
-	require.NoError(t, err)
-
-	defer func() {
-		_ = os.RemoveAll(tempdir)
-	}()
+	tempdir := t.TempDir()
 
 	genRecs, _, err := createStore(tempdir, nil, nil)
 	assert.NoError(t, err)
@@ -206,14 +186,9 @@ func TestRemoveRecipient(t *testing.T) {
 	ctx := context.Background()
 	ctx = ctxutil.WithHidden(ctx, true)
 
-	tempdir, err := os.MkdirTemp("", "gopass-")
-	require.NoError(t, err)
+	tempdir := t.TempDir()
 
-	defer func() {
-		_ = os.RemoveAll(tempdir)
-	}()
-
-	_, _, err = createStore(tempdir, nil, nil)
+	_, _, err := createStore(tempdir, nil, nil)
 	assert.NoError(t, err)
 
 	obuf := &bytes.Buffer{}
@@ -243,12 +218,7 @@ func TestListRecipients(t *testing.T) {
 
 	ctx := context.Background()
 
-	tempdir, err := os.MkdirTemp("", "gopass-")
-	require.NoError(t, err)
-
-	defer func() {
-		_ = os.RemoveAll(tempdir)
-	}()
+	tempdir := t.TempDir()
 
 	genRecs, _, err := createStore(tempdir, nil, nil)
 	require.NoError(t, err)

--- a/internal/store/leaf/store_test.go
+++ b/internal/store/leaf/store_test.go
@@ -101,12 +101,7 @@ func createStore(dir string, recipients, entries []string) ([]string, []string, 
 func TestStore(t *testing.T) {
 	t.Parallel()
 
-	tempdir, err := os.MkdirTemp("", "gopass-")
-	require.NoError(t, err)
-
-	defer func() {
-		_ = os.RemoveAll(tempdir)
-	}()
+	tempdir := t.TempDir()
 
 	s, err := createSubStore(tempdir)
 	require.NoError(t, err)
@@ -121,12 +116,7 @@ func TestIdFile(t *testing.T) {
 
 	ctx := context.Background()
 
-	tempdir, err := os.MkdirTemp("", "gopass-")
-	require.NoError(t, err)
-
-	defer func() {
-		_ = os.RemoveAll(tempdir)
-	}()
+	tempdir := t.TempDir()
 
 	s, err := createSubStore(tempdir)
 	require.NoError(t, err)
@@ -205,13 +195,7 @@ func TestNew(t *testing.T) {
 
 			var tempdir string
 			if !tc.noDir {
-				var err error
-				tempdir, err = os.MkdirTemp("", "gopass-")
-				require.NoError(t, err)
-
-				defer func() {
-					_ = os.RemoveAll(tempdir)
-				}()
+				tempdir = t.TempDir()
 			}
 
 			s, err := New(tc.ctx, "", tempdir)

--- a/internal/store/leaf/templates_test.go
+++ b/internal/store/leaf/templates_test.go
@@ -2,7 +2,6 @@ package leaf
 
 import (
 	"context"
-	"os"
 	"testing"
 
 	"github.com/fatih/color"
@@ -16,16 +15,11 @@ func TestTemplates(t *testing.T) {
 
 	ctx := context.Background()
 
-	tempdir, err := os.MkdirTemp("", "gopass-")
-	require.NoError(t, err)
-
-	defer func() {
-		_ = os.RemoveAll(tempdir)
-	}()
+	tempdir := t.TempDir()
 
 	color.NoColor = true
 
-	_, _, err = createStore(tempdir, nil, nil)
+	_, _, err := createStore(tempdir, nil, nil)
 	require.NoError(t, err)
 
 	ctx = backend.WithCryptoBackendString(ctx, "plain")

--- a/internal/store/leaf/write_test.go
+++ b/internal/store/leaf/write_test.go
@@ -2,7 +2,6 @@ package leaf
 
 import (
 	"context"
-	"os"
 	"runtime"
 	"testing"
 
@@ -16,12 +15,7 @@ func TestSet(t *testing.T) {
 
 	ctx := context.Background()
 
-	tempdir, err := os.MkdirTemp("", "gopass-")
-	require.NoError(t, err)
-
-	defer func() {
-		_ = os.RemoveAll(tempdir)
-	}()
+	tempdir := t.TempDir()
 
 	s, err := createSubStore(tempdir)
 	require.NoError(t, err)

--- a/internal/updater/update_test.go
+++ b/internal/updater/update_test.go
@@ -23,12 +23,7 @@ func TestIsUpdateable(t *testing.T) { //nolint:paralleltest
 		executable = oldExec
 	}()
 
-	td, err := os.MkdirTemp("", "gopass-")
-	require.NoError(t, err)
-
-	defer func() {
-		_ = os.RemoveAll(td)
-	}()
+	td := t.TempDir()
 
 	for _, tc := range []struct {
 		name string

--- a/pkg/fsutil/fsutil_test.go
+++ b/pkg/fsutil/fsutil_test.go
@@ -27,12 +27,7 @@ func TestCleanFilename(t *testing.T) {
 }
 
 func TestCleanPath(t *testing.T) { //nolint:paralleltest
-	tempdir, err := os.MkdirTemp("", "gopass-")
-	require.NoError(t, err)
-
-	defer func() {
-		_ = os.RemoveAll(tempdir)
-	}()
+	tempdir := t.TempDir()
 
 	m := map[string]string{
 		".":                                 "",
@@ -64,12 +59,7 @@ func TestCleanPath(t *testing.T) { //nolint:paralleltest
 func TestIsDir(t *testing.T) {
 	t.Parallel()
 
-	tempdir, err := os.MkdirTemp("", "gopass-")
-	require.NoError(t, err)
-
-	defer func() {
-		_ = os.RemoveAll(tempdir)
-	}()
+	tempdir := t.TempDir()
 
 	fn := filepath.Join(tempdir, "foo")
 	assert.NoError(t, os.WriteFile(fn, []byte("bar"), 0o644))
@@ -81,12 +71,7 @@ func TestIsDir(t *testing.T) {
 func TestIsFile(t *testing.T) {
 	t.Parallel()
 
-	tempdir, err := os.MkdirTemp("", "gopass-")
-	require.NoError(t, err)
-
-	defer func() {
-		_ = os.RemoveAll(tempdir)
-	}()
+	tempdir := t.TempDir()
 
 	fn := filepath.Join(tempdir, "foo")
 	assert.NoError(t, os.WriteFile(fn, []byte("bar"), 0o644))
@@ -97,12 +82,7 @@ func TestIsFile(t *testing.T) {
 func TestShred(t *testing.T) {
 	t.Parallel()
 
-	tempdir, err := os.MkdirTemp("", "gopass-")
-	require.NoError(t, err)
-
-	defer func() {
-		_ = os.RemoveAll(tempdir)
-	}()
+	tempdir := t.TempDir()
 
 	fn := filepath.Join(tempdir, "file")
 	// test successful shread
@@ -137,12 +117,7 @@ func TestShred(t *testing.T) {
 func TestIsEmptyDir(t *testing.T) {
 	t.Parallel()
 
-	tempdir, err := os.MkdirTemp("", "gopass-")
-	require.NoError(t, err)
-
-	defer func() {
-		_ = os.RemoveAll(tempdir)
-	}()
+	tempdir := t.TempDir()
 
 	fn := filepath.Join(tempdir, "foo", "bar", "baz", "zab")
 	require.NoError(t, os.MkdirAll(fn, 0o755))
@@ -162,12 +137,7 @@ func TestIsEmptyDir(t *testing.T) {
 func TestCopyFile(t *testing.T) {
 	t.Parallel()
 
-	tempdir, err := os.MkdirTemp("", "gopass-")
-	require.NoError(t, err)
-
-	defer func() {
-		_ = os.RemoveAll(tempdir)
-	}()
+	tempdir := t.TempDir()
 
 	sfn := filepath.Join(tempdir, "foo")
 	require.NoError(t, os.MkdirAll(filepath.Dir(sfn), 0o755))

--- a/pkg/otp/otp_test.go
+++ b/pkg/otp/otp_test.go
@@ -2,7 +2,6 @@ package otp
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -47,12 +46,7 @@ func TestCalculate(t *testing.T) {
 func TestWrite(t *testing.T) {
 	t.Parallel()
 
-	td, err := os.MkdirTemp("", "gopass-")
-	assert.NoError(t, err)
-
-	defer func() {
-		_ = os.RemoveAll(td)
-	}()
+	td := t.TempDir()
 
 	tf := filepath.Join(td, "qr.png")
 


### PR DESCRIPTION
This pull request replaces `os.MkdirTemp` with `t.TempDir`. We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete. 

This saves us at least 2 lines (error check, and cleanup) on every instance, or in some cases adds cleanup that we forgot.

Reference: https://pkg.go.dev/testing#T.TempDir

```go
func TestFoo(t *testing.T) {
	// before
	tmpDir, err := os.MkdirTemp("", "")
	require.NoError(t, err)
	defer os.RemoveAll(tmpDir)

	// now
	tmpDir := t.TempDir()
}
```