### PR TITLE
storage/fs: replace `bytes.Compare` with `bytes.Equal`

### DIFF
--- a/internal/backend/storage/fs/store.go
+++ b/internal/backend/storage/fs/store.go
@@ -67,7 +67,7 @@ func (s *Store) Set(ctx context.Context, name string, value []byte) error {
 	// (for instance, by not adding/committing/pushing the secret in git,
 	//  or by panicking in the case of password generation)
 	oldvalue, err := os.ReadFile(filepath.Join(s.path, name))
-	if err == nil && bytes.Compare(oldvalue, value) == 0 {
+	if err == nil && bytes.Equal(oldvalue, value) {
 		return store.ErrMeaninglessWrite
 	}
 


### PR DESCRIPTION
Prefer `bytes.Equal` to `bytes.Compare` for equality comparisons, as suggested by Go example [^1]

Besides, `bytes.Equal` is slightly faster than `bytes.Compare` in this case. Although the difference is minor, we still get free performance wins for one line change.

```go
func BenchmarkBytesCompare(b *testing.B)  {
	foo := []byte("foo")
	bar := []byte("bar")

	for i := 0; i < b.N; i++ {
		if bytes.Compare(foo, bar) == 0 {
			b.Fail()
		}
	}
}

func BenchmarkBytesEqual(b *testing.B)  {
	foo := []byte("foo")
	bar := []byte("bar")

	for i := 0; i < b.N; i++ {
		if bytes.Equal(foo, bar) {
			b.Fail()
		}
	}
}
```
```
goos: linux
goarch: amd64
pkg: example
cpu: AMD Ryzen 7 PRO 4750U with Radeon Graphics
BenchmarkBytesCompare-16    	188355594	         6.636 ns/op	       0 B/op	       0 allocs/op
BenchmarkBytesEqual-16      	240546348	         4.498 ns/op	       0 B/op	       0 allocs/op
```

[^1]: https://github.com/golang/go/blob/go1.20.7/src/bytes/example_test.go#L129-L135