### PR TITLE
Add generate.symbols and generate.length options to

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -95,3 +95,5 @@ This is a list of available options:
 | `core.showautoclip`      | `bool`   | Use autoclip for gopass show by default. | `false` |
 | `autosync.interval`      | `int`   | AutoSync interval in days. | `3` |
 | `updater.check`        | `bool`   | Check for updates when running `gopass version` | `true` |
+| `generate.symbols`     | `bool`   | Include symbols in generated password. | `false` |
+| `generate.length`      | `int`    | Default lenght for generated password. | `24` |

--- a/internal/action/edit.go
+++ b/internal/action/edit.go
@@ -92,7 +92,7 @@ func (s *Action) editGetContent(ctx context.Context, name string, create bool) (
 	}
 
 	// load template if it exists.
-	pwLength, _ := defaultLengthFromEnv()
+	pwLength, _ := defaultLengthFromEnv(ctx)
 	if content, found := s.renderTemplate(ctx, name, []byte(pwgen.GeneratePassword(pwLength, false))); found {
 		return name, content, true, nil
 	}

--- a/internal/action/generate_test.go
+++ b/internal/action/generate_test.go
@@ -373,8 +373,10 @@ func TestFilterPrefix(t *testing.T) {
 func TestDefaultLengthFromEnv(t *testing.T) { //nolint:paralleltest
 	const pwLengthEnvName = "GOPASS_PW_DEFAULT_LENGTH"
 
+	ctx := context.Background()
+
 	t.Run("use default value if no environment variable is set", func(t *testing.T) { //nolint:paralleltest
-		actual, isCustom := defaultLengthFromEnv()
+		actual, isCustom := defaultLengthFromEnv(ctx)
 		expected := defaultLength
 		assert.Equal(t, actual, expected)
 		assert.False(t, isCustom)
@@ -394,7 +396,7 @@ func TestDefaultLengthFromEnv(t *testing.T) { //nolint:paralleltest
 		} {
 			tc := tc
 			t.Setenv(pwLengthEnvName, tc.in)
-			actual, isCustom := defaultLengthFromEnv()
+			actual, isCustom := defaultLengthFromEnv(ctx)
 			assert.Equal(t, actual, tc.expected)
 			assert.Equal(t, isCustom, tc.custom)
 		}

--- a/internal/config/docs_test.go
+++ b/internal/config/docs_test.go
@@ -68,7 +68,7 @@ func TestConfigOptsInDocs(t *testing.T) {
 func usedOpts(t *testing.T) map[string]bool {
 	t.Helper()
 
-	optRE := regexp.MustCompile(`(?:\.Get(?:|Int|Bool)\(\"([a-z]+\.[a-z]+)\"\)|\.GetM\([^,]+, \"([a-z]+\.[a-z]+)\"\)|config\.Bool\(ctx, \"([a-z]+\.[a-z]+)\"\))`)
+	optRE := regexp.MustCompile(`(?:\.Get(?:|Int|Bool)\(\"([a-z]+\.[a-z]+)\"\)|\.GetM\([^,]+, \"([a-z]+\.[a-z]+)\"\)|config\.(?:Bool|Int|String)\(ctx, \"([a-z]+\.[a-z]+)\"\))`)
 	opts := make(map[string]bool, 42)
 
 	dir := filepath.Join("..", "..")


### PR DESCRIPTION
control gopass password generation behavior.

Fixes #2151

RELEASE_NOTES=[ENHANCEMENT] Add generate.symbols and generate.length options.

Signed-off-by: Dominik Schulz <dominik.schulz@gauner.org>