### PR TITLE
Provide a global nosync option to turn off auto-sync

### DIFF
--- a/internal/action/commands.go
+++ b/internal/action/commands.go
@@ -52,6 +52,10 @@ func ShowFlags() []cli.Flag {
 			Aliases: []string{"n"},
 			Usage:   "Do not parse the output.",
 		},
+		&cli.BoolFlag{
+			Name:  "nosync",
+			Usage: "Disable auto-sync",
+		},
 		&cli.StringFlag{
 			Name:  "chars",
 			Usage: "Print specific characters from the secret",

--- a/internal/action/init.go
+++ b/internal/action/init.go
@@ -37,7 +37,7 @@ func (s *Action) IsInitialized(c *cli.Context) error {
 	if inited {
 		debug.Log("Store is fully initialized and ready to go\n\nAll systems go. 🚀\n")
 		s.printReminder(ctx)
-		if c.Command.Name != "sync" {
+		if c.Command.Name != "sync" && !c.Bool("nosync") {
 			_ = s.autoSync(ctx)
 		}
 


### PR DESCRIPTION
This is mainly intended for tests or other restricted environments. Regular users should prefer the core.autosync option in the config.

Fixes #2616