### PR TITLE
upgrade to ergochat/readline@v0.1.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/caspr-io/yamlpath v0.0.0-20200722075116-502e8d113a9b
 	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/dustin/go-humanize v1.0.1
-	github.com/ergochat/readline v0.0.6
+	github.com/ergochat/readline v0.1.0
 	github.com/fatih/color v1.16.0
 	github.com/godbus/dbus v0.0.0-20190623212516-8a1682060722
 	github.com/gokyle/twofactor v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -40,8 +40,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
-github.com/ergochat/readline v0.0.6 h1:tzs8UNseob/yqphZt0GTgC07JUnQNJSFhLWAnwvd2sg=
-github.com/ergochat/readline v0.0.6/go.mod h1:8RNv74chpO0eTm6rdD1H6WZGihL5rJ+RfSlhv4fIfjg=
+github.com/ergochat/readline v0.1.0 h1:KEIiAnyH9qGZB4K8oq5mgDcExlEKwmZDcyyocgJiABc=
+github.com/ergochat/readline v0.1.0/go.mod h1:o3ux9QLHLm77bq7hDB21UTm6HlV2++IPDMfIfKDuOgY=
 github.com/fatih/color v1.16.0 h1:zmkK9Ngbjj+K0yRhTVONQh1p/HknKYSlNT+vZCzyokM=
 github.com/fatih/color v1.16.0/go.mod h1:fL2Sau1YI5c0pdGEVCbKQbLXB6edEj1ZgiY4NijnWvE=
 github.com/frankban/quicktest v1.14.4 h1:g2rn0vABPOOXmZUj+vbmUp0lPoXEMuhTpIluN0XL9UY=

--- a/internal/action/repl.go
+++ b/internal/action/repl.go
@@ -13,8 +13,8 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-func (s *Action) entriesForCompleter(ctx context.Context) ([]readline.PrefixCompleterInterface, error) {
-	args := []readline.PrefixCompleterInterface{}
+func (s *Action) entriesForCompleter(ctx context.Context) ([]*readline.PrefixCompleter, error) {
+	args := []*readline.PrefixCompleter{}
 	list, err := s.Store.List(ctx, tree.INF)
 	if err != nil {
 		return args, err
@@ -26,14 +26,14 @@ func (s *Action) entriesForCompleter(ctx context.Context) ([]readline.PrefixComp
 	return args, nil
 }
 
-func (s *Action) replCompleteRecipients(ctx context.Context, cmd *cli.Command) []readline.PrefixCompleterInterface {
-	subCmds := []readline.PrefixCompleterInterface{}
+func (s *Action) replCompleteRecipients(ctx context.Context, cmd *cli.Command) []*readline.PrefixCompleter {
+	subCmds := []*readline.PrefixCompleter{}
 	if cmd.Name == "remove" {
 		for _, r := range s.recipientsList(ctx) {
 			subCmds = append(subCmds, readline.PcItem(r))
 		}
 	}
-	args := []readline.PrefixCompleterInterface{}
+	args := []*readline.PrefixCompleter{}
 	args = append(args, readline.PcItem(cmd.Name, subCmds...))
 	for _, alias := range cmd.Aliases {
 		args = append(args, readline.PcItem(alias, subCmds...))
@@ -42,12 +42,12 @@ func (s *Action) replCompleteRecipients(ctx context.Context, cmd *cli.Command) [
 	return args
 }
 
-func (s *Action) replCompleteTemplates(ctx context.Context, cmd *cli.Command) []readline.PrefixCompleterInterface {
-	subCmds := []readline.PrefixCompleterInterface{}
+func (s *Action) replCompleteTemplates(ctx context.Context, cmd *cli.Command) []*readline.PrefixCompleter {
+	subCmds := []*readline.PrefixCompleter{}
 	for _, r := range s.templatesList(ctx) {
 		subCmds = append(subCmds, readline.PcItem(r))
 	}
-	args := []readline.PrefixCompleterInterface{}
+	args := []*readline.PrefixCompleter{}
 	args = append(args, readline.PcItem(cmd.Name, subCmds...))
 	for _, alias := range cmd.Aliases {
 		args = append(args, readline.PcItem(alias, subCmds...))
@@ -61,12 +61,12 @@ func (s *Action) prefixCompleter(c *cli.Context) *readline.PrefixCompleter {
 	if err != nil {
 		debug.Log("failed to list secrets: %s", err)
 	}
-	cmds := []readline.PrefixCompleterInterface{}
+	cmds := []*readline.PrefixCompleter{}
 	for _, cmd := range c.App.Commands {
 		if cmd.Hidden {
 			continue
 		}
-		subCmds := []readline.PrefixCompleterInterface{}
+		subCmds := []*readline.PrefixCompleter{}
 		switch cmd.Name {
 		case "config":
 			for _, k := range s.configKeys() {


### PR DESCRIPTION
I just tagged https://github.com/ergochat/readline/releases/tag/v0.1.0 which has a minor API break. Here's the changelog:

https://github.com/ergochat/readline/blob/a16c9c0b4a38ce80181b7e716074be2532b94493/docs/CHANGELOG.md

Thanks for your patience! Going forward from here, I don't anticipate any more API breaks that would affect gopass :-)