### PR TITLE
test: fix failing `debug_test.go` on Windows

### DIFF
--- a/pkg/debug/debug.go
+++ b/pkg/debug/debug.go
@@ -32,6 +32,10 @@ var logFn = doNotLog
 var enabled = initDebug()
 
 func initDebug() bool {
+	if opts.logFile != nil {
+		_ = opts.logFile.Close()
+	}
+
 	if os.Getenv("GOPASS_DEBUG") == "" && os.Getenv("GOPASS_DEBUG_LOG") == "" {
 		logFn = doNotLog
 
@@ -250,13 +254,4 @@ func doLog(offset int, f string, args ...any) {
 // IsEnabled returns true if debug logging was enabled.
 func IsEnabled() bool {
 	return enabled
-}
-
-// CloseLogfile closes the GOPASS_DEBUG_LOG file.
-func CloseLogfile() error {
-	if opts.logFile == nil {
-		return nil
-	}
-
-	return opts.logFile.Close()
 }

--- a/pkg/debug/debug.go
+++ b/pkg/debug/debug.go
@@ -20,9 +20,10 @@ var (
 )
 
 var opts struct {
-	logger *log.Logger
-	funcs  map[string]bool
-	files  map[string]bool
+	logger  *log.Logger
+	funcs   map[string]bool
+	files   map[string]bool
+	logFile *os.File
 }
 
 var logFn = doNotLog
@@ -62,6 +63,7 @@ func initDebugLogger() {
 		// seek to the end of the file (offset, whence [2 = end])
 		_, err := f.Seek(0, 2)
 		if err != nil {
+			_ = f.Close()
 			fmt.Fprintf(Stderr, "unable to seek to end of %v: %v\n", debugfile, err)
 			os.Exit(3)
 		}
@@ -76,6 +78,7 @@ func initDebugLogger() {
 		os.Exit(2)
 	}
 
+	opts.logFile = f
 	opts.logger = log.New(f, "", log.Ldate|log.Lmicroseconds)
 }
 
@@ -247,4 +250,13 @@ func doLog(offset int, f string, args ...any) {
 // IsEnabled returns true if debug logging was enabled.
 func IsEnabled() bool {
 	return enabled
+}
+
+// CloseLogfile closes the GOPASS_DEBUG_LOG file.
+func CloseLogfile() error {
+	if opts.logFile == nil {
+		return nil
+	}
+
+	return opts.logFile.Close()
 }

--- a/pkg/debug/debug_test.go
+++ b/pkg/debug/debug_test.go
@@ -48,7 +48,6 @@ func TestDebug(t *testing.T) {
 	td := t.TempDir()
 	t.Cleanup(func() {
 		initDebug()
-		require.NoError(t, CloseLogfile())
 	})
 
 	fn := filepath.Join(td, "gopass.log")
@@ -75,7 +74,6 @@ func TestDebugSecret(t *testing.T) {
 	td := t.TempDir()
 	t.Cleanup(func() {
 		initDebug()
-		require.NoError(t, CloseLogfile())
 	})
 
 	fn := filepath.Join(td, "gopass.log")
@@ -102,7 +100,6 @@ func TestDebugFilter(t *testing.T) {
 	td := t.TempDir()
 	t.Cleanup(func() {
 		initDebug()
-		require.NoError(t, CloseLogfile())
 	})
 
 	fn := filepath.Join(td, "gopass.log")

--- a/pkg/debug/debug_test.go
+++ b/pkg/debug/debug_test.go
@@ -48,6 +48,7 @@ func TestDebug(t *testing.T) {
 	td := t.TempDir()
 	t.Cleanup(func() {
 		initDebug()
+		require.NoError(t, CloseLogfile())
 	})
 
 	fn := filepath.Join(td, "gopass.log")
@@ -74,6 +75,7 @@ func TestDebugSecret(t *testing.T) {
 	td := t.TempDir()
 	t.Cleanup(func() {
 		initDebug()
+		require.NoError(t, CloseLogfile())
 	})
 
 	fn := filepath.Join(td, "gopass.log")
@@ -100,6 +102,7 @@ func TestDebugFilter(t *testing.T) {
 	td := t.TempDir()
 	t.Cleanup(func() {
 		initDebug()
+		require.NoError(t, CloseLogfile())
 	})
 
 	fn := filepath.Join(td, "gopass.log")


### PR DESCRIPTION
```
--- FAIL: TestDebug (1.52s)
    testing.go:1097: TempDir RemoveAll cleanup: remove C:\Users\RUNNER~1\AppData\Local\Temp\TestDebug1334287763\001\gopass.log: The process cannot access the file because it is being used by another process.
--- FAIL: TestDebugSecret (1.90s)
    testing.go:1097: TempDir RemoveAll cleanup: remove C:\Users\RUNNER~1\AppData\Local\Temp\TestDebugSecret2374267425\001\gopass.log: The process cannot access the file because it is being used by another process.
--- FAIL: TestDebugFilter (1.77s)
    testing.go:1097: TempDir RemoveAll cleanup: remove C:\Users\RUNNER~1\AppData\Local\Temp\TestDebugFilter836798913\001\gopass.log: The process cannot access the file because it is being used by another process.
```

The `gopass.log` needs to be closed before it can be deleted on Windows.