### PR TITLE
Use git identity when pre-populating git config

### DIFF
--- a/internal/config/docs_test.go
+++ b/internal/config/docs_test.go
@@ -36,6 +36,14 @@ var ignoredEnvs = set.Map([]string{
 	"XDG_DATA_HOME",
 })
 
+// ignoredOptions is a list of config options that are used by gopass
+// but originate elsewhere (e.g. git). They should not be documented
+// here as well.
+var ignoredOptions = set.Map([]string{
+	"user.email",
+	"user.name",
+})
+
 func TestConfigOptsInDocs(t *testing.T) {
 	t.Parallel()
 
@@ -113,16 +121,25 @@ func usedOptsInFile(t *testing.T, fn string, opts map[string]bool, re *regexp.Re
 		}
 
 		if found[1] != "" {
+			if ignoredOptions[found[1]] {
+				continue
+			}
 			opts[found[1]] = true
 
 			continue
 		}
 
 		if found[2] != "" {
+			if ignoredOptions[found[2]] {
+				continue
+			}
 			opts[found[2]] = true
 		}
 
 		if found[3] != "" {
+			if ignoredOptions[found[3]] {
+				continue
+			}
 			opts[found[3]] = true
 
 			continue

--- a/pkg/termio/context.go
+++ b/pkg/termio/context.go
@@ -6,6 +6,7 @@ type contextKey int
 
 const (
 	ctxKeyPassPromptFunc contextKey = iota
+	ctxKeyWorkdir
 )
 
 // PassPromptFunc is a password prompt function.
@@ -33,4 +34,20 @@ func GetPassPromptFunc(ctx context.Context) PassPromptFunc {
 	}
 
 	return ppf
+}
+
+// WithWorkdir returns a context with the working directory option set.
+func WithWorkdir(ctx context.Context, dir string) context.Context {
+	return context.WithValue(ctx, ctxKeyWorkdir, dir)
+}
+
+// GetWorkdir returns the working directory from the context or an empty
+// string if it is not set.
+func GetWorkdir(ctx context.Context) string {
+	sv, ok := ctx.Value(ctxKeyWorkdir).(string)
+	if !ok {
+		return ""
+	}
+
+	return sv
 }

--- a/pkg/termio/identity.go
+++ b/pkg/termio/identity.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/gopasspw/gopass/pkg/ctxutil"
+	"github.com/gopasspw/gopass/pkg/gitconfig"
 	"github.com/urfave/cli/v2"
 )
 
@@ -25,7 +26,7 @@ var (
 
 // DetectName tries to guess the name of the logged in user.
 func DetectName(ctx context.Context, c *cli.Context) string {
-	cand := make([]string, 0, 5)
+	cand := make([]string, 0, 10)
 	cand = append(cand, ctxutil.GetUsername(ctx))
 
 	if c != nil {
@@ -35,6 +36,9 @@ func DetectName(ctx context.Context, c *cli.Context) string {
 	for _, k := range NameVars {
 		cand = append(cand, os.Getenv(k))
 	}
+
+	cfg := gitconfig.New().LoadAll(GetWorkdir(ctx))
+	cand = append(cand, cfg.Get("user.name"))
 
 	for _, e := range cand {
 		if e != "" {
@@ -47,7 +51,7 @@ func DetectName(ctx context.Context, c *cli.Context) string {
 
 // DetectEmail tries to guess the email of the logged in user.
 func DetectEmail(ctx context.Context, c *cli.Context) string {
-	cand := make([]string, 0, 5)
+	cand := make([]string, 0, 10)
 	cand = append(cand, ctxutil.GetEmail(ctx))
 
 	if c != nil {
@@ -57,6 +61,9 @@ func DetectEmail(ctx context.Context, c *cli.Context) string {
 	for _, k := range EmailVars {
 		cand = append(cand, os.Getenv(k))
 	}
+
+	cfg := gitconfig.New().LoadAll(GetWorkdir(ctx))
+	cand = append(cand, cfg.Get("user.email"))
 
 	for _, e := range cand {
 		if e != "" {


### PR DESCRIPTION
Fixes #968

RELEASE_NOTES=[ENHANCEMENT] Pre-populate ID with git values

Signed-off-by: Dominik Schulz <dominik.schulz@gauner.org>