### PR TITLE
Drop all options when we are not sure if EDITOR is vim

### DIFF
--- a/internal/editor/editor.go
+++ b/internal/editor/editor.go
@@ -91,7 +91,9 @@ func Invoke(ctx context.Context, editor string, content []byte) ([]byte, error) 
 }
 
 func vimOptions(editor string) []string {
-	if editor != "vi" && editor != "vim" && editor != "neovim" && editor != "nvi" {
+	if editor != "vi" && editor != "vim" && editor != "neovim" && !isVim(editor) {
+		debug.Log("Editor %s is not known to be vim compatible", editor)
+
 		return []string{}
 	}
 
@@ -108,13 +110,6 @@ func vimOptions(editor string) []string {
 		"-c",
 		fmt.Sprintf("autocmd BufNewFile,BufRead %s setlocal noswapfile nobackup noundofile %s", path, viminfo),
 	}
-
-	if !isVim(editor) {
-		debug.Log("Editor %s is not known to be vim compatible", editor)
-
-		return args
-	}
-
 	args = append(args, "-i", "NONE") // disable viminfo
 	args = append(args, "-n")         // disable swap
 

--- a/internal/editor/editor_test.go
+++ b/internal/editor/editor_test.go
@@ -16,10 +16,10 @@ func TestVimArgs(t *testing.T) {
 
 	for ed, args := range map[string][]string{
 		"vi":     {"-c", "autocmd BufNewFile,BufRead /dev/shm/gopass* setlocal noswapfile nobackup noundofile viminfo=\"\"", "-i", "NONE", "-n"},
-		"nvi":    {"-c", "autocmd BufNewFile,BufRead /dev/shm/gopass* setlocal noswapfile nobackup noundofile viminfo=\"\""},
+		"nvi":    {},
 		"neovim": {"-c", "autocmd BufNewFile,BufRead /dev/shm/gopass* setlocal noswapfile nobackup noundofile shada=\"\"", "-i", "NONE", "-n"},
 		"vim":    {"-c", "autocmd BufNewFile,BufRead /dev/shm/gopass* setlocal noswapfile nobackup noundofile viminfo=\"\"", "-i", "NONE", "-n"},
 	} {
-		assert.Equal(t, vimOptions(ed), args, ed)
+		assert.Equal(t, args, vimOptions(ed), ed)
 	}
 }


### PR DESCRIPTION
Fixes #2424

RELEASE_NOTES=[BUGFIX] Improve support for non-vim editors

Signed-off-by: Dominik Schulz <dominik.schulz@gauner.org>