### PR TITLE
[feat] Add XCKD pwgen config options

### DIFF
--- a/internal/action/pwgen/pwgen.go
+++ b/internal/action/pwgen/pwgen.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 
 	"github.com/gopasspw/gopass/internal/action/exit"
+	"github.com/gopasspw/gopass/internal/config"
 	"github.com/gopasspw/gopass/internal/out"
 	"github.com/gopasspw/gopass/pkg/pwgen"
 	"github.com/gopasspw/gopass/pkg/pwgen/xkcdgen"
@@ -47,8 +48,20 @@ func Pwgen(c *cli.Context) error {
 }
 
 func xkcdGen(c *cli.Context, num int) error {
+	sep := config.String(c.Context, "pwgen.xkcd.sep")
+	if c.IsSet("sep") {
+		sep = c.String("sep")
+	}
+	lang := config.String(c.Context, "pwgen.xkcd.lang")
+	if c.IsSet("lang") {
+		lang = c.String("lang")
+	}
+	length := config.Int(c.Context, "pwgen.xkcd.len")
+	if length < 1 {
+		length = 4
+	}
 	for i := 0; i < num; i++ {
-		s, err := xkcdgen.RandomLengthDelim(4, c.String("sep"), c.String("lang"))
+		s, err := xkcdgen.RandomLengthDelim(length, sep, lang)
 		if err != nil {
 			return err
 		}

--- a/internal/action/pwgen/pwgen.go
+++ b/internal/action/pwgen/pwgen.go
@@ -41,13 +41,13 @@ func Pwgen(c *cli.Context) error {
 	}
 
 	if c.Bool("xkcd") {
-		return xkcdGen(c, pwNum)
+		return xkcdGen(c, pwLen, pwNum)
 	}
 
 	return pwGen(c, pwLen, pwNum)
 }
 
-func xkcdGen(c *cli.Context, num int) error {
+func xkcdGen(c *cli.Context, length, num int) error {
 	sep := config.String(c.Context, "pwgen.xkcd.sep")
 	if c.IsSet("sep") {
 		sep = c.String("sep")
@@ -56,9 +56,11 @@ func xkcdGen(c *cli.Context, num int) error {
 	if c.IsSet("lang") {
 		lang = c.String("lang")
 	}
-	length := config.Int(c.Context, "pwgen.xkcd.len")
 	if length < 1 {
-		length = 4
+		length = config.Int(c.Context, "pwgen.xkcd.len")
+		if length < 1 {
+			length = 4
+		}
 	}
 	for i := 0; i < num; i++ {
 		s, err := xkcdgen.RandomLengthDelim(length, sep, lang)


### PR DESCRIPTION
This commit adds three new config options to influence the default behaviour of the XKCD password generator.

* pwgen.xkcd.sep for the word separator (string)
* pwgen.xkcd.lang for the language (string)
* pwgen.xkcd.len for the number of words (int)

Fixes #2595