### PR TITLE
Add --create flag to gopass mounts add

### DIFF
--- a/internal/action/commands.go
+++ b/internal/action/commands.go
@@ -634,6 +634,13 @@ func (s *Action) GetCommands() []*cli.Command {
 						"at any path in an existing root store.",
 					Before: s.IsInitialized,
 					Action: s.MountAdd,
+					Flags: []cli.Flag{
+						&cli.BoolFlag{
+							Name:    "create",
+							Aliases: []string{"c"},
+							Usage:   "Create a new store at this location",
+						},
+					},
 				},
 				{
 					Name:    "remove",

--- a/internal/action/mount.go
+++ b/internal/action/mount.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gopasspw/gopass/internal/backend"
 	"github.com/gopasspw/gopass/internal/config"
 	"github.com/gopasspw/gopass/internal/out"
+	"github.com/gopasspw/gopass/internal/set"
 	"github.com/gopasspw/gopass/internal/store"
 	"github.com/gopasspw/gopass/internal/store/root"
 	"github.com/gopasspw/gopass/internal/tree"
@@ -86,6 +87,12 @@ func (s *Action) MountAdd(c *cli.Context) error {
 
 	if s.Store.Exists(ctx, alias) {
 		out.Warningf(ctx, "shadowing %s entry", alias)
+	}
+
+	if c.Bool("create") && !set.New(alias).IsSubset(set.New(s.Store.MountPoints()...)) {
+		debug.Log("creating new mount %s at %s", alias, localPath)
+
+		return s.init(ctx, alias, localPath)
 	}
 
 	if err := s.Store.AddMount(ctx, alias, localPath); err != nil {

--- a/internal/backend/storage/fs/store.go
+++ b/internal/backend/storage/fs/store.go
@@ -30,7 +30,7 @@ func New(dir string) *Store {
 	}
 
 	return &Store{
-		path: dir,
+		path: fsutil.ExpandHomedir(dir),
 	}
 }
 

--- a/pkg/fsutil/fsutil.go
+++ b/pkg/fsutil/fsutil.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gopasspw/gopass/pkg/appdir"
 	"github.com/gopasspw/gopass/pkg/debug"
 )
 
@@ -21,6 +22,20 @@ var reCleanFilename = regexp.MustCompile(`[^\w\d@.-]`)
 // WARNING: NOT suiteable for pathnames as slashes will be stripped as well!
 func CleanFilename(in string) string {
 	return strings.Trim(reCleanFilename.ReplaceAllString(in, "_"), "_ ")
+}
+
+// ExpandHomedir expands the tilde to the users home dir (if present).
+func ExpandHomedir(path string) string {
+	if len(path) > 1 && path[:2] == "~/" {
+		dir := filepath.Clean(appdir.UserHome() + path[1:])
+		debug.Log("Expanding %s to %s", path, dir)
+
+		return dir
+	}
+
+	debug.Log("No tilde found in %s", path)
+
+	return path
 }
 
 // CleanPath resolves common aliases in a path and cleans it as much as possible.


### PR DESCRIPTION
This allows creating mounts when adding them.

Fixes #2501

Signed-off-by: Dominik Schulz <dominik.schulz@gauner.org>