### PR TITLE
Explicitly pass context to goroutine

### DIFF
--- a/main.go
+++ b/main.go
@@ -67,13 +67,13 @@ func main() {
 		cancel()
 	}()
 
-	go func() {
+	go func(ctx context.Context) {
 		select {
 		case <-sigChan:
 			cancel()
 		case <-ctx.Done():
 		}
-	}()
+	}(ctx)
 
 	cli.ErrWriter = errorWriter{ //nolint:reassign
 		out: colorable.NewColorableStderr(),


### PR DESCRIPTION
Previously, the `ctx` when calling ctx.Done() is fetched from main function stack, which is updated multiple times.

Signed-off-by: Tony Wang <tony@initialcommit.net>