### PR TITLE
Remove recipients based on Key ID

### DIFF
--- a/internal/action/commands.go
+++ b/internal/action/commands.go
@@ -756,6 +756,13 @@ func (s *Action) GetCommands() []*cli.Command {
 				"The subcommands allow adding or removing recipients.",
 			Before: s.IsInitialized,
 			Action: s.RecipientsPrint,
+			Flags: []cli.Flag{
+				&cli.BoolFlag{
+					Name:  "pretty",
+					Usage: "Pretty print recipients",
+					Value: true,
+				},
+			},
 			Subcommands: []*cli.Command{
 				{
 					Name:    "ack",

--- a/internal/action/recipients_test.go
+++ b/internal/action/recipients_test.go
@@ -117,7 +117,7 @@ func TestRecipientsGpg(t *testing.T) {
 
 		hint := `Hint: run 'gopass sync' to import any missing public keys`
 		want := `gopass
-└── 0x82EBD945BE73F104`
+└── BE73F104`
 
 		assert.Contains(t, buf.String(), hint)
 		assert.Contains(t, buf.String(), want)
@@ -126,7 +126,7 @@ func TestRecipientsGpg(t *testing.T) {
 	t.Run("complete recipients", func(t *testing.T) {
 		defer buf.Reset()
 		act.RecipientsComplete(gptest.CliCtx(ctx, t))
-		want := "0x82EBD945BE73F104\n"
+		want := "BE73F104\n"
 		assert.Equal(t, want, buf.String())
 	})
 
@@ -162,7 +162,16 @@ func TestRecipientsGpg(t *testing.T) {
 
 	t.Run("remove recipient 0xFEEDFEED", func(t *testing.T) {
 		defer buf.Reset()
-		assert.Error(t, act.RecipientsRemove(gptest.CliCtx(ctx, t, "0xFEEDFEED")))
+		assert.NoError(t, act.RecipientsRemove(gptest.CliCtx(ctx, t, "0xFEEDFEED")))
+	})
+
+	t.Run("add recipient 0xFEEDFEED", func(t *testing.T) {
+		defer buf.Reset()
+		assert.NoError(t, act.RecipientsAdd(gptest.CliCtxWithFlags(ctx, t, map[string]string{"force": "true"}, "0xFEEDFEED")))
+	})
+
+	t.Run("remove recipient 0xFEEDFEED (force)", func(t *testing.T) {
+		defer buf.Reset()
 		assert.NoError(t, act.RecipientsRemove(gptest.CliCtxWithFlags(ctx, t, map[string]string{"force": "true"}, "0xFEEDFEED")))
 	})
 }

--- a/internal/set/filter.go
+++ b/internal/set/filter.go
@@ -13,3 +13,12 @@ func Filter[K comparable](in []K, r ...K) []K {
 
 	return out
 }
+
+// Contains returns true if e is contained in the input list.
+func Contains[K comparable](in []K, e K) bool {
+	rs := Map(in)
+
+	_, found := rs[e]
+
+	return found
+}

--- a/internal/tree/node.go
+++ b/internal/tree/node.go
@@ -2,8 +2,6 @@ package tree
 
 import (
 	"bytes"
-
-	"github.com/gopasspw/gopass/pkg/debug"
 )
 
 // Node is a tree node.
@@ -111,7 +109,7 @@ func (n Node) Merge(other Node) *Node {
 		r.Subtree = other.Subtree
 	}
 
-	debug.Log("merged %+v and %+v into %+v", n, other, r)
+	// debug.Log("merged %+v and %+v into %+v", n, other, r)
 
 	return &r
 }

--- a/internal/tree/root.go
+++ b/internal/tree/root.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/fatih/color"
-	"github.com/gopasspw/gopass/pkg/debug"
 )
 
 const (
@@ -61,7 +60,8 @@ func (r *Root) AddTemplate(path string) error {
 func (r *Root) insert(path string, template bool, mountPath string) error {
 	t := r.Subtree
 
-	debug.Log("adding: %s [tpl: %t, mp: %q]", path, template, mountPath)
+	// debug.Log("adding: %s [tpl: %t, mp: %q]", path, template, mountPath)
+
 	// split the path into its components, iterate over them and create
 	// the tree structure. Everything but the last element is a folder.
 	p := strings.Split(path, "/")
@@ -82,10 +82,10 @@ func (r *Root) insert(path string, template bool, mountPath string) error {
 			}
 		}
 
-		debug.Log("[%d] %s -> Node: %+v", i, e, n)
+		// debug.Log("[%d] %s -> Node: %+v", i, e, n)
 
 		node := t.Insert(n)
-		debug.Log("node after insert: %+v", node)
+		// debug.Log("node after insert: %+v", node)
 
 		// do we need to extend an existing subtree?
 		if i < len(p)-1 && node.Subtree == nil {

--- a/pkg/gitconfig/gitconfig_test.go
+++ b/pkg/gitconfig/gitconfig_test.go
@@ -341,6 +341,17 @@ func TestParseComplex(t *testing.T) {
 	assert.Equal(t, "ssh -oControlMaster=auto -oControlPersist=600 -oControlPath=/tmp/.ssh-%C", c.vars["core.sshCommand"])
 }
 
+func TestParseDocs(t *testing.T) {
+	t.Parallel()
+
+	c := ParseConfig(strings.NewReader(configSampleComplex))
+
+	// TODO(#2479) - fix parsing
+	t.Skip("TODO - broken")
+
+	assert.Equal(t, "ssh -oControlMaster=auto -oControlPersist=600 -oControlPath=/tmp/.ssh-%C", c.vars["core.sshCommand"])
+}
+
 func TestGitBinary(t *testing.T) {
 	t.Skip("not ready, yet") // TODO(gitconfig) make tests pass
 

--- a/zsh.completion
+++ b/zsh.completion
@@ -203,7 +203,7 @@ _gopass () {
 	      "remove:Remove any number of Recipients from any store"
 	      )
 	      _describe -t commands "gopass recipients" subcommands
-	      
+	      _arguments : "--pretty[Pretty print recipients]"
 	      
 	      
 	      ;;


### PR DESCRIPTION
This PR removes some unnecessary logic in the recipients removal and adds a shortcut to remove recipients based on the Key ID instead of looking up key fingerprints over and over again. Also it fixes an issue where subkeys of the same key wouldn't be displayed in gopass recipients even if they were actually present in the .gpg-id files.

Fixes #2416

Signed-off-by: Dominik Schulz <dominik.schulz@gauner.org>