### PR TITLE
feat: on pinentry request, allow password to be cached in os keyring

### DIFF
--- a/internal/backend/crypto/age/askpass.go
+++ b/internal/backend/crypto/age/askpass.go
@@ -131,6 +131,11 @@ func (a *askPass) getPassphrase(reason string, repeat bool) (string, error) {
 
 			return match.Score, true
 		}))
+	} else {
+		opts = append(opts,
+			pinentry.WithOption(pinentry.OptionAllowExternalPasswordCache),
+			pinentry.WithKeyInfo("gopass/age-identities"),
+		)
 	}
 
 	p, err := pinentry.NewClient(opts...)


### PR DESCRIPTION
When using pinentry to request the passphrase to decrypt the age identities file, allow the pinentry program to cache the password.

Example:
<img width="562" alt="save-password" src="https://github.com/gopasspw/gopass/assets/222027/35211c88-2e18-474d-8d57-2129fc08e2f3">
