### PR TITLE
Ignore comments when parsing recipient files

### DIFF
--- a/internal/recipients/recipients.go
+++ b/internal/recipients/recipients.go
@@ -15,7 +15,7 @@ func Marshal(r []string) []byte {
 
 	out := bytes.Buffer{}
 	for _, k := range set.Sorted(r) {
-		_, _ = out.WriteString(k)
+		_, _ = out.WriteString(strings.TrimSpace(k))
 		_, _ = out.WriteString("\n")
 	}
 
@@ -23,12 +23,18 @@ func Marshal(r []string) []byte {
 }
 
 // Unmarshal Recipients line by line from a io.Reader. Handles Unix, Windows and Mac line endings.
+// Note: Does not preserve comments!
 func Unmarshal(buf []byte) []string {
 	in := strings.ReplaceAll(string(buf), "\r", "\n")
 
 	return set.Apply(set.SortedFiltered(strings.Split(in, "\n"), func(k string) bool {
-		return k != ""
+		return k != "" && !strings.HasPrefix(k, "#")
 	}), func(k string) string {
-		return strings.TrimSpace(k)
+		out := strings.TrimSpace(k)
+		if strings.Contains(out, " #") {
+			out = out[:strings.Index(k, " #")]
+		}
+
+		return out
 	})
 }

--- a/internal/recipients/recipients_test.go
+++ b/internal/recipients/recipients_test.go
@@ -65,6 +65,10 @@ func TestUnmarshal(t *testing.T) {
 			in:   "# foo@bar.com\nbaz@bar.com\nzab@zab.com # comment",
 			want: []string{"baz@bar.com", "zab@zab.com"},
 		},
+		{
+			in:   "# foo@bar.com\nbaz@bar.com\n# comment\nzab@zab.com\n",
+			want: []string{"baz@bar.com", "zab@zab.com"},
+		},
 	} {
 		tc := tc
 		t.Run(tc.in, func(t *testing.T) {

--- a/internal/recipients/recipients_test.go
+++ b/internal/recipients/recipients_test.go
@@ -10,7 +10,32 @@ import (
 func TestMarshal(t *testing.T) {
 	t.Parallel()
 
-	t.Skip("implement this")
+	for _, tc := range []struct {
+		in   []string
+		want string
+	}{
+		{
+			want: "foo@bar.com\n",
+			in:   []string{"foo@bar.com\n\r"},
+		},
+		{
+			want: "baz@bar.com\nfoo@bar.com\n",
+			in:   []string{"baz@bar.com", "foo@bar.com"},
+		},
+		{
+			want: "baz@bar.com\nzab@zab.com\n",
+			in:   []string{"baz@bar.com", "zab@zab.com"},
+		},
+	} {
+		tc := tc
+		t.Run(tc.want, func(t *testing.T) {
+			t.Parallel()
+
+			sort.Strings(tc.in)
+			got := string(Marshal(tc.in))
+			assert.Equal(t, tc.want, got, tc.want)
+		})
+	}
 }
 
 func TestUnmarshal(t *testing.T) {
@@ -35,6 +60,10 @@ func TestUnmarshal(t *testing.T) {
 		{
 			in:   "foo@bar.com\rbaz@bar.com\r",
 			want: []string{"baz@bar.com", "foo@bar.com"},
+		},
+		{
+			in:   "# foo@bar.com\nbaz@bar.com\nzab@zab.com # comment",
+			want: []string{"baz@bar.com", "zab@zab.com"},
 		},
 	} {
 		tc := tc


### PR DESCRIPTION
This implementation does not preserve comments, yet. That would require major changes to how recipients are currently handled.

Fixes #2393

RELEASE_NOTES=[ENHANCEMENT] Ignore comments in recipient files.

Signed-off-by: Dominik Schulz <dominik.schulz@gauner.org>