### PR TITLE
Fixing typo in mount docs

### DIFF
--- a/docs/commands/mounts.md
+++ b/docs/commands/mounts.md
@@ -1,6 +1,6 @@
-# `mount` commands
+# `mounts` commands
 
-The `mount` commands allow managing mounted substores. This is one of the
+The `mounts` commands allow managing mounted substores. This is one of the
 distinctive core features of `gopass` and we aim making working with substores
 as seamless as possible.
 

--- a/docs/usecases/secure-otp.md
+++ b/docs/usecases/secure-otp.md
@@ -69,7 +69,7 @@ gopass otp local-passwordstore/website/yourOtp
 Notice that ideally, the secret key that's able to decrypt your OTP secrets should be stored on a hardware token that is requiring some kind of user interaction to decrypt them.
 
 This is done with Gopass by setting up a second store and not using the same public keys as for your main password store.
-Refer to [our mount doc for setting one up](docs/commands/mount.md).
+Refer to [our mount doc for setting one up](docs/commands/mounts.md).
 
 The public keys used for your OTP store should ideally be stored only on hardware tokens, or maybe generated on an airgaped machined and then backuped offline, before being transferred on a hardware token.
 (There are [multiple](https://research.kudelskisecurity.com/2017/04/28/configuring-yubikey-for-gpg-and-u2f/) [guides](https://support.yubico.com/hc/en-us/articles/360013790259-Using-Your-YubiKey-with-OpenPGP) online about how to do this.)


### PR DESCRIPTION
The `mounts` command was misspelled.