### PR TITLE
[bugfix] Do not report findings with severity none in audit summary

### DIFF
--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -219,6 +219,8 @@ func (a *Auditor) auditSecret(ctx context.Context, secret string) {
 
 	// do not check empty secrets.
 	if sec.Password() == "" {
+		debug.Log("Skipping empty secret %s", secret)
+
 		return
 	}
 

--- a/internal/audit/report.go
+++ b/internal/audit/report.go
@@ -127,6 +127,11 @@ func (r *ReportBuilder) AddFinding(secret, finding, message, severity string) {
 	s.Findings[finding] = f
 	r.secrets[secret] = s
 
+	debug.Log("Secret %q has finding %q: %s with severity %s", secret, finding, message, severity)
+	if severity == "none" {
+		return
+	}
+
 	// record secrets per finding, for the summary
 	ss := r.findings[finding]
 	ss.Add(secret)


### PR DESCRIPTION
We were accidentially also reporting findings with a severity of none as a finding in the summary. Since we report a none finding for every secret that doesn't have a real finding this made us report all secrets.

Fixes #2835