### PR TITLE
[BUGFIX] Use 'en' as default language for the xkcd generator

### DIFF
--- a/internal/action/config_test.go
+++ b/internal/action/config_test.go
@@ -46,7 +46,8 @@ core.nopager = true
 core.notifications = true
 generate.autoclip = true
 `
-		want += "mounts.path = " + u.StoreDir("") + "\n"
+		want += "mounts.path = " + u.StoreDir("") + "\n" +
+			"pwgen.xkcd-lang = en\n"
 		assert.Equal(t, want, buf.String())
 	})
 
@@ -87,8 +88,10 @@ core.nopager = true
 core.notifications = true
 generate.autoclip = true
 `
-		want += "mounts.path = " + u.StoreDir("")
-		assert.Equal(t, want, strings.TrimSpace(buf.String()), "action.printConfigValues")
+		want += "mounts.path = " + u.StoreDir("") + "\n" +
+			"pwgen.xkcd-lang = en\n"
+
+		assert.Equal(t, want, buf.String(), "action.printConfigValues")
 	})
 
 	t.Run("show autoimport value", func(t *testing.T) {
@@ -120,6 +123,7 @@ core.nopager
 core.notifications
 generate.autoclip
 mounts.path
+pwgen.xkcd-lang
 `
 		assert.Equal(t, want, buf.String())
 	})

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -49,6 +49,7 @@ var defaults = map[string]string{
 	"core.cliptimeout":   "45",
 	"core.exportkeys":    "true",
 	"core.notifications": "true",
+	"pwgen.xkcd-lang":    "en",
 }
 
 // Config is a gopass config handler.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -31,7 +31,13 @@ func TestConfig(t *testing.T) {
 	require.NoError(t, cfg.SetEnv("env.string", "foo"))
 	assert.Equal(t, "foo", cfg.Get("env.string"))
 
-	assert.Equal(t, []string{"core.autopush", "core.autosync", "core.bool", "core.cliptimeout", "core.exportkeys", "core.int", "core.notifications", "core.string", "env.string", "mounts.path"}, cfg.Keys(""))
+	// test default values
+	assert.Equal(t, []string{"core.autopush", "core.autosync", "core.bool", "core.cliptimeout", "core.exportkeys", "core.int", "core.notifications", "core.string", "env.string", "mounts.path", "pwgen.xkcd-lang"}, cfg.Keys(""))
+	for key, expected := range defaults {
+		assert.Equal(t, expected, cfg.Get(key))
+	}
+	require.NoError(t, cfg.Set("", "pwgen.xkcd-lang", "de"))
+	assert.Equal(t, "de", cfg.Get("pwgen.xkcd-lang"))
 
 	ctx := cfg.WithConfig(context.Background())
 	assert.True(t, Bool(ctx, "core.bool"))
@@ -39,8 +45,8 @@ func TestConfig(t *testing.T) {
 	assert.Equal(t, 42, Int(ctx, "core.int"))
 
 	require.NoError(t, cfg.SetEnv("generate.length", "16"))
-	actual_length, _ := DefaultPasswordLengthFromEnv(ctx)
-	assert.Equal(t, 16, actual_length)
+	actualLength, _ := DefaultPasswordLengthFromEnv(ctx)
+	assert.Equal(t, 16, actualLength)
 }
 
 func TestEnvConfig(t *testing.T) {

--- a/tests/config_test.go
+++ b/tests/config_test.go
@@ -21,7 +21,8 @@ core.cliptimeout = 45
 core.exportkeys = false
 core.notifications = true
 `
-	wanted += "mounts.path = " + ts.storeDir("root")
+	wanted += "mounts.path = " + ts.storeDir("root") + "\n" +
+		"pwgen.xkcd-lang = en"
 
 	assert.Equal(t, wanted, out)
 
@@ -74,6 +75,7 @@ core.notifications = true
 `
 	wanted += "mounts.mnt/m1.path = " + ts.storeDir("m1") + "\n"
 	wanted += "mounts.path = " + ts.storeDir("root") + "\n"
+	wanted += "pwgen.xkcd-lang = en\n"
 	wanted += "recipients.mnt/m1.hash = 9a4c4b1e0eb9ade2e692ff948f43d9668145eca3df88ffff67e0e21426252907\n"
 
 	out, err := ts.run("config")


### PR DESCRIPTION
This adds the xkcd language as a default.

Fixes #2792

Speaking of default config options: should we have explicit default values for all supported config options, so that users who run `gopass config` would see all possible config options?