### PR TITLE
chore: Switch to static list of linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,6 @@
 run:
   timeout: 5m
+  go: "1.22"
 
 linters-settings:
   gocyclo:
@@ -8,7 +9,6 @@ linters-settings:
     max-complexity: 22
     skip-tests: true
   staticcheck:
-    go: "1.22"
     # https://staticcheck.io/docs/options#checks
     checks: ["all","-SA1019"]
   funlen:
@@ -16,65 +16,68 @@ linters-settings:
     statements: 100
 
 linters:
-  enable-all: true
-  disable:
+  enable:
+  - asasalint
+  - asciicheck
+  - bidichk
   - bodyclose
-  - contextcheck
-  - deadcode
-  - depguard
-  - durationcheck
-  - dupl
-  - dupword
-  - exhaustruct
-  - exhaustivestruct
-  - forbidigo
-  - gci
-  - gochecknoglobals
-  - gochecknoinits
-  - gocognit
-  - goconst
-  - gocritic
-  - gocyclo
-  - godox
-  - goerr113
-  - golint
-  - gomnd
-  - gosec
-  - gosimple
-  - govet
-  - interfacer
-  - ifshort
-  - inamedparam
-  - interfacebloat
-  - ireturn
-  - lll
-  - maintidx
-  - maligned
-  - musttag
-  - nilerr
-  - noctx
-  - nolintlint
-  - nosnakecase
-  - paralleltest
-  - perfsprint
-  - revive
-  - rowserrcheck
-  - scopelint
-  - sqlclosecheck
-  - staticcheck
-  - structcheck
-  - stylecheck
-  - tagliatelle
-  - testpackage
-  - tparallel
-  - typecheck
-  - unparam
-  - unused
-  - varcheck
-  - varnamelen
-  - wastedassign
-  - wrapcheck
-  - wsl
+  - canonicalheader
+  - containedctx
+  - copyloopvar
+  - cyclop
+  - decorder
+  - dogsled
+  - errcheck
+  - errchkjson
+  - errname
+  - errorlint
+  - exhaustive
+  - exportloopref
+  - fatcontext
+  - forcetypeassert
+  - funlen
+  - ginkgolinter
+  - gocheckcompilerdirectives
+  - gochecksumtype
+  - godot
+  - gofmt
+  - gofumpt
+  - goheader
+  - goimports
+  - gomoddirectives
+  - gomodguard
+  - goprintffuncname
+  - gosmopolitan
+  - grouper
+  - importas
+  - ineffassign
+  - intrange
+  - loggercheck
+  - makezero
+  - mirror
+  - misspell
+  - nakedret
+  - nestif
+  - nilnil
+  - nlreturn
+  - nonamedreturns
+  - nosprintfhostport
+  - prealloc
+  - predeclared
+  - promlinter
+  - protogetter
+  - reassign
+  - sloglint
+  - spancheck
+  - tagalign
+  - tenv
+  - testableexamples
+  - testifylint
+  - thelper
+  - unconvert
+  - usestdlibvars
+  - whitespace
+  - zerologlint
 
 issues:
   max-issues-per-linter: 0 # disable limit; report all issues of a linter

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,7 +21,6 @@ linters:
   - asciicheck
   - bidichk
   - bodyclose
-  - canonicalheader
   - containedctx
   - copyloopvar
   - cyclop
@@ -33,7 +32,6 @@ linters:
   - errorlint
   - exhaustive
   - exportloopref
-  - fatcontext
   - forcetypeassert
   - funlen
   - ginkgolinter

--- a/internal/action/action.go
+++ b/internal/action/action.go
@@ -15,7 +15,7 @@ import (
 var (
 	stdin  io.Reader = os.Stdin
 	stdout io.Writer = os.Stdout
-	stderr io.Writer = os.Stderr
+	stderr io.Writer = os.Stderr //nolint:unused
 )
 
 // Action knows everything to run gopass CLI actions.

--- a/internal/action/action_test.go
+++ b/internal/action/action_test.go
@@ -54,7 +54,6 @@ func TestAction(t *testing.T) {
 	act, err := newMock(ctx, u.StoreDir(""))
 	require.NoError(t, err)
 	require.NotNil(t, act)
-	ctx = act.cfg.WithConfig(ctx) //nolint:ineffassign
 
 	actName := "action.test"
 

--- a/internal/action/commands_test.go
+++ b/internal/action/commands_test.go
@@ -45,7 +45,6 @@ func TestCommands(t *testing.T) {
 	act, err := newMock(ctx, u.StoreDir(""))
 	require.NoError(t, err)
 	require.NotNil(t, act)
-	ctx = act.cfg.WithConfig(ctx) //nolint:ineffassign
 
 	for _, cmd := range act.GetCommands() {
 		t.Run(cmd.Name, func(t *testing.T) {

--- a/internal/action/pwgen/pwgen_test.go
+++ b/internal/action/pwgen/pwgen_test.go
@@ -27,5 +27,5 @@ func TestPwgen(t *testing.T) {
 	}()
 
 	require.NoError(t, Pwgen(gptest.CliCtxWithFlags(ctx, t, map[string]string{"one-per-line": "true"}, "24", "1")))
-	assert.GreaterOrEqual(t, len(buf.Bytes()), 24, string(buf.Bytes()))
+	assert.GreaterOrEqual(t, len(buf.Bytes()), 24, buf.String())
 }

--- a/internal/action/setup_test.go
+++ b/internal/action/setup_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestSetupAgeGitFS(t *testing.T) {
-	u := gptest.NewUnitTester(t)
+	u := gptest.NewUnitTester(t) //nolint:staticcheck
 
 	ctx := config.NewContextInMemory()
 	ctx = ctxutil.WithAlwaysYes(ctx, true)
@@ -27,7 +27,7 @@ func TestSetupAgeGitFS(t *testing.T) {
 	ctx = ctxutil.WithPasswordCallback(ctx, func(_ string, _ bool) ([]byte, error) {
 		return []byte("foobar"), nil
 	})
-	ctx = ctxutil.WithPasswordPurgeCallback(ctx, func(s string) {})
+	ctx = ctxutil.WithPasswordPurgeCallback(ctx, func(s string) {}) //nolint:staticcheck
 
 	t.Skip("TODO: fix setup test")
 

--- a/internal/action/show_test.go
+++ b/internal/action/show_test.go
@@ -383,7 +383,7 @@ func TestShowPrintQR(t *testing.T) {
 	act, err := newMock(ctx, u.StoreDir(""))
 	require.NoError(t, err)
 	require.NotNil(t, act)
-	ctx = act.cfg.WithConfig(ctx) //nolint:ineffassign
+	ctx = act.cfg.WithConfig(ctx) //nolint:ineffassign,staticcheck
 
 	color.NoColor = true
 	buf := &bytes.Buffer{}

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -42,11 +42,10 @@ type validator struct {
 var DefaultExpiration = time.Hour * 24 * 365
 
 type Auditor struct {
-	s      secretGetter
-	r      *ReportBuilder
-	expiry time.Duration
-	pcb    func()
-	v      []validator
+	s   secretGetter
+	r   *ReportBuilder
+	pcb func()
+	v   []validator
 }
 
 func New(ctx context.Context, s secretGetter) *Auditor {

--- a/internal/audit/report.go
+++ b/internal/audit/report.go
@@ -49,15 +49,6 @@ func (s *SecretReport) HumanizeAge() string {
 	return fmt.Sprintf("%d years", years)
 }
 
-func errors(e []error) []string {
-	s := make([]string, 0, len(e))
-	for _, es := range e {
-		s = append(s, es.Error())
-	}
-
-	return s
-}
-
 type Report struct {
 	// secret name -> report
 	Secrets map[string]SecretReport

--- a/internal/backend/storage/fs/walk.go
+++ b/internal/backend/storage/fs/walk.go
@@ -11,7 +11,7 @@ func walkSymlinks(path string, walkFn filepath.WalkFunc) error {
 }
 
 func walk(filename, linkDir string, walkFn filepath.WalkFunc) error {
-	sWalkFn := func(path string, info fs.FileInfo, err error) error {
+	sWalkFn := func(path string, info fs.FileInfo, _ error) error {
 		fname, err := filepath.Rel(filename, path)
 		if err != nil {
 			return err

--- a/internal/store/leaf/fsck.go
+++ b/internal/store/leaf/fsck.go
@@ -22,9 +22,9 @@ import (
 type ErrorSeverity int
 
 const (
-	errsNil      ErrorSeverity = 0
-	errsNonFatal               = 1 // an error that was recovered from, but still should be acknowledged
-	errsFatal                  = 2 // an error that terminated the function early
+	errsNil      ErrorSeverity = iota
+	errsNonFatal               // an error that was recovered from, but still should be acknowledged
+	errsFatal                  // an error that terminated the function early
 )
 
 func (e ErrorSeverity) String() string {
@@ -174,6 +174,7 @@ func (s *Store) fsckLoop(ctx context.Context, path string) error {
 	sort.Strings(names)
 
 	debug.Log("names (%d): %q", len(names), names)
+	buf := &strings.Builder{}
 	for _, name := range names {
 		pcb()
 		if strings.HasPrefix(name, s.alias+"/") {
@@ -189,7 +190,11 @@ func (s *Store) fsckLoop(ctx context.Context, path string) error {
 			continue
 		}
 
-		ctx = ctxutil.AddToCommitMessageBody(ctx, msg)
+		buf.WriteString(msg)
+		buf.WriteString("\n")
+	}
+	if buf.Len() > 0 {
+		ctx = ctxutil.AddToCommitMessageBody(ctx, buf.String())
 	}
 
 	// print out any deferred warnings (if any)

--- a/internal/updater/download.go
+++ b/internal/updater/download.go
@@ -69,6 +69,7 @@ func download(ctx context.Context, url string) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to download %s: %w", url, err)
 	}
+	defer resp.Body.Close() //nolint:errcheck
 
 	var body io.ReadCloser
 	// do not show progress bar for small assets, like SHA256SUMS

--- a/pkg/gitconfig/gitconfig_test.go
+++ b/pkg/gitconfig/gitconfig_test.go
@@ -353,7 +353,7 @@ func TestParseComplex(t *testing.T) {
 func TestParseDocs(t *testing.T) {
 	t.Parallel()
 
-	c := ParseConfig(strings.NewReader(configSampleComplex))
+	c := ParseConfig(strings.NewReader(configSampleComplex)) //nolint:staticcheck
 
 	// TODO(#2479) - fix parsing
 	t.Skip("TODO - broken")

--- a/pkg/otp/otp_test.go
+++ b/pkg/otp/otp_test.go
@@ -30,7 +30,7 @@ func TestCalculate(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		t.Run(fmt.Sprintf("%s", tc), func(t *testing.T) {
+		t.Run(string(tc), func(t *testing.T) {
 			t.Parallel()
 
 			s, err := secparse.Parse(tc)

--- a/tests/tester.go
+++ b/tests/tester.go
@@ -171,7 +171,7 @@ func (ts tester) run(arg string) (string, error) {
 	return strings.TrimSpace(string(out)), nil
 }
 
-func (ts tester) runWithInput(arg, input string) ([]byte, error) {
+func (ts tester) runWithInput(arg, input string) ([]byte, error) { //nolint:unused
 	ts.t.Helper()
 
 	reader := strings.NewReader(input)
@@ -179,7 +179,7 @@ func (ts tester) runWithInput(arg, input string) ([]byte, error) {
 	return ts.runWithInputReader(arg, reader)
 }
 
-func (ts tester) runWithInputReader(arg string, input io.Reader) ([]byte, error) {
+func (ts tester) runWithInputReader(arg string, input io.Reader) ([]byte, error) { //nolint:unused
 	ts.t.Helper()
 
 	args, err := shellquote.Split(arg)


### PR DESCRIPTION
The old approach was prone to random CI failures when a golangci-lint was updated and did enable new linters. This approach means we will have to update the include list from time to time but won't get random CI failures.