### PR TITLE
[chore] Update hashicorp/golang-lru to v2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/google/go-github v17.0.0+incompatible
 	github.com/google/go-github/v33 v33.0.0
 	github.com/gopasspw/gopass-hibp v1.15.12
-	github.com/hashicorp/golang-lru v1.0.2
+	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/jsimonetti/pwscheme v0.0.0-20220922140336-67a4d090f150
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/kbinani/screenshot v0.0.0-20230812210009-b87d31814237
@@ -66,7 +66,6 @@ require (
 	github.com/gen2brain/shm v0.1.0 // indirect
 	github.com/godbus/dbus/v5 v5.1.0 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
-	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
 	github.com/jezek/xgb v1.1.1 // indirect
 	github.com/jwalton/gchalk v1.3.0 // indirect
 	github.com/jwalton/go-supportscolor v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -80,8 +80,6 @@ github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/gopasspw/gopass-hibp v1.15.12 h1:no/CpU3WSSAI3CQ6UZazESv2tiWNeCgMRFNanoXCqJQ=
 github.com/gopasspw/gopass-hibp v1.15.12/go.mod h1:eDjymys5niAolSMbuFVWXaYba4Sq4XF2F8KOdgiZxP0=
-github.com/hashicorp/golang-lru v1.0.2 h1:dV3g9Z/unq5DpblPpw+Oqcv4dU/1omnb4Ok8iPY6p1c=
-github.com/hashicorp/golang-lru v1.0.2/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=

--- a/internal/backend/crypto/gpg/cli/gpg.go
+++ b/internal/backend/crypto/gpg/cli/gpg.go
@@ -10,7 +10,7 @@ import (
 	"github.com/gopasspw/gopass/internal/backend/crypto/gpg"
 	"github.com/gopasspw/gopass/internal/backend/crypto/gpg/gpgconf"
 	"github.com/gopasspw/gopass/pkg/debug"
-	lru "github.com/hashicorp/golang-lru"
+	lru "github.com/hashicorp/golang-lru/v2"
 )
 
 var (
@@ -33,7 +33,7 @@ type GPG struct {
 	args      []string
 	pubKeys   gpg.KeyList
 	privKeys  gpg.KeyList
-	listCache *lru.TwoQueueCache
+	listCache *lru.TwoQueueCache[string, gpg.KeyList]
 	throwKids bool
 }
 
@@ -69,7 +69,7 @@ func New(ctx context.Context, cfg Config) (*GPG, error) {
 		throwKids: hasThrowKids,
 	}
 
-	cache, err := lru.New2Q(1024)
+	cache, err := lru.New2Q[string, gpg.KeyList](1024)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize the LRU cache: %w", err)
 	}

--- a/internal/backend/crypto/gpg/cli/keyring.go
+++ b/internal/backend/crypto/gpg/cli/keyring.go
@@ -23,9 +23,7 @@ func (g *GPG) listKeys(ctx context.Context, typ string, search ...string) (gpg.K
 	args := []string{"--with-colons", "--with-fingerprint", "--fixed-list-mode", "--list-" + typ + "-keys"}
 	args = append(args, search...)
 	if e, found := g.listCache.Get(strings.Join(args, ",")); found && gpg.UseCache(ctx) {
-		if ev, ok := e.(gpg.KeyList); ok {
-			return ev, nil
-		}
+		return e, nil
 	}
 
 	cmd := exec.CommandContext(ctx, g.binary, args...)


### PR DESCRIPTION
Updates the GPG backend to use version 2 of hashicorp/golang-lru library.