### PR TITLE
Improved config handling and bugfixes

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -18,8 +18,8 @@ Some configuration options are only available through setting environment variab
 | `GOPASS_DEBUG_FILES`         | `string` | Comma separated filter for console debug output (files)                                                                                                           |
 | `GOPASS_DEBUG_FUNCS`         | `string` | Comma separated filter for console debug output (functions)                                                                                                       |
 | `GOPASS_DEBUG_LOG_SECRETS`   | `bool`   | Set to any non-empty value to enable logging of credentials                                                                                                       |
-| `GOPASS_DEBUG_LOG`           | `string` | Set to a filename to enable debug logging                                                                                                                         |
-| `GOPASS_DEBUG`               | `bool`   | Set to any non-empty value to enable verbose debug output                                                                                                         |
+| `GOPASS_DEBUG_LOG`           | `string` | Set to a filename to enable debug logging (only set GOPASS_DEBUG to log to stderr)                                                                                |
+| `GOPASS_DEBUG`               | `bool`   | Set to any non-empty value to enable verbose debug output, by default on stderr, unless GOPASS_DEBUG_LOG is set                                                   |
 | `GOPASS_EXTERNAL_PWGEN`      | `string` | Use an external password generator. See [Features](features.md#using-custom-password-generators) for details                                                      |
 | `GOPASS_FORCE_CHECK`         | `string` | (internal) Force the updater to check for updates. Used for testing.                                                                                              |
 | `GOPASS_FORCE_UPDATE`        | `bool`   | Set to any non-empty value to force an update (if available)                                                                                                      |

--- a/internal/action/config.go
+++ b/internal/action/config.go
@@ -37,7 +37,7 @@ func (s *Action) Config(c *cli.Context) error {
 
 	// sub-stores need to have been initialized so we can update their local configs.
 	// special case: we can always update the global config. NB: IsInitialized initializes the store if nil.
-	if inited, err := s.Store.IsInitialized(ctx); err != nil || store != "" && !inited {
+	if inited, err := s.Store.IsInitialized(ctx); err != nil || (store != "" && !inited) {
 		return exit.Error(exit.Unknown, err, "Store %s seems uninitialized or cannot be initialized", store)
 	}
 

--- a/internal/action/config.go
+++ b/internal/action/config.go
@@ -34,10 +34,10 @@ func (s *Action) Config(c *cli.Context) error {
 		return exit.Error(exit.Usage, nil, "Usage: %s config key value", s.Name)
 	}
 
-	// need to initialize sub-stores so we can update their configs.
-	// special case: we can always update the root config.
-	if err := s.IsInitialized(c); err != nil && store != "" {
-		return err
+	// sub-stores need to have been initialized so we can update their local configs.
+	// special case: we can always update the global config. NB: IsInitialized initializes the store if nil.
+	if inited, err := s.Store.IsInitialized(ctx); err != nil || store != "" && !inited {
+		return exit.Error(exit.Unknown, err, "Store %s seems uninitialized or cannot be initialized", store)
 	}
 
 	if err := s.setConfigValue(ctx, store, c.Args().Get(0), c.Args().Get(1)); err != nil {

--- a/internal/backend/storage/fs/store.go
+++ b/internal/backend/storage/fs/store.go
@@ -151,7 +151,7 @@ func (s *Store) Exists(ctx context.Context, name string) bool {
 	}
 	path := filepath.Join(s.path, filepath.Clean(name))
 	found := fsutil.IsFile(path)
-	debug.Log("Checking if %s exists at %s: %t", name, path, found)
+	debug.Log("Checking if '%s' exists at %s: %t", name, path, found)
 
 	return found
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -190,7 +190,9 @@ func (c *Config) Set(mount, key, value string) error {
 		return c.root.SetLocal(key, value)
 	}
 
-	if cfg := c.cfgs[mount]; cfg != nil {
+	if cfg, ok := c.cfgs[mount]; !ok {
+		return fmt.Errorf("substore '%s' is not initialized or doesn't exist", mount)
+	} else if cfg != nil {
 		return cfg.SetLocal(key, value)
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -211,7 +211,7 @@ func (c *Config) SetWithLevel(mount, key, value string) (Level, error) {
 	}
 
 	if cfg, ok := c.cfgs[mount]; !ok {
-		return None, fmt.Errorf("substore '%s' is not initialized or doesn't exist", mount)
+		return None, fmt.Errorf("substore %q is not initialized or doesn't exist", mount)
 	} else if cfg != nil {
 		return Local, cfg.SetLocal(key, value)
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,6 +22,18 @@ var (
 	systemConfig = "/etc/gopass/config"
 )
 
+type Level int
+
+const (
+	None Level = iota
+	Env
+	Worktree
+	Local
+	Global
+	System
+	Preset
+)
+
 func newGitconfig() *gitconfig.Configs {
 	c := gitconfig.New()
 	c.EnvPrefix = envPrefix
@@ -182,21 +194,29 @@ func (c *Config) GetInt(key string) int {
 //   - If mount has any other value we will attempt to write the setting to the per-directory config of this mount.
 //   - If the mount point does not exist we will return nil.
 func (c *Config) Set(mount, key, value string) error {
+	_, err := c.SetWithLevel(mount, key, value)
+
+	return err
+}
+
+// SetWithLevel is the same as Set, but it also returns the level at which the config was set.
+// It currently only supports global and local configs.
+func (c *Config) SetWithLevel(mount, key, value string) (Level, error) {
 	if mount == "" {
-		return c.root.SetGlobal(key, value)
+		return Global, c.root.SetGlobal(key, value)
 	}
 
 	if mount == "<root>" {
-		return c.root.SetLocal(key, value)
+		return Local, c.root.SetLocal(key, value)
 	}
 
 	if cfg, ok := c.cfgs[mount]; !ok {
-		return fmt.Errorf("substore '%s' is not initialized or doesn't exist", mount)
+		return None, fmt.Errorf("substore '%s' is not initialized or doesn't exist", mount)
 	} else if cfg != nil {
-		return cfg.SetLocal(key, value)
+		return Local, cfg.SetLocal(key, value)
 	}
 
-	return nil
+	return None, nil
 }
 
 // SetEnv overrides a key in the non-persistent layer.
@@ -219,7 +239,7 @@ func (c *Config) SetPath(path string) error {
 	return c.Set("", "mounts.path", path)
 }
 
-// SetMountPath is a short cut to set a mount to a path.
+// SetMountPath is a shortcut to set a mount to a path.
 func (c *Config) SetMountPath(mount, path string) error {
 	return c.Set("", mpk(mount), path)
 }

--- a/pkg/gitconfig/config.go
+++ b/pkg/gitconfig/config.go
@@ -130,7 +130,7 @@ func (c *Config) Set(key, value string) error {
 }
 
 func (c *Config) insertValue(key, value string) error {
-	debug.Log("input (%s: %s): ---------\n%s\n-----------\n", key, value, c.raw.String())
+	debug.Log("input (%s: %s): \n--------------\n%s\n--------------\n", key, value, strings.Join(strings.Split("- "+c.raw.String(), "\n"), "\n- "))
 
 	wSection, wSubsection, wKey := splitKey(key)
 
@@ -188,7 +188,7 @@ func (c *Config) insertValue(key, value string) error {
 	c.raw.WriteString(strings.Join(lines, "\n"))
 	c.raw.WriteString("\n")
 
-	debug.Log("output: ---------\n%s\n-----------\n", c.raw.String())
+	debug.Log("output: \n--------------\n%s\n--------------\n", strings.Join(strings.Split("+ "+c.raw.String(), "\n"), "\n+ "))
 
 	return c.flushRaw()
 }
@@ -215,7 +215,7 @@ func parseSectionHeader(line string) (section, subsection string, skip bool) { /
 // rewriteRaw is used to rewrite the raw config copy. It is used for set and unset operations
 // with different callbacks each.
 func (c *Config) rewriteRaw(key, value string, cb parseFunc) error {
-	debug.Log("input (%s: %s): ---------\n%s\n-----------\n", key, value, c.raw.String())
+	debug.Log("input (%s: %s): \n--------------\n%s\n--------------\n", key, value, strings.Join(strings.Split("- "+c.raw.String(), "\n"), "\n- "))
 
 	lines := parseConfig(strings.NewReader(c.raw.String()), key, value, cb)
 
@@ -223,7 +223,7 @@ func (c *Config) rewriteRaw(key, value string, cb parseFunc) error {
 	c.raw.WriteString(strings.Join(lines, "\n"))
 	c.raw.WriteString("\n")
 
-	debug.Log("output: ---------\n%s\n-----------\n", c.raw.String())
+	debug.Log("output: \n--------------\n%s\n--------------\n", strings.Join(strings.Split("+ "+c.raw.String(), "\n"), "\n+ "))
 
 	return c.flushRaw()
 }
@@ -239,7 +239,7 @@ func (c *Config) flushRaw() error {
 		return err
 	}
 
-	debug.Log("writing config to %s: -----------\n%s\n--------------", c.path, c.raw.String())
+	debug.Log("writing config to %s: \n--------------\n%s\n--------------", c.path, c.raw.String())
 
 	if err := os.WriteFile(c.path, []byte(c.raw.String()), 0o600); err != nil {
 		return fmt.Errorf("failed to write config to %s: %w", c.path, err)

--- a/pkg/gitconfig/config.go
+++ b/pkg/gitconfig/config.go
@@ -24,6 +24,22 @@ type Config struct {
 	vars     map[string][]string
 }
 
+// IsEmpty returns true if the config is empty (typically a newly initialized config, but still unused).
+// Since gitconfig.New() already sets the global path to the globalConfigFile() one, we cannot rely on
+// the path being set to checki this. We need to check the  raw length to be sure it wasn't just
+// the default empty config struct.
+func (c *Config) IsEmpty() bool {
+	if c == nil || c.vars == nil {
+		return true
+	}
+
+	if c.raw.Len() > 0 {
+		return false
+	}
+
+	return true
+}
+
 // Unset deletes a key.
 func (c *Config) Unset(key string) error {
 	if c.readonly {

--- a/pkg/gitconfig/configs.go
+++ b/pkg/gitconfig/configs.go
@@ -115,7 +115,7 @@ func (cs *Configs) LoadAll(workdir string) *Configs {
 			// set the path just in case we want to modify / write to it later
 			cs.worktree.path = worktreeConfigPath
 		} else {
-			debug.Log("[%s] loaded local config from %s", cs.EnvPrefix, worktreeConfigPath)
+			debug.Log("[%s] loaded worktree config from %s", cs.EnvPrefix, worktreeConfigPath)
 			cs.worktree = c
 		}
 	}
@@ -146,9 +146,7 @@ func (cs *Configs) loadGlobalConfigs() string {
 	}
 
 	// if we already have a global config we can just reload it instead of trying all locations
-	// but since gitconfig.New() already sets the global path to the globalConfigFile() one, we need to check
-	// its raw length to be sure it wasn't just the default empty config struct and was previously loaded
-	if cs.global != nil && cs.global.raw.Len() > 0 {
+	if !cs.global.IsEmpty() {
 		if p := cs.global.path; p != "" {
 			debug.Log("[%s] reloading existing global config from %s", cs.EnvPrefix, p)
 			cfg, err := LoadConfig(p)

--- a/pkg/gitconfig/configs.go
+++ b/pkg/gitconfig/configs.go
@@ -60,7 +60,7 @@ func (cs *Configs) Reload() {
 
 // String implements fmt.Stringer.
 func (cs *Configs) String() string {
-	return fmt.Sprintf("GitConfigs{Env: %s - System: %s - Global: %s - Local: %s - Worktree: %s}", cs.EnvPrefix, cs.SystemConfig, cs.GlobalConfig, cs.LocalConfig, cs.WorktreeConfig)
+	return fmt.Sprintf("GitConfigs{Workdir: %s - Env: %s - System: %s - Global: %s - Local: %s - Worktree: %s}", cs.workdir, cs.EnvPrefix, cs.SystemConfig, cs.GlobalConfig, cs.LocalConfig, cs.WorktreeConfig)
 }
 
 // LoadAll tries to load all known config files. Missing or invalid files are
@@ -69,7 +69,7 @@ func (cs *Configs) String() string {
 func (cs *Configs) LoadAll(workdir string) *Configs {
 	cs.workdir = workdir
 
-	debug.Log("Loading gitconfigs for %s ...", cs)
+	debug.Log("Loading gitconfigs for %s", cs)
 
 	// load the system config, if any
 	if os.Getenv(cs.EnvPrefix+"_NOSYSTEM") == "" {
@@ -145,6 +145,24 @@ func (cs *Configs) loadGlobalConfigs() string {
 		locs = append(locs, filepath.Join(appdir.UserHome(), cs.GlobalConfig))
 	}
 
+	// if we already have a global config we can just reload it instead of trying all locations
+	// but since gitconfig.New() already sets the global path to the globalConfigFile() one, we need to check
+	// its raw length to be sure it wasn't just the default empty config struct and was previously loaded
+	if cs.global != nil && cs.global.raw.Len() > 0 {
+		if p := cs.global.path; p != "" {
+			debug.Log("[%s] reloading existing global config from %s", cs.EnvPrefix, p)
+			cfg, err := LoadConfig(p)
+			if err != nil {
+				debug.Log("[%s] failed to reload global config from %s", cs.EnvPrefix, p)
+			} else {
+				cs.global = cfg
+
+				return p
+			}
+		}
+	}
+
+	debug.Log("[%s] trying to find global configs in %v", cs.EnvPrefix, locs)
 	for _, p := range locs {
 		// GlobalConfig might be set to an empty string to disable it
 		// and instead of the XDG_CONFIG_HOME path only.
@@ -166,7 +184,7 @@ func (cs *Configs) loadGlobalConfigs() string {
 
 	debug.Log("[%s] no global config found", cs.EnvPrefix)
 
-	// set the path in case we want to write to it (create it) later
+	// set the path to the default one in case we want to write to it (create it) later
 	cs.global = &Config{
 		path: globalConfigFile(),
 	}


### PR DESCRIPTION
This PR is doing a few changes to the way we handle the Config action, its logging and also improves a few comments.

This is notably fixing #2673 by properly handling all the different cases for a _local_ vs _global_ config change not necessarily leading to a `git add` and `git commit` in the store.
Sadly, there is no way when using the gitconfig `Set` command to know if the option was written to the global vs local config, and so to do this really nicely we would need to change the signature of the `func (c *Config) Set(mount, key, value string) error` function to include a more explicit return value.
But we can fix the problem by properly handling the different errors than can arise during the Add and Commit phases of the config, which is what this PR does. 

This PR also prevents us from setting the global config while reporting a misleading "No existing configuration found" error.
Previously, upon using `gopass config some.name true` on an uninitialized store, we would get the following:
```
🌟 Welcome to gopass!
⚠ No existing configuration found.
☝ Please run 'gopass setup'
true
``` 
Now we get just the expected `true`, since we do support changing the global config without having a store. When trying to do it on a local config, tho, it will now fail:
- for the root store with:
	``` 
	$ gopass config --store "<root>" some.name true
	
	Error: Store <root> seems uninitialized or cannot be initialized
	```
- on a substore, with:
	``` 
	$ gopass config --store "test" some.name true
	Error: Error setting config value: failed to set config value "some.name": substore 'test' is not initialized or doesn't exist
	``` 