### PR TITLE
Disable possible git concurrency during fsck

### DIFF
--- a/internal/queue/background.go
+++ b/internal/queue/background.go
@@ -29,7 +29,8 @@ type Queuer interface {
 	Idle(time.Duration) error
 }
 
-// WithQueue adds the given queue to the context.
+// WithQueue adds the given queue to the context. Add a nil
+// queue to disable queuing in this context.
 func WithQueue(ctx context.Context, q *Queue) context.Context {
 	return context.WithValue(ctx, ctxKeyQueue, q)
 }
@@ -37,7 +38,7 @@ func WithQueue(ctx context.Context, q *Queue) context.Context {
 // GetQueue returns an existing queue from the context or
 // returns a noop one.
 func GetQueue(ctx context.Context) Queuer {
-	if q, ok := ctx.Value(ctxKeyQueue).(*Queue); ok {
+	if q, ok := ctx.Value(ctxKeyQueue).(*Queue); ok && q != nil {
 		return q
 	}
 


### PR DESCRIPTION
By using the default queue some git operations might still have been running when gopass did attempt to update exported keys. Disabling the queue in the inner loop makes more sense since it's more predictable and less brittle and using the queue there wouldn't help much anyway.

Fixes #2459

RELEASE_NOTES=[BUGFIX] Fix possible concurrency issues in fsck.

Signed-off-by: Dominik Schulz <dominik.schulz@gauner.org>