### PR TITLE
[Fix] Using the correct env prefix for env settings

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,7 +11,7 @@ import (
 )
 
 var (
-	envPrefix    = "GOPASS_CONFIG_"
+	envPrefix    = "GOPASS_CONFIG"
 	systemConfig = "/etc/gopass/config"
 )
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -37,3 +37,47 @@ func TestConfig(t *testing.T) {
 	assert.Equal(t, "foo", String(ctx, "core.string"))
 	assert.Equal(t, 42, Int(ctx, "core.int"))
 }
+
+func TestEnvConfig(t *testing.T) {
+	envs := map[string]string{
+		"GOPASS_CONFIG_CONFIG_COUNT":   "1",
+		"GOPASS_CONFIG_CONFIG_KEY_0":   "core.autosync",
+		"GOPASS_CONFIG_CONFIG_VALUE_0": "false",
+	}
+	for k, v := range envs {
+		t.Setenv(k, v)
+	}
+
+	u := gptest.NewUnitTester(t)
+	assert.NotNil(t, u)
+
+	td := t.TempDir()
+	t.Setenv("GOPASS_HOMEDIR", td)
+
+	// this will write to the tempdir
+	cfg := New()
+
+	assert.Equal(t, "false", cfg.Get("core.autosync"))
+}
+
+func TestInvalidEnvConfig(t *testing.T) {
+	envs := map[string]string{
+		"GOPASS_CONFIG__CONFIG_COUNT":   "1",
+		"GOPASS_CONFIG__CONFIG_KEY_0":   "core.autosync",
+		"GOPASS_CONFIG__CONFIG_VALUE_0": "false",
+	}
+	for k, v := range envs {
+		t.Setenv(k, v)
+	}
+
+	u := gptest.NewUnitTester(t)
+	assert.NotNil(t, u)
+
+	td := t.TempDir()
+	t.Setenv("GOPASS_HOMEDIR", td)
+
+	// this will write to the tempdir
+	cfg := New()
+
+	assert.Equal(t, "true", cfg.Get("core.autosync"))
+}


### PR DESCRIPTION
Currently our config options can be set using the `GOPASS_CONFIG__CONFIG_COUNT`  option followed by `GOPASS_CONFIG__CONFIG_KEY_0` and same for values, but this seems to be a bug.

It should be `GOPASS_CONFIG_CONFIG_KEY_0` without 2 underscores according to our documentation.

This PR fixes it.