### PR TITLE
Reduce dependabot frequency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,5 +4,5 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
-    open-pull-requests-limit: 5
+      interval: "monthly"
+    open-pull-requests-limit: 15


### PR DESCRIPTION
The bot is too noisy and and gomod dependencies are automatically bumped during every release anyway.