### PR TITLE
Add DirName template

### DIFF
--- a/docs/commands/templates.md
+++ b/docs/commands/templates.md
@@ -68,6 +68,7 @@ the generated password `VerySecure`.
 Name | Example | Description
 ---- | ------- | -----------
 `Dir` | `foo/bar` | The directory containing the secret.
+`DirName` | `bar` | The directory name containing the secret.
 `Path` | `foo/bar/baz` | The path or full name of the secret.
 `Name` | `baz` | The last element of the path or short name of the secret.
 `Content` | `VerySecure` | The generated password.

--- a/internal/tpl/template.go
+++ b/internal/tpl/template.go
@@ -16,6 +16,7 @@ type kvstore interface {
 
 type payload struct {
 	Dir     string
+	DirName string
 	Path    string
 	Name    string
 	Content string
@@ -24,8 +25,12 @@ type payload struct {
 // Execute executes the given template.
 func Execute(ctx context.Context, tpl, name string, content []byte, s kvstore) ([]byte, error) {
 	funcs := funcMap(ctx, s)
+
+	dir := filepath.Dir(name)
+
 	pl := payload{
-		Dir:     filepath.Dir(name),
+		Dir:     dir,
+		DirName: filepath.Base(dir),
 		Path:    name,
 		Name:    filepath.Base(name),
 		Content: string(content),

--- a/internal/tpl/template_test.go
+++ b/internal/tpl/template_test.go
@@ -76,6 +76,12 @@ func TestVars(t *testing.T) {
 			Output:   "testdir",
 		},
 		{
+			Template: "{{.DirName}}",
+			Name:     "foo/bar/baz",
+			Content:  []byte("foobar"),
+			Output:   "bar",
+		},
+		{
 			Template: "{{.Name}}",
 			Name:     "testdir",
 			Content:  []byte("foobar"),


### PR DESCRIPTION
Makes templating example.com/username file structure easier

RELEASE_NOTES=[ENHANCEMENT] Add DirName template

Signed-off-by: Yaroslav Yadryshnikov <me@yay.qa>

This template:
```
{{ .Content }}
username: {{ .Name }}
url: {{ .DirName }}
```
Will provide this output
```
pass
username: username
url: example.com
```