### PR TITLE
Hide unnecessary git error messages during gopass init

### DIFF
--- a/.license-lint.yml
+++ b/.license-lint.yml
@@ -7,3 +7,7 @@ unrestricted_licenses:
 reciprocal_licenses:
   - MPL-2.0
   - MPL-2.0-no-copyleft-exception
+allowlisted_modules:
+# Simplified BSD (BSD-2-Clause): https://github.com/russross/blackfriday/blob/master/LICENSE.txt
+- github.com/russross/blackfriday
+- github.com/russross/blackfriday/v2

--- a/internal/action/config.go
+++ b/internal/action/config.go
@@ -34,8 +34,9 @@ func (s *Action) Config(c *cli.Context) error {
 		return exit.Error(exit.Usage, nil, "Usage: %s config key value", s.Name)
 	}
 
-	// need to initialize sub-stores so we can update their configs
-	if err := s.IsInitialized(c); err != nil {
+	// need to initialize sub-stores so we can update their configs.
+	// special case: we can always update the root config.
+	if err := s.IsInitialized(c); err != nil && store != "" {
 		return err
 	}
 

--- a/internal/hook/hook.go
+++ b/internal/hook/hook.go
@@ -35,6 +35,12 @@ func InvokeRoot(ctx context.Context, hookName, secName string, s subStoreGetter,
 }
 
 func Invoke(ctx context.Context, hook, dir string, hookArgs ...string) error {
+	if true {
+		// TODO(GH-2546) disabled until further discussion, cf. https://www.cvedetails.com/cve/CVE-2023-24055/
+
+		return nil
+	}
+
 	hCmd := strings.TrimSpace(config.String(ctx, hook))
 	if hCmd == "" {
 		return nil

--- a/internal/store/leaf/recipients.go
+++ b/internal/store/leaf/recipients.go
@@ -398,10 +398,17 @@ func (s *Store) UpdateExportedPublicKeys(ctx context.Context, rs []string) (bool
 	}
 
 	if exported && ctxutil.IsGitCommit(ctx) {
-		if err := s.storage.Commit(ctx, fmt.Sprintf("Updated exported Public Keys")); err != nil && !errors.Is(err, store.ErrGitNothingToCommit) {
-			failed = true
+		if err := s.storage.Commit(ctx, fmt.Sprintf("Updated exported Public Keys")); err != nil {
+			switch {
+			case errors.Is(err, store.ErrGitNothingToCommit):
+				debug.Log("nothing to commit: %s", err)
+			case errors.Is(err, store.ErrGitNotInit):
+				debug.Log("git not initialized: %s", err)
+			default:
+				failed = true
 
-			out.Errorf(ctx, "Failed to git commit: %s", err)
+				out.Errorf(ctx, "Failed to git commit: %s", err)
+			}
 		}
 	}
 

--- a/tests/config_test.go
+++ b/tests/config_test.go
@@ -31,13 +31,15 @@ core.notifications = true
 
 	for _, invert := range invertables {
 		t.Run("invert "+invert, func(t *testing.T) {
-			out, err = ts.run("config " + invert + " false")
-			assert.NoError(t, err)
-			assert.Equal(t, "false", out)
+			arg := "config " + invert + " false"
+			out, err = ts.run(arg)
+			assert.NoError(t, err, "Running gopass "+arg)
+			assert.Equal(t, "false", out, "Output of gopass "+arg)
 
-			out, err = ts.run("config " + invert)
-			assert.NoError(t, err)
-			assert.Equal(t, "false", out)
+			arg = "config " + invert
+			out, err = ts.run(arg)
+			assert.NoError(t, err, "Running gopass "+arg)
+			assert.Equal(t, "false", out, "Output of gopass "+arg)
 		})
 	}
 
@@ -70,6 +72,7 @@ core.notifications = true
 `
 	wanted += "mounts.mnt/m1.path = " + ts.storeDir("m1") + "\n"
 	wanted += "mounts.path = " + ts.storeDir("root") + "\n"
+	wanted += "recipients.mnt/m1.hash = 9a4c4b1e0eb9ade2e692ff948f43d9668145eca3df88ffff67e0e21426252907\n"
 
 	out, err := ts.run("config")
 	assert.NoError(t, err)


### PR DESCRIPTION
These don't impact the setup workflow but confuse users.

Fixes #2543

RELEASE_NOTES=[BUGFIX] Hide harmless git error messages.

Signed-off-by: Dominik Schulz <dominik.schulz@gauner.org>