### PR TITLE
Add edit.auto-create option

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -103,6 +103,7 @@ This is a list of available options:
 | `create.pre-hook` | `string` | This hook is executed right before the secret creation during `gopass create`. | `None` |
 | `delete.post-hook` | `string` | This hook is run right after removing a record with `gopass rm` | `None` |
 | `domain-alias.<from>.insteadOf`   | `string` | Alias from domain to the string value of this entry. | `` |
+| `edit.auto-create` | `bool` | Automatically create new secrets when editing. | `false` |
 | `edit.editor` | `string` | This setting controls which editor is used when opening a file with `gopass edit`. It takes precedence over the `$EDITOR` environment variable. This setting can contain flags. | `None` |
 | `edit.post-hook` | `string` | This hook is run right after editing a record with `gopass edit` |
 | `edit.pre-hook` | `string` | This hook is run right before editing a record with `gopass edit` |

--- a/internal/action/edit.go
+++ b/internal/action/edit.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/gopasspw/gopass/internal/action/exit"
 	"github.com/gopasspw/gopass/internal/audit"
+	"github.com/gopasspw/gopass/internal/config"
 	"github.com/gopasspw/gopass/internal/editor"
 	"github.com/gopasspw/gopass/internal/hook"
 	"github.com/gopasspw/gopass/internal/out"
@@ -86,7 +87,7 @@ func (s *Action) editUpdate(ctx context.Context, name string, content, nContent 
 }
 
 func (s *Action) editGetContent(ctx context.Context, name string, create bool) (string, []byte, bool, error) {
-	if !s.Store.Exists(ctx, name) && !create {
+	if !s.Store.Exists(ctx, name) && !create && !config.Bool(ctx, "edit.auto-create") {
 		var err error
 		name, err = s.editFindName(ctx, name)
 		if err != nil {


### PR DESCRIPTION
This will allow to restore the old behaviour where gopass edit would automatically create a secret if a non-existing name was given.

RELEASE_NOTES=[ENHANCEMENT] Add edit.auto-create

Fixes #2531

Signed-off-by: Dominik Schulz <dominik.schulz@gauner.org>