### PR TITLE
Use diskutil mount to mount the ramdisk

### DIFF
--- a/pkg/tempfile/mount_darwin.go
+++ b/pkg/tempfile/mount_darwin.go
@@ -54,7 +54,7 @@ func (t *File) mount(ctx context.Context) error {
 	}
 
 	// mount ramdisk
-	cmd = exec.CommandContext(ctx, "mount", "-t", "hfs", "-o", "noatime", "-o", "nobrowse", t.dev, t.dir)
+	cmd = exec.CommandContext(ctx, "diskutil", "mount", "nobrowse", "-mountOptions", "noatime", "-mountpoint", t.dir, t.dev)
 	cmd.Stderr = os.Stderr
 	if debug.IsEnabled() {
 		cmd.Stdout = os.Stdout


### PR DESCRIPTION
Credits to brianjkinney: https://github.com/gopasspw/gopass/issues/2400#issuecomment-1325839294

Fixes #2400

RELEASE_NOTES=[BUGFIX] Fix edit on MacOS Ventura

Signed-off-by: Dominik Schulz <dominik.schulz@gauner.org>