### PR TITLE
fix: OTP screenshot only on ARM, ARM64, 386 and AMD64

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.20
 
 require (
 	filippo.io/age v1.1.1
-	github.com/AnomalRoil/screenshot v0.0.2
 	github.com/ProtonMail/go-crypto v0.0.0-20230717121422-5aa5874ade95
 	github.com/atotto/clipboard v0.1.4
 	github.com/blang/semver/v4 v4.0.0
@@ -22,6 +21,7 @@ require (
 	github.com/hashicorp/golang-lru v0.5.4
 	github.com/jsimonetti/pwscheme v0.0.0-20220922140336-67a4d090f150
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
+	github.com/kbinani/screenshot v0.0.0-20230812210009-b87d31814237
 	github.com/makiuchi-d/gozxing v0.1.1
 	github.com/martinhoefling/goxkcdpwgen v0.1.2-0.20221205222637-737661b92a0e
 	github.com/mattn/go-colorable v0.1.13

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,6 @@ filippo.io/age v1.1.1 h1:pIpO7l151hCnQ4BdyBujnGP2YlUo0uj6sAVNHGBvXHg=
 filippo.io/age v1.1.1/go.mod h1:l03SrzDUrBkdBx8+IILdnn2KZysqQdbEBUQ4p3sqEQE=
 filippo.io/edwards25519 v1.0.0 h1:0wAIcmJUqRdI8IJ/3eGi5/HwXZWPujYXXlkrQogz0Ek=
 filippo.io/edwards25519 v1.0.0/go.mod h1:N1IkdkCkiLB6tki+MYJoSx2JTY9NUlxZE7eHn5EwJns=
-github.com/AnomalRoil/screenshot v0.0.2 h1:MVFqxkjOeCznTldJSzlcyvwmTIKh3q1L57yr4I29rz4=
-github.com/AnomalRoil/screenshot v0.0.2/go.mod h1:f1wcpgUow6TZKOZBBHXGhjGnU0S1lSnurTRpK9BR6R0=
 github.com/ProtonMail/go-crypto v0.0.0-20230717121422-5aa5874ade95 h1:KLq8BE0KwCL+mmXnjLWEAOYO+2l2AE4YMmqG1ZpZHBs=
 github.com/ProtonMail/go-crypto v0.0.0-20230717121422-5aa5874ade95/go.mod h1:EjAoLdwvbIOoOQr3ihjnSoLZRtE8azugULFRteWMNc0=
 github.com/alessio/shellescape v1.4.2 h1:MHPfaU+ddJ0/bYWpgIeUnQUqKrlJ1S7BfEYPM4uEoM0=
@@ -98,6 +96,8 @@ github.com/jwalton/go-supportscolor v1.2.0 h1:g6Ha4u7Vm3LIsQ5wmeBpS4gazu0UP1DRDE
 github.com/jwalton/go-supportscolor v1.2.0/go.mod h1:hFVUAZV2cWg+WFFC4v8pT2X/S2qUUBYMioBD9AINXGs=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNUXsshfwJMBgNA0RU6/i7WVaAegv3PtuIHPMs=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
+github.com/kbinani/screenshot v0.0.0-20230812210009-b87d31814237 h1:YOp8St+CM/AQ9Vp4XYm4272E77MptJDHkwypQHIRl9Q=
+github.com/kbinani/screenshot v0.0.0-20230812210009-b87d31814237/go.mod h1:e7qQlOY68wOz4b82D7n+DdaptZAi+SHW0+yKiWZzEYE=
 github.com/kjk/lzmadec v0.0.0-20210713164611-19ac3ee91a71 h1:TYp9Fj0apeZMWentXRaFM6B0ixdFefrlgY8n8XYEz1s=
 github.com/kjk/lzmadec v0.0.0-20210713164611-19ac3ee91a71/go.mod h1:2zRkQCuw/eK6cqkYAeNqyBU7JKa2Gcq40BZ9GSJbmfE=
 github.com/klauspost/compress v1.16.7 h1:2mk3MPGNzKyxErAw8YaohYh69+pa4sIQSC0fPGCFR9I=

--- a/pkg/otp/screenshot_others.go
+++ b/pkg/otp/screenshot_others.go
@@ -1,5 +1,5 @@
-//go:build !(linux || windows || darwin || freebsd || netbsd || openbsd)
-// +build !linux,!windows,!darwin,!freebsd,!netbsd,!openbsd
+//go:build !(arm || arm64 || amd64 || 386) || !(linux || windows || darwin || freebsd || netbsd || openbsd)
+// +build !arm,!arm64,!amd64,!386 !linux,!windows,!darwin,!freebsd,!netbsd,!openbsd
 
 package otp
 

--- a/pkg/otp/screenshot_supported.go
+++ b/pkg/otp/screenshot_supported.go
@@ -1,4 +1,5 @@
-//go:build linux || windows || darwin || freebsd || netbsd || openbsd
+//go:build (arm || arm64 || amd64 || 386) && (linux || windows || darwin || freebsd || netbsd || openbsd)
+// +build arm arm64 amd64 386
 // +build linux windows darwin freebsd netbsd openbsd
 
 package otp
@@ -7,8 +8,8 @@ import (
 	"context"
 	"strings"
 
-	"github.com/AnomalRoil/screenshot"
 	"github.com/gopasspw/gopass/internal/out"
+	"github.com/kbinani/screenshot"
 	"github.com/makiuchi-d/gozxing"
 	"github.com/makiuchi-d/gozxing/qrcode"
 )


### PR DESCRIPTION
This also stops using my fork of screenshot since my PR was merged upstream.

Fixes #2638.