### PR TITLE
Add zsh files completion to otp command

### DIFF
--- a/internal/completion/zsh/template.go
+++ b/internal/completion/zsh/template.go
@@ -22,7 +22,7 @@ _{{ $prog }} () {
 	      {{- end }}
 	      {{ if .Flags }}_arguments :{{ range .Flags }} "{{ . | formatFlag }}"{{ end }}{{ end }}
 	      {{ if or (eq .Name "insert") (eq .Name "generate")  (eq .Name "list") }}_{{ $prog }}_complete_folders{{ end }}
-	      {{ if or (eq .Name "copy") (eq .Name "move") (eq .Name "delete") (eq .Name "show") (eq .Name "edit") (eq .Name "insert") (eq .Name "generate") }}_{{ $prog }}_complete_passwords{{ end }}
+	      {{ if or (eq .Name "copy") (eq .Name "move") (eq .Name "delete") (eq .Name "show") (eq .Name "edit") (eq .Name "insert") (eq .Name "generate") (eq .Name "otp") }}_{{ $prog }}_complete_passwords{{ end }}
 	      ;;
 {{- end }}
 	  *)

--- a/zsh.completion
+++ b/zsh.completion
@@ -172,7 +172,7 @@ WARNING: This will update the secret content to the latest format. This might be
 	  otp|totp|hotp)
 	      _arguments : "--clip[Copy the time-based token into the clipboard]" "--qr[Write QR code to FILE]" "--password[Only display the token]"
 	      
-	      
+	      _gopass_complete_passwords
 	      ;;
 	  process)
 	      


### PR DESCRIPTION
The `gopass otp`  command does not complete files when using the zsh completion.

This PR intends to add the files completion to the `otp`  command.

Old OTP zsh completion
![image](https://user-images.githubusercontent.com/11147206/206926551-76ca228c-e490-45c3-8c33-69442355b120.png)

Fixed OTP zsh completion:
![image](https://user-images.githubusercontent.com/11147206/206926657-e5a00e38-52b0-45e4-90d1-1b4ca2a15b45.png)
