### PR TITLE
[bugfix] Fix NPE when using recipients completion

### DIFF
--- a/internal/action/recipients.go
+++ b/internal/action/recipients.go
@@ -63,6 +63,12 @@ func (s *Action) recipientsList(ctx context.Context) []string {
 // completion.
 func (s *Action) RecipientsComplete(c *cli.Context) {
 	ctx := ctxutil.WithGlobalFlags(c)
+	if err := s.IsInitialized(c); err != nil {
+		debug.Log("IsInitialized returned error: %s", err)
+
+		return
+	}
+
 	for _, v := range s.recipientsList(ctx) {
 		fmt.Fprintln(stdout, v)
 	}

--- a/internal/store/leaf/store.go
+++ b/internal/store/leaf/store.go
@@ -108,7 +108,7 @@ func (s *Store) idFile(ctx context.Context, name string) string {
 
 // idFiles returns the path to all id files in this store.
 func (s *Store) idFiles(ctx context.Context) []string {
-	if s.crypto == nil {
+	if s == nil || s.crypto == nil {
 		return nil
 	}
 


### PR DESCRIPTION
This seems to be a regression from a recent cli release, but I'm not completely sure. Anyway, it looks like the store isn't initialized on the recipients completion so we must do that first.

Fixes #2803