### PR TITLE
[feat] Allow supression of password generation in create templates

### DIFF
--- a/docs/commands/create.md
+++ b/docs/commands/create.md
@@ -46,8 +46,10 @@ attributes:
     prompt: "User"
     min: 1
   - name: "password"
-    type: "password"
+    type: "password" # hide input
     prompt: "Password"
+    always_prompt: true # do not offer password generation, always ask
+    charset: abcdefghijklmnop # generate password with this charset
   - name: "comment"
     type: "string"
     prompt: "Comments"

--- a/internal/create/wizard.go
+++ b/internal/create/wizard.go
@@ -34,12 +34,13 @@ const (
 // Attribute is a credential attribute that is being asked for
 // when populating a template.
 type Attribute struct {
-	Name    string `yaml:"name"`
-	Type    string `yaml:"type"`
-	Prompt  string `yaml:"prompt"`
-	Charset string `yaml:"charset"`
-	Min     int    `yaml:"min"`
-	Max     int    `yaml:"max"`
+	Name         string `yaml:"name"`
+	Type         string `yaml:"type"`
+	Prompt       string `yaml:"prompt"`
+	Charset      string `yaml:"charset"`
+	Min          int    `yaml:"min"`
+	Max          int    `yaml:"max"`
+	AlwaysPrompt bool   `yaml:"always_prompt"` // always prompt for the crendentials
 }
 
 // Template is an action template for the create wizard.
@@ -225,9 +226,11 @@ func mkActFunc(tpl Template, s *root.Store, cb ActionCallback) func(context.Cont
 				_ = sec.Set(k, sv)
 			case "password":
 				var err error
-				genPw, err = termio.AskForBool(ctx, fmtfn(2, strconv.Itoa(step), "Generate Password?"), true)
-				if err != nil {
-					return err
+				if !v.AlwaysPrompt {
+					genPw, err = termio.AskForBool(ctx, fmtfn(2, strconv.Itoa(step), "Generate Password?"), true)
+					if err != nil {
+						return err
+					}
 				}
 
 				if genPw { //nolint:nestif

--- a/internal/create/wizard_test.go
+++ b/internal/create/wizard_test.go
@@ -69,6 +69,7 @@ attributes:
     charset: "0123456789"
     min: 1
     max: 64
+    always_prompt: true
   - name: "comment"
     type: "string"
 `))
@@ -88,6 +89,7 @@ attributes:
 	assert.Equal(t, "Entity", w.Templates[0].Attributes[1].Prompt, "wrong prompt")
 	assert.Equal(t, 1, w.Templates[0].Attributes[1].Min, "wrong min")
 	assert.Equal(t, "password", w.Templates[0].Attributes[2].Type, "wrong type")
+	assert.Equal(t, true, w.Templates[0].Attributes[2].AlwaysPrompt, "wrong always_prompt")
 }
 
 func TestExtractHostname(t *testing.T) {

--- a/internal/create/wizard_test.go
+++ b/internal/create/wizard_test.go
@@ -89,7 +89,7 @@ attributes:
 	assert.Equal(t, "Entity", w.Templates[0].Attributes[1].Prompt, "wrong prompt")
 	assert.Equal(t, 1, w.Templates[0].Attributes[1].Min, "wrong min")
 	assert.Equal(t, "password", w.Templates[0].Attributes[2].Type, "wrong type")
-	assert.Equal(t, true, w.Templates[0].Attributes[2].AlwaysPrompt, "wrong always_prompt")
+	assert.True(t, w.Templates[0].Attributes[2].AlwaysPrompt, "wrong always_prompt")
 }
 
 func TestExtractHostname(t *testing.T) {

--- a/tests/audit_test.go
+++ b/tests/audit_test.go
@@ -17,7 +17,6 @@ func TestAudit(t *testing.T) {
 	t.Run("audit the test store", func(t *testing.T) {
 		out, err := ts.run("audit")
 		require.Error(t, err)
-		assert.Contains(t, out, "Password is too short")
 		assert.Contains(t, out, "weak password")
 	})
 }


### PR DESCRIPTION
This PR adds a new always_prompt boolean that allows suppressing the question that ask for generating a password in create templates. Use this if you always want to force entering the credentials, e.g. if you use a specific template for vendor-supplied credentials.

Fixes #2819