### PR TITLE
[DEPRECATION] Remove references to deprecated rand.Seed

### DIFF
--- a/pkg/fsutil/fsutil.go
+++ b/pkg/fsutil/fsutil.go
@@ -10,7 +10,6 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
-	"time"
 
 	"github.com/gopasspw/gopass/pkg/appdir"
 	"github.com/gopasspw/gopass/pkg/debug"
@@ -138,8 +137,6 @@ func IsEmptyDir(path string) (bool, error) {
 
 // Shred overwrite the given file any number of times.
 func Shred(path string, runs int) error {
-	rand.Seed(time.Now().UnixNano())
-
 	fh, err := os.OpenFile(path, os.O_WRONLY, 0o600)
 	if err != nil {
 		return fmt.Errorf("failed to open file %q: %w", path, err)

--- a/pkg/gitconfig/config_test.go
+++ b/pkg/gitconfig/config_test.go
@@ -9,7 +9,6 @@ import (
 	"strconv"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/gopasspw/gopass/internal/set"
 	"github.com/stretchr/testify/assert"
@@ -274,7 +273,6 @@ func TestLoadFromEnv(t *testing.T) {
 		"core.timeout": "10",
 	}
 
-	rand.Seed(time.Now().Unix())
 	prefix := fmt.Sprintf("GPTEST%d", rand.Int31n(8192))
 
 	i := 0

--- a/pkg/pwgen/pwgen_test.go
+++ b/pkg/pwgen/pwgen_test.go
@@ -2,10 +2,10 @@ package pwgen
 
 import (
 	"bytes"
-	"crypto/rand"
+	crand "crypto/rand"
 	"fmt"
 	"io"
-	mrand "math/rand"
+	"math/rand"
 	"os"
 	"strings"
 	"testing"
@@ -40,12 +40,14 @@ func TestPwgenCharset(t *testing.T) {
 	assert.Equal(t, "", GeneratePasswordCharsetCheck(4, "a"))
 }
 
-func TestPwgenNoCrand(t *testing.T) {
-	old := rand.Reader
-	rand.Reader = strings.NewReader("")
+func TestPwgenNoCrandFallback(t *testing.T) {
+	oldFallback := randFallback
+	oldReader := crand.Reader
+	crand.Reader = strings.NewReader("")
 
 	defer func() {
-		rand.Reader = old
+		crand.Reader = oldReader
+		randFallback = oldFallback
 	}()
 
 	oldOut := os.Stdout
@@ -61,7 +63,7 @@ func TestPwgenNoCrand(t *testing.T) {
 	}()
 
 	// if we seed math/rand with 1789, the first "random number" will be 42
-	mrand.Seed(1789)
+	randFallback = rand.New(rand.NewSource(1789))
 
 	n := randomInteger(1024)
 

--- a/pkg/pwgen/rand.go
+++ b/pkg/pwgen/rand.go
@@ -11,8 +11,10 @@ import (
 
 func init() {
 	// seed math/rand in case we have to fall back to using it
-	rand.Seed(time.Now().Unix() + int64(os.Getpid()+os.Getppid()))
+	randFallback = rand.New(rand.NewSource(time.Now().Unix() + int64(os.Getpid()+os.Getppid())))
 }
+
+var randFallback *rand.Rand
 
 func randomInteger(max int) int {
 	i, err := crand.Int(crand.Reader, big.NewInt(int64(max)))
@@ -22,5 +24,5 @@ func randomInteger(max int) int {
 
 	fmt.Fprintln(os.Stderr, "WARNING: No crypto/rand available. Falling back to PRNG")
 
-	return rand.Intn(max)
+	return randFallback.Intn(max)
 }


### PR DESCRIPTION
**(Note: reopened this PR after creating and squashing `gofumpt` commit)**

Remove references to deprecated rand.Seed (#2650).

### Context:

- From Go 1.20 (Feb 2023) onwards, `math/rand.Seed` is deprecated, and `math/rand` is already seeded by default.
- From Go 1.24 (Feb 2025?) onwards, `math/rand.Seed` [will be a no-op](https://github.com/golang/go/blob/master/src/math/rand/rand.go), breaking the test `TestPwgenNoCrand`. 

See method documentation in the link above for further info.

### Code Changes:

-  We must have our own `Rand` variable, so that its value can be injected in tests;
-  I changed the test name of `TestPwgenNoCrand` to `TestPwgenNoCrandFallback`, to make the expected behaviour clearer;
- `Shred` does not need to seed, nor does `TestLoadFromEnv` in config_test,  
  - But note that `TestPwgenNoCrandFallback` must restore the randomness so that `TestLoadFromEnv` can work properly.

This also removes the side-effect that fsutil's Shred was overwriting the seed set by pwgen. 