### PR TITLE
Improve recipients file handling

### DIFF
--- a/internal/action/sync.go
+++ b/internal/action/sync.go
@@ -241,7 +241,7 @@ func syncExportKeys(ctx context.Context, sub *leaf.Store, name string) error {
 
 		return err
 	}
-	exported, err := sub.UpdateExportedPublicKeys(ctx, rs)
+	exported, err := sub.UpdateExportedPublicKeys(ctx, rs.IDs())
 	if err != nil {
 		out.Errorf(ctx, "Failed to export missing public keys for %q: %s", name, err)
 

--- a/internal/recipients/recipients.go
+++ b/internal/recipients/recipients.go
@@ -1,40 +1,155 @@
 package recipients
 
 import (
+	"bufio"
 	"bytes"
+	"sort"
 	"strings"
 
 	"github.com/gopasspw/gopass/internal/set"
+	"golang.org/x/exp/maps"
 )
 
+// Recipients is a list of Key IDs. It will try to retain the file as much as possible while manipulating the recipients.
+type Recipients struct {
+	r   map[string]bool
+	raw strings.Builder
+}
+
+// New creates a new list of Key IDs.
+func New() *Recipients {
+	return &Recipients{
+		r:   make(map[string]bool, 4),
+		raw: strings.Builder{},
+	}
+}
+
+// IDs returns the key IDs.
+func (r *Recipients) IDs() []string {
+	res := maps.Keys(r.r)
+	sort.Strings(res)
+
+	return res
+}
+
+// Add adds a new recipients. It returns true if the recipient was added.
+func (r *Recipients) Add(key string) bool {
+	key = strings.TrimSpace(key)
+	if _, found := r.r[key]; found {
+		return false
+	}
+
+	r.r[key] = true
+
+	return true
+}
+
+// Remove deletes an existing recipient. It returns true if the recipients
+// was present and got removed.
+func (r *Recipients) Remove(key string) bool {
+	key = strings.TrimSpace(key)
+	if _, found := r.r[key]; !found {
+		return false
+	}
+
+	delete(r.r, key)
+
+	return true
+}
+
+// Has returns true if the recipient is found.
+func (r *Recipients) Has(key string) bool {
+	key = strings.TrimSpace(key)
+	_, found := r.r[key]
+
+	return found
+}
+
 // Marshal all in memory Recipients line by line to []byte.
-func Marshal(r []string) []byte {
-	if len(r) == 0 {
+func (r *Recipients) Marshal() []byte {
+	if len(r.r) == 0 {
 		return []byte("\n")
 	}
 
+	seen := make(map[string]bool, len(r.r))
+
 	out := bytes.Buffer{}
-	for _, k := range set.Sorted(r) {
-		_, _ = out.WriteString(strings.TrimSpace(k))
-		_, _ = out.WriteString("\n")
+	s := bufio.NewScanner(strings.NewReader(r.raw.String()))
+	for s.Scan() {
+		line := strings.TrimSpace(s.Text())
+
+		// pass through comments
+		if strings.HasPrefix(line, "#") || line == "" {
+			out.WriteString(line)
+			out.WriteString("\n")
+
+			continue
+		}
+
+		key := line
+		// trim any trailing comments
+		if idx := strings.Index(line, "#"); idx != -1 {
+			key = strings.TrimSpace(line[:idx])
+		}
+
+		// skip deleted IDs
+		if _, found := r.r[key]; !found {
+			continue
+		}
+
+		out.WriteString(line)
+		out.WriteString("\n")
+
+		seen[key] = true
+	}
+
+	// add new keys
+	for _, k := range set.SortedKeys(r.r) {
+		// added before
+		if _, found := seen[k]; found {
+			continue
+		}
+
+		out.WriteString(k)
+		out.WriteString("\n")
+
+		seen[k] = true
 	}
 
 	return out.Bytes()
 }
 
 // Unmarshal Recipients line by line from a io.Reader. Handles Unix, Windows and Mac line endings.
-// Note: Does not preserve comments!
-func Unmarshal(buf []byte) []string {
+func Unmarshal(buf []byte) *Recipients {
 	in := strings.ReplaceAll(string(buf), "\r", "\n")
 
-	return set.Apply(set.SortedFiltered(strings.Split(in, "\n"), func(k string) bool {
-		return k != "" && !strings.HasPrefix(k, "#")
-	}), func(k string) string {
-		out := strings.TrimSpace(k)
-		if strings.Contains(out, " #") {
-			out = out[:strings.Index(k, " #")]
+	r := New()
+	s := bufio.NewScanner(strings.NewReader(in))
+	for s.Scan() {
+		line := s.Text()
+
+		r.raw.WriteString(line)
+		r.raw.WriteString("\n")
+
+		line = strings.TrimSpace(line)
+
+		// skip comments
+		if strings.HasPrefix(line, "#") {
+			continue
 		}
 
-		return out
-	})
+		// trim trailing comments
+		key := line
+		if idx := strings.Index(line, "#"); idx != -1 {
+			key = strings.TrimSpace(line[:idx])
+		}
+
+		if len(key) < 1 {
+			continue
+		}
+
+		r.r[key] = true
+	}
+
+	return r
 }

--- a/internal/set/sorted.go
+++ b/internal/set/sorted.go
@@ -6,6 +6,15 @@ import (
 	"golang.org/x/exp/slices"
 )
 
+// SortedKeys returns the sorted keys of the map.
+func SortedKeys[K constraints.Ordered, V any](m map[K]V) []K {
+	// sort
+	keys := maps.Keys(m)
+	slices.Sort(keys)
+
+	return keys
+}
+
 // Sorted returns a sorted set of the input.
 func Sorted[K constraints.Ordered](l []K) []K {
 	return SortedFiltered(l, func(k K) bool {

--- a/internal/store/leaf/crypto.go
+++ b/internal/store/leaf/crypto.go
@@ -37,13 +37,14 @@ func (s *Store) ImportMissingPublicKeys(ctx context.Context, newrs ...string) er
 
 		return nil
 	}
+
 	rs, err := s.GetRecipients(ctx, "")
 	if err != nil {
 		return fmt.Errorf("failed to get recipients: %w", err)
 	}
 
-	rs = append(rs, newrs...)
-	for _, r := range rs {
+	ids := append(rs.IDs(), newrs...)
+	for _, r := range ids {
 		debug.Log("Checking recipients %s ...", r)
 		// check if this recipient is missing
 		// we could list all keys outside the loop and just do the lookup here

--- a/internal/store/leaf/fsck.go
+++ b/internal/store/leaf/fsck.go
@@ -150,12 +150,12 @@ func (s *Store) fsckCheckRecipients(ctx context.Context, name string) error {
 
 	itemRecps = fingerprints(ctx, s.crypto, itemRecps)
 
-	perItemStoreRecps, err := s.GetRecipients(ctx, name)
+	rs, err := s.GetRecipients(ctx, name)
 	if err != nil {
 		return fmt.Errorf("failed to get recipients from store: %w", err)
 	}
 
-	perItemStoreRecps = fingerprints(ctx, s.crypto, perItemStoreRecps)
+	perItemStoreRecps := fingerprints(ctx, s.crypto, rs.IDs())
 
 	// check itemRecps matches storeRecps
 	extra, missing := diff.List(perItemStoreRecps, itemRecps)

--- a/internal/store/leaf/fsck_test.go
+++ b/internal/store/leaf/fsck_test.go
@@ -9,8 +9,10 @@ import (
 	"github.com/gopasspw/gopass/internal/backend/crypto/plain"
 	"github.com/gopasspw/gopass/internal/backend/storage/fs"
 	"github.com/gopasspw/gopass/internal/out"
+	"github.com/gopasspw/gopass/internal/recipients"
 	"github.com/gopasspw/gopass/pkg/gopass/secrets"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestFsck(t *testing.T) {
@@ -33,7 +35,11 @@ func TestFsck(t *testing.T) {
 		crypto:  plain.New(),
 		storage: fs.New(tempdir),
 	}
-	assert.NoError(t, s.saveRecipients(ctx, []string{"john.doe"}, "test"))
+
+	rs := recipients.New()
+	rs.Add("john.doe")
+
+	require.NoError(t, s.saveRecipients(ctx, rs, "test"))
 
 	for _, e := range []string{"foo/bar", "foo/baz", "foo/zab"} {
 		sec := &secrets.Plain{}

--- a/internal/store/leaf/list_test.go
+++ b/internal/store/leaf/list_test.go
@@ -9,6 +9,7 @@ import (
 	plain "github.com/gopasspw/gopass/internal/backend/crypto/plain"
 	"github.com/gopasspw/gopass/internal/backend/storage/fs"
 	"github.com/gopasspw/gopass/internal/out"
+	"github.com/gopasspw/gopass/internal/recipients"
 	"github.com/gopasspw/gopass/pkg/gopass/secrets"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -93,7 +94,10 @@ func TestList(t *testing.T) {
 				storage: fs.New(tempdir),
 			}
 
-			assert.NoError(t, s.saveRecipients(ctx, []string{"john.doe"}, "test"))
+			rs := recipients.New()
+			rs.Add("john.doe")
+
+			assert.NoError(t, s.saveRecipients(ctx, rs, "test"))
 
 			// prepare store
 			assert.NoError(t, tc.prep(s))

--- a/internal/store/leaf/move_test.go
+++ b/internal/store/leaf/move_test.go
@@ -9,6 +9,7 @@ import (
 	plain "github.com/gopasspw/gopass/internal/backend/crypto/plain"
 	"github.com/gopasspw/gopass/internal/backend/storage/fs"
 	"github.com/gopasspw/gopass/internal/out"
+	"github.com/gopasspw/gopass/internal/recipients"
 	"github.com/gopasspw/gopass/pkg/gopass/secrets"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -88,7 +89,9 @@ func TestCopy(t *testing.T) {
 				storage: fs.New(tempdir),
 			}
 
-			assert.NoError(t, s.saveRecipients(ctx, []string{"john.doe"}, "test"))
+			rs := recipients.New()
+			rs.Add("john.doe")
+			assert.NoError(t, s.saveRecipients(ctx, rs, "test"))
 
 			// run test case
 			t.Run(tc.name, tc.tf(s))
@@ -170,8 +173,10 @@ func TestMove(t *testing.T) {
 				storage: fs.New(tempdir),
 			}
 
-			err := s.saveRecipients(ctx, []string{"john.doe"}, "test")
-			require.NoError(t, err)
+			rs := recipients.New()
+			rs.Add("john.doe")
+
+			require.NoError(t, s.saveRecipients(ctx, rs, "test"))
 
 			// run test case
 			t.Run(tc.name, tc.tf(s))
@@ -235,8 +240,10 @@ func TestDelete(t *testing.T) {
 				storage: fs.New(tempdir),
 			}
 
-			err := s.saveRecipients(ctx, []string{"john.doe"}, "test")
-			require.NoError(t, err)
+			rs := recipients.New()
+			rs.Add("john.doe")
+
+			require.NoError(t, s.saveRecipients(ctx, rs, "test"))
 
 			// run test case
 			t.Run(tc.name, tc.tf(s))
@@ -323,8 +330,10 @@ func TestPrune(t *testing.T) {
 				storage: fs.New(tempdir),
 			}
 
-			err := s.saveRecipients(ctx, []string{"john.doe"}, "test")
-			assert.NoError(t, err)
+			rs := recipients.New()
+			rs.Add("john.doe")
+
+			require.NoError(t, s.saveRecipients(ctx, rs, "test"))
 
 			// run test case
 			t.Run(tc.name, tc.tf(s))

--- a/internal/store/leaf/recipients_test.go
+++ b/internal/store/leaf/recipients_test.go
@@ -14,6 +14,7 @@ import (
 	plain "github.com/gopasspw/gopass/internal/backend/crypto/plain"
 	"github.com/gopasspw/gopass/internal/backend/storage/fs"
 	"github.com/gopasspw/gopass/internal/out"
+	"github.com/gopasspw/gopass/internal/recipients"
 	"github.com/gopasspw/gopass/pkg/ctxutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -46,7 +47,10 @@ func TestGetRecipientsDefault(t *testing.T) {
 	assert.Equal(t, genRecs, s.Recipients(ctx))
 	recs, err := s.GetRecipients(ctx, "")
 	require.NoError(t, err)
-	assert.Equal(t, genRecs, recs)
+
+	ids := recs.IDs()
+	sort.Strings(ids)
+	assert.Equal(t, genRecs, ids)
 }
 
 func TestGetRecipientsSubID(t *testing.T) {
@@ -75,14 +79,14 @@ func TestGetRecipientsSubID(t *testing.T) {
 
 	recs, err := s.GetRecipients(ctx, "")
 	require.NoError(t, err)
-	assert.Equal(t, genRecs, recs)
+	assert.Equal(t, genRecs, recs.IDs())
 
 	err = os.WriteFile(filepath.Join(tempdir, "foo", "bar", s.crypto.IDFile()), []byte("john.doe\n"), 0o600)
 	require.NoError(t, err)
 
 	recs, err = s.GetRecipients(ctx, "foo/bar/baz")
 	require.NoError(t, err)
-	assert.Equal(t, []string{"john.doe"}, recs)
+	assert.Equal(t, []string{"john.doe"}, recs.IDs())
 }
 
 func TestSaveRecipients(t *testing.T) {
@@ -102,7 +106,6 @@ func TestSaveRecipients(t *testing.T) {
 		out.Stdout = os.Stdout
 	}()
 
-	recp := []string{"john.doe"}
 	s := &Store{
 		alias:   "",
 		path:    tempdir,
@@ -113,7 +116,10 @@ func TestSaveRecipients(t *testing.T) {
 	// remove recipients
 	_ = os.Remove(filepath.Join(tempdir, s.crypto.IDFile()))
 
-	assert.NoError(t, s.saveRecipients(ctx, recp, "test-save-recipients"))
+	rs := recipients.New()
+	rs.Add("john.doe")
+
+	require.NoError(t, s.saveRecipients(ctx, rs, "test-save-recipients"))
 	assert.Error(t, s.saveRecipients(ctx, nil, "test-save-recipients"))
 
 	buf, err := s.storage.Get(ctx, s.idFile(ctx, ""))
@@ -128,15 +134,16 @@ func TestSaveRecipients(t *testing.T) {
 
 	sort.Strings(foundRecs)
 
-	for i := 0; i < len(recp); i++ {
+	ids := rs.IDs()
+	for i := 0; i < len(ids); i++ {
 		if i >= len(foundRecs) {
 			t.Errorf("Read too few recipients")
 
 			break
 		}
 
-		if recp[i] != foundRecs[i] {
-			t.Errorf("Mismatch at %d: %s vs %s", i, recp[i], foundRecs[i])
+		if ids[i] != foundRecs[i] {
+			t.Errorf("Mismatch at %d: %s vs %s", i, ids[i], foundRecs[i])
 		}
 	}
 }
@@ -173,7 +180,7 @@ func TestAddRecipient(t *testing.T) {
 
 	rs, err := s.GetRecipients(ctx, "")
 	require.NoError(t, err)
-	assert.Equal(t, append(genRecs, newRecp), rs)
+	assert.Equal(t, append(genRecs, newRecp), rs.IDs())
 
 	err = s.SaveRecipients(ctx)
 	assert.NoError(t, err)
@@ -209,7 +216,7 @@ func TestRemoveRecipient(t *testing.T) {
 
 	rs, err := s.GetRecipients(ctx, "")
 	require.NoError(t, err)
-	assert.Equal(t, []string{"0xFEEDBEEF"}, rs)
+	assert.Equal(t, []string{"0xFEEDBEEF"}, rs.IDs())
 }
 
 func TestListRecipients(t *testing.T) {
@@ -239,7 +246,7 @@ func TestListRecipients(t *testing.T) {
 
 	rs, err := s.GetRecipients(ctx, "")
 	require.NoError(t, err)
-	assert.Equal(t, genRecs, rs)
+	assert.Equal(t, genRecs, rs.IDs())
 
 	assert.Equal(t, "0xDEADBEEF", s.OurKeyID(ctx))
 }

--- a/internal/store/leaf/store.go
+++ b/internal/store/leaf/store.go
@@ -163,12 +163,12 @@ func (s *Store) useableKeys(ctx context.Context, name string) ([]string, error) 
 	}
 
 	if !IsCheckRecipients(ctx) {
-		return rs, nil
+		return rs.IDs(), nil
 	}
 
-	kl, err := s.crypto.FindRecipients(ctx, rs...)
+	kl, err := s.crypto.FindRecipients(ctx, rs.IDs()...)
 	if err != nil {
-		return rs, err
+		return rs.IDs(), err
 	}
 
 	return kl, nil

--- a/pkg/gitconfig/config.go
+++ b/pkg/gitconfig/config.go
@@ -231,6 +231,7 @@ func parseConfig(in io.Reader, key, value string, cb parseFunc) []string {
 
 		lines = append(lines, line)
 
+		line = strings.TrimSpace(line)
 		if strings.HasPrefix(line, "#") {
 			continue
 		}


### PR DESCRIPTION
This commit introduces a recipient type that will try to retain the original layout of the recipients file as much as possible.

Fixes #2430

RELEASE_NOTES=[ENHANCEMENT] Retain recipients file format

Signed-off-by: Dominik Schulz <dominik.schulz@gauner.org>