### PR TITLE
[docs] add/update choco, scoop, winget instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ pacman -S gopass
 [![Scoop version](https://img.shields.io/scoop/v/gopass)](https://github.com/ScoopInstaller/Main/blob/master/bucket/gopass.json)
 
 ```shell
-# WinGet#
+# WinGet
 winget install Git.Git
 winget install GnuPG.Gpg4win
 winget install gopass.gopass

--- a/README.md
+++ b/README.md
@@ -77,7 +77,9 @@ pacman -S gopass
 [![Scoop version](https://img.shields.io/scoop/v/gopass)](https://github.com/ScoopInstaller/Main/blob/master/bucket/gopass.json)
 
 ```shell
-# WinGet
+# WinGet#
+winget install Git.Git
+winget install GnuPG.Gpg4win
 winget install gopass.gopass
 # Chocolatey
 choco install gpg4win

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -62,7 +62,7 @@ choco install gpg4win
 
 ```ps1
 scoop install git
-# add Extras bucket
+# add Extras bucket, if you haven't already
 # scoop bucket add extras
 scoop install gpg4win
 ```

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -51,9 +51,28 @@ brew install gnupg2 git
 * Download and install [GPG4Win](https://www.gpg4win.org/).
 * Download and install [the Windows git installer](https://git-scm.com/download/win).
 
-Alternatively, it can be installed via [chocolatey](https://chocolatey.org/packages/gopass)
+Alternatively, these can be installed via [chocolatey](https://chocolatey.org), 
 
-* `choco install gopass` (requires admin privileges)
+```ps1
+choco install git
+choco install gpg4win
+```
+
+[Scoop](https://scoop.sh), 
+
+```ps1
+scoop install git
+# add Extras bucket
+# scoop bucket add extras
+scoop install gpg4win
+```
+
+or [winget](https://aka.ms/winget-docs).
+
+```ps1
+winget install Git.Git
+winget install GnuPG.Gpg4win
+```
 
 #### OpenBSD
 
@@ -203,16 +222,22 @@ pacman -S gopass
 
 **WARNING**: Windows is not yet officially supported. We try to support it in the future. These are steps are only meant to help you setup gopass on Windows so you can provide us with feedback about the current state of our Windows support.
 
-You can install `gopass` by [Chocolatey](https://chocolatey.org/):
+You can install `gopass` with [Chocolatey](https://chocolatey.org/packages/gopass),
 
-```bash
+```ps1
 choco install gopass
 ```
 
-Or by [Scoop](https://scoop.sh/):
+[Scoop](https://scoop.sh/#/apps?q=gopass),
 
-```bash
+```ps1
 scoop install gopass
+```
+
+or winget.
+
+```ps1
+winget install gopass.gopass
 ```
 
 Alternatively, download and install a suitable Windows build from the repository [releases page](https://github.com/gopasspw/gopass/releases).

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -220,8 +220,6 @@ pacman -S gopass
 
 ### Windows
 
-**WARNING**: Windows is not yet officially supported. We try to support it in the future. These are steps are only meant to help you setup gopass on Windows so you can provide us with feedback about the current state of our Windows support.
-
 You can install `gopass` with [Chocolatey](https://chocolatey.org/packages/gopass),
 
 ```ps1


### PR DESCRIPTION
This adds/updates Windows installation instructions with chocolatey, scoop, and winget.

The [scoop](https://github.com/ScoopInstaller/Main/blob/master/bucket/gopass.json) and [choco](https://github.com/lyze237/GopassChoco/blob/master/gopass.nuspec) manifests do not include the git and gpg4win dependencies, so they have to be installed separately. Should we add those to the README? 
There is a `choco install gpg4win` there already, which is why I added `winget install git` and `winget install gpg4win`. The alternative would be to add the dependencies to the manifests so that `choco/scoop install gopass` would also install the dependencies.

~~The winget manifest already includes both dependencies, but the winget cli does not support installing those just yet ([the next minor version will add this functionality](https://github.com/microsoft/winget-cli/issues/163#issuecomment-1697930113)).~~ winget probably needs some more time to properly support dependencies (i.e. I am currently failing at submitting the manifest with dependencies included due to (IMHO) overzealous checks).

BTW is this warning still valid?
https://github.com/gopasspw/gopass/blob/439bc00268a67139b69cb22c7d083ab6d4add040/docs/setup.md?plain=1#L204