### PR TITLE
[ENHANCEMENT] Allow for whitespace-trailing passwords (#2873)

### DIFF
--- a/pkg/gopass/secrets/akv.go
+++ b/pkg/gopass/secrets/akv.go
@@ -260,15 +260,13 @@ func ParseAKV(in []byte) *AKV {
 			continue
 		}
 
-		line = strings.TrimSpace(line)
-
 		key, val, found := strings.Cut(line, kvSep)
 		if !found {
 			continue
 		}
 
 		key = strings.TrimSpace(key)
-		val = strings.TrimSpace(val)
+		// val = strings.TrimSpace(val)
 		// we only store lower case keys for KV
 		a.kvp[key] = append(a.kvp[key], val)
 	}

--- a/pkg/gopass/secrets/akv.go
+++ b/pkg/gopass/secrets/akv.go
@@ -250,7 +250,7 @@ func ParseAKV(in []byte) *AKV {
 
 		// handle the password that must be in the very first line
 		if first {
-			a.password = strings.TrimSpace(line)
+			a.password = line
 			first = false
 
 			continue
@@ -266,7 +266,7 @@ func ParseAKV(in []byte) *AKV {
 		}
 
 		key = strings.TrimSpace(key)
-		// val = strings.TrimSpace(val)
+		// val is not Trimmed. See https://github.com/gopasspw/gopass/issues/2873
 		// we only store lower case keys for KV
 		a.kvp[key] = append(a.kvp[key], val)
 	}

--- a/pkg/gopass/secrets/akv_test.go
+++ b/pkg/gopass/secrets/akv_test.go
@@ -121,6 +121,24 @@ func TestSetKeyValuePairToEmptyAKV(t *testing.T) {
 	assert.Equal(t, "bar", v)
 }
 
+func TestAKVTrailingWhitespace(t *testing.T) {
+	t.Parallel()
+	// Expected behaviour is KEY: VALUE, with one space.
+	// Fallback should exist for KEY:VALUE, with no spaces.
+	mlValue := `foobar
+defaultBehaviour: cd
+sorroundedBySpace:   cd 	 
+withoutSpace:cd`
+	s := ParseAKV([]byte(mlValue))
+	assert.NotNil(t, s)
+	v1, _ := s.Get("defaultBehaviour")
+	assert.Equal(t, "cd", v1)
+	v2, _ := s.Get("sorroundedBySpace")
+	assert.Equal(t, "  cd \t ", v2)
+	v3, _ := s.Get("defaultBehaviour")
+	assert.Equal(t, "cd", v3)
+}
+
 func TestParseAKV(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/gopass/secrets/akv_test.go
+++ b/pkg/gopass/secrets/akv_test.go
@@ -139,6 +139,57 @@ withoutSpace:cd`
 	assert.Equal(t, "cd", v3)
 }
 
+func TestAKVPasswordWhitespace(t *testing.T) {
+	t.Parallel()
+
+	helloIsWorldStr := "\nhello: world\n"
+	helloIsWorldPair := map[string][]string{
+		"hello": {"world"},
+	}
+
+	for _, tc := range []struct {
+		name string
+		in   string
+		pw   string
+		kvp  map[string][]string
+	}{
+		{
+			name: "justpassword",
+			in:   `this is a password.` + helloIsWorldStr,
+			pw:   "this is a password.",
+			kvp:  helloIsWorldPair,
+		},
+		{
+			name: "spaceonly",
+			in:   "   " + helloIsWorldStr,
+			pw:   "   ",
+			kvp:  helloIsWorldPair,
+		},
+		{
+			name: "tab",
+			in:   "\t tab padded password \t" + helloIsWorldStr,
+			pw:   "\t tab padded password \t",
+			kvp:  helloIsWorldPair,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			a := ParseAKV([]byte(tc.in))
+
+			assert.Equal(t, tc.pw, a.password, tc.name)
+			for k, vs := range tc.kvp {
+				sort.Strings(vs)
+				gvs := a.kvp[k]
+				sort.Strings(gvs)
+				assert.Equal(t, vs, gvs, k)
+			}
+
+			assert.Equal(t, tc.in, string(a.Bytes()), tc.name)
+		})
+	}
+}
+
 func TestParseAKV(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
### Summary

- Adding support for whitespace-trailed passwords. This means blocking `AKV` from `Trim`ming the first line.
- Adding support for whitespace-trailed values on AKV. 

### Technical Notes

- The `TrimSpace` on `ParseAKV` only applies to Keys, not Values. So keys must be trimmed, but values are taken as-is.