### PR TITLE
Fix recipients check for age

### DIFF
--- a/internal/store/leaf/store.go
+++ b/internal/store/leaf/store.go
@@ -127,6 +127,7 @@ func (s *Store) idFiles(ctx context.Context) []string {
 		}
 
 		idf := s.idFile(ctx, f)
+		debug.Log("checking for if %q has an idf: %q", f, idf)
 		if s.storage.Exists(ctx, idf) {
 			idfs = append(idfs, idf)
 		}


### PR DESCRIPTION
The new recipients check for unusable GPG keys did not work for age. In fact most age keys can be used as-is. At the same time this is cleaning up the recipients handling for age a bit.

Fixes #2544

RELEASE_NOTES=[BUGFIX] Fix recipients check for age.

Signed-off-by: Dominik Schulz <dominik.schulz@gauner.org>