### PR TITLE
Default to using the root stores backends for newly added mounts

### DIFF
--- a/internal/action/action_test.go
+++ b/internal/action/action_test.go
@@ -39,7 +39,7 @@ func newMock(ctx context.Context, path string) (*Action, error) {
 	c := cli.NewContext(cli.NewApp(), fs, nil)
 	c.Context = ctx
 	if err := act.IsInitialized(c); err != nil {
-		return nil, err
+		return act, err
 	}
 
 	return act, nil

--- a/internal/action/init_test.go
+++ b/internal/action/init_test.go
@@ -61,6 +61,16 @@ func TestInit(t *testing.T) {
 	buf.Reset()
 }
 
+func TestInitContext(t *testing.T) {
+	ctx := context.Background()
+
+	ctx = backend.WithCryptoBackend(ctx, backend.GPGCLI)
+	ctx = backend.WithCryptoBackend(ctx, backend.Age)
+	ctx = backend.WithCryptoBackend(ctx, backend.GPGCLI)
+
+	assert.Equal(t, backend.GetCryptoBackend(ctx), backend.GPGCLI)
+}
+
 func TestInitParseContext(t *testing.T) {
 	buf := &bytes.Buffer{}
 	out.Stdout = buf

--- a/internal/action/setup.go
+++ b/internal/action/setup.go
@@ -29,7 +29,7 @@ func (s *Action) Setup(c *cli.Context) error {
 	team := c.String("alias")
 	create := c.Bool("create")
 
-	ctx = initParseContext(ctx, c)
+	ctx = s.initParseContext(ctx, c)
 
 	out.Printf(ctx, logo)
 	out.Printf(ctx, "🌟 Welcome to gopass!")
@@ -47,6 +47,7 @@ func (s *Action) Setup(c *cli.Context) error {
 	// "[ssh] types should only be used for compatibility with existing keys,
 	// and native X25519 keys should be preferred otherwise."
 	// https://pkg.go.dev/filippo.io/age@v1.0.0/agessh#pkg-overview.
+
 	ctx = age.WithOnlyNative(ctx, true)
 	// gpg: only trusted keys
 	// only list "usable" / properly trused and signed GPG keys by requesting


### PR DESCRIPTION
Fixes #2515

RELEASE_NOTES=[ENHANCEMENT] Default to the root stores backends for mounts.

Signed-off-by: Dominik Schulz <dominik.schulz@gauner.org>