### PR TITLE
[bugfix] Use Go 1.22.0 instead of Go 1.22 to fix CodeQL

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gopasspw/gopass
 
-go 1.22
+go 1.22.0
 
 require (
 	filippo.io/age v1.1.1


### PR DESCRIPTION
See: github/codeql#15647 (comment)