### PR TITLE
[bugfix] Allow fsck to check a single secret

### DIFF
--- a/internal/store/root/fsck.go
+++ b/internal/store/root/fsck.go
@@ -25,17 +25,18 @@ func (s *Store) Fsck(ctx context.Context, path string) error {
 		path = strings.TrimPrefix(path, alias+"/")
 
 		// check sub store
-		debug.Log("Checking %s", alias)
+		debug.Log("Checking mount point %s", alias)
 
 		if err := sub.Fsck(ctx, path); err != nil {
 			out.Errorf(ctx, "fsck failed on sub store %s: %s", alias, err)
 			result = append(result, err)
 		}
 
-		debug.Log("Checked %s", alias)
+		debug.Log("Checked mount point %s", alias)
 	}
 
 	// check root store
+	debug.Log("Checking root store")
 	if err := s.store.Fsck(ctx, path); err != nil {
 		out.Errorf(ctx, "fsck failed on root store: %s", err)
 		result = append(result, err)


### PR DESCRIPTION
This commit changes the fsck filtering to also allow targeting a single secret. Previously it would only work on folders and fail on single files.

Fixes #2517 