### PR TITLE
[chore] use the same version of golangci-lint

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -43,5 +43,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@3cfe3a4abbb849e10058ce4af15d205b6da42804 # v4.0.0
         with:
-          version: v1.56.1 # we have a list of linters in our .golangci.yml config file
+          version: v1.57.1 # we have a list of linters in our .golangci.yml config file
           only-new-issues: true


### PR DESCRIPTION
There are 2 different version of golangci-lint used inside the project, which lead to CI failure: https://github.com/gopasspw/gopass/actions/runs/8425200501/job/23070742289


https://github.com/gopasspw/gopass/blob/b8f0ff8ff2570963b534d70961919d638c6a763b/Makefile#L136

https://github.com/gopasspw/gopass/blob/b8f0ff8ff2570963b534d70961919d638c6a763b/.github/workflows/golangci-lint.yml#L46
