### PR TITLE
Initial support of FIDO2 credential creation

### DIFF
--- a/pkg/passkey/passkey.go
+++ b/pkg/passkey/passkey.go
@@ -1,0 +1,127 @@
+// Package passkey implements the support of Webauthn credentials for authentication.
+// It is based on the W3C's "Web Authentication: An API for accessing Public Key Credentials"
+// https://www.w3.org/TR/webauthn-2/
+package passkey
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+)
+
+// Flags for the credential parameters: https://www.w3.org/TR/webauthn-2/#flags
+type CredentialFlags struct {
+	UserPresent     bool
+	UserVerified    bool
+	AttestationData bool
+	ExtensionData   bool
+}
+
+// Structure to store information and key of public key credential.
+type Credential struct {
+	Id        string
+	Rp        string
+	UserName  string
+	Algorithm string
+	SecretKey *ecdsa.PrivateKey
+	Counter   uint32
+	Flags     CredentialFlags
+}
+
+// Client data for signature: https://www.w3.org/TR/webauthn-1/#sec-client-data
+type ClientData struct {
+	Challenge string `json:"challenge"`
+	Origin    string `json:"origin"`
+	CredType  string `json:"type"`
+}
+
+// Response from a GetAssertion: https://www.w3.org/TR/webauthn-1/#authenticatorGetAssertion-return-values
+type Response struct {
+	AuthenticatorData []byte `json:"authdata"`
+	ClientDataJSON    []byte `json:"client_data_json"`
+	Signature         []byte `json:"signature"`
+	Login             string `json:"login"`
+}
+
+func authDataFlags(options CredentialFlags) uint8 {
+	flags := uint8(0)
+
+	if options.ExtensionData {
+		flags |= 0b10000000
+	}
+
+	if options.AttestationData {
+		flags |= 0b01000000
+	}
+
+	if options.UserVerified {
+		flags |= 0b00000100
+	}
+
+	if options.UserPresent {
+		flags |= 0b00000001
+	}
+
+	return flags
+}
+
+// Implementation of the authenticatorMakeCredential Operation: https://www.w3.org/TR/webauthn-2/#sctn-op-make-cred
+func CreateCredential(rp string, user string, flags CredentialFlags) (*Credential, error) {
+	rawId := make([]byte, 32)
+	_, err := rand.Read(rawId)
+	if err != nil {
+		return nil, fmt.Errorf("error while generating random ID: %w", err)
+	}
+	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+
+	return &Credential{
+		Id:        base64.RawURLEncoding.EncodeToString(rawId),
+		Rp:        rp,
+		UserName:  user,
+		Algorithm: "ECDSA",
+		SecretKey: privateKey,
+		Counter:   0,
+		Flags:     flags,
+	}, nil
+}
+
+// Implementation of the authenticatorGetAssertion Operation: https://www.w3.org/TR/webauthn-2/#authenticatorgetassertion
+func (cred *Credential) GetAssertion(challenge string, origin string) (*Response, error) {
+	credType := "webauthn.get"
+	clientData := ClientData{
+		CredType:  credType,
+		Challenge: challenge,
+		Origin:    origin,
+	}
+	clientDataJSON, err := json.Marshal(clientData)
+	if err != nil {
+		return nil, fmt.Errorf("error while reading client data: %w", err)
+	}
+	clientDataHash := sha256.Sum256(clientDataJSON)
+	rpIdHash := sha256.Sum256([]byte(cred.Rp))
+	flags := []byte{authDataFlags(cred.Flags)}
+
+	// Signature counter is incremented according to https://www.w3.org/TR/webauthn-2/#signature-counter
+	cred.Counter += 1
+	signCount := make([]byte, 4)
+	binary.BigEndian.PutUint32(signCount, cred.Counter)
+	authData := append(rpIdHash[:], flags...)
+	authData = append(authData[:], signCount[:]...)
+	message := sha256.Sum256(append(authData[:], clientDataHash[:]...))
+	signature, serr := ecdsa.SignASN1(rand.Reader, cred.SecretKey, message[:])
+	if err != nil {
+		return nil, serr
+	}
+
+	return &Response{
+		AuthenticatorData: authData,
+		ClientDataJSON:    clientDataJSON,
+		Signature:         signature,
+		Login:             cred.UserName,
+	}, nil
+}

--- a/pkg/passkey/passkey_test.go
+++ b/pkg/passkey/passkey_test.go
@@ -1,0 +1,43 @@
+package passkey_test
+
+import (
+	"crypto/ecdsa"
+	"crypto/sha256"
+	"encoding/base64"
+	"testing"
+
+	"github.com/gopasspw/gopass/pkg/passkey"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var flags passkey.CredentialFlags = passkey.CredentialFlags{
+	UserPresent:     true,
+	UserVerified:    true,
+	AttestationData: false,
+	ExtensionData:   false,
+}
+
+func TestCreate(t *testing.T) {
+	cred, err := passkey.CreateCredential("test.com", "user", flags)
+	require.NoError(t, err)
+	assert.Equal(t, "test.com", cred.Rp)
+	assert.Equal(t, uint32(0), cred.Counter)
+}
+
+func TestGetAssertion(t *testing.T) {
+	cred, err := passkey.CreateCredential("test.com", "user", flags)
+	require.NoError(t, err)
+
+	rsp, err := cred.GetAssertion(base64.RawURLEncoding.EncodeToString([]byte("test_challenge")), "test")
+	require.NoError(t, err)
+
+	// Verify signature
+	clientDataHash := sha256.Sum256(rsp.ClientDataJSON)
+
+	authData := rsp.AuthenticatorData
+	require.NoError(t, err)
+
+	message := sha256.Sum256(append(authData[:], clientDataHash[:]...))
+	assert.True(t, ecdsa.VerifyASN1(&cred.SecretKey.PublicKey, message[:], rsp.Signature))
+}


### PR DESCRIPTION
Initial incomplete support of passkeys. The goal is to use the passkey package in [gopass-jsonapi](https://github.com/gopasspw/gopass-jsonapi).