### PR TITLE
Readme cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,81 +2,146 @@
     <img src="docs/logo.png" height="250" alt="gopass Gopher by Vincent Leinweber, remixed from the Renée French original Gopher" title="gopass Gopher by Vincent Leinweber, remixed from the Renée French original Gopher" />
 </p>
 
-# gopass
+# Overview [![Build Status](https://img.shields.io/github/workflow/status/gopasspw/gopass/Build%20gopass/master)](https://github.com/gopasspw/gopass/actions/workflows/build.yml?query=branch%3Amaster) [![Packaging status](https://repology.org/badge/tiny-repos/gopass-gopasspw.svg)](https://repology.org/project/gopass-gopasspw/versions) [![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/gopasspw/gopass/blob/master/LICENSE) [![Github All Releases](https://img.shields.io/github/downloads/gopasspw/gopass/total.svg)](https://github.com/gopasspw/gopass/releases) [![Gopass Slack](https://img.shields.io/badge/%23gopass-Slack-brightgreen)](https://join.slack.com/t/gopassworkspace/shared_invite/zt-17jl74b5x-U1OUW4ts4AQ7eAf2V4QaaQ)
 
-[![Build Status](https://img.shields.io/github/workflow/status/gopasspw/gopass/Build%20gopass/master)](https://github.com/gopasspw/gopass/actions/workflows/build.yml?query=branch%3Amaster)
-[![Packaging status](https://repology.org/badge/tiny-repos/gopass-gopasspw.svg)](https://repology.org/project/gopass-gopasspw/versions)
-[![Go Report Card](https://goreportcard.com/badge/github.com/gopasspw/gopass)](https://goreportcard.com/report/github.com/gopasspw/gopass)
-[![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/gopasspw/gopass/blob/master/LICENSE)
-[![Github All Releases](https://img.shields.io/github/downloads/gopasspw/gopass/total.svg)](https://github.com/gopasspw/gopass/releases)
-[![codecov](https://codecov.io/gh/gopasspw/gopass/branch/master/graph/badge.svg)](https://codecov.io/gh/gopasspw/gopass)
-[![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/1899/badge)](https://bestpractices.coreinfrastructure.org/projects/1899)
-[![Gopass Slack](https://img.shields.io/badge/%23gopass-Slack-brightgreen)](https://join.slack.com/t/gopassworkspace/shared_invite/zt-17jl74b5x-U1OUW4ts4AQ7eAf2V4QaaQ)
+> The slightly more awesome standard UNIX password manager for teams.
 
-## Introduction
+Manage your credentials with easy. In a globally distributed team, on multiple devices or fully offline on an air gapped machine.
 
-gopass is a password manager for the command line written in Go.
-It works on all major desktop and server operating
-systems (Linux, MacOS, BSD, Windows).
+- **Works everywhere** - The same user experience on Linux, MacOS, *BSD or Windows
+- **Built for teams** - Built from our experience working in distributed development teams
+- **Full autonomy** - No network connectivity required, unless you want it
 
-For detailed usage and installation instructions please check out our [documentation](docs/).
+# How Does It Work?
 
-## Screenshot
+By default your credentials are encrypted with GPG and versioned in git. This can be customized easily.
+The primary interface is the command line. Making it an excellent choice for CLI fans, CI/CD systems or
+anything you can hook it up with. Gopass can also integrate with your browser so you can largely avoid
+the command line - if you want.
 
-![screenshot](docs/showcase.png)
+# Installation
 
-## Features
+## Necessary prerequisits for running `gopass`
 
-Please see [docs/features.md](https://github.com/gopasspw/gopass/blob/master/docs/features.md) for an extensive list of all features along with several usage examples. Some examples are available in our
-[example password store](https://github.com/gopasspw/password-store-example).
+`gopass` can operate without any dependencies but most users will want to use it with `gpg` and `git`.
+An external editor is required if you want to be able to use `gopass edit`.
 
-| **Feature**                 | **State**     | **Description**                                                   |
-| --------------------------- | ------------- | ----------------------------------------------------------------- |
-| Secure secret storage       | *stable*      | Securely storing encrypted secrets                                |
-| Multiple stores             | *stable*      | Mount multiple stores in your root store, like file systems       |
-| Recipient management        | *stable*      | Easily manage multiple users of each store                        |
-| password quality assistance | *beta*        | Checks existing or new passwords for common flaws **offline**     |
-| password leak checker       | *integration* | Perform **offline** checks against known leaked passwords using [gopass-hibp](https://github.com/gopasspw/gopass-hibp)  |
-| PAGER support               | *stable*      | Automatically invoke a pager on long output                       |
-| JSON API                    | *integration* | Allow gopass to be used as a native extension for browser plugins |
-| Automatic fuzzy search      | *stable*      | Automatically search for matching store entries if a literal entry was not found |
-| gopass sync                 | *stable*      | Easy to use syncing of remote repos and GPG keys                  |
-| Desktop Notifications       | *stable*      | Display desktop notifications and completing long running operations |
-| REPL                        | *beta*        | Integrated Read-Eval-Print-Loop shell with autocompletion by running `gopass`. |
-| OTP support                 | *stable*      | Generate TOTP/(HOTP) tokens based on the stored secret            |
-| Extensions                  |               | [Extend](docs/hacking.md#extending-gopass) gopass with custom commands using our [API](https://pkg.go.dev/github.com/gopasspw/gopass/pkg/gopass/api)                  |
-| Fully open source!          |               | No need to trust it, check our code and/or improve it!            |
+## Installation through package managers
 
-## Design Principles
+### [Homebrew](https://brew.sh) (Linux/MacOS)
 
-Gopass is a versatile command line based password manager that is being developed with the following principles in mind:
+[![homebrew version](https://img.shields.io/homebrew/v/gopass)](https://github.com/Homebrew/homebrew-core/blob/master/Formula/gopass.rb)
 
-- **Easy**: For technical users (i.e. those who are used to the command line) it should be easy to get started with gopass.
-- **Secure**: Security is hard. We aim to make it as easy as possible while still providing a good level of protection against common adversaries. *Caution*: If your personal threat level is very high, we might not offer a good tool for you.
-- **Extensible**: While Gopass includes a fair amount of useful features, we can't cover every use-case. To support more special use cases we want to provide a clean and simple API to integration gopass into your own binaries.
+```shell
+brew install act
+```
 
-## Installation
+### Debian (Ubuntu, Debian, Raspbian, ...)
 
-Please see [docs/setup.md](https://github.com/gopasspw/gopass/blob/master/docs/setup.md).
+**Warning**: Do not install the `gopass` package for the official repositories. That is a completely different project that has no relation to us.
 
-If you have [Go](https://golang.org/) 1.18 (or greater) installed:
+```shell
+$ curl https://packages.gopass.pw/repos/gopass/gopass-archive-keyring.gpg | sudo tee /usr/share/keyrings/gopass-archive-keyring.gpg >/dev/null
+$ cat << EOF | sudo tee /etc/apt/sources.list.d/gopass.sources
+Types: deb
+URIs: https://packages.gopass.pw/repos/gopass
+Suites: stable
+Architectures: all amd64 arm64 armhf
+Components: main
+Signed-By: /usr/share/keyrings/gopass-archive-keyring.gpg
+EOF
+$ sudo apt update
+$ sudo apt install gopass gopass-archive-keyring
+```
 
-```bash
+### Fedora / RedHat / CentOS
+
+```shell
+dnf install gopass
+```
+
+Note: You might need to run `dnf copr enable daftaupe/gopass` first.
+
+### Arch Linux
+
+```shell
+pacmsn -S gopass
+```
+
+### Windows
+
+
+```shell
+# Chocolatey
+choco install gpg4win
+choco install gopass
+# Alternatively
+scopp install gopass
+```
+
+### FreeBSD / OpenBSD
+
+
+```shell
+cd /usr/ports/security/gopass
+make install
+```
+
+### Alpine Linux
+
+```shell
+apk add gopass
+```
+
+## Other installation options
+
+Please see [docs/setup.md](https://github.com/gopasspw/gopass/blob/master/docs/setup.md) for other options.
+
+### From Source
+
+```shell
 go install github.com/gopasspw/gopass@latest
 ```
 
-(and make sure your `$GOBIN` is in your `$PATH`.)
+Note: `latest` is not a stable release. We recommend to only use released versions.
 
-WARNING: Please prefer releases, unless you want to contribute to the
-development of gopass. The master branch might not be stable and can contain breaking changes without any notice.
+### Manual download
 
-## Getting Started
+Download the [latest release](https://github.com/gopasspw/gopass/releases/latest) and add the binary to your PATH.
 
-Either initialize a new git repository or clone an existing one.
+# Example usage
 
-### New password store
+```shell
+# Command structure
+gopass [<command>] [options] [args]
+# Shortcut for gopass show [<key>]
+gopass [<key>]
 
+# Enter the gopass REPL
+gopass
+
+# Find all entries matching the search string
+gopass find github
+
+# List your store
+gopass ls
+
+# List all mounts
+gopass mounts
+
+# List all recipients
+gopass recipients
+
+# Sync with all remotes
+gopass sync
+
+# Setup a new store
+gopass setup
 ```
+
+## First `gopass` run
+
+```shell
 $ gopass setup
 
    __     _    _ _      _ _   ___   ___
@@ -98,107 +163,25 @@ Please enter the git remote for your shared store []: git@gitlab.example.org:joh
 ✅ Configured
 ```
 
-Hint: `gopass setup` will use `gpg` encryption and `git` storage by default.
+Hint: `gopass setup` will use `gpg` encryption and `git` storage by default. Use `--crypto=age` to
+use `age` encryption instead. Or you can opt out of using a versioned store with `--storage=fs`.
 
-### Existing password store
+An existing store can be cloned with e.g. `gopass clone git@gitlab.example.org:john/passwords.git`.
 
-```
-$ gopass clone git@gitlab.example.org:john/passwords.git
+## Screenshot
 
-   __     _    _ _      _ _   ___   ___
- /'_ '\ /'_'\ ( '_'\  /'_' )/',__)/',__)
-( (_) |( (_) )| (_) )( (_| |\__, \\__, \
-'\__  |'\___/'| ,__/''\__,_)(____/(____/
-( )_) |       | |
- \___/'       (_)
+![screenshot](docs/showcase.png)
 
-🌟 Welcome to gopass!
-🌟 Cloning an existing password store from "git@gitlab.example.org:john/passwords.git" ...
-⚠ Cloning git repository "git@gitlab.example.org:john/passwords.git" to "/home/john/.local/share/gopass/stores/root" ...
-⚠ Configuring git repository ...
-🎩 Gathering information for the git repository ...
-🚶 What is your name? [John Doe]:
-📧 What is your email? [john.doe@example.org]:
-Your password store is ready to use! Have a look around: `gopass list`
-```
+## Support
 
-## Upgrade
+Please ask on [Slack](https://join.slack.com/t/gopassworkspace/shared_invite/zt-17jl74b5x-U1OUW4ts4AQ7eAf2V4QaaQ).
 
-To use the self-updater run:
+## Contributing
 
-```bash
-gopass update
-```
-
-or to upgrade with Go installed, run:
-
-```bash
-go install github.com/gopasspw/gopass@latest
-```
-
-Otherwise, use the setup docs mentioned in the installation section to reinstall the latest version.
-
-## Development
-
-This project uses [GitHub Flow](https://guides.github.com/introduction/flow/). In other words, create feature branches from master, open an PR against master, and rebase onto master if necessary.
-
-We aim for compatibility with the [latest stable Go Release](https://golang.org/dl/) only.
-
-While this project is maintained by volunteers in their free time we aim to triage issues weekly and release a new version at least every quarter.
+We welcome any contributions. Please see the [CONTRIBUTING.md](https://github.com/gopasspw/gopass/blob/master/CONTRIBUTING.md) for more information.
 
 ## Credit & License
 
 gopass is licensed under the terms of the MIT license. You can find the complete text in `LICENSE`.
 
 Please refer to the Git commit log for a complete list of contributors.
-
-## Community
-
-gopass is developed in the open. Here are some of the channels we use to communicate and contribute:
-
-- Issue tracker: Use the [GitHub issue tracker](https://github.com/gopasspw/gopass/issues) to file bugs and feature requests.
-
-## Integrations
-
-- [gopassbridge](https://github.com/gopasspw/gopassbridge): Browser plugin for Firefox, Chrome and other Chromium based browsers
-- [gopass-ui](https://github.com/codecentric/gopass-ui): Graphical user interface for gopass
-- [kubectl gopass](https://github.com/gopasspw/kubectl-gopass): Kubernetes / kubectl plugin to support reading and writing secrets directly from/to gopass.
-- [gopass alfred](https://github.com/gopasspw/gopass-alfred): Alfred workflow to use gopass from the Alfred Mac launcher
-- [git-credential-gopass](https://github.com/gopasspw/git-credential-gopass): Integrate gopass as an git-credential helper
-- [gopass-hibp](https://github.com/gopasspw/gopass-hibp): haveibeenpwned.com leak checker
-- [gopass-jsonapi](https://github.com/gopasspw/gopass-jsonapi): native messaging for browser plugins, e.g. gopassbridge
-- [gopass-summon-prover](https://github.com/gopasspw/gopass-summon-provider): gopass as a summon provider
-- [`terraform-provider-gopass`](https://github.com/camptocamp/terraform-provider-pass): a Terraform provider to interact with gopass
-- [chezmoi](https://github.com/twpayne/chezmoi): dotfile manager with gopass support
-- [tessen](https://github.com/ayushnix/tessen): autotype and copy gopass data on wayland compositors on Linux
-- [raycast-gopass](https://github.com/raycast/extensions/tree/main/extensions/gopass): a gopass extension for Raycast Mac launcher
-- [gnome-pass-search-provider](https://github.com/jle64/gnome-pass-search-provider): pass search provider for GNOME Shell, which also supports gopass
-
-## Mobile apps
-
-- [Pass - Password Store](https://apps.apple.com/us/app/pass-password-store/id1205820573) - iOS, [source code](https://github.com/mssun/passforios), [supports only 1 repository now](https://github.com/mssun/passforios/issues/88)
-- [Password Store](https://play.google.com/store/apps/details?id=dev.msfjarvis.aps) - Android, [source code](https://github.com/android-password-store/android-password-store)
-
-## Related Projects
-
-- [pass](https://www.passwordstore.org) - The inspiration for this project, by Jason A. Donenfeld. `gopass` is a drop-in replacement for `pass` and can be used interchangeably (mostly!).
-- [passage](https://github.com/FiloSottile/passage) - passage is a fork of [password-store](https://www.passwordstore.org) that uses
-[age](https://age-encryption.org) as a backend instead of GnuPG. `gopass` has some amount of support for `passage` but can not be used fully interchangeably as of today. This might change in the future.
-
-## Contributing
-
-We welcome any contributions. Please see the [CONTRIBUTING.md](https://github.com/gopasspw/gopass/blob/master/CONTRIBUTING.md) file for instructions on how to submit changes.
-
-## Further Documentation
-
-- [Security, Known Limitations, and Caveats](https://github.com/gopasspw/gopass/blob/master/docs/security.md)
-- [Configuration](https://github.com/gopasspw/gopass/blob/master/docs/config.md)
-- [FAQ](https://github.com/gopasspw/gopass/blob/master/docs/faq.md)
-- [JSON API](https://github.com/gopasspw/gopass-jsonapi)
-- [Gopass as Summon provider](https://github.com/gopasspw/gopass-summon-provider)
-
-## External Documentation
-
-* [gopass cheat sheet](https://woile.github.io/gopass-cheat-sheet/) ([source on github](https://github.com/Woile/gopass-cheat-sheet))
-
-- [gopass presentation](https://woile.github.io/gopass-presentation/) ([source on github](https://github.com/Woile/gopass-presentation))

--- a/docs/features.md
+++ b/docs/features.md
@@ -3,6 +3,46 @@
 This document provides a broad overview over the features and use-cases
 gopass supports.
 
+Some examples are available in our [example password store](https://github.com/gopasspw/password-store-example).
+
+| **Feature**                 | **State**     | **Description**                                                   |
+| --------------------------- | ------------- | ----------------------------------------------------------------- |
+| Secure secret storage       | *stable*      | Securely storing encrypted secrets                                |
+| Multiple stores             | *stable*      | Mount multiple stores in your root store, like file systems       |
+| Recipient management        | *stable*      | Easily manage multiple users of each store                        |
+| password quality assistance | *beta*        | Checks existing or new passwords for common flaws **offline**     |
+| password leak checker       | *integration* | Perform **offline** checks against known leaked passwords using [gopass-hibp](https://github.com/gopasspw/gopass-hibp)  |
+| PAGER support               | *stable*      | Automatically invoke a pager on long output                       |
+| JSON API                    | *integration* | Allow gopass to be used as a native extension for browser plugins |
+| Automatic fuzzy search      | *stable*      | Automatically search for matching store entries if a literal entry was not found |
+| gopass sync                 | *stable*      | Easy to use syncing of remote repos and GPG keys                  |
+| Desktop Notifications       | *stable*      | Display desktop notifications and completing long running operations |
+| REPL                        | *beta*        | Integrated Read-Eval-Print-Loop shell with autocompletion by running `gopass`. |
+| OTP support                 | *stable*      | Generate TOTP/(HOTP) tokens based on the stored secret            |
+| Extensions                  |               | [Extend](docs/hacking.md#extending-gopass) gopass with custom commands using our [API](https://pkg.go.dev/github.com/gopasspw/gopass/pkg/gopass/api)                  |
+| Fully open source!          |               | No need to trust it, check our code and/or improve it!            |
+
+## Integrations
+
+- [gopassbridge](https://github.com/gopasspw/gopassbridge): Browser plugin for Firefox, Chrome and other Chromium based browsers
+- [gopass-ui](https://github.com/codecentric/gopass-ui): Graphical user interface for gopass
+- [kubectl gopass](https://github.com/gopasspw/kubectl-gopass): Kubernetes / kubectl plugin to support reading and writing secrets directly from/to gopass.
+- [gopass alfred](https://github.com/gopasspw/gopass-alfred): Alfred workflow to use gopass from the Alfred Mac launcher
+- [git-credential-gopass](https://github.com/gopasspw/git-credential-gopass): Integrate gopass as an git-credential helper
+- [gopass-hibp](https://github.com/gopasspw/gopass-hibp): haveibeenpwned.com leak checker
+- [gopass-jsonapi](https://github.com/gopasspw/gopass-jsonapi): native messaging for browser plugins, e.g. gopassbridge
+- [gopass-summon-prover](https://github.com/gopasspw/gopass-summon-provider): gopass as a summon provider
+- [`terraform-provider-gopass`](https://github.com/camptocamp/terraform-provider-pass): a Terraform provider to interact with gopass
+- [chezmoi](https://github.com/twpayne/chezmoi): dotfile manager with gopass support
+- [tessen](https://github.com/ayushnix/tessen): autotype and copy gopass data on wayland compositors on Linux
+- [raycast-gopass](https://github.com/raycast/extensions/tree/main/extensions/gopass): a gopass extension for Raycast Mac launcher
+- [gnome-pass-search-provider](https://github.com/jle64/gnome-pass-search-provider): pass search provider for GNOME Shell, which also supports gopass
+
+## Mobile apps
+
+- [Pass - Password Store](https://apps.apple.com/us/app/pass-password-store/id1205820573) - iOS, [source code](https://github.com/mssun/passforios), [supports only 1 repository now](https://github.com/mssun/passforios/issues/88)
+- [Password Store](https://play.google.com/store/apps/details?id=dev.msfjarvis.aps) - Android, [source code](https://github.com/android-password-store/android-password-store)
+
 ## Standard Features
 
 Note: Running `gopass` without any arguments opens up an interactive mode where
@@ -496,3 +536,13 @@ Also the special `unsafe-keys` key is evaluated. It expectes
 a comma separated list of keys that will be obstructed when
 printing the secret.
 
+## Related Projects
+
+- [pass](https://www.passwordstore.org) - The inspiration for this project, by Jason A. Donenfeld. `gopass` is a drop-in replacement for `pass` and can be used interchangeably (mostly!).
+- [passage](https://github.com/FiloSottile/passage) - passage is a fork of [password-store](https://www.passwordstore.org) that uses
+[age](https://age-encryption.org) as a backend instead of GnuPG. `gopass` has some amount of support for `passage` but can not be used fully interchangeably as of today. This might change in the future.
+
+## External Documentation
+
+* [gopass cheat sheet](https://woile.github.io/gopass-cheat-sheet/) ([source on github](https://github.com/Woile/gopass-cheat-sheet))
+* [gopass presentation](https://woile.github.io/gopass-presentation/) ([source on github](https://github.com/Woile/gopass-presentation))

--- a/docs/hacking.md
+++ b/docs/hacking.md
@@ -4,6 +4,14 @@ Note: See [CONTRIBUTING.md](../CONTRIBUTING.md) for an overview.
 
 This document provides an overview on how to develop on gopass.
 
+## Development
+
+This project uses [GitHub Flow](https://guides.github.com/introduction/flow/). In other words, create feature branches from master, open an PR against master, and rebase onto master if necessary.
+
+We aim for compatibility with the [latest stable Go Release](https://golang.org/dl/) only.
+
+While this project is maintained by volunteers in their free time we aim to triage issues weekly and release a new version at least every quarter.
+
 ## Setting up an isolated development environment
 
 ### With GPG

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -273,6 +273,20 @@ WARNING: `latest` is not a stable release. It is recommended to use a specific v
 
 If `$GOPATH/bin` is in your `$PATH`, you can now run `gopass` from anywhere on your system.
 
+### Upgrade
+
+To use the self-updater run:
+
+```bash
+gopass update
+```
+
+or to upgrade with Go installed, run:
+
+```bash
+go install github.com/gopasspw/gopass@latest
+```
+
 ## Optional Post-Installation Steps
 
 ### Securing Your Editor


### PR DESCRIPTION
Readme cleanup

This commit moves much of the content out of the overloaded
README with the goal of making it easier for new users to get
a first impression and start using gopass. Most information
is still retained inside the docs/ folder.