### PR TITLE
Check recipients before editing a secret to avoid loosing editor content

### DIFF
--- a/internal/action/edit.go
+++ b/internal/action/edit.go
@@ -25,6 +25,10 @@ func (s *Action) Edit(c *cli.Context) error {
 		return exit.Error(exit.Usage, nil, "Usage: %s edit secret", s.Name)
 	}
 
+	if err := s.Store.CheckRecipients(ctx, name); err != nil {
+		return exit.Error(exit.Recipients, err, "Invalid recipients detected: %s", err)
+	}
+
 	return s.edit(ctx, c, name)
 }
 

--- a/internal/store/leaf/fsck.go
+++ b/internal/store/leaf/fsck.go
@@ -37,7 +37,11 @@ func (s *Store) Fsck(ctx context.Context, path string) error {
 	// make sure all recipients are valid
 	debug.Log("Checking recipients")
 	if err := s.CheckRecipients(ctx); err != nil {
-		return fmt.Errorf("invalid recipients found: %w", err)
+		if IsCheckRecipients(ctx) {
+			return fmt.Errorf("invalid recipients found: %w", err)
+		}
+
+		out.Errorf(ctx, "Invalid recipients found: %s", err)
 	}
 
 	// then we'll make sure all the secrets are readable by us and every

--- a/internal/store/leaf/fsck.go
+++ b/internal/store/leaf/fsck.go
@@ -34,6 +34,12 @@ func (s *Store) Fsck(ctx context.Context, path string) error {
 		return fmt.Errorf("storage backend compaction failed: %w", err)
 	}
 
+	// make sure all recipients are valid
+	debug.Log("Checking recipients")
+	if err := s.CheckRecipients(ctx); err != nil {
+		return fmt.Errorf("invalid recipients found: %w", err)
+	}
+
 	// then we'll make sure all the secrets are readable by us and every
 	// valid recipient
 	if path != "" {

--- a/internal/store/leaf/fsck_test.go
+++ b/internal/store/leaf/fsck_test.go
@@ -19,6 +19,7 @@ func TestFsck(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
+	ctx = WithCheckRecipients(ctx, false)
 
 	obuf := &bytes.Buffer{}
 	out.Stdout = obuf


### PR DESCRIPTION
Fixes #1565

RELEASE_NOTES=[BUGFIX] Check recipients before launching editor.

Signed-off-by: Dominik Schulz <dominik.schulz@gauner.org>