### PR TITLE
Add storage.TryAdd and TryCommit methods

### DIFF
--- a/internal/action/sync.go
+++ b/internal/action/sync.go
@@ -183,9 +183,8 @@ func (s *Action) syncMount(ctx context.Context, mp string) error {
 	}
 
 	out.Printf(ctxno, "\n   "+color.GreenString("%s pull and push ... ", sub.Storage().Name()))
-	err = sub.Storage().Push(ctx, "", "")
 
-	switch {
+	switch err := sub.Storage().Push(ctx, "", ""); {
 	case err == nil:
 		debug.Log("Push succeeded")
 		out.Printf(ctxno, color.GreenString("OK"))

--- a/internal/backend/rcs.go
+++ b/internal/backend/rcs.go
@@ -15,6 +15,10 @@ type rcs interface {
 	Push(ctx context.Context, remote, location string) error
 	Pull(ctx context.Context, remote, location string) error
 
+	TryAdd(ctx context.Context, args ...string) error
+	TryCommit(ctx context.Context, msg string) error
+	TryPush(ctx context.Context, remote, location string) error
+
 	InitConfig(ctx context.Context, name, email string) error
 	AddRemote(ctx context.Context, remote, location string) error
 	RemoveRemote(ctx context.Context, remote string) error

--- a/internal/backend/storage/fossilfs/fossil.go
+++ b/internal/backend/storage/fossilfs/fossil.go
@@ -3,6 +3,7 @@ package fossilfs
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"os/exec"
 	"path/filepath"
@@ -213,7 +214,7 @@ func (f *Fossil) TryAdd(ctx context.Context, files ...string) error {
 	if err == nil {
 		return nil
 	}
-	if err == store.ErrGitNotInit {
+	if errors.Is(err, store.ErrGitNotInit) {
 		debug.Log("Fossil not initialized. Ignoring.")
 
 		return nil
@@ -272,13 +273,13 @@ func (f *Fossil) TryCommit(ctx context.Context, msg string) error {
 	if err == nil {
 		return nil
 	}
-	if err == store.ErrGitNothingToCommit {
+	if errors.Is(err, store.ErrGitNothingToCommit) {
 		debug.Log("Nothing to commit. Ignoring.")
 
 		return nil
 	}
-	if err == store.ErrGitNotInit {
-		debug.Log("Git not initialized. Ignoring.")
+	if errors.Is(err, store.ErrGitNotInit) {
+		debug.Log("Fossil not initialized. Ignoring.")
 
 		return nil
 	}
@@ -335,13 +336,13 @@ func (f *Fossil) TryPush(ctx context.Context, remote, branch string) error {
 		return nil
 	}
 
-	switch err {
-	case store.ErrGitNotInit:
-		debug.Log("Git not initialized. Ignoring.")
+	switch {
+	case errors.Is(err, store.ErrGitNotInit):
+		debug.Log("Fossil not initialized. Ignoring.")
 
 		return nil
-	case store.ErrGitNoRemote:
-		debug.Log("Git has no remote. Ignoring.")
+	case errors.Is(err, store.ErrGitNoRemote):
+		debug.Log("Fossil has no remote. Ignoring.")
 
 		return nil
 	default:

--- a/internal/backend/storage/fs/rcs.go
+++ b/internal/backend/storage/fs/rcs.go
@@ -13,14 +13,29 @@ func (s *Store) Add(ctx context.Context, args ...string) error {
 	return store.ErrGitNotInit
 }
 
+// TryAdd does nothing.
+func (s *Store) TryAdd(ctx context.Context, args ...string) error {
+	return nil
+}
+
 // Commit does nothing.
 func (s *Store) Commit(ctx context.Context, msg string) error {
 	return store.ErrGitNotInit
 }
 
+// TryCommit does nothing.
+func (s *Store) TryCommit(ctx context.Context, msg string) error {
+	return nil
+}
+
 // Push does nothing.
 func (s *Store) Push(ctx context.Context, origin, branch string) error {
 	return store.ErrGitNotInit
+}
+
+// TryPush does nothing.
+func (s *Store) TryPush(ctx context.Context, origin, branch string) error {
+	return nil
 }
 
 // Pull does nothing.

--- a/internal/backend/storage/gitfs/git.go
+++ b/internal/backend/storage/gitfs/git.go
@@ -4,6 +4,7 @@ package gitfs
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"os/exec"
 	"path/filepath"
@@ -239,7 +240,7 @@ func (g *Git) TryAdd(ctx context.Context, files ...string) error {
 	if err == nil {
 		return nil
 	}
-	if err == store.ErrGitNotInit {
+	if errors.Is(err, store.ErrGitNotInit) {
 		debug.Log("Git not initialized. Ignoring.")
 
 		return nil
@@ -293,12 +294,12 @@ func (g *Git) TryCommit(ctx context.Context, msg string) error {
 	if err == nil {
 		return nil
 	}
-	if err == store.ErrGitNothingToCommit {
+	if errors.Is(err, store.ErrGitNothingToCommit) {
 		debug.Log("Nothing to commit. Ignoring.")
 
 		return nil
 	}
-	if err == store.ErrGitNotInit {
+	if errors.Is(err, store.ErrGitNotInit) {
 		debug.Log("Git not initialized. Ignoring.")
 
 		return nil
@@ -392,12 +393,12 @@ func (g *Git) TryPush(ctx context.Context, remote, branch string) error {
 		return nil
 	}
 
-	switch err {
-	case store.ErrGitNotInit:
+	switch {
+	case errors.Is(err, store.ErrGitNotInit):
 		debug.Log("Git not initialized. Ignoring.")
 
 		return nil
-	case store.ErrGitNoRemote:
+	case errors.Is(err, store.ErrGitNoRemote):
 		debug.Log("Git has no remote. Ignoring.")
 
 		return nil

--- a/internal/backend/storage/gitfs/git.go
+++ b/internal/backend/storage/gitfs/git.go
@@ -233,6 +233,21 @@ func (g *Git) Add(ctx context.Context, files ...string) error {
 	return g.Cmd(ctx, "gitAdd", args...)
 }
 
+// TryAdd calls Add and returns nil if the git repo was not initialized.
+func (g *Git) TryAdd(ctx context.Context, files ...string) error {
+	err := g.Add(ctx, files...)
+	if err == nil {
+		return nil
+	}
+	if err == store.ErrGitNotInit {
+		debug.Log("Git not initialized. Ignoring.")
+
+		return nil
+	}
+
+	return err
+}
+
 // HasStagedChanges returns true if there are any staged changes which can be committed.
 func (g *Git) HasStagedChanges(ctx context.Context) bool {
 	if err := g.Cmd(ctx, "gitDiffIndex", "diff-index", "--quiet", "HEAD"); err != nil {
@@ -270,6 +285,26 @@ func (g *Git) Commit(ctx context.Context, msg string) error {
 	}
 
 	return g.Cmd(ctx, "gitCommit", "commit", fmt.Sprintf("--date=%d +00:00", ctxutil.GetCommitTimestamp(ctx).UTC().Unix()), "-m", msg)
+}
+
+// TryCommit calls commit and returns nil if there was nothing to commit or if the git repo was not initialized.
+func (g *Git) TryCommit(ctx context.Context, msg string) error {
+	err := g.Commit(ctx, msg)
+	if err == nil {
+		return nil
+	}
+	if err == store.ErrGitNothingToCommit {
+		debug.Log("Nothing to commit. Ignoring.")
+
+		return nil
+	}
+	if err == store.ErrGitNotInit {
+		debug.Log("Git not initialized. Ignoring.")
+
+		return nil
+	}
+
+	return err
 }
 
 func (g *Git) defaultRemote(ctx context.Context, branch string) string {
@@ -348,6 +383,27 @@ func (g *Git) PushPull(ctx context.Context, op, remote, branch string) error {
 	}
 
 	return g.Cmd(ctx, "gitPush", "push", remote, branch)
+}
+
+// TryPush calls Push and returns nil if the git repo was not initialized.
+func (g *Git) TryPush(ctx context.Context, remote, branch string) error {
+	err := g.Push(ctx, remote, branch)
+	if err == nil {
+		return nil
+	}
+
+	switch err {
+	case store.ErrGitNotInit:
+		debug.Log("Git not initialized. Ignoring.")
+
+		return nil
+	case store.ErrGitNoRemote:
+		debug.Log("Git has no remote. Ignoring.")
+
+		return nil
+	default:
+		return err
+	}
 }
 
 // Push pushes to the git remote.

--- a/internal/create/templates.go
+++ b/internal/create/templates.go
@@ -63,8 +63,8 @@ attributes:
 
 type storageSetter interface {
 	Set(context.Context, string, []byte) error
-	Add(context.Context, ...string) error
-	Commit(context.Context, string) error
+	TryAdd(context.Context, ...string) error
+	TryCommit(context.Context, string) error
 }
 
 func (w *Wizard) writeTemplates(ctx context.Context, s storageSetter) error {
@@ -86,14 +86,14 @@ func (w *Wizard) writeTemplates(ctx context.Context, s storageSetter) error {
 			return fmt.Errorf("failed to write default template %s: %w", path, err)
 		}
 
-		if err := s.Add(ctx, path); err != nil && !errors.Is(err, store.ErrGitNotInit) {
+		if err := s.TryAdd(ctx, path); err != nil {
 			return fmt.Errorf("failed to stage changes %s: %w", path, err)
 		}
 
 		debug.Log("wrote default template to %s", path)
 	}
 
-	if err := s.Commit(ctx, "Added default wizard templates"); err != nil && !errors.Is(err, store.ErrGitNotInit) {
+	if err := s.TryCommit(ctx, "Added default wizard templates"); err != nil {
 		return fmt.Errorf("failed to commit changes: %w", err)
 	}
 

--- a/internal/create/wizard_test.go
+++ b/internal/create/wizard_test.go
@@ -19,7 +19,15 @@ func (f *fakeSetter) Add(ctx context.Context, args ...string) error {
 	return nil
 }
 
+func (f *fakeSetter) TryAdd(ctx context.Context, args ...string) error {
+	return nil
+}
+
 func (f *fakeSetter) Commit(ctx context.Context, msg string) error {
+	return nil
+}
+
+func (f *fakeSetter) TryCommit(ctx context.Context, msg string) error {
 	return nil
 }
 

--- a/internal/store/leaf/fsck.go
+++ b/internal/store/leaf/fsck.go
@@ -205,15 +205,8 @@ func (s *Store) fsckLoop(ctx context.Context, path string) error {
 		out.Warningf(ctx, "Nothing to commit: all secrets up to date")
 	}
 
-	if err := s.storage.Commit(ctx, ctxutil.GetCommitMessageFull(ctx)); err != nil {
-		switch {
-		case errors.Is(err, store.ErrGitNotInit):
-			out.Warning(ctx, "Cannot commit: git not initialized\nplease run `gopass git init` (and note that manual intervention might be needed)")
-		case errors.Is(err, store.ErrGitNothingToCommit):
-			debug.Log("commitAndPush - skipping git commit - nothing to commit")
-		default:
-			return fmt.Errorf("failed to commit changes to git: %w", err)
-		}
+	if err := s.storage.TryCommit(ctx, ctxutil.GetCommitMessageFull(ctx)); err != nil {
+		return fmt.Errorf("failed to commit changes to git: %w", err)
 	}
 
 	return nil

--- a/internal/store/leaf/reencrypt.go
+++ b/internal/store/leaf/reencrypt.go
@@ -100,13 +100,7 @@ func (s *Store) reencrypt(ctx context.Context) error {
 	if conc > 1 {
 		for _, name := range entries {
 			p := s.Passfile(name)
-			if err := s.storage.Add(ctx, p); err != nil {
-				if errors.Is(err, store.ErrGitNotInit) {
-					debug.Log("skipping git add - git not initialized")
-
-					continue
-				}
-
+			if err := s.storage.TryAdd(ctx, p); err != nil {
 				return fmt.Errorf("failed to add %q to git: %w", p, err)
 			}
 
@@ -114,15 +108,8 @@ func (s *Store) reencrypt(ctx context.Context) error {
 		}
 	}
 
-	if err := s.storage.Commit(ctx, ctxutil.GetCommitMessage(ctx)); err != nil {
-		switch {
-		case errors.Is(err, store.ErrGitNotInit):
-			debug.Log("skipping git commit - git not initialized")
-		case errors.Is(err, store.ErrGitNothingToCommit):
-			debug.Log("skipping git commit - nothing to commit")
-		default:
-			return fmt.Errorf("failed to commit changes to git: %w", err)
-		}
+	if err := s.storage.TryCommit(ctx, ctxutil.GetCommitMessage(ctx)); err != nil {
+		return fmt.Errorf("failed to commit changes to git: %w", err)
 	}
 
 	return s.reencryptGitPush(ctx)
@@ -135,23 +122,7 @@ func (s *Store) reencryptGitPush(ctx context.Context) error {
 		return nil
 	}
 
-	if err := s.storage.Push(ctx, "", ""); err != nil {
-		if errors.Is(err, store.ErrGitNotInit) {
-			msg := "Warning: git is not initialized for this.storage. Ignoring auto-push option\n" +
-				"Run: gopass git init"
-			debug.Log(msg)
-
-			return nil
-		}
-
-		if errors.Is(err, store.ErrGitNoRemote) {
-			msg := "Warning: git has no remote. Ignoring auto-push option\n" +
-				"Run: gopass git remote add origin ..."
-			debug.Log(msg)
-
-			return nil
-		}
-
+	if err := s.storage.TryPush(ctx, "", ""); err != nil {
 		return fmt.Errorf("failed to push change to git remote: %w", err)
 	}
 

--- a/internal/store/leaf/templates.go
+++ b/internal/store/leaf/templates.go
@@ -123,11 +123,7 @@ func (s *Store) SetTemplate(ctx context.Context, name string, content []byte) er
 		return fmt.Errorf("failed to write template: %w", err)
 	}
 
-	if err := s.storage.Add(ctx, p); err != nil {
-		if errors.Is(err, store.ErrGitNotInit) {
-			return nil
-		}
-
+	if err := s.storage.TryAdd(ctx, p); err != nil {
 		return fmt.Errorf("failed to add %q to git: %w", p, err)
 	}
 

--- a/internal/store/leaf/write.go
+++ b/internal/store/leaf/write.go
@@ -2,12 +2,10 @@ package leaf
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/gopasspw/gopass/internal/config"
-	"github.com/gopasspw/gopass/internal/out"
 	"github.com/gopasspw/gopass/internal/queue"
 	"github.com/gopasspw/gopass/internal/store"
 	"github.com/gopasspw/gopass/pkg/ctxutil"
@@ -55,11 +53,7 @@ func (s *Store) Set(ctx context.Context, name string, sec gopass.Byter) error {
 		return nil
 	}
 
-	if err := s.storage.Add(ctx, p); err != nil {
-		if errors.Is(err, store.ErrGitNotInit) {
-			return nil
-		}
-
+	if err := s.storage.TryAdd(ctx, p); err != nil {
 		return fmt.Errorf("failed to add %q to git: %w", p, err)
 	}
 
@@ -79,15 +73,8 @@ func (s *Store) Set(ctx context.Context, name string, sec gopass.Byter) error {
 }
 
 func (s *Store) gitCommitAndPush(ctx context.Context, name string) error {
-	if err := s.storage.Commit(ctx, fmt.Sprintf("Save secret to %s: %s", name, ctxutil.GetCommitMessage(ctx))); err != nil {
-		switch {
-		case errors.Is(err, store.ErrGitNotInit):
-			debug.Log("commitAndPush - skipping git commit - git not initialized")
-		case errors.Is(err, store.ErrGitNothingToCommit):
-			debug.Log("commitAndPush - skipping git commit - nothing to commit")
-		default:
-			return fmt.Errorf("failed to commit changes to git: %w", err)
-		}
+	if err := s.storage.TryCommit(ctx, fmt.Sprintf("Save secret to %s: %s", name, ctxutil.GetCommitMessage(ctx))); err != nil {
+		return fmt.Errorf("failed to commit changes to git: %w", err)
 	}
 
 	if !config.Bool(ctx, "core.autopush") {
@@ -98,23 +85,7 @@ func (s *Store) gitCommitAndPush(ctx context.Context, name string) error {
 
 	debug.Log("pushing to remote ...")
 
-	if err := s.storage.Push(ctx, "", ""); err != nil {
-		if errors.Is(err, store.ErrGitNotInit) {
-			msg := "Warning: git is not initialized for this.storage. Ignoring auto-push option\n" +
-				"Run: gopass git init"
-			out.Errorf(ctx, msg)
-
-			return nil
-		}
-
-		if errors.Is(err, store.ErrGitNoRemote) {
-			msg := "Warning: git has no remote. Ignoring auto-push option\n" +
-				"Run: gopass git remote add origin ..."
-			debug.Log(msg)
-
-			return nil
-		}
-
+	if err := s.storage.TryPush(ctx, "", ""); err != nil {
 		return fmt.Errorf("failed to push to git remote: %w", err)
 	}
 

--- a/internal/store/mockstore/inmem/store.go
+++ b/internal/store/mockstore/inmem/store.go
@@ -152,13 +152,28 @@ func (m *InMem) Add(ctx context.Context, args ...string) error {
 	return nil
 }
 
+// TryAdd does nothing.
+func (m *InMem) TryAdd(ctx context.Context, args ...string) error {
+	return nil
+}
+
 // Commit does nothing.
 func (m *InMem) Commit(ctx context.Context, msg string) error {
 	return nil
 }
 
+// TryCommit does nothing.
+func (m *InMem) TryCommit(ctx context.Context, msg string) error {
+	return nil
+}
+
 // Push does nothing.
 func (m *InMem) Push(ctx context.Context, origin, branch string) error {
+	return nil
+}
+
+// TryPush does nothing.
+func (m *InMem) TryPush(ctx context.Context, origin, branch string) error {
 	return nil
 }
 


### PR DESCRIPTION
This PR adds new Try methods to the RCS backends. Each of the new methods will attempt to Add, Commit or Push but ignore any non-critical errors.

This simplifies the call sites since they no longer have to have lenghty error handling.