### PR TITLE
cli/decrypt: improve debugging of gpg command

### DIFF
--- a/internal/backend/crypto/gpg/cli/decrypt.go
+++ b/internal/backend/crypto/gpg/cli/decrypt.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bytes"
 	"context"
+	"io"
 	"os"
 	"os/exec"
 
@@ -15,11 +16,21 @@ func (g *GPG) Decrypt(ctx context.Context, ciphertext []byte) ([]byte, error) {
 	defer cancel()
 
 	args := append(g.args, "--decrypt")
+	// Useful information may appear there
+	if debug.IsEnabled() {
+		args = append(args, "--verbose", "--verbose")
+	}
 	cmd := exec.CommandContext(ctx, g.binary, args...)
 	cmd.Stdin = bytes.NewReader(ciphertext)
-	cmd.Stderr = os.Stderr
+	// If gopass-jsonapi is used, there is no way to reach this os.Stderr, so
+	// we write this stderr to the log file as well.
+	cmd.Stderr = io.MultiWriter(os.Stderr, debug.LogWriter)
 
-	debug.Log("%s %+v", cmd.Path, cmd.Args)
+	debug.Log("Running %s %+v", cmd.Path, cmd.Args)
+	stdout, err := cmd.Output()
+	if err != nil {
+		debug.Log("Got %+v when running gpg command!", err)
+	}
 
-	return cmd.Output()
+	return stdout, err
 }


### PR DESCRIPTION
Today I experienced another obscure issue with `gopass-jsonapi` with my setup (related to my non-standard `pinentry` program) and I needed to edit the source code to see the information in the log that was missing for me. This patch helps users do that without editing the source code. This is a continuation of https://github.com/gopasspw/gopass/pull/2869 .
