### PR TITLE
Only show desktop notification if sync produced any differences

### DIFF
--- a/internal/action/sync.go
+++ b/internal/action/sync.go
@@ -139,7 +139,10 @@ func (s *Action) sync(ctx context.Context, store string) error {
 	} else if numEntries < 0 {
 		diff = fmt.Sprintf(" Removed %d entries", -1*numEntries)
 	}
-	_ = notify.Notify(ctx, "gopass - sync", fmt.Sprintf("Finished. Synced %d remotes.%s", numMPs, diff))
+
+	if numEntries != 0 {
+		_ = notify.Notify(ctx, "gopass - sync", fmt.Sprintf("Finished. Synced %d remotes.%s", numMPs, diff))
+	}
 
 	return nil
 }


### PR DESCRIPTION
This simple change will suppress the desktop notification if the diff is zero. Please note that this is not perfect since an even number of additions and removals might add up to zero.

Fixes #2618