### PR TITLE
[feat] Add --store option to gopass fsck

### DIFF
--- a/internal/action/commands.go
+++ b/internal/action/commands.go
@@ -344,6 +344,10 @@ func (s *Action) GetCommands() []*cli.Command {
 					Name:  "decrypt",
 					Usage: "Decrypt and reencrypt during fsck.",
 				},
+				&cli.StringFlag{
+					Name:  "store",
+					Usage: "Limit fsck to this mount point",
+				},
 			},
 		},
 		{

--- a/internal/action/fsck.go
+++ b/internal/action/fsck.go
@@ -62,7 +62,7 @@ func (s *Action) Fsck(c *cli.Context) error {
 	ctx = out.AddPrefix(ctx, "\n")
 
 	// the main work in done by the sub stores.
-	if err := s.Store.Fsck(ctx, filter); err != nil {
+	if err := s.Store.Fsck(ctx, c.String("store"), filter); err != nil {
 		return exit.Error(exit.Fsck, err, "fsck found errors: %s", err)
 	}
 	bar.Done()

--- a/internal/store/root/fsck.go
+++ b/internal/store/root/fsck.go
@@ -10,11 +10,15 @@ import (
 )
 
 // Fsck checks all stores/entries matching the given prefix.
-func (s *Store) Fsck(ctx context.Context, path string) error {
+func (s *Store) Fsck(ctx context.Context, store, path string) error {
 	var result []error
 
 	for alias, sub := range s.mounts {
 		if sub == nil {
+			continue
+		}
+
+		if store != "" && alias != store {
 			continue
 		}
 

--- a/internal/store/root/fsck_test.go
+++ b/internal/store/root/fsck_test.go
@@ -21,5 +21,5 @@ func TestFsck(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, rs)
 
-	assert.NoError(t, rs.Fsck(ctx, ""))
+	assert.NoError(t, rs.Fsck(ctx, "", ""))
 }


### PR DESCRIPTION
This allows limiting fsck to a specific mount-point to speed up the process for large password stores.