### PR TITLE
gpg: log gpg output to debug.LogWriter & log more messages

### DIFF
--- a/internal/backend/crypto/gpg/cli/encrypt.go
+++ b/internal/backend/crypto/gpg/cli/encrypt.go
@@ -3,6 +3,8 @@ package cli
 import (
 	"bytes"
 	"context"
+	"errors"
+	"fmt"
 	"io"
 	"os"
 	"os/exec"
@@ -26,19 +28,26 @@ func (g *GPG) Encrypt(ctx context.Context, plaintext []byte, recipients []string
 		args = append(args, "--trust-model=always")
 	}
 
+	debug.Log("recipients are %s", recipients)
+	var badRecipients []string
 	for _, r := range recipients {
 		kl, err := g.listKeys(ctx, "public", r)
 		if err != nil {
 			debug.Log("Failed to check key %s. Adding anyway. %s", err)
 		} else if len(kl.UseableKeys(gpg.IsAlwaysTrust(ctx))) < 1 {
-			out.Printf(ctx, "Not using invalid key %s for encryption. (Check its expiration date or its encryption capabilities.)", r)
-
+			badRecipients = append(badRecipients, r)
+			errmsg := fmt.Sprintf("Not using invalid key %s for encryption. Check its expiration date, its encryption capabilities and trust.", r)
+			debug.Log(errmsg)
+			out.Printf(ctx, errmsg)
 			continue
 		}
+		debug.Log("adding recipient %s", r)
 		args = append(args, "--recipient", r)
 	}
-
 	buf := &bytes.Buffer{}
+	if len(badRecipients) == len(recipients) {
+		return buf.Bytes(), errors.New("no valid and trusted recipients were found!")
+	}
 
 	cmd := exec.CommandContext(ctx, g.binary, args...)
 	cmd.Stdin = bytes.NewReader(plaintext)

--- a/internal/backend/crypto/gpg/cli/encrypt.go
+++ b/internal/backend/crypto/gpg/cli/encrypt.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bytes"
 	"context"
+	"io"
 	"os"
 	"os/exec"
 
@@ -41,9 +42,9 @@ func (g *GPG) Encrypt(ctx context.Context, plaintext []byte, recipients []string
 
 	cmd := exec.CommandContext(ctx, g.binary, args...)
 	cmd.Stdin = bytes.NewReader(plaintext)
-	// the encrypted blob is written to stdout
-	cmd.Stdout = buf
-	cmd.Stderr = os.Stderr
+	// the encrypted blob and errors are printed to the log file, and to stdout
+	cmd.Stdout = io.MultiWriter(buf, debug.LogWriter)
+	cmd.Stderr = io.MultiWriter(os.Stderr, debug.LogWriter)
 
 	debug.Log("%s %+v", cmd.Path, cmd.Args)
 	err := cmd.Run()


### PR DESCRIPTION
Trying to debug an issue I had with `gopass-jsonapi` for ages, I found the following changes useful. I think they'll be useful for others too. My issue was that my GnuPG key wasn't "trusted ultimately". Reading the error messages this patch helped me to see, pointed me to `git grep trust -- docs/` and make gnupg trust my key.