### PR TITLE
feat: Add --qrbody flag to encode the entire body of a secret into a QR

### DIFF
--- a/internal/action/commands.go
+++ b/internal/action/commands.go
@@ -33,6 +33,10 @@ func ShowFlags() []cli.Flag {
 			Usage: "Print the password as a QR Code",
 		},
 		&cli.BoolFlag{
+			Name:  "qrbody",
+			Usage: "Print the body as a QR Code",
+		},
+		&cli.BoolFlag{
 			Name:    "unsafe",
 			Aliases: []string{"u", "force", "f"},
 			Usage:   "Display unsafe content (e.g. the password) even if safecontent is enabled",

--- a/internal/action/context.go
+++ b/internal/action/context.go
@@ -13,6 +13,7 @@ const (
 	ctxKeyOnlyClip
 	ctxKeyAlsoClip
 	ctxKeyPrintChars
+	ctxKeyWithQRBody
 )
 
 // WithClip returns a context with the value for clip (for copy to clipboard)
@@ -150,4 +151,19 @@ func GetPrintChars(ctx context.Context) []int {
 	}
 
 	return mv
+}
+
+// WithQRBody returns the context with the value of with QR body set.
+func WithQRBody(ctx context.Context, qr bool) context.Context {
+	return context.WithValue(ctx, ctxKeyWithQRBody, qr)
+}
+
+// IsQRBody returns the value of with QR body or the default (false).
+func IsQRBody(ctx context.Context) bool {
+	bv, ok := ctx.Value(ctxKeyWithQRBody).(bool)
+	if !ok {
+		return false
+	}
+
+	return bv
 }

--- a/internal/action/show.go
+++ b/internal/action/show.go
@@ -36,6 +36,9 @@ func showParseArgs(c *cli.Context) context.Context {
 	if c.IsSet("qr") {
 		ctx = WithPrintQR(ctx, c.Bool("qr"))
 	}
+	if c.IsSet("qrbody") {
+		ctx = WithQRBody(ctx, c.Bool("qrbody"))
+	}
 
 	if c.IsSet("password") {
 		ctx = WithPasswordOnly(ctx, c.Bool("password"))
@@ -197,6 +200,13 @@ func (s *Action) showHandleOutput(ctx context.Context, name string, sec gopass.S
 		return exit.Error(exit.NotFound, store.ErrEmptySecret, store.ErrEmptySecret.Error())
 	}
 
+	if IsPrintQR(ctx) && IsQRBody(ctx) {
+		if err := s.showPrintQR(name, body); err != nil {
+			return err
+		}
+
+		return nil
+	}
 	if IsPrintQR(ctx) && pw != "" {
 		if err := s.showPrintQR(name, pw); err != nil {
 			return err
@@ -245,6 +255,9 @@ func (s *Action) showGetContent(ctx context.Context, sec gopass.Secret) (string,
 	// fallback for old MIME secrets.
 	fullBody := strings.TrimPrefix(string(sec.Bytes()), secrets.Ident+"\n")
 
+	if IsQRBody(ctx) {
+		return pw, fullBody, nil
+	}
 	// first line of the secret only.
 	if IsPrintQR(ctx) || IsOnlyClip(ctx) {
 		return pw, "", nil


### PR DESCRIPTION
code

This comes in handy when storing Wireguard configs in gopass as it allows to import the entire config on a mobile device easily.