### PR TITLE
Use default length defined in config file

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -109,7 +109,7 @@ This is a list of available options:
 | `edit.post-hook` | `string` | This hook is run right after editing a record with `gopass edit` |
 | `edit.pre-hook` | `string` | This hook is run right before editing a record with `gopass edit` |
 | `generate.generator`   | `string` | Default password generator. `xkcd`, `memorable`, `external` or `` | `` |
-| `generate.length`      | `int`    | Default lenght for generated password. | `24` |
+| `generate.length`      | `int`    | Default length for generated password. | `24` |
 | `generate.symbols`     | `bool`   | Include symbols in generated password. | `false` |
 | `mounts.path`          | `string` | Path to the root store. | `$XDG_DATA_HOME/gopass/stores/root` |
 | `recipients.check`     | `bool`   | Check recipients hash. | `false` |

--- a/internal/action/edit.go
+++ b/internal/action/edit.go
@@ -111,7 +111,7 @@ func (s *Action) editGetContent(ctx context.Context, name string, create bool) (
 	}
 
 	// load template if it exists.
-	pwLength, _ := defaultLengthFromEnv(ctx)
+	pwLength, _ := config.DefaultLengthFromEnv(ctx)
 	if content, found := s.renderTemplate(ctx, name, []byte(pwgen.GeneratePassword(pwLength, false))); found {
 		return name, content, true, nil
 	}

--- a/internal/action/edit.go
+++ b/internal/action/edit.go
@@ -111,7 +111,7 @@ func (s *Action) editGetContent(ctx context.Context, name string, create bool) (
 	}
 
 	// load template if it exists.
-	pwLength, _ := config.DefaultLengthFromEnv(ctx)
+	pwLength, _ := config.DefaultPasswordLengthFromEnv(ctx)
 	if content, found := s.renderTemplate(ctx, name, []byte(pwgen.GeneratePassword(pwLength, false))); found {
 		return name, content, true, nil
 	}

--- a/internal/action/generate.go
+++ b/internal/action/generate.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"path"
 	"regexp"
 	"sort"
@@ -27,37 +26,6 @@ import (
 	"github.com/gopasspw/gopass/pkg/termio"
 	"github.com/urfave/cli/v2"
 )
-
-const (
-	defaultLength     = 24
-	defaultXKCDLength = 4
-)
-
-// defaultLengthFromEnv will determine the password length from the env variable
-// GOPASS_PW_DEFAULT_LENGTH or fallback to the hard-coded default length.
-// If the env variable is set by the user and is valid, the boolean return value
-// will be true, otherwise it will be false.
-func defaultLengthFromEnv(ctx context.Context) (int, bool) {
-	def := defaultLength
-
-	if l := config.Int(ctx, "generate.length"); l > 0 {
-		def = l
-	}
-
-	lengthStr, isSet := os.LookupEnv("GOPASS_PW_DEFAULT_LENGTH")
-	if !isSet {
-		return def, false
-	}
-	length, err := strconv.Atoi(lengthStr)
-	if err != nil {
-		return def, false
-	}
-	if length < 1 {
-		return def, false
-	}
-
-	return length, true
-}
 
 var reNumber = regexp.MustCompile(`^\d+$`)
 
@@ -262,7 +230,7 @@ func (s *Action) generatePassword(ctx context.Context, c *cli.Context, length, n
 // again.
 func getPwLengthFromEnvOrAskUser(ctx context.Context) (int, error) {
 	var pwlen int
-	candidateLength, isCustom := defaultLengthFromEnv(ctx)
+	candidateLength, isCustom := config.DefaultLengthFromEnv(ctx)
 	if !isCustom {
 		question := "How long should the password be?"
 		iv, err := termio.AskForInt(ctx, question, candidateLength)
@@ -324,7 +292,7 @@ func (s *Action) generatePasswordXKCD(ctx context.Context, c *cli.Context, lengt
 
 	var pwlen int
 	if length == "" {
-		candidateLength := defaultXKCDLength
+		candidateLength := config.DefaultXKCDLength
 		question := "How many words should be combined to a password?"
 		iv, err := termio.AskForInt(ctx, question, candidateLength)
 		if err != nil {

--- a/internal/action/generate.go
+++ b/internal/action/generate.go
@@ -230,7 +230,7 @@ func (s *Action) generatePassword(ctx context.Context, c *cli.Context, length, n
 // again.
 func getPwLengthFromEnvOrAskUser(ctx context.Context) (int, error) {
 	var pwlen int
-	candidateLength, isCustom := config.DefaultLengthFromEnv(ctx)
+	candidateLength, isCustom := config.DefaultPasswordLengthFromEnv(ctx)
 	if !isCustom {
 		question := "How long should the password be?"
 		iv, err := termio.AskForInt(ctx, question, candidateLength)

--- a/internal/action/generate_test.go
+++ b/internal/action/generate_test.go
@@ -354,8 +354,8 @@ func TestDefaultLengthFromEnv(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("use default value if no environment variable is set", func(t *testing.T) {
-		actual, isCustom := config.DefaultLengthFromEnv(ctx)
-		expected := config.DefaultLength
+		actual, isCustom := config.DefaultPasswordLengthFromEnv(ctx)
+		expected := config.DefaultPasswordLength
 		assert.Equal(t, actual, expected)
 		assert.False(t, isCustom)
 	})
@@ -368,13 +368,13 @@ func TestDefaultLengthFromEnv(t *testing.T) {
 		}{
 			{in: "42", expected: 42, custom: true},
 			{in: "1", expected: 1, custom: true},
-			{in: "0", expected: config.DefaultLength, custom: false},
-			{in: "abc", expected: config.DefaultLength, custom: false},
-			{in: "-1", expected: config.DefaultLength, custom: false},
+			{in: "0", expected: config.DefaultPasswordLength, custom: false},
+			{in: "abc", expected: config.DefaultPasswordLength, custom: false},
+			{in: "-1", expected: config.DefaultPasswordLength, custom: false},
 		} {
 			tc := tc
 			t.Setenv(pwLengthEnvName, tc.in)
-			actual, isCustom := config.DefaultLengthFromEnv(ctx)
+			actual, isCustom := config.DefaultPasswordLengthFromEnv(ctx)
 			assert.Equal(t, actual, tc.expected)
 			assert.Equal(t, isCustom, tc.custom)
 		}

--- a/internal/action/generate_test.go
+++ b/internal/action/generate_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/fatih/color"
+	"github.com/gopasspw/gopass/internal/config"
 	"github.com/gopasspw/gopass/internal/out"
 	"github.com/gopasspw/gopass/pkg/ctxutil"
 	"github.com/gopasspw/gopass/tests/gptest"
@@ -353,8 +354,8 @@ func TestDefaultLengthFromEnv(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("use default value if no environment variable is set", func(t *testing.T) {
-		actual, isCustom := defaultLengthFromEnv(ctx)
-		expected := defaultLength
+		actual, isCustom := config.DefaultLengthFromEnv(ctx)
+		expected := config.DefaultLength
 		assert.Equal(t, actual, expected)
 		assert.False(t, isCustom)
 	})
@@ -367,13 +368,13 @@ func TestDefaultLengthFromEnv(t *testing.T) {
 		}{
 			{in: "42", expected: 42, custom: true},
 			{in: "1", expected: 1, custom: true},
-			{in: "0", expected: defaultLength, custom: false},
-			{in: "abc", expected: defaultLength, custom: false},
-			{in: "-1", expected: defaultLength, custom: false},
+			{in: "0", expected: config.DefaultLength, custom: false},
+			{in: "abc", expected: config.DefaultLength, custom: false},
+			{in: "-1", expected: config.DefaultLength, custom: false},
 		} {
 			tc := tc
 			t.Setenv(pwLengthEnvName, tc.in)
-			actual, isCustom := defaultLengthFromEnv(ctx)
+			actual, isCustom := config.DefaultLengthFromEnv(ctx)
 			assert.Equal(t, actual, tc.expected)
 			assert.Equal(t, isCustom, tc.custom)
 		}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strconv"
@@ -8,6 +9,11 @@ import (
 
 	"github.com/gopasspw/gopass/pkg/debug"
 	"github.com/gopasspw/gopass/pkg/gitconfig"
+)
+
+const (
+	DefaultLength     = 24
+	DefaultXKCDLength = 4
 )
 
 var (
@@ -236,4 +242,28 @@ func (c *Config) Keys(mount string) []string {
 	}
 
 	return nil
+}
+
+// DefaultLengthFromEnv will determine the password length from the env variable
+// GOPASS_PW_DEFAULT_LENGTH or fallback to the hard-coded default length.
+// If the env variable is set by the user and is valid, the boolean return value
+// will be true, otherwise it will be false.
+func DefaultLengthFromEnv(ctx context.Context) (int, bool) {
+	def := DefaultLength
+	cfg := FromContext(ctx)
+
+	if l := cfg.GetInt("generate.length"); l > 0 {
+		def = l
+	}
+
+	lengthStr, isSet := os.LookupEnv("GOPASS_PW_DEFAULT_LENGTH")
+	if !isSet {
+		return def, false
+	}
+	length, err := strconv.Atoi(lengthStr)
+	if err != nil || length < 1 {
+		return def, false
+	}
+
+	return length, true
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,8 +12,8 @@ import (
 )
 
 const (
-	DefaultLength     = 24
-	DefaultXKCDLength = 4
+	DefaultPasswordLength = 24
+	DefaultXKCDLength     = 4
 )
 
 var (
@@ -244,12 +244,12 @@ func (c *Config) Keys(mount string) []string {
 	return nil
 }
 
-// DefaultLengthFromEnv will determine the password length from the env variable
+// DefaultPasswordLengthFromEnv will determine the password length from the env variable
 // GOPASS_PW_DEFAULT_LENGTH or fallback to the hard-coded default length.
 // If the env variable is set by the user and is valid, the boolean return value
 // will be true, otherwise it will be false.
-func DefaultLengthFromEnv(ctx context.Context) (int, bool) {
-	def := DefaultLength
+func DefaultPasswordLengthFromEnv(ctx context.Context) (int, bool) {
+	def := DefaultPasswordLength
 	cfg := FromContext(ctx)
 
 	if l := cfg.GetInt("generate.length"); l > 0 {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -38,7 +38,7 @@ func TestConfig(t *testing.T) {
 	assert.Equal(t, 42, Int(ctx, "core.int"))
 
 	assert.NoError(t, cfg.SetEnv("generate.length", "16"))
-	actual_length, _ := DefaultLengthFromEnv(ctx)
+	actual_length, _ := DefaultPasswordLengthFromEnv(ctx)
 	assert.Equal(t, 16, actual_length)
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -36,6 +36,10 @@ func TestConfig(t *testing.T) {
 	assert.Equal(t, true, Bool(ctx, "core.bool"))
 	assert.Equal(t, "foo", String(ctx, "core.string"))
 	assert.Equal(t, 42, Int(ctx, "core.int"))
+
+	assert.NoError(t, cfg.SetEnv("generate.length", "16"))
+	actual_length, _ := DefaultLengthFromEnv(ctx)
+	assert.Equal(t, 16, actual_length)
 }
 
 func TestEnvConfig(t *testing.T) {

--- a/internal/create/wizard.go
+++ b/internal/create/wizard.go
@@ -28,9 +28,7 @@ import (
 )
 
 const (
-	defaultLength     = 24
-	defaultXKCDLength = 4
-	tplPath           = ".gopass/create/"
+	tplPath = ".gopass/create/"
 )
 
 // Attribute is a credential attribute that is being asked for
@@ -294,6 +292,8 @@ func mkActFunc(tpl Template, s *root.Store, cb ActionCallback) func(context.Cont
 
 // generatePasssword will walk through the password generation steps.
 func generatePassword(ctx context.Context, hostname, charset string) (string, error) {
+	defaultLength, _ := config.DefaultLengthFromEnv(ctx)
+
 	if charset != "" {
 		length, err := termio.AskForInt(ctx, fmtfn(4, "a", "How long?"), 4)
 		if err != nil {
@@ -316,7 +316,7 @@ func generatePassword(ctx context.Context, hostname, charset string) (string, er
 		return "", err
 	}
 	if xkcd {
-		length, err := termio.AskForInt(ctx, fmtfn(4, "b", "How many words?"), defaultXKCDLength)
+		length, err := termio.AskForInt(ctx, fmtfn(4, "b", "How many words?"), config.DefaultXKCDLength)
 		if err != nil {
 			return "", err
 		}

--- a/internal/create/wizard.go
+++ b/internal/create/wizard.go
@@ -292,7 +292,7 @@ func mkActFunc(tpl Template, s *root.Store, cb ActionCallback) func(context.Cont
 
 // generatePasssword will walk through the password generation steps.
 func generatePassword(ctx context.Context, hostname, charset string) (string, error) {
-	defaultLength, _ := config.DefaultLengthFromEnv(ctx)
+	defaultLength, _ := config.DefaultPasswordLengthFromEnv(ctx)
 
 	if charset != "" {
 		length, err := termio.AskForInt(ctx, fmtfn(4, "a", "How long?"), 4)


### PR DESCRIPTION
Takes into account the configuration `generate.length` by the wizard will creating a new password.