### PR TITLE
gitfs: support git submodules

### DIFF
--- a/internal/backend/storage/gitfs/loader.go
+++ b/internal/backend/storage/gitfs/loader.go
@@ -41,7 +41,8 @@ func (l loader) Init(ctx context.Context, path string) (backend.Storage, error) 
 
 func (l loader) Handles(ctx context.Context, path string) error {
 	path = fsutil.ExpandHomedir(path)
-	if !fsutil.IsDir(filepath.Join(path, ".git")) {
+	gitPath := filepath.Join(path, ".git")
+	if !fsutil.IsDir(gitPath) && !fsutil.IsFile(gitPath) {
 		return fmt.Errorf("no .git at %s", path)
 	}
 


### PR DESCRIPTION
Hello.

I use git submodule as a store, and gopass didn't recognize it as a git repo.

With this change gopass can recognize git submodules as a repository, so `gopass sync` works. (tested locally)