### PR TITLE
[fix] Pass remote, if given, to local init as well

### DIFF
--- a/internal/action/commands.go
+++ b/internal/action/commands.go
@@ -1033,7 +1033,7 @@ func (s *Action) GetCommands() []*cli.Command {
 			continue
 		}
 		nc := bc.Commands()
-		debug.Log("Backend %s added %d commands", be, len(nc))
+		debug.V(2).Log("Backend %s added %d commands", be, len(nc))
 		cmds = append(cmds, nc...)
 	}
 
@@ -1052,7 +1052,7 @@ func (s *Action) GetCommands() []*cli.Command {
 
 			return sub.Path(), nil
 		})
-		debug.Log("Backend %s added %d commands", be, len(nc))
+		debug.V(2).Log("Backend %s added %d commands", be, len(nc))
 		cmds = append(cmds, nc...)
 	}
 

--- a/internal/action/setup.go
+++ b/internal/action/setup.go
@@ -89,6 +89,10 @@ func (s *Action) Setup(c *cli.Context) error {
 		return s.initJoinTeam(ctx, team, remote)
 	}
 
+	if team == "" && create {
+		return fmt.Errorf("can not create a team without a team name")
+	}
+
 	// assume local setup by default, remotes can be added easily later.
 	if err := s.initLocal(ctx, remote); err != nil {
 		debug.Log("Setup failed. initLocal error: %s", err)
@@ -295,7 +299,7 @@ func (s *Action) initLocal(ctx context.Context, remote string) error {
 
 	if backend.GetStorageBackend(ctx) == backend.GitFS {
 		debug.Log("configuring git remotes")
-		if want, err := termio.AskForBool(ctx, "❓ Do you want to add a git remote?", false); err == nil && want {
+		if want, err := termio.AskForBool(ctx, "❓ Do you want to add a git remote?", false); (err == nil && want) || remote != "" {
 			out.Printf(ctx, "Configuring the git remote ...")
 			if err := s.initSetupGitRemote(ctx, "", remote); err != nil {
 				return fmt.Errorf("failed to setup git remote: %w", err)

--- a/internal/action/setup.go
+++ b/internal/action/setup.go
@@ -90,7 +90,7 @@ func (s *Action) Setup(c *cli.Context) error {
 	}
 
 	// assume local setup by default, remotes can be added easily later.
-	if err := s.initLocal(ctx); err != nil {
+	if err := s.initLocal(ctx, remote); err != nil {
 		debug.Log("Setup failed. initLocal error: %s", err)
 
 		return err
@@ -282,7 +282,7 @@ func (s *Action) initSetupGitRemote(ctx context.Context, team, remote string) er
 
 // initLocal will initialize a local store, useful for local-only setups or as
 // part of team setups to create the root store.
-func (s *Action) initLocal(ctx context.Context) error {
+func (s *Action) initLocal(ctx context.Context, remote string) error {
 	path := ""
 	if s.Store != nil {
 		path = s.Store.Path()
@@ -297,7 +297,7 @@ func (s *Action) initLocal(ctx context.Context) error {
 		debug.Log("configuring git remotes")
 		if want, err := termio.AskForBool(ctx, "❓ Do you want to add a git remote?", false); err == nil && want {
 			out.Printf(ctx, "Configuring the git remote ...")
-			if err := s.initSetupGitRemote(ctx, "", ""); err != nil {
+			if err := s.initSetupGitRemote(ctx, "", remote); err != nil {
 				return fmt.Errorf("failed to setup git remote: %w", err)
 			}
 		}
@@ -338,7 +338,7 @@ func (s *Action) initCreateTeam(ctx context.Context, team, remote string) error 
 	var err error
 
 	out.Printf(ctx, "Creating a new team ...")
-	if err := s.initLocal(ctx); err != nil {
+	if err := s.initLocal(ctx, ""); err != nil {
 		return fmt.Errorf("failed to create local store: %w", err)
 	}
 
@@ -370,7 +370,7 @@ func (s *Action) initJoinTeam(ctx context.Context, team, remote string) error {
 	var err error
 
 	out.Printf(ctx, "Joining existing team ...")
-	if err := s.initLocal(ctx); err != nil {
+	if err := s.initLocal(ctx, ""); err != nil {
 		return fmt.Errorf("failed to create local store: %w", err)
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -296,17 +296,17 @@ func (c *Config) migrateOptions(migrations map[string]string) {
 		return
 	}
 	var errs []error
-	debug.Log("migrateOptions running")
+	debug.V(2).Log("migrateOptions running")
 	for oldK, newK := range migrations {
 		found := false
 		if val := c.root.GetGlobal(oldK); val != "" {
-			debug.Log("migrating option in root global store: %s -> %s ", oldK, newK)
+			debug.V(2).Log("migrating option in root global store: %s -> %s ", oldK, newK)
 			errs = append(errs, c.root.SetGlobal(newK, val))
 			errs = append(errs, c.root.UnsetGlobal(oldK))
 			found = true
 		}
 		if val := c.root.GetLocal(oldK); val != "" {
-			debug.Log("migrating option in <root> local store: %s -> %s ", oldK, newK)
+			debug.V(2).Log("migrating option in <root> local store: %s -> %s ", oldK, newK)
 			errs = append(errs, c.root.SetLocal(newK, val))
 			errs = append(errs, c.root.UnsetLocal(oldK))
 			found = true
@@ -314,13 +314,13 @@ func (c *Config) migrateOptions(migrations map[string]string) {
 		for _, m := range c.Mounts() {
 			if cfg := c.cfgs[m]; cfg != nil {
 				if val := cfg.GetLocal(oldK); val != "" {
-					debug.Log("migrating option in local store %s: %s -> %s ", m, oldK, newK)
+					debug.V(2).Log("migrating option in local store %s: %s -> %s ", m, oldK, newK)
 					errs = append(errs, cfg.SetLocal(newK, val))
 					errs = append(errs, cfg.UnsetLocal(oldK))
 					found = true
 				}
 				if val := cfg.Get(oldK); !found && val != "" {
-					debug.Log("Found old option %s = %s in config, probably at the worktree or env level, "+
+					debug.V(2).Log("Found old option %s = %s in config, probably at the worktree or env level, "+
 						"or maybe at the system level cannot migrate it.", oldK, val)
 				}
 			}

--- a/internal/config/legacy.go
+++ b/internal/config/legacy.go
@@ -10,7 +10,7 @@ import (
 func migrateConfigs() error {
 	cfg := legacy.LoadWithOptions(true, false)
 	if cfg == nil {
-		debug.Log("no legacy config found. not migrating.")
+		debug.V(2).Log("no legacy config found. not migrating.")
 
 		return nil
 	}

--- a/internal/env/env_darwin.go
+++ b/internal/env/env_darwin.go
@@ -6,6 +6,7 @@ package env
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"os"
 	"os/exec"
@@ -28,7 +29,7 @@ func Check(ctx context.Context) (string, error) {
 	cmd.Stderr = Stderr
 
 	if err := cmd.Run(); err != nil {
-		return "", err
+		return "", fmt.Errorf("`default read org.gpgtools.common UseKeychain` failed: %w", err)
 	}
 
 	// if the keychain is not used, we can skip the rest

--- a/pkg/fsutil/fsutil.go
+++ b/pkg/fsutil/fsutil.go
@@ -28,12 +28,12 @@ func CleanFilename(in string) string {
 func ExpandHomedir(path string) string {
 	if len(path) > 1 && path[:2] == "~/" {
 		dir := filepath.Clean(appdir.UserHome() + path[1:])
-		debug.Log("Expanding %s to %s", path, dir)
+		debug.V(1).Log("Expanding %s to %s", path, dir)
 
 		return dir
 	}
 
-	debug.Log("No tilde found in %s", path)
+	debug.V(2).Log("No tilde found in %s", path)
 
 	return path
 }

--- a/pkg/gitconfig/config.go
+++ b/pkg/gitconfig/config.go
@@ -108,7 +108,7 @@ func (c *Config) Set(key, value string) error {
 	if vs, found := c.vars[key]; found {
 		for _, v := range vs {
 			if v == value {
-				debug.Log("key %q with value %q already present. Not re-writing.", key, value)
+				debug.V(1).Log("key %q with value %q already present. Not re-writing.", key, value)
 
 				return nil
 			}
@@ -246,7 +246,7 @@ func (c *Config) rewriteRaw(key, value string, cb parseFunc) error {
 
 func (c *Config) flushRaw() error {
 	if c.noWrites || c.path == "" {
-		debug.Log("not writing changes to disk (noWrites %t, path %q)", c.noWrites, c.path)
+		debug.V(3).Log("not writing changes to disk (noWrites %t, path %q)", c.noWrites, c.path)
 
 		return nil
 	}
@@ -261,7 +261,7 @@ func (c *Config) flushRaw() error {
 		return fmt.Errorf("failed to write config to %s: %w", c.path, err)
 	}
 
-	debug.Log("wrote config to %s", c.path)
+	debug.V(1).Log("wrote config to %s", c.path)
 
 	return nil
 }
@@ -437,7 +437,7 @@ func LoadConfigFromEnv(envPrefix string) *Config {
 		}
 
 		c.vars[key] = append(c.vars[key], value)
-		debug.Log("added %s from env", key)
+		debug.V(3).Log("added %s from env", key)
 	}
 
 	return c

--- a/pkg/gitconfig/configs.go
+++ b/pkg/gitconfig/configs.go
@@ -77,9 +77,9 @@ func (cs *Configs) LoadAll(workdir string) *Configs {
 	if os.Getenv(cs.EnvPrefix+"_NOSYSTEM") == "" {
 		c, err := LoadConfig(cs.SystemConfig)
 		if err != nil {
-			debug.Log("[%s] failed to load system config: %s", cs.Name, err)
+			debug.V(1).Log("[%s] failed to load system config: %s", cs.Name, err)
 		} else {
-			debug.Log("[%s] loaded system config from %s", cs.Name, cs.SystemConfig)
+			debug.V(1).Log("[%s] loaded system config from %s", cs.Name, cs.SystemConfig)
 			cs.system = c
 			// the system config should generally not be written from gopass.
 			// in almost any scenario gopass shouldn't have write access
@@ -98,11 +98,11 @@ func (cs *Configs) LoadAll(workdir string) *Configs {
 		localConfigPath := filepath.Join(workdir, cs.LocalConfig)
 		c, err := LoadConfig(localConfigPath)
 		if err != nil {
-			debug.Log("[%s] failed to load local config from %s: %s", cs.Name, localConfigPath, err)
+			debug.V(1).Log("[%s] failed to load local config from %s: %s", cs.Name, localConfigPath, err)
 			// set the path just in case we want to modify / write to it later
 			cs.local.path = localConfigPath
 		} else {
-			debug.Log("[%s] loaded local config from %s", cs.Name, localConfigPath)
+			debug.V(1).Log("[%s] loaded local config from %s", cs.Name, localConfigPath)
 			cs.local = c
 		}
 	}
@@ -117,7 +117,7 @@ func (cs *Configs) LoadAll(workdir string) *Configs {
 			// set the path just in case we want to modify / write to it later
 			cs.worktree.path = worktreeConfigPath
 		} else {
-			debug.Log("[%s] loaded worktree config from %s", cs.Name, worktreeConfigPath)
+			debug.V(1).Log("[%s] loaded worktree config from %s", cs.Name, worktreeConfigPath)
 			cs.worktree = c
 		}
 	}
@@ -150,10 +150,10 @@ func (cs *Configs) loadGlobalConfigs() string {
 	// if we already have a global config we can just reload it instead of trying all locations
 	if !cs.global.IsEmpty() {
 		if p := cs.global.path; p != "" {
-			debug.Log("[%s] reloading existing global config from %s", cs.Name, p)
+			debug.V(1).Log("[%s] reloading existing global config from %s", cs.Name, p)
 			cfg, err := LoadConfig(p)
 			if err != nil {
-				debug.Log("[%s] failed to reload global config from %s", cs.Name, p)
+				debug.V(1).Log("[%s] failed to reload global config from %s", cs.Name, p)
 			} else {
 				cs.global = cfg
 
@@ -162,7 +162,7 @@ func (cs *Configs) loadGlobalConfigs() string {
 		}
 	}
 
-	debug.Log("[%s] trying to find global configs in %v", cs.Name, locs)
+	debug.V(1).Log("[%s] trying to find global configs in %v", cs.Name, locs)
 	for _, p := range locs {
 		// GlobalConfig might be set to an empty string to disable it
 		// and instead of the XDG_CONFIG_HOME path only.
@@ -171,18 +171,18 @@ func (cs *Configs) loadGlobalConfigs() string {
 		}
 		cfg, err := LoadConfig(p)
 		if err != nil {
-			debug.Log("[%s] failed to load global config from %s: %s", cs.Name, p, err)
+			debug.V(1).Log("[%s] failed to load global config from %s: %s", cs.Name, p, err)
 
 			continue
 		}
 
-		debug.Log("[%s] loaded global config from %s", cs.Name, p)
+		debug.V(1).Log("[%s] loaded global config from %s", cs.Name, p)
 		cs.global = cfg
 
 		return p
 	}
 
-	debug.Log("[%s] no global config found", cs.Name)
+	debug.V(1).Log("[%s] no global config found", cs.Name)
 
 	// set the path to the default one in case we want to write to it (create it) later
 	cs.global = &Config{


### PR DESCRIPTION
This should cover the case when creating a new team with an existing remote.

Part of #2779 