### PR TITLE
[fix] Disble safecontent parsing if noparsing is requested

### DIFF
--- a/internal/action/show.go
+++ b/internal/action/show.go
@@ -258,7 +258,7 @@ func (s *Action) showGetContent(ctx context.Context, sec gopass.Secret) (string,
 	}
 
 	// everything but the first line.
-	if config.Bool(ctx, "show.safecontent") && !ctxutil.IsForce(ctx) {
+	if config.Bool(ctx, "show.safecontent") && !ctxutil.IsForce(ctx) && ctxutil.IsShowParsing(ctx) {
 		body := showSafeContent(sec)
 		if IsAlsoClip(ctx) {
 			return pw, body, nil
@@ -278,7 +278,7 @@ func showSafeContent(sec gopass.Secret) string {
 		sb.WriteString(": ")
 		// check if this key should be obstructed.
 		if isUnsafeKey(k, sec) {
-			debug.Log("obstructing unsafe key %s", k)
+			debug.V(1).Log("obstructing unsafe key %s", k)
 			sb.WriteString(randAsterisk())
 		} else {
 			v, found := sec.Values(k)

--- a/internal/backend/crypto/age/askpass.go
+++ b/internal/backend/crypto/age/askpass.go
@@ -85,7 +85,7 @@ func newAskPass(ctx context.Context) *askPass {
 
 	if config.Bool(ctx, "age.usekeychain") {
 		if err := keyring.Set("gopass", "sentinel", "empty"); err == nil {
-			debug.Log("using OS keychain to cache age credentials")
+			debug.V(1).Log("using OS keychain to cache age credentials")
 			a.cache = newOsKeyring()
 		}
 	}
@@ -99,7 +99,7 @@ func (a *askPass) Ping(_ context.Context) error {
 
 func (a *askPass) Passphrase(key string, reason string, repeat bool) (string, error) {
 	if value, found := a.cache.Get(key); found || a.testing {
-		debug.Log("Read value for %s from cache", key)
+		debug.V(1).Log("Read value for %s from cache", key)
 
 		return value, nil
 	}
@@ -110,7 +110,7 @@ func (a *askPass) Passphrase(key string, reason string, repeat bool) (string, er
 		return "", fmt.Errorf("pinentry error: %w", err)
 	}
 
-	debug.Log("Updated value for %s in cache", key)
+	debug.V(1).Log("Updated value for %s in cache", key)
 	a.cache.Set(key, pw)
 
 	return pw, nil

--- a/internal/backend/crypto/gpg/gpgconf/binary_others.go
+++ b/internal/backend/crypto/gpg/gpgconf/binary_others.go
@@ -26,7 +26,7 @@ func detectBinary(_ context.Context, name string) (string, error) {
 		return exec.LookPath("gpg")
 	}
 
-	debug.Log("gpgconf returned %q for gpg", p)
+	debug.V(3).Log("gpgconf returned %q for gpg", p)
 
 	return p, nil
 }

--- a/internal/backend/crypto/gpg/gpgconf/binary_windows.go
+++ b/internal/backend/crypto/gpg/gpgconf/binary_windows.go
@@ -22,13 +22,13 @@ func detectBinary(ctx context.Context, bin string) (string, error) {
 
 	bv := make(byVersion, 0, len(bins))
 	for _, b := range bins {
-		debug.Log("Looking for %q ...", b)
+		debug.V(3).Log("Looking for %q ...", b)
 		if p, err := exec.LookPath(b); err == nil {
 			gb := gpgBin{
 				path: p,
 				ver:  Version(ctx, p),
 			}
-			debug.Log("Found %q at %q (%s)", b, p, gb.ver.String())
+			debug.V(1).Log("Found %q at %q (%s)", b, p, gb.ver.String())
 			bv = append(bv, gb)
 		}
 	}
@@ -38,7 +38,7 @@ func detectBinary(ctx context.Context, bin string) (string, error) {
 	}
 
 	binary := bv[0].path
-	debug.Log("using %q", binary)
+	debug.V(1).Log("using %q", binary)
 
 	return binary, nil
 }

--- a/internal/backend/storage.go
+++ b/internal/backend/storage.go
@@ -56,7 +56,7 @@ func DetectStorage(ctx context.Context, path string) (Storage, error) {
 	// The call to HasStorageBackend is important since GetStorageBackend will always return FS
 	// if nothing is found in the context.
 	if be, err := StorageRegistry.Get(GetStorageBackend(ctx)); HasStorageBackend(ctx) && err == nil {
-		debug.Log("Trying requested %s for %s", be, path)
+		debug.V(1).Log("Trying requested %s for %s", be, path)
 		st, err := be.New(ctx, path)
 		if err == nil {
 			debug.Log("Using requested %s for %s", be, path)
@@ -77,7 +77,7 @@ func DetectStorage(ctx context.Context, path string) (Storage, error) {
 
 	// Nothing requested in the context. Try to detect the backend.
 	for _, be := range StorageRegistry.Prioritized() {
-		debug.Log("Trying %s for %s", be, path)
+		debug.V(1).Log("Trying %s for %s", be, path)
 		if err := be.Handles(ctx, path); err != nil {
 			debug.Log("failed to use %s for %s: %s", be, path, err)
 

--- a/internal/backend/storage/fs/store.go
+++ b/internal/backend/storage/fs/store.go
@@ -41,7 +41,7 @@ func (s *Store) Get(ctx context.Context, name string) ([]byte, error) {
 	}
 
 	path := filepath.Join(s.path, filepath.Clean(name))
-	debug.Log("Reading %s from %s", name, path)
+	debug.V(3).Log("Reading %s from %s", name, path)
 
 	return os.ReadFile(path)
 }
@@ -60,7 +60,7 @@ func (s *Store) Set(ctx context.Context, name string, value []byte) error {
 			return err
 		}
 	}
-	debug.Log("Writing %s to %q", name, filename)
+	debug.V(3).Log("Writing %s to %q", name, filename)
 
 	// if we ever try to write a secret that is identical (in ciphertext) to the secret in store,
 	// we might want to act differently
@@ -90,7 +90,7 @@ func (s *Store) Move(ctx context.Context, from, to string, del bool) error {
 			return fmt.Errorf("failed to create directory %q: %w", toDir, err)
 		}
 	}
-	debug.Log("Copying %q (%q) to %q (%q)", from, fromFn, to, toFn)
+	debug.V(3).Log("Copying %q (%q) to %q (%q)", from, fromFn, to, toFn)
 
 	if del {
 		if err := os.Rename(fromFn, toFn); err != nil {
@@ -109,7 +109,7 @@ func (s *Store) Delete(ctx context.Context, name string) error {
 		name = filepath.FromSlash(name)
 	}
 	path := filepath.Join(s.path, filepath.Clean(name))
-	debug.Log("Deleting %s from %s", name, path)
+	debug.V(3).Log("Deleting %s from %s", name, path)
 
 	if err := os.Remove(path); err != nil {
 		return err
@@ -131,7 +131,7 @@ func (s *Store) removeEmptyParentDirectories(path string) error {
 		return nil
 	}
 
-	debug.Log("removing empty parent dir: %q", parent)
+	debug.V(1).Log("removing empty parent dir: %q", parent)
 	err := os.Remove(parent)
 	switch {
 	case err == nil:
@@ -151,7 +151,7 @@ func (s *Store) Exists(ctx context.Context, name string) bool {
 	}
 	path := filepath.Join(s.path, filepath.Clean(name))
 	found := fsutil.IsFile(path)
-	debug.Log("Checking if '%s' exists at %s: %t", name, path, found)
+	debug.V(2).Log("Checking if '%s' exists at %s: %t", name, path, found)
 
 	return found
 }
@@ -161,7 +161,7 @@ func (s *Store) Exists(ctx context.Context, name string) bool {
 // directory separator are normalized using `/`.
 func (s *Store) List(ctx context.Context, prefix string) ([]string, error) {
 	prefix = strings.TrimPrefix(prefix, "/")
-	debug.Log("Listing %s/%s", s.path, prefix)
+	debug.V(2).Log("Listing %s/%s", s.path, prefix)
 
 	files := make([]string, 0, 100)
 	if err := walkSymlinks(s.path, func(path string, info os.FileInfo, err error) error {
@@ -171,7 +171,7 @@ func (s *Store) List(ctx context.Context, prefix string) ([]string, error) {
 
 		relPath := strings.TrimPrefix(path, s.path+string(filepath.Separator)) + string(filepath.Separator)
 		if info.IsDir() && strings.HasPrefix(info.Name(), ".") && path != s.path && !strings.HasPrefix(prefix, relPath) && filepath.Base(path) != filepath.Base(prefix) {
-			debug.Log("skipping dot dir (relPath: %s, prefix: %s)", relPath, prefix)
+			debug.V(3).Log("skipping dot dir (relPath: %s, prefix: %s)", relPath, prefix)
 
 			return filepath.SkipDir
 		}
@@ -207,7 +207,7 @@ func (s *Store) IsDir(ctx context.Context, name string) bool {
 	}
 	path := filepath.Join(s.path, filepath.Clean(name))
 	isDir := fsutil.IsDir(path)
-	debug.Log("%s at %s is a directory? %t", name, path, isDir)
+	debug.V(2).Log("%s at %s is a directory? %t", name, path, isDir)
 
 	return isDir
 }

--- a/internal/cache/disk.go
+++ b/internal/cache/disk.go
@@ -28,7 +28,7 @@ func NewOnDisk(name string, ttl time.Duration) (*OnDisk, error) {
 
 // NewOnDiskWithDir creates a new on disk cache.
 func NewOnDiskWithDir(name, dir string, ttl time.Duration) (*OnDisk, error) {
-	debug.Log("New on disk cache %s created at %s", name, dir)
+	debug.V(1).Log("New on disk cache %s created at %s", name, dir)
 
 	o := &OnDisk{
 		ttl:  ttl,

--- a/pkg/gopass/secrets/akv.go
+++ b/pkg/gopass/secrets/akv.go
@@ -240,7 +240,7 @@ func ParseAKV(in []byte) *AKV {
 	a.raw = strings.Builder{}
 	s := newScanner(bytes.NewReader(in), len(in))
 
-	debug.Log("Parsing %d bytes of input", len(in))
+	debug.V(2).Log("Parsing %d bytes of input", len(in))
 
 	first := true
 	for s.Scan() {
@@ -290,7 +290,7 @@ func (a *AKV) Body() string {
 		a.raw.WriteString("\n")
 	}
 
-	debug.Log("Building body from %d chars", a.raw.Len())
+	debug.V(2).Log("Building body from %d chars", a.raw.Len())
 	s := newScanner(strings.NewReader(a.raw.String()), a.raw.Len())
 
 	first := true
@@ -305,16 +305,16 @@ func (a *AKV) Body() string {
 		line := s.Text()
 		// ignore KV pairs
 		if strings.Contains(line, kvSep) {
-			debug.Log("ignoring line: %q", line)
+			debug.V(3).Log("ignoring line: %q", line)
 
 			continue
 		}
-		debug.Log("adding line of %d chars", len(line))
+		debug.V(3).Log("adding line of %d chars", len(line))
 		out.WriteString(line)
 		out.WriteString("\n")
 	}
 
-	debug.Log("built %d chars body", out.Len())
+	debug.V(2).Log("built %d chars body", out.Len())
 
 	return out.String()
 }
@@ -330,7 +330,7 @@ func newScanner(in io.Reader, inSize int) *bufio.Scanner {
 	scanBuf := make([]byte, bufSize)
 	s.Buffer(scanBuf, bufSize)
 
-	debug.Log("Using buffer of len %d and max %d", len(scanBuf), bufSize)
+	debug.V(4).Log("Using buffer of len %d and max %d", len(scanBuf), bufSize)
 
 	return s
 }

--- a/pkg/gopass/secrets/yaml.go
+++ b/pkg/gopass/secrets/yaml.go
@@ -108,7 +108,7 @@ func ParseYAML(in []byte) (*YAML, error) {
 		data: make(map[string]any, 10),
 	}
 
-	debug.Log("Parsing %q", out.Secret(in))
+	debug.V(3).Log("Parsing %q", out.Secret(in))
 
 	r := bufio.NewReader(bytes.NewReader(in))
 
@@ -166,7 +166,7 @@ func parseBody(r *bufio.Reader) (string, error) {
 		}
 
 		if string(nextLine) == "---" {
-			debug.Log("Beginning of YAML section detected")
+			debug.V(2).Log("Beginning of YAML section detected")
 
 			return sb.String(), nil
 		}


### PR DESCRIPTION
We can not parse and check the secret for suppressed keys if we are not supposed to parse the secret.

The actual change is one line, the rest are debug verbosity changes that did allow me to spot the issue
better (at default verbosity).

Fixes #2737