### PR TITLE
test: use `T.Setenv` to set env vars in tests

### DIFF
--- a/internal/backend/crypto/gpg/gpgconf/utils_test.go
+++ b/internal/backend/crypto/gpg/gpgconf/utils_test.go
@@ -2,7 +2,6 @@ package gpgconf
 
 import (
 	"bytes"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -15,9 +14,10 @@ func TestGpgOpts(t *testing.T) {
 			"": nil,
 			"--decrypt --armor --recipient 0xDEADBEEF": {"--decrypt", "--armor", "--recipient", "0xDEADBEEF"},
 		} {
-			assert.NoError(t, os.Setenv(vn, in))
-			assert.Equal(t, out, GPGOpts())
-			assert.NoError(t, os.Unsetenv(vn))
+			t.Run(vn, func(t *testing.T) {
+				t.Setenv(vn, in)
+				assert.Equal(t, out, GPGOpts())
+			})
 		}
 	}
 }

--- a/internal/config/legacy/config_test.go
+++ b/internal/config/legacy/config_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestNewConfig(t *testing.T) {
-	assert.NoError(t, os.Setenv("GOPASS_CONFIG", filepath.Join(os.TempDir(), ".gopass.yml")))
+	t.Setenv("GOPASS_CONFIG", filepath.Join(os.TempDir(), ".gopass.yml"))
 
 	cfg := legacy.New()
 	cs := cfg.String()
@@ -31,7 +31,7 @@ func TestNewConfig(t *testing.T) {
 }
 
 func TestSetConfigValue(t *testing.T) {
-	assert.NoError(t, os.Setenv("GOPASS_CONFIG", filepath.Join(os.TempDir(), ".gopass.yml")))
+	t.Setenv("GOPASS_CONFIG", filepath.Join(os.TempDir(), ".gopass.yml"))
 
 	cfg := legacy.New()
 	assert.NoError(t, cfg.SetConfigValue("autoclip", "true"))

--- a/internal/config/legacy/io_test.go
+++ b/internal/config/legacy/io_test.go
@@ -380,8 +380,8 @@ func TestLoad(t *testing.T) {
 	td := os.TempDir()
 	gcfg := filepath.Join(td, ".gopass.yml")
 	_ = os.Remove(gcfg)
-	assert.NoError(t, os.Setenv("GOPASS_CONFIG", gcfg))
-	assert.NoError(t, os.Setenv("GOPASS_HOMEDIR", td))
+	t.Setenv("GOPASS_CONFIG", gcfg)
+	t.Setenv("GOPASS_HOMEDIR", td)
 
 	require.NoError(t, os.WriteFile(gcfg, []byte(testConfig), 0o600))
 
@@ -391,7 +391,7 @@ func TestLoad(t *testing.T) {
 
 func TestLoadError(t *testing.T) {
 	gcfg := filepath.Join(os.TempDir(), ".gopass-err.yml")
-	assert.NoError(t, os.Setenv("GOPASS_CONFIG", gcfg))
+	t.Setenv("GOPASS_CONFIG", gcfg)
 
 	_ = os.Remove(gcfg)
 
@@ -409,13 +409,13 @@ func TestLoadError(t *testing.T) {
 	assert.Error(t, err)
 
 	gcfg = filepath.Join(t.TempDir(), "foo", ".gopass.yml")
-	assert.NoError(t, os.Setenv("GOPASS_CONFIG", gcfg))
+	t.Setenv("GOPASS_CONFIG", gcfg)
 	assert.NoError(t, cfg.Save())
 }
 
 func TestDecodeError(t *testing.T) {
 	gcfg := filepath.Join(os.TempDir(), ".gopass-err2.yml")
-	assert.NoError(t, os.Setenv("GOPASS_CONFIG", gcfg))
+	t.Setenv("GOPASS_CONFIG", gcfg)
 
 	_ = os.Remove(gcfg)
 	require.NoError(t, os.WriteFile(gcfg, []byte(testConfig+"\nfoobar: zab\n"), 0o600))

--- a/internal/editor/edit_others_test.go
+++ b/internal/editor/edit_others_test.go
@@ -8,7 +8,6 @@ import (
 	"flag"
 	"os"
 	"os/exec"
-	"runtime"
 	"testing"
 
 	"github.com/gopasspw/gopass/tests/gptest"
@@ -37,38 +36,39 @@ func TestEditor(t *testing.T) {
 func TestGetEditor(t *testing.T) {
 	app := cli.NewApp()
 
-	// --editor=fooed
-	fs := flag.NewFlagSet("default", flag.ContinueOnError)
-	sf := cli.StringFlag{
-		Name:  "editor",
-		Usage: "editor",
-	}
-	require.NoError(t, sf.Apply(fs))
-	require.NoError(t, fs.Parse([]string{"--editor", "fooed"}))
-	c := cli.NewContext(app, fs, nil)
+	t.Run("--editor=fooed", func(t *testing.T) {
+		fs := flag.NewFlagSet("default", flag.ContinueOnError)
+		sf := cli.StringFlag{
+			Name:  "editor",
+			Usage: "editor",
+		}
+		require.NoError(t, sf.Apply(fs))
+		require.NoError(t, fs.Parse([]string{"--editor", "fooed"}))
+		c := cli.NewContext(app, fs, nil)
 
-	assert.Equal(t, "fooed", Path(c))
+		assert.Equal(t, "fooed", Path(c))
+	})
 
-	// EDITOR
-	fs = flag.NewFlagSet("default", flag.ContinueOnError)
-	c = cli.NewContext(app, fs, nil)
-	assert.NoError(t, os.Setenv("EDITOR", "fooenv"))
-	assert.Equal(t, "fooenv", Path(c))
-	assert.NoError(t, os.Unsetenv("EDITOR"))
+	t.Run("/usr/bin/editor", func(t *testing.T) {
+		fs := flag.NewFlagSet("default", flag.ContinueOnError)
+		c := cli.NewContext(app, fs, nil)
+		pathed, err := exec.LookPath("editor")
+		if err == nil {
+			assert.Equal(t, pathed, Path(c))
+		}
+	})
 
-	// editor
-	pathed, err := exec.LookPath("editor")
-	if err == nil {
-		assert.Equal(t, pathed, Path(c))
-	}
+	t.Run("EDITOR", func(t *testing.T) {
+		fs := flag.NewFlagSet("default", flag.ContinueOnError)
+		c := cli.NewContext(app, fs, nil)
+		t.Setenv("EDITOR", "fooenv")
+		assert.Equal(t, "fooenv", Path(c))
+	})
 
-	// vi
-	op := os.Getenv("PATH")
-	assert.NoError(t, os.Setenv("PATH", "/tmp"))
-	if runtime.GOOS == "windows" {
-		assert.Equal(t, "notepad.exe", Path(c))
-	} else {
+	t.Run("vi", func(t *testing.T) {
+		fs := flag.NewFlagSet("default", flag.ContinueOnError)
+		c := cli.NewContext(app, fs, nil)
+		t.Setenv("PATH", "/tmp")
 		assert.Equal(t, "vi", Path(c))
-	}
-	assert.NoError(t, os.Setenv("PATH", op))
+	})
 }

--- a/internal/editor/edit_windows_test.go
+++ b/internal/editor/edit_windows_test.go
@@ -3,7 +3,6 @@ package editor
 import (
 	"context"
 	"flag"
-	"os"
 	"os/exec"
 	"testing"
 
@@ -32,34 +31,39 @@ func TestEditor(t *testing.T) {
 func TestGetEditor(t *testing.T) {
 	app := cli.NewApp()
 
-	// --editor=fooed
-	fs := flag.NewFlagSet("default", flag.ContinueOnError)
-	sf := cli.StringFlag{
-		Name:  "editor",
-		Usage: "editor",
-	}
-	require.NoError(t, sf.Apply(fs))
-	require.NoError(t, fs.Parse([]string{"--editor", "fooed"}))
-	c := cli.NewContext(app, fs, nil)
+	t.Run("--editor=fooed", func(t *testing.T) {
+		fs := flag.NewFlagSet("default", flag.ContinueOnError)
+		sf := cli.StringFlag{
+			Name:  "editor",
+			Usage: "editor",
+		}
+		require.NoError(t, sf.Apply(fs))
+		require.NoError(t, fs.Parse([]string{"--editor", "fooed"}))
+		c := cli.NewContext(app, fs, nil)
 
-	assert.Equal(t, "fooed", Path(c))
+		assert.Equal(t, "fooed", Path(c))
+	})
 
-	// EDITOR
-	fs = flag.NewFlagSet("default", flag.ContinueOnError)
-	c = cli.NewContext(app, fs, nil)
-	assert.NoError(t, os.Setenv("EDITOR", "fooenv"))
-	assert.Equal(t, "fooenv", Path(c))
-	assert.NoError(t, os.Unsetenv("EDITOR"))
+	t.Run("/usr/bin/editor", func(t *testing.T) {
+		fs := flag.NewFlagSet("default", flag.ContinueOnError)
+		c := cli.NewContext(app, fs, nil)
+		pathed, err := exec.LookPath("editor")
+		if err == nil {
+			assert.Equal(t, pathed, Path(c))
+		}
+	})
 
-	// editor
-	pathed, err := exec.LookPath("editor")
-	if err == nil {
-		assert.Equal(t, pathed, Path(c))
-	}
+	t.Run("EDITOR", func(t *testing.T) {
+		fs := flag.NewFlagSet("default", flag.ContinueOnError)
+		c := cli.NewContext(app, fs, nil)
+		t.Setenv("EDITOR", "fooenv")
+		assert.Equal(t, "fooenv", Path(c))
+	})
 
-	// notepad
-	op := os.Getenv("PATH")
-	assert.NoError(t, os.Setenv("PATH", "/tmp"))
-	assert.Equal(t, "notepad.exe", Path(c))
-	assert.NoError(t, os.Setenv("PATH", op))
+	t.Run("vi", func(t *testing.T) {
+		fs := flag.NewFlagSet("default", flag.ContinueOnError)
+		c := cli.NewContext(app, fs, nil)
+		t.Setenv("PATH", "/tmp")
+		assert.Equal(t, "notepad.exe", Path(c))
+	})
 }

--- a/internal/store/leaf/crypto_test.go
+++ b/internal/store/leaf/crypto_test.go
@@ -12,11 +12,7 @@ import (
 )
 
 func TestGPG(t *testing.T) {
-	t.Parallel()
-
 	ctx := context.Background()
-
-	tempdir := t.TempDir()
 
 	obuf := &bytes.Buffer{}
 	out.Stdout = obuf
@@ -24,7 +20,7 @@ func TestGPG(t *testing.T) {
 		out.Stdout = os.Stdout
 	}()
 
-	s, err := createSubStore(tempdir)
+	s, err := createSubStore(t)
 	require.NoError(t, err)
 
 	assert.NoError(t, s.ImportMissingPublicKeys(ctx))

--- a/internal/store/leaf/init_test.go
+++ b/internal/store/leaf/init_test.go
@@ -8,13 +8,9 @@ import (
 )
 
 func TestInit(t *testing.T) {
-	t.Parallel()
-
 	ctx := context.Background()
 
-	tempdir := t.TempDir()
-
-	s, err := createSubStore(tempdir)
+	s, err := createSubStore(t)
 	assert.NoError(t, err)
 
 	assert.Error(t, s.Init(ctx, "", "0xDEADBEEF"))

--- a/internal/store/leaf/link_test.go
+++ b/internal/store/leaf/link_test.go
@@ -10,14 +10,9 @@ import (
 )
 
 func TestLink(t *testing.T) {
-	t.Parallel()
-
 	ctx := context.Background()
 
-	tempdir := t.TempDir()
-	t.Logf(tempdir)
-
-	s, err := createSubStore(tempdir)
+	s, err := createSubStore(t)
 	require.NoError(t, err)
 
 	sec := secrets.NewAKV()

--- a/internal/store/leaf/rcs_test.go
+++ b/internal/store/leaf/rcs_test.go
@@ -12,13 +12,9 @@ import (
 )
 
 func TestGit(t *testing.T) {
-	t.Parallel()
-
 	ctx := context.Background()
 
-	tempdir := t.TempDir()
-
-	s, err := createSubStore(tempdir)
+	s, err := createSubStore(t)
 	require.NoError(t, err)
 
 	require.NotNil(t, s.Storage())
@@ -40,13 +36,9 @@ func TestGit(t *testing.T) {
 }
 
 func TestGitRevisions(t *testing.T) {
-	t.Parallel()
-
 	ctx := context.Background()
 
-	tempdir := t.TempDir()
-
-	s, err := createSubStore(tempdir)
+	s, err := createSubStore(t)
 	require.NoError(t, err)
 
 	require.NotNil(t, s.Storage())

--- a/internal/store/leaf/write_test.go
+++ b/internal/store/leaf/write_test.go
@@ -11,13 +11,9 @@ import (
 )
 
 func TestSet(t *testing.T) {
-	t.Parallel()
-
 	ctx := context.Background()
 
-	tempdir := t.TempDir()
-
-	s, err := createSubStore(tempdir)
+	s, err := createSubStore(t)
 	require.NoError(t, err)
 
 	sec := secrets.NewAKV()

--- a/pkg/appdir/appdir_xdg_test.go
+++ b/pkg/appdir/appdir_xdg_test.go
@@ -4,12 +4,10 @@
 package appdir
 
 import (
-	"os"
 	"testing"
 
 	"github.com/gopasspw/gopass/tests/gptest"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestUserConfig(t *testing.T) {
@@ -17,21 +15,18 @@ func TestUserConfig(t *testing.T) {
 	defer ov()
 
 	t.Run("gopass homedir", func(t *testing.T) {
-		require.NoError(t, os.Setenv("GOPASS_HOMEDIR", "/foo/bar"))
+		t.Setenv("GOPASS_HOMEDIR", "/foo/bar")
 		assert.Equal(t, "/foo/bar/.config/gopass", UserConfig())
-		require.NoError(t, os.Unsetenv("GOPASS_HOMEDIR"))
 	})
 
 	t.Run("xdg_config_home", func(t *testing.T) {
-		require.NoError(t, os.Setenv("XDG_CONFIG_HOME", "/foo/baz/myconfig"))
+		t.Setenv("XDG_CONFIG_HOME", "/foo/baz/myconfig")
 		assert.Equal(t, "/foo/baz/myconfig/gopass", UserConfig())
-		require.NoError(t, os.Unsetenv("XDG_CONFIG_HOME"))
 	})
 
 	t.Run("default", func(t *testing.T) {
-		require.NoError(t, os.Setenv("HOME", "/home/gopass"))
+		t.Setenv("HOME", "/home/gopass")
 		assert.Equal(t, "/home/gopass/.config/gopass", UserConfig())
-		require.NoError(t, os.Unsetenv("HOME"))
 	})
 }
 
@@ -40,21 +35,18 @@ func TestUserCache(t *testing.T) {
 	defer ov()
 
 	t.Run("gopass homedir", func(t *testing.T) {
-		require.NoError(t, os.Setenv("GOPASS_HOMEDIR", "/foo/bar"))
+		t.Setenv("GOPASS_HOMEDIR", "/foo/bar")
 		assert.Equal(t, "/foo/bar/.cache/gopass", UserCache())
-		require.NoError(t, os.Unsetenv("GOPASS_HOMEDIR"))
 	})
 
 	t.Run("xdg_cache_home", func(t *testing.T) {
-		require.NoError(t, os.Setenv("XDG_CACHE_HOME", "/foo/baz/mycache"))
+		t.Setenv("XDG_CACHE_HOME", "/foo/baz/mycache")
 		assert.Equal(t, "/foo/baz/mycache/gopass", UserCache())
-		require.NoError(t, os.Unsetenv("XDG_CACHE_HOME"))
 	})
 
 	t.Run("default", func(t *testing.T) {
-		require.NoError(t, os.Setenv("HOME", "/home/gopass"))
+		t.Setenv("HOME", "/home/gopass")
 		assert.Equal(t, "/home/gopass/.cache/gopass", UserCache())
-		require.NoError(t, os.Unsetenv("HOME"))
 	})
 }
 
@@ -63,20 +55,17 @@ func TestUserData(t *testing.T) {
 	defer ov()
 
 	t.Run("gopass homedir", func(t *testing.T) {
-		require.NoError(t, os.Setenv("GOPASS_HOMEDIR", "/foo/bar"))
+		t.Setenv("GOPASS_HOMEDIR", "/foo/bar")
 		assert.Equal(t, "/foo/bar/.local/share/gopass", UserData())
-		require.NoError(t, os.Unsetenv("GOPASS_HOMEDIR"))
 	})
 
 	t.Run("xdg_data_home", func(t *testing.T) {
-		require.NoError(t, os.Setenv("XDG_DATA_HOME", "/foo/baz/mydata"))
+		t.Setenv("XDG_DATA_HOME", "/foo/baz/mydata")
 		assert.Equal(t, "/foo/baz/mydata/gopass", UserData())
-		require.NoError(t, os.Unsetenv("XDG_DATA_HOME"))
 	})
 
 	t.Run("default", func(t *testing.T) {
-		require.NoError(t, os.Setenv("HOME", "/home/gopass"))
+		t.Setenv("HOME", "/home/gopass")
 		assert.Equal(t, "/home/gopass/.local/share/gopass", UserData())
-		require.NoError(t, os.Unsetenv("HOME"))
 	})
 }

--- a/pkg/fsutil/umask_test.go
+++ b/pkg/fsutil/umask_test.go
@@ -1,7 +1,6 @@
 package fsutil
 
 import (
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -15,9 +14,10 @@ func TestUmask(t *testing.T) {
 			"000":      0,
 			"07557575": 0o77,
 		} {
-			assert.NoError(t, os.Setenv(vn, in))
-			assert.Equal(t, out, Umask())
-			assert.NoError(t, os.Unsetenv(vn))
+			t.Run(vn, func(t *testing.T) {
+				t.Setenv(vn, in)
+				assert.Equal(t, out, Umask())
+			})
 		}
 	}
 }

--- a/pkg/pwgen/pwgen_windows_test.go
+++ b/pkg/pwgen/pwgen_windows_test.go
@@ -1,14 +1,13 @@
 package pwgen
 
 import (
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestPwgenExternal(t *testing.T) {
-	_ = os.Setenv("GOPASS_EXTERNAL_PWGEN", "powershell.exe -Command write-output 1234 #")
+	t.Setenv("GOPASS_EXTERNAL_PWGEN", "powershell.exe -Command write-output 1234 #")
 	ans, err := GenerateExternal(4)
 	if err != nil {
 		panic("Unable to generate using external generator")


### PR DESCRIPTION
A testing cleanup.

This PR replaces `os.Setenv` with `t.Setenv`. Starting from Go 1.17, we can use `t.Setenv` to set environment variable in test. The environment variable is automatically restored to its original value when the test and all its subtests complete. This ensures that each test does not start with leftover environment variables from previous completed tests.

Reference: https://pkg.go.dev/testing#T.Setenv

```go
func TestFoo(t *testing.T) {
	// before
	key := "ENV"
	originalEnv := os.Getenv(key)

	assert.NoError(t, os.Setenv(key, "new value"))
	defer assert.NoError(t, os.Setenv(key, originalEnv))
	
	// after
	t.Setenv(key, "new value")
}
```