### PR TITLE
feat: add core.autopush to separate push/autosync behavior

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -87,7 +87,8 @@ This is a list of available options:
 | `autosync.interval`      | `int`   | AutoSync interval in days. | `3` |
 | `core.autoclip`        | `bool`   | Always copy the password created by `gopass generate`. Only applies to generate. | `false` |
 | `core.autoimport`      | `bool`   | Import missing keys stored in the pass repository without asking. | `false` |
-| `core.autosync`        | `bool`   | Always do a `git push` after a commit to the store. Makes sure your local changes are always available on your git remote. | `true` |
+| `core.autopush`        | `bool`   | Always do a `git push` after a commit to the store. Makes sure your local changes are always available on your git remote. | `true` |
+| `core.autosync`        | `bool`   | Automatically sync (fetch & push) the git remote on an interval. | `true` |
 | `core.cliptimeout`     | `int`    | How many seconds the secret is stored when using `-c`. Setting this to `0` disables auto-clear. | `45` |
 | `core.exportkeys`      | `bool`   | Export public keys of all recipients to the store. | `true` |
 | `core.nocolor`         | `bool`   | Do not use color. | `false` |

--- a/internal/action/config_test.go
+++ b/internal/action/config_test.go
@@ -39,6 +39,7 @@ func TestConfig(t *testing.T) {
 		assert.NoError(t, act.Config(c))
 		want := `core.autoclip = true
 core.autoimport = true
+core.autopush = true
 core.autosync = true
 core.cliptimeout = 45
 core.exportkeys = true
@@ -79,6 +80,7 @@ core.notifications = true
 		act.printConfigValues(ctx, "")
 		want := `core.autoclip = true
 core.autoimport = true
+core.autopush = true
 core.autosync = true
 core.cliptimeout = 45
 core.exportkeys = true
@@ -111,6 +113,7 @@ core.notifications = true
 		act.ConfigComplete(gptest.CliCtx(ctx, t))
 		want := `core.autoclip
 core.autoimport
+core.autopush
 core.autosync
 core.cliptimeout
 core.exportkeys

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -25,6 +25,7 @@ func newGitconfig() *gitconfig.Configs {
 }
 
 var defaults = map[string]string{
+	"core.autopush":      "true",
 	"core.autosync":      "true",
 	"core.cliptimeout":   "45",
 	"core.exportkeys":    "true",

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -30,7 +30,7 @@ func TestConfig(t *testing.T) {
 	assert.NoError(t, cfg.SetEnv("env.string", "foo"))
 	assert.Equal(t, "foo", cfg.Get("env.string"))
 
-	assert.Equal(t, []string{"core.autosync", "core.bool", "core.cliptimeout", "core.exportkeys", "core.int", "core.notifications", "core.string", "env.string", "mounts.path"}, cfg.Keys(""))
+	assert.Equal(t, []string{"core.autopush", "core.autosync", "core.bool", "core.cliptimeout", "core.exportkeys", "core.int", "core.notifications", "core.string", "env.string", "mounts.path"}, cfg.Keys(""))
 
 	ctx := cfg.WithConfig(context.Background())
 	assert.Equal(t, true, Bool(ctx, "core.bool"))

--- a/internal/store/leaf/fsck.go
+++ b/internal/store/leaf/fsck.go
@@ -125,8 +125,8 @@ func (s *Store) Fsck(ctx context.Context, path string) error {
 		return err
 	}
 
-	if !config.Bool(ctx, "core.autosync") {
-		debug.Log("not pushing to git remote, core.autosync is false")
+	if !config.Bool(ctx, "core.autopush") {
+		debug.Log("not pushing to git remote, core.autopush is false")
 
 		return nil
 	}

--- a/internal/store/leaf/move.go
+++ b/internal/store/leaf/move.go
@@ -175,8 +175,8 @@ func (s *Store) delete(ctx context.Context, name string, recurse bool) error {
 		}
 	}
 
-	if !config.Bool(ctx, "core.autosync") {
-		debug.Log("not pushing to git remote, core.autosync is false")
+	if !config.Bool(ctx, "core.autopush") {
+		debug.Log("not pushing to git remote, core.autopush is false")
 
 		return nil
 	}

--- a/internal/store/leaf/recipients.go
+++ b/internal/store/leaf/recipients.go
@@ -472,8 +472,8 @@ func (s *Store) saveRecipients(ctx context.Context, rs recipientMarshaler, msg s
 		debug.Log("updating exported keys not requested")
 	}
 
-	if !config.Bool(ctx, "core.autosync") {
-		debug.Log("not pushing to git remote, core.autosync is false")
+	if !config.Bool(ctx, "core.autopush") {
+		debug.Log("not pushing to git remote, core.autopush is false")
 
 		return nil
 	}

--- a/internal/store/leaf/reencrypt.go
+++ b/internal/store/leaf/reencrypt.go
@@ -129,8 +129,8 @@ func (s *Store) reencrypt(ctx context.Context) error {
 }
 
 func (s *Store) reencryptGitPush(ctx context.Context) error {
-	if !config.Bool(ctx, "core.autosync") {
-		debug.Log("not pushing to git remote, core.autosync is false")
+	if !config.Bool(ctx, "core.autopush") {
+		debug.Log("not pushing to git remote, core.autopush is false")
 
 		return nil
 	}

--- a/internal/store/leaf/write.go
+++ b/internal/store/leaf/write.go
@@ -90,13 +90,13 @@ func (s *Store) gitCommitAndPush(ctx context.Context, name string) error {
 		}
 	}
 
-	if !config.Bool(ctx, "core.autosync") {
-		debug.Log("not pushing to git remote, core.autosync is false")
+	if !config.Bool(ctx, "core.autopush") {
+		debug.Log("not pushing to git remote, core.autopush is false")
 
 		return nil
 	}
 
-	debug.Log("syncing with remote ...")
+	debug.Log("pushing to remote ...")
 
 	if err := s.storage.Push(ctx, "", ""); err != nil {
 		if errors.Is(err, store.ErrGitNotInit) {
@@ -118,7 +118,7 @@ func (s *Store) gitCommitAndPush(ctx context.Context, name string) error {
 		return fmt.Errorf("failed to push to git remote: %w", err)
 	}
 
-	debug.Log("synced with remote")
+	debug.Log("pushed to remote")
 
 	return nil
 }

--- a/tests/config_test.go
+++ b/tests/config_test.go
@@ -15,7 +15,8 @@ func TestBaseConfig(t *testing.T) {
 	out, err := ts.run("config")
 	assert.NoError(t, err)
 
-	wanted := `core.autosync = true
+	wanted := `core.autopush = true
+core.autosync = true
 core.cliptimeout = 45
 core.exportkeys = false
 core.notifications = true
@@ -65,7 +66,8 @@ func TestMountConfig(t *testing.T) {
 	_, err = ts.run("config")
 	assert.NoError(t, err)
 
-	wanted := `core.autosync = true
+	wanted := `core.autopush = true
+core.autosync = true
 core.cliptimeout = 45
 core.exportkeys = false
 core.notifications = true


### PR DESCRIPTION
```
feat: add core.autopush to separate push/autosync behavior

This change adds a `core.autopush` configuration option (which defaults
to a value of `true`). This new configuration option is used in
post-write-ish actions, to determine if the remote repository should be
pushed to. In doing this, we support workflows where a user may want to
always push to the remote, but disable the behavior of "sync", which
fetches updates from remotes for all mounts (including the root store).

Closes: gopasspw/gopass#2551
```