### PR TITLE
docs: example for gopass mounts add command

### DIFF
--- a/internal/action/commands.go
+++ b/internal/action/commands.go
@@ -662,7 +662,11 @@ func (s *Action) GetCommands() []*cli.Command {
 					Usage:   "Mount a password store",
 					Description: "" +
 						"This command allows for mounting an existing or new password store " +
-						"at any path in an existing root store.",
+						"at any path in an existing root store." +
+						"\n\n" +
+						"For example: gopass mounts add secondary-store /path/to/existing/store" +
+						"\n\n" +
+						"Learn more: https://github.com/gopasspw/gopass/blob/master/docs/commands/mounts.md",
 					Before: s.IsInitialized,
 					Action: s.MountAdd,
 					Flags: []cli.Flag{


### PR DESCRIPTION
Putting the link to the docs here might not make as much sense as putting in the main command I guess. Let me know if you want me to pull them up. Of course you don't have to accept this, open to your feedback

I've been feeling a bit dense using gopass to be honest, originally was trying to add an existing mount and it spits out this ugly message:

```
ben2204@lenovo-legion:~/dotfiles$ gopass mounts add $(pwd)/.password-store

Error: failed to add mount "/home/ben2204/dotfiles/.password-store" to "/home/ben2204/.local/share/gopass/stores/-home-ben2204-dotfiles-.password-store": failed to add mount: failed to init sub store "home/ben2204/dotfiles/.password-store" at "/home/ben2204/.local/share/gopass/stores/-home-ben2204-dotfiles-.password-store": password store home/ben2204/dotfiles/.password-store is not initialized. Try gopass init --store home/ben2204/dotfiles/.password-store --path /home/ben2204/.local/share/gopass/stores/-home-ben2204-dotfiles-.password-store
```

I then followed that up with this:

```
gopass mounts add -c $(pwd)/.password-store
```

which created this ugliness:

```
ben2204@lenovo-legion:~/dotfiles$ gopass ls
gopass
└── home/
    └── ben2204/
        └── dotfiles/
            └── .password-store (/home/ben2204/.local/share/gopass/stores/-home-ben2204-dotfiles-.password-store)
```

Finally figured it out after reading the fine manual (RTFM) 😄 

```
ben2204@lenovo-legion:~/dotfiles$ gopass mounts add  secondary-store $(pwd)/.password-store
Mounted secondary-store as /home/ben2204/dotfiles/.password-store
ben2204@lenovo-legion:~/dotfiles$ gopass ls
gopass
├── asecret
└── secondary-store (/home/ben2204/dotfiles/.password-store)
    └── test1
```