### PR TITLE
[enhancement] Add input validation to block illegal mount points

### DIFF
--- a/internal/store/root/mount.go
+++ b/internal/store/root/mount.go
@@ -3,6 +3,7 @@ package root
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"sort"
 	"strings"
 
@@ -26,6 +27,14 @@ func (r *Store) AddMount(ctx context.Context, alias, path string, keys ...string
 func (r *Store) addMount(ctx context.Context, alias, path string, keys ...string) error {
 	if alias == "" {
 		return fmt.Errorf("alias must not be empty")
+	}
+	// disallow filepath separators in alias and always disallow regular slashes
+	// even on Windows, since these are used internally to separate folders.
+	if strings.HasSuffix(alias, "/") {
+		return fmt.Errorf("alias must not end with '/'")
+	}
+	if strings.HasSuffix(alias, string(filepath.Separator)) {
+		return fmt.Errorf("alias must not end with '%s'", string(filepath.Separator))
 	}
 
 	if r.mounts == nil {

--- a/internal/store/root/mount_test.go
+++ b/internal/store/root/mount_test.go
@@ -2,6 +2,7 @@ package root
 
 import (
 	"context"
+	"runtime"
 	"testing"
 
 	"github.com/gopasspw/gopass/pkg/ctxutil"
@@ -51,4 +52,24 @@ func TestMountPoint(t *testing.T) {
 	assert.NoError(t, rs.AddMount(ctx, "sub2", u.StoreDir("sub2")))
 
 	assert.Equal(t, "sub1", rs.MountPoint("sub1"))
+}
+
+func TestMountPointIllegal(t *testing.T) {
+	u := gptest.NewUnitTester(t)
+
+	ctx := context.Background()
+	ctx = ctxutil.WithAlwaysYes(ctx, true)
+	ctx = ctxutil.WithHidden(ctx, true)
+
+	rs, err := createRootStore(ctx, u)
+	require.NoError(t, err)
+
+	assert.NoError(t, u.InitStore("sub1"))
+	assert.NoError(t, u.InitStore("sub2"))
+	assert.NoError(t, rs.AddMount(ctx, "sub1/foo", u.StoreDir("sub1")))
+	if runtime.GOOS == "windows" {
+		assert.NoError(t, rs.AddMount(ctx, "sub2\\foo", u.StoreDir("sub2")))
+		assert.Error(t, rs.AddMount(ctx, "sub2\\", u.StoreDir("sub2")))
+	}
+	assert.Error(t, rs.AddMount(ctx, "sub2/", u.StoreDir("sub2")))
 }


### PR DESCRIPTION
This commit adds a check to prevent mounting mount points that can not be used later on.