### PR TITLE
[cleanup] Remove Deprecated math/rand.Seed Usage

### DIFF
--- a/pkg/fsutil/fsutil.go
+++ b/pkg/fsutil/fsutil.go
@@ -137,7 +137,6 @@ func IsEmptyDir(path string) (bool, error) {
 
 // Shred overwrite the given file any number of times.
 func Shred(path string, runs int) error {
-
 	fh, err := os.OpenFile(path, os.O_WRONLY, 0o600)
 	if err != nil {
 		return fmt.Errorf("failed to open file %q: %w", path, err)
@@ -159,7 +158,7 @@ func Shred(path string, runs int) error {
 	// use zeros in the last iteration
 	bufFn := func() []byte {
 		buf := make([]byte, 1024)
-		rand.Read(buf)
+		_, _ = rand.Read(buf)
 
 		return buf
 	}

--- a/pkg/fsutil/fsutil.go
+++ b/pkg/fsutil/fsutil.go
@@ -2,15 +2,14 @@ package fsutil
 
 import (
 	"bufio"
+	"crypto/rand"
 	"errors"
 	"fmt"
 	"io"
-	"math/rand"
 	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
-	"time"
 
 	"github.com/gopasspw/gopass/pkg/appdir"
 	"github.com/gopasspw/gopass/pkg/debug"
@@ -138,7 +137,6 @@ func IsEmptyDir(path string) (bool, error) {
 
 // Shred overwrite the given file any number of times.
 func Shred(path string, runs int) error {
-	rand.Seed(time.Now().UnixNano())
 
 	fh, err := os.OpenFile(path, os.O_WRONLY, 0o600)
 	if err != nil {
@@ -161,7 +159,7 @@ func Shred(path string, runs int) error {
 	// use zeros in the last iteration
 	bufFn := func() []byte {
 		buf := make([]byte, 1024)
-		_, _ = rand.Read(buf)
+		rand.Read(buf)
 
 		return buf
 	}

--- a/pkg/gitconfig/config_test.go
+++ b/pkg/gitconfig/config_test.go
@@ -2,14 +2,14 @@ package gitconfig
 
 import (
 	"bytes"
+	"crypto/rand"
 	"fmt"
-	"math/rand"
+	"math/big"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/gopasspw/gopass/internal/set"
 	"github.com/stretchr/testify/assert"
@@ -271,8 +271,8 @@ func TestLoadFromEnv(t *testing.T) {
 		"core.timeout": "10",
 	}
 
-	rand.Seed(time.Now().Unix())
-	prefix := fmt.Sprintf("GPTEST%d", rand.Int31n(8192))
+	n, _ := rand.Int(rand.Reader, big.NewInt(8192))
+	prefix := fmt.Sprintf("GPTEST%d", n)
 
 	i := 0
 	for k, v := range tc {

--- a/pkg/pwgen/pwgen_test.go
+++ b/pkg/pwgen/pwgen_test.go
@@ -2,10 +2,10 @@ package pwgen
 
 import (
 	"bytes"
-	"crypto/rand"
+	crand "crypto/rand"
 	"fmt"
 	"io"
-	mrand "math/rand"
+	"math/rand"
 	"os"
 	"strings"
 	"testing"
@@ -40,11 +40,14 @@ func TestPwgenCharset(t *testing.T) {
 }
 
 func TestPwgenNoCrand(t *testing.T) {
-	old := rand.Reader
-	rand.Reader = strings.NewReader("")
-
+	old := crand.Reader
+	crand.Reader = strings.NewReader("")
+	oldrand := gr
+	// if we seed math/rand with 1789, the first "random number" will be 42
+	gr = rand.New(rand.NewSource(1789))
 	defer func() {
-		rand.Reader = old
+		crand.Reader = old
+		gr = oldrand
 	}()
 
 	oldOut := os.Stdout
@@ -58,9 +61,6 @@ func TestPwgenNoCrand(t *testing.T) {
 		_, _ = io.Copy(buf, r)
 		done <- buf.String()
 	}()
-
-	// if we seed math/rand with 1789, the first "random number" will be 42
-	mrand.Seed(1789)
 
 	n := randomInteger(1024)
 

--- a/pkg/pwgen/rand.go
+++ b/pkg/pwgen/rand.go
@@ -9,9 +9,10 @@ import (
 	"time"
 )
 
+var gr *rand.Rand
+
 func init() {
-	// seed math/rand in case we have to fall back to using it
-	rand.Seed(time.Now().Unix() + int64(os.Getpid()+os.Getppid()))
+	gr = rand.New(rand.NewSource(time.Now().Unix() + int64(os.Getpid()+os.Getppid())))
 }
 
 func randomInteger(max int) int {
@@ -19,8 +20,7 @@ func randomInteger(max int) int {
 	if err == nil {
 		return int(i.Int64())
 	}
-
 	fmt.Fprintln(os.Stderr, "WARNING: No crypto/rand available. Falling back to PRNG")
 
-	return rand.Intn(max)
+	return gr.Intn(max)
 }


### PR DESCRIPTION
## Issue
https://github.com/gopasspw/gopass/issues/2650

## Description
This commit removes the use of the deprecated math/rand.Seed method.

## Checked

▼make test 

```shell
gopass [ fix/issue-2650][🐹 v1.21.0]
❯ make test
>> BUILD, version = 1.15.8/ecf31ca3, output = gopass [OK]
>> TEST, "fast-mode": race detector off
     ok  	github.com/gopasspw/gopass	0.050s
     ?   	github.com/gopasspw/gopass/helpers/changelog	[no test files]
     ?   	github.com/gopasspw/gopass/helpers/man	[no test files]
     ?   	github.com/gopasspw/gopass/helpers/msipkg	[no test files]
     ?   	github.com/gopasspw/gopass/helpers/postrel	[no test files]
     ?   	github.com/gopasspw/gopass/helpers/release	[no test files]
     ok  	github.com/gopasspw/gopass/internal/action	3.087s
     ok  	github.com/gopasspw/gopass/internal/action/exit	0.001s
     ok  	github.com/gopasspw/gopass/internal/action/pwgen	0.004s
     ok  	github.com/gopasspw/gopass/internal/audit	0.028s
     ok  	github.com/gopasspw/gopass/internal/backend	0.038s
     ?   	github.com/gopasspw/gopass/internal/backend/crypto	[no test files]
     ok  	github.com/gopasspw/gopass/internal/backend/crypto/age	0.029s
     ok  	github.com/gopasspw/gopass/internal/backend/crypto/gpg	0.001s
     ok  	github.com/gopasspw/gopass/internal/backend/crypto/gpg/cli	0.012s
     ok  	github.com/gopasspw/gopass/internal/backend/crypto/gpg/colons	0.001s
     ok  	github.com/gopasspw/gopass/internal/backend/crypto/gpg/gpgconf	0.001s
     ok  	github.com/gopasspw/gopass/internal/backend/crypto/plain	0.001s
     ?   	github.com/gopasspw/gopass/internal/backend/storage	[no test files]
     ?   	github.com/gopasspw/gopass/internal/backend/storage/fossilfs	[no test files]
     ok  	github.com/gopasspw/gopass/internal/backend/storage/fs	0.251s
     ok  	github.com/gopasspw/gopass/internal/backend/storage/gitfs	0.037s
     ok  	github.com/gopasspw/gopass/internal/cache	1.102s
     ?   	github.com/gopasspw/gopass/internal/cache/ghssh	[no test files]
     ok  	github.com/gopasspw/gopass/internal/completion/fish	0.002s
     ok  	github.com/gopasspw/gopass/internal/completion/zsh	0.002s
     ok  	github.com/gopasspw/gopass/internal/config	0.037s
     ok  	github.com/gopasspw/gopass/internal/config/legacy	0.031s
     ok  	github.com/gopasspw/gopass/internal/create	0.030s
     ok  	github.com/gopasspw/gopass/internal/cui	0.003s
     ok  	github.com/gopasspw/gopass/internal/diff	0.001s
     ok  	github.com/gopasspw/gopass/internal/editor	0.004s
     ?   	github.com/gopasspw/gopass/internal/env	[no test files]
     ?   	github.com/gopasspw/gopass/internal/hashsum	[no test files]
     ?   	github.com/gopasspw/gopass/internal/hook	[no test files]
     ok  	github.com/gopasspw/gopass/internal/notify	0.001s
     ok  	github.com/gopasspw/gopass/internal/out	0.001s
     ok  	github.com/gopasspw/gopass/internal/pwschemes/argon2i	0.468s
     ok  	github.com/gopasspw/gopass/internal/pwschemes/argon2id	0.731s
     ok  	github.com/gopasspw/gopass/internal/pwschemes/bcrypt	0.376s
     ?   	github.com/gopasspw/gopass/internal/queue	[no test files]
     ok  	github.com/gopasspw/gopass/internal/recipients	0.001s
     ?   	github.com/gopasspw/gopass/internal/reminder	[no test files]
     ok  	github.com/gopasspw/gopass/internal/set	0.001s
     ok  	github.com/gopasspw/gopass/internal/store	0.001s
     ok  	github.com/gopasspw/gopass/internal/store/leaf	2.847s
     ?   	github.com/gopasspw/gopass/internal/store/mockstore	[no test files]
     ?   	github.com/gopasspw/gopass/internal/store/mockstore/inmem	[no test files]
     ok  	github.com/gopasspw/gopass/internal/store/root	0.036s
     ok  	github.com/gopasspw/gopass/internal/tpl	0.846s
     ok  	github.com/gopasspw/gopass/internal/tree	0.001s
     ok  	github.com/gopasspw/gopass/internal/updater	0.003s
     ok  	github.com/gopasspw/gopass/pkg/appdir	0.002s
     ok  	github.com/gopasspw/gopass/pkg/clipboard	0.377s
     ok  	github.com/gopasspw/gopass/pkg/ctxutil	0.003s
     ok  	github.com/gopasspw/gopass/pkg/debug	0.001s
     ok  	github.com/gopasspw/gopass/pkg/fsutil	0.234s
     ok  	github.com/gopasspw/gopass/pkg/gitconfig	0.002s
     ?   	github.com/gopasspw/gopass/pkg/gopass	[no test files]
     ok  	github.com/gopasspw/gopass/pkg/gopass/api	0.029s
     ?   	github.com/gopasspw/gopass/pkg/gopass/apimock	[no test files]
     ok  	github.com/gopasspw/gopass/pkg/gopass/secrets	0.026s
     ok  	github.com/gopasspw/gopass/pkg/gopass/secrets/secparse	0.001s
     ok  	github.com/gopasspw/gopass/pkg/otp	0.005s
     ?   	github.com/gopasspw/gopass/pkg/pinentry/cli	[no test files]
     ok  	github.com/gopasspw/gopass/pkg/protect	0.001s
     ok  	github.com/gopasspw/gopass/pkg/pwgen	0.015s
     ok  	github.com/gopasspw/gopass/pkg/pwgen/pwrules	0.002s
     ok  	github.com/gopasspw/gopass/pkg/pwgen/xkcdgen	0.001s
     ok  	github.com/gopasspw/gopass/pkg/qrcon	0.001s
     ok  	github.com/gopasspw/gopass/pkg/tempfile	0.001s
     ok  	github.com/gopasspw/gopass/pkg/termio	0.002s
```