### PR TITLE
[BUGFIX] Disabling the OTP snip screenshot feature on OpenBSD

### DIFF
--- a/pkg/otp/screenshot_others.go
+++ b/pkg/otp/screenshot_others.go
@@ -1,5 +1,5 @@
-//go:build !(arm || arm64 || amd64 || 386) || !(linux || windows || darwin || freebsd || netbsd || openbsd)
-// +build !arm,!arm64,!amd64,!386 !linux,!windows,!darwin,!freebsd,!netbsd,!openbsd
+//go:build !(arm || arm64 || amd64 || 386) || !(linux || windows || freebsd || netbsd) || (darwin && !cgo)
+// +build !arm,!arm64,!amd64,!386 !linux,!windows,!freebsd,!netbsd darwin,!cgo
 
 package otp
 
@@ -11,5 +11,5 @@ import (
 // ParseScreen will attempt to parse all available screen and will look for otpauth QR codes. It returns the first one
 // it has found.
 func ParseScreen(ctx context.Context) (string, error) {
-	return "", fmt.Errorf("Not supported on your platform")
+	return "", fmt.Errorf("not supported on your platform")
 }

--- a/pkg/otp/screenshot_others.go
+++ b/pkg/otp/screenshot_others.go
@@ -1,5 +1,4 @@
-//go:build !(arm || arm64 || amd64 || 386) || !(linux || windows || freebsd || netbsd) || (darwin && !cgo)
-// +build !arm,!arm64,!amd64,!386 !linux,!windows,!freebsd,!netbsd darwin,!cgo
+//go:build !((arm || arm64 || amd64 || 386) && (linux || windows || (cgo && darwin) || freebsd || netbsd))
 
 package otp
 

--- a/pkg/otp/screenshot_supported.go
+++ b/pkg/otp/screenshot_supported.go
@@ -1,6 +1,4 @@
 //go:build (arm || arm64 || amd64 || 386) && (linux || windows || (cgo && darwin) || freebsd || netbsd)
-// +build arm arm64 amd64 386
-// +build linux windows cgo,darwin freebsd netbsd
 
 package otp
 
@@ -45,7 +43,6 @@ func ParseScreen(ctx context.Context) (string, error) {
 				qr[10:10+strings.Index(qr[10:], "?")])
 
 			return qr, nil
-
 		}
 		out.Warningf(ctx, "Not an otpauth:// QR code, please make sure to only have your OTP qrcode displayed.")
 	}

--- a/pkg/otp/screenshot_supported.go
+++ b/pkg/otp/screenshot_supported.go
@@ -1,6 +1,6 @@
-//go:build (arm || arm64 || amd64 || 386) && (linux || windows || darwin || freebsd || netbsd || openbsd)
+//go:build (arm || arm64 || amd64 || 386) && (linux || windows || (cgo && darwin) || freebsd || netbsd)
 // +build arm arm64 amd64 386
-// +build linux windows darwin freebsd netbsd openbsd
+// +build linux windows cgo,darwin freebsd netbsd
 
 package otp
 
@@ -17,7 +17,6 @@ import (
 // ParseScreen will attempt to parse all available screen and will look for otpauth QR codes. It returns the first one
 // it has found.
 func ParseScreen(ctx context.Context) (string, error) {
-	var qr string
 	for i := 0; i < screenshot.NumActiveDisplays(); i++ {
 		out.Noticef(ctx, "Scanning screen n°%d", i)
 
@@ -40,14 +39,16 @@ func ParseScreen(ctx context.Context) (string, error) {
 		}
 
 		out.Noticef(ctx, "Found a qrcode, checking.")
-		if strings.HasPrefix(result.GetText(), "otpauth://") {
-			qr = result.GetText()
-			out.OKf(ctx, "Found an otpauth:// QR code on screen n°%d (%v)", i, img.Bounds())
+		if qr := result.GetText(); strings.HasPrefix(qr, "otpauth://") {
+			out.OKf(ctx, "Found an otpauth:// QR code on screen n°%d (%v) for %s", i, img.Bounds(),
+				// otpauth:// is 10 char, we display label information, but not the parameters containing the secret
+				qr[10:10+strings.Index(qr[10:], "?")])
 
-			break
+			return qr, nil
+
 		}
 		out.Warningf(ctx, "Not an otpauth:// QR code, please make sure to only have your OTP qrcode displayed.")
 	}
 
-	return qr, nil
+	return "", nil
 }


### PR DESCRIPTION
Disabling the OTP snip screenshot feature on OpenBSD as discussed in #2683.

Also do not rely on our dependency returning an error on Darwin and disable that too if it's not compiled with CGO.

@dominikschulz If you have a Darwin device handy, it'd be cool if you could test the `gopass otp -snip testentry` feature with this branch both with and without CGO enabled to confirm whether it works fine or not.
```
CGO_ENABLED=1 go build
``` 
should do it.