### PR TITLE
[cleanup] Add package description

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -66,6 +66,8 @@ nfpms:
     homepage: "https://www.gopass.pw"
     maintainer: "Gopass Authors <gopass@gopass.pw>"
     description: |-
+      gopass password manager - full featured CLI replacement for pass, designed for teams.
+
       gopass is a simple but powerful password manager for your terminal. It is a
       Pass implementation in Go that can be used as a drop in replacement.
 
@@ -89,6 +91,8 @@ nfpms:
     homepage: "https://www.gopass.pw"
     maintainer: "Gopass Authors <gopass@gopass.pw>"
     description: |-
+      gopass password manager - full featured CLI replacement for pass, designed for teams.
+
       gopass is a simple but powerful password manager for your terminal. It is a
       Pass implementation in Go that can be used as a drop in replacement.
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -65,6 +65,17 @@ nfpms:
     vendor: Gopass Authors
     homepage: "https://www.gopass.pw"
     maintainer: "Gopass Authors <gopass@gopass.pw>"
+    description: |-
+      gopass is a simple but powerful password manager for your terminal. It is a
+      Pass implementation in Go that can be used as a drop in replacement.
+
+      Every secret lives inside of a gpg (or: age) encrypted textfile. These secrets
+      can be organized into meaninful hierachies and are by default versioned using
+      git.
+
+      This package contains the main gopass binary from gopass.pw. In Debian and
+      Ubuntu there is an unfortunate name clash with another gopass package. That is
+      completely different and not related to this package.
     license: MIT
     formats:
       - deb
@@ -77,6 +88,13 @@ nfpms:
     vendor: Gopass Authors
     homepage: "https://www.gopass.pw"
     maintainer: "Gopass Authors <gopass@gopass.pw>"
+    description: |-
+      gopass is a simple but powerful password manager for your terminal. It is a
+      Pass implementation in Go that can be used as a drop in replacement.
+
+      Every secret lives inside of a gpg (or: age) encrypted textfile. These secrets
+      can be organized into meaninful hierachies and are by default versioned using
+      git.
     license: MIT
     formats:
       - rpm


### PR DESCRIPTION
This commit adds package descriptions to the generated Deb and RPM packages to make them easier to discover and separate from other similar packages.

Fixes #2695