### PR TITLE
[FEATURE] Adding support for `age.Plugin` identities

### DIFF
--- a/docs/backends/age.md
+++ b/docs/backends/age.md
@@ -13,8 +13,14 @@ WARNING: This backend is experimental and the on-disk format likely to change.
 To start using the `age` backend initialize a new (sub) store with the `--crypto=age` flag:
 
 ```
-gopass init --crypto age
-gopass recipients add github:user
+$ gopass age identity add [AGE-... age1...]
+<if you do not specify an age secret key, you'll be prompted for one>
+$ gopass init --crypto age
+```
+
+or use the wizard that will help you create a new age key:
+```
+$ gopass setup --crypto age
 ```
 
 This will automatically create a new age keypair and initialize the new store.
@@ -29,6 +35,31 @@ Existing stores can be migrated using `gopass convert --crypto age`.
 * Support for using GitHub users' private keys, e.g. `github:user` as recipient
 * Automatic downloading and caching of SSH keys from GitHub
 * Encrypted keyring for age keypairs
+* Support for age plugins
+
+## Usage with a yubikey
+
+To use with a Yubikey, `age` requires the usage of the [age-plugin-yubikey plugin](https://github.com/str4d/age-plugin-yubikey/).
+
+Assuming you have Rust installed:
+```bash
+$ cargo install age-plugin-yubikey
+$ age-plugin-yubikey -i
+<should be empty>
+$ age-plugin-yubikey
+✨ Let's get your YubiKey set up for age! ✨
+<follow instructions to setup a PIV slot>
+$ age-plugin-yubikey -i
+<should display your PIV slot information now>
+$ gopass age identities add
+Enter the age identity starting in AGE-:
+<paste the `AGE-PLUGIN-YUBIKEY-...` identity from the previous command>
+Provide the corresponding age recipient starting in age1:
+<paste the `age1yubikey1...` recipient from the previous command>
+```
+
+If gopass tells you `waiting on yubikey plugin...` when decrypting secrets, it probably is waiting for you to touch
+your Yubikey because you've set a Touch policy when setting up your PIV slot.
 
 ## Roadmap
 
@@ -39,4 +70,3 @@ Assuming `age` is supporting this, we'd like to:
 * Finalize GitHub recipient support
 * Add Hardware token support
 * Make age the default gopass backend
-

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/gopasspw/gopass
 go 1.22.1
 
 require (
-	filippo.io/age v1.2.0
+	filippo.io/age v1.2.1-0.20240618131852-7eedd929a6cf
 	github.com/ProtonMail/go-crypto v1.0.0
 	github.com/atotto/clipboard v0.1.4
 	github.com/blang/semver/v4 v4.0.0

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ c2sp.org/CCTV/age v0.0.0-20240306222714-3ec4d716e805 h1:u2qwJeEvnypw+OCPUHmoZE3I
 c2sp.org/CCTV/age v0.0.0-20240306222714-3ec4d716e805/go.mod h1:FomMrUJ2Lxt5jCLmZkG3FHa72zUprnhd3v/Z18Snm4w=
 code.rocketnine.space/tslocum/cbind v0.1.5 h1:i6NkeLLNPNMS4NWNi3302Ay3zSU6MrqOT+yJskiodxE=
 code.rocketnine.space/tslocum/cbind v0.1.5/go.mod h1:LtfqJTzM7qhg88nAvNhx+VnTjZ0SXBJtxBObbfBWo/M=
-filippo.io/age v1.2.0 h1:vRDp7pUMaAJzXNIWJVAZnEf/Dyi4Vu4wI8S1LBzufhE=
-filippo.io/age v1.2.0/go.mod h1:JL9ew2lTN+Pyft4RiNGguFfOpewKwSHm5ayKD/A4004=
+filippo.io/age v1.2.1-0.20240618131852-7eedd929a6cf h1:3hBTgZCvtC31eCc8CWH0w+55Yn/R/HI3Of4Zb5TAuWU=
+filippo.io/age v1.2.1-0.20240618131852-7eedd929a6cf/go.mod h1:JL9ew2lTN+Pyft4RiNGguFfOpewKwSHm5ayKD/A4004=
 filippo.io/edwards25519 v1.1.0 h1:FNf4tywRC1HmFuKW5xopWpigGjJKiJSV0Cqo0cJWDaA=
 filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
 github.com/ProtonMail/go-crypto v1.0.0 h1:LRuvITjQWX+WIfr930YHG2HNfjR1uOfyf5vE0kC2U78=

--- a/internal/action/init.go
+++ b/internal/action/init.go
@@ -138,9 +138,13 @@ func (s *Action) init(ctx context.Context, alias, path string, keys ...string) e
 	}
 
 	if len(keys) < 1 {
-		out.Notice(ctx, "Hint: Use 'gopass init <subkey> to use subkeys!'")
+		if crypto.Name() != "age" {
+			out.Notice(ctx, "Hint: Use 'gopass init <subkey> to use subkeys!'")
+		}
 		nk, err := cui.AskForPrivateKey(ctx, crypto, "🎮 Please select a private key for encrypting secrets:")
 		if err != nil {
+			out.Noticef(ctx, "Hint: Use 'gopass setup --crypto %s' to be guided through an initial setup instead of 'gopass init'", crypto.Name())
+
 			return fmt.Errorf("failed to read user input: %w", err)
 		}
 		keys = []string{nk}

--- a/internal/backend/crypto/age/age.go
+++ b/internal/backend/crypto/age/age.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
-	"runtime"
 	"time"
 
 	"github.com/blang/semver/v4"
@@ -82,7 +81,7 @@ func (a *Age) IDFile() string {
 	return IDFile
 }
 
-// Concurrency returns the number of CPUs.
+// Concurrency returns 1 for `age` since otherwise it prompts for the identity password for each worker.
 func (a *Age) Concurrency() int {
-	return runtime.NumCPU()
+	return 1
 }

--- a/internal/backend/crypto/age/clientUI.go
+++ b/internal/backend/crypto/age/clientUI.go
@@ -1,0 +1,44 @@
+package age
+
+import (
+	"context"
+
+	"filippo.io/age/plugin"
+	"github.com/gopasspw/gopass/internal/cui"
+	"github.com/gopasspw/gopass/internal/out"
+	"github.com/gopasspw/gopass/pkg/termio"
+)
+
+var pluginTerminalUI = &plugin.ClientUI{
+	DisplayMessage: func(name, message string) error {
+		out.Printf(context.Background(), "%s plugin: %s", name, message)
+
+		return nil
+	},
+	RequestValue: func(name, message string, _ bool) (string, error) {
+		var err error
+		defer func() {
+			if err != nil {
+				out.Warningf(context.Background(), "could not read value for age-plugin-%s: %v", name, err)
+			}
+		}()
+		secret, err := termio.AskForPassword(context.Background(), "secret", false)
+		if err != nil {
+			return "", err
+		}
+
+		return secret, nil
+	},
+	Confirm: func(name, message, yes, no string) (bool, error) {
+		rep, _ := cui.GetSelection(context.Background(), message, []string{yes, no})
+		if rep == yes {
+			return true, nil
+		}
+
+		return false, nil
+	},
+
+	WaitTimer: func(name string) {
+		out.Printf(context.Background(), "waiting on %s plugin...", name)
+	},
+}

--- a/internal/backend/crypto/age/commands.go
+++ b/internal/backend/crypto/age/commands.go
@@ -2,27 +2,36 @@ package age
 
 import (
 	"fmt"
+	"strings"
 
 	"filippo.io/age"
 	"github.com/gopasspw/gopass/internal/action/exit"
 	"github.com/gopasspw/gopass/internal/out"
 	"github.com/gopasspw/gopass/pkg/ctxutil"
+	"github.com/gopasspw/gopass/pkg/debug"
+	"github.com/gopasspw/gopass/pkg/termio"
 	"github.com/urfave/cli/v2"
 )
 
+//nolint:cyclop
 func (l loader) Commands() []*cli.Command {
 	return []*cli.Command{
 		{
 			Name:   name,
-			Hidden: true,
+			Hidden: false,
 			Usage:  "age commands",
 			Description: "" +
 				"Built-in commands for the age backend.\n" +
-				"These allow limited interactions with the gopass specific age identities.",
+				"These allow limited interactions with the gopass specific age identities.\n " +
+				"Added identities are automatically added as recipient to your secrets when encrypting, but not to" +
+				"your recipients, make sure to keep your recipients and identities in sync as you want to.\n" +
+				"All age identities, including plugin ones should be supported. We also still support github" +
+				"identities despite them being deprecated by age, we do so by falling back to the ssh identities" +
+				"for these and keeping a local cache of ssh keys for a given github identity.",
 			Subcommands: []*cli.Command{
 				{
 					Name:  "identities",
-					Usage: "List identities",
+					Usage: "List age identities used for decryption and encryption",
 					Description: "" +
 						"List identities",
 					Action: func(c *cli.Context) error {
@@ -41,8 +50,8 @@ func (l loader) Commands() []*cli.Command {
 							out.Notice(ctx, "No identities found")
 						}
 
-						for _, id := range recipientsToBech32(ids) {
-							out.Printf(ctx, id)
+						for _, id := range recipientsToString(ids) {
+							out.Print(ctx, out.Secret(id))
 						}
 
 						return nil
@@ -50,9 +59,9 @@ func (l loader) Commands() []*cli.Command {
 					Subcommands: []*cli.Command{
 						{
 							Name:  "add",
-							Usage: "Add an identity",
+							Usage: "Add an existing age identity",
 							Description: "" +
-								"Add an identity",
+								"Add an existing age identity, interactively",
 							Action: func(c *cli.Context) error {
 								ctx := ctxutil.WithGlobalFlags(c)
 								a, err := New(ctx)
@@ -60,18 +69,67 @@ func (l loader) Commands() []*cli.Command {
 									return exit.Error(exit.Unknown, err, "failed to create age backend")
 								}
 
-								if err := a.GenerateIdentity(ctx, "", "", ""); err != nil {
-									return exit.Error(exit.Unknown, err, "failed to generate age identity")
+								idS, recEncm := c.Args().Get(0), c.Args().Get(1)
+
+								if len(idS) < 1 {
+									idS, err = termio.AskForPassword(ctx, "the age identity starting in AGE-", false)
+									if err != nil {
+										return exit.Error(exit.Unknown, err, "failed to read age identity")
+									}
 								}
+								if len(recEncm) < 1 && !strings.HasPrefix(idS, "AGE-SECRET-KEY-1") {
+									recEncm, err = termio.AskForString(ctx, "Provide the corresponding age recipient", "")
+									if err != nil || recEncm == "" {
+										return exit.Error(exit.Unknown, err, "failed to read corresponding age recipient")
+									}
+								}
+
+								id, err := parseIdentity(idS + "|" + recEncm)
+								if err != nil {
+									return exit.Error(exit.Unknown, err, "failed to parse age identity")
+								}
+
+								err = a.addIdentity(ctx, id)
+								if err != nil {
+									return exit.Error(exit.Unknown, err, "failed to save age identity")
+								}
+
+								rec := IdentityToRecipient(id)
+								out.Noticef(ctx, "New age identities are not automatically added to your recipient list, consider adding it using 'gopass recipients add %s'", rec)
+								out.Warning(ctx, "If you do not add this recipient to the recipient list, make sure to re-encrypt using 'gopass fsck --decrypt' to properly support this identity")
 
 								return nil
 							},
 						},
 						{
-							Name:  "remove",
-							Usage: "Remove an identity",
+							Name:  "keygen",
+							Usage: "Generate a new age identity",
 							Description: "" +
-								"Remove an identity",
+								"Generate a new age identity",
+							Action: func(c *cli.Context) error {
+								ctx := ctxutil.WithGlobalFlags(c)
+								a, err := New(ctx)
+								if err != nil {
+									return exit.Error(exit.Unknown, err, "failed to create age backend")
+								}
+
+								err = a.GenerateIdentity(ctx, "", "", "")
+								if err != nil {
+									return exit.Error(exit.Unknown, err, "failed to generate age identity")
+								}
+
+								out.Notice(ctx, "New age identities are not automatically added to your recipient list, consider adding it using 'gopass recipients add age1...'")
+								out.Warning(ctx, "If you do not add this recipient to the recipient list, make sure to re-encrypt using 'gopass fsck --decrypt' to properly support this identity")
+
+								return nil
+							},
+						},
+						{
+							Name:    "remove",
+							Aliases: []string{"rm"},
+							Usage:   "Remove an identity",
+							Description: "" +
+								"Remove all identity matching the argument",
 							Action: func(c *cli.Context) error {
 								ctx := ctxutil.WithGlobalFlags(c)
 								a, err := New(ctx)
@@ -79,18 +137,46 @@ func (l loader) Commands() []*cli.Command {
 									return exit.Error(exit.Unknown, err, "failed to create age backend")
 								}
 								victim := c.Args().First()
+								if len(victim) == 0 {
+									return exit.Error(exit.Usage, err, "missing argument to remove")
+								}
 
 								ids, _ := a.Identities(ctx)
 								newIds := make([]string, 0, len(ids))
 
 								for _, id := range ids {
-									// we only need to care about X25519 identities here because SSH identities are
-									// considered external and are not managed by gopass. users should use ssh-keygen
-									// and such to deal with them. At least we definitely don't want to remove them.
-									if x, ok := id.(*age.X25519Identity); ok && x.Recipient().String() == victim {
-										continue
+									// we only need to care about X25519 and plugin/wrapped identities here because
+									// SSH identities are considered external and are not managed by gopass.
+									// Users should use ssh-keygen and such to deal with them.
+									// At least we definitely don't want to remove them.
+									switch x := id.(type) {
+									case *age.X25519Identity:
+										if x.Recipient().String() == victim {
+											debug.Log("removed X25519Identity %s", x.Recipient())
+
+											continue
+										}
+									case *wrappedIdentity:
+										skip := false
+										// to avoid fuzzy matching, let's match on entire parts
+										for _, part := range strings.Split(x.String(), "|") {
+											if part == victim {
+												skip = true
+											}
+										}
+										if skip {
+											debug.Log("removed Plugin Identity %s", x)
+
+											continue
+										}
 									}
+
 									newIds = append(newIds, fmt.Sprintf("%s", id))
+								}
+								if len(newIds) != len(ids) {
+									out.Warning(ctx, "Make sure to run 'gopass fsck --decrypt' to re-encrypt your secrets without including that identity if it's not in your recipient list.")
+								} else {
+									out.Notice(ctx, "no matching identity found in list")
 								}
 
 								return a.saveIdentities(ctx, newIds, false)

--- a/internal/backend/crypto/age/decrypt.go
+++ b/internal/backend/crypto/age/decrypt.go
@@ -33,6 +33,8 @@ func (a *Age) Decrypt(ctx context.Context, ciphertext []byte) ([]byte, error) {
 }
 
 func (a *Age) decrypt(ciphertext []byte, ids ...age.Identity) ([]byte, error) {
+	debug.Log("decrypting with %d ids", len(ids))
+
 	out := &bytes.Buffer{}
 	f := bytes.NewReader(ciphertext)
 	r, err := age.Decrypt(f, ids...)
@@ -48,6 +50,7 @@ func (a *Age) decrypt(ciphertext []byte, ids ...age.Identity) ([]byte, error) {
 	return out.Bytes(), nil
 }
 
+// decryptFile is used to decrypt a scrypt encrypted age keyring/identity file.
 func (a *Age) decryptFile(ctx context.Context, filename string) ([]byte, error) {
 	ciphertext, err := os.ReadFile(filename)
 	if err != nil {

--- a/internal/backend/crypto/age/encrypt.go
+++ b/internal/backend/crypto/age/encrypt.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"slices"
 
 	"filippo.io/age"
 	"github.com/gopasspw/gopass/pkg/ctxutil"
@@ -48,6 +49,22 @@ func dedupe(recp []age.Recipient) []age.Recipient {
 	for _, r := range set {
 		out = append(out, r)
 	}
+
+	// we make sure they are sorted so that age1 identities are first
+	slices.SortFunc(out, func(a, b age.Recipient) int {
+		i, oka := a.(fmt.Stringer)
+		j, okb := b.(fmt.Stringer)
+
+		// handle non-native recipients such as SSH, we want them at the bottom
+		if !oka {
+			return -1
+		}
+		if !okb {
+			return -1
+		}
+		// yubikey identities are typically longer
+		return len(i.String()) - len(j.String())
+	})
 	debug.Log("in: %+v - out: %+v", recp, out)
 
 	return out

--- a/internal/backend/crypto/age/encrypt.go
+++ b/internal/backend/crypto/age/encrypt.go
@@ -26,6 +26,7 @@ func (a *Age) Encrypt(ctx context.Context, plaintext []byte, recipients []string
 		return nil, fmt.Errorf("failed to parse recipients file for encryption: %w", err)
 	}
 
+	// dedupe also order recipients so that native ones are first
 	recp = dedupe(append(recp, idRecps...))
 
 	return a.encrypt(plaintext, recp...)
@@ -50,7 +51,10 @@ func dedupe(recp []age.Recipient) []age.Recipient {
 		out = append(out, r)
 	}
 
-	// we make sure they are sorted so that age1 identities are first
+	// we make sure they are sorted so that age1 identities are first,
+	// because age by default tries to decrypt in the order of the stanzas,
+	// and if we do have a native identity on our machine, we probably want to
+	// use that first before using a hardware token which might require a PIN.
 	slices.SortFunc(out, func(a, b age.Recipient) int {
 		i, oka := a.(fmt.Stringer)
 		j, okb := b.(fmt.Stringer)

--- a/internal/backend/crypto/age/identities_test.go
+++ b/internal/backend/crypto/age/identities_test.go
@@ -1,0 +1,109 @@
+package age
+
+import (
+	"fmt"
+	"testing"
+
+	"filippo.io/age"
+	"filippo.io/age/plugin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseIdentity(t *testing.T) {
+	tests := []struct {
+		name         string
+		encoding     string
+		expectedType any
+		shouldFail   bool
+	}{
+		{
+			"plugin id",
+			"AGE-PLUGIN-YUBIKEY-1GKZKJQYZL98RLMC67F9PJ",
+			&wrappedIdentity{},
+			false,
+		},
+		{
+			"native age id",
+			"AGE-SECRET-KEY-1RLNPSS8EV69RL40DKHUFUPU9SNWHUYYJQQMF3ZXQ7S4F3PTPS8EQ2RWVNA",
+			&age.X25519Identity{},
+			false,
+		},
+		{
+			"invalid age id",
+			"AGE-NONSECRET-KEY-TEST",
+			nil,
+			true,
+		},
+		{
+			"invalid bech32 plugin",
+			"AGE-PLUGIN-YUBIKEY-1GKKJQYZL98RLM7FJ",
+			nil,
+			true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tId, err := parseIdentity(tt.encoding)
+			if tt.shouldFail {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.IsType(t, tt.expectedType, tId)
+			}
+		})
+	}
+}
+
+func TestIdentityAndRecipient(t *testing.T) {
+	testId, err := age.GenerateX25519Identity()
+	require.NoError(t, err)
+
+	pluginId, err := plugin.NewIdentity("AGE-PLUGIN-YUBIKEY-1GKZKJQYZL98RLMC67F9PJ", nil)
+	require.NoError(t, err)
+	pluginRec, err := plugin.NewRecipient("age1yubikey1qt2r3tfk7wvlykudm7ew28dqqm3h8ln9zfsxsq4lcd2w8rh4n4hhz46ur24", nil)
+	require.NoError(t, err)
+	wrRec := &wrappedRecipient{
+		rec:      pluginRec,
+		encoding: "age0yubikey1qt2r3tfk7wvlykudm7ew28dqqm3h8ln9zfsxsq4lcd2w8rh4n4hhz46ur24",
+	}
+	tests := []struct {
+		name string
+		id   age.Identity
+		want age.Recipient
+	}{
+		{
+			"native identity",
+			testId,
+			testId.Recipient(),
+		},
+		{
+			"wrapped native id",
+			&wrappedIdentity{
+				id:       testId,
+				rec:      testId.Recipient(),
+				encoding: testId.String(),
+			},
+			testId.Recipient(),
+		},
+		{
+			"wrapped plugin id",
+			&wrappedIdentity{
+				id:       pluginId,
+				rec:      wrRec,
+				encoding: "AGE-PLUGIN-YUBIKEY-1GKZKJQYZL98RLMC67F9PJ",
+			},
+			wrRec,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.want, IdentityToRecipient(tt.id), "IdentityToRecipient(%v)", tt.id)
+			// ensure recipient strings aren't equal identity strings
+			assert.NotEqual(t, fmt.Sprintf("%s", tt.id), fmt.Sprintf("%s", tt.want))
+			// ensure Parsing works on the String of the id:
+			_, err = parseIdentity(fmt.Sprintf("%s", tt.id))
+			require.NoError(t, err)
+		})
+	}
+}

--- a/internal/backend/crypto/age/recipients.go
+++ b/internal/backend/crypto/age/recipients.go
@@ -6,6 +6,8 @@ import (
 
 	"filippo.io/age"
 	"filippo.io/age/agessh"
+	"filippo.io/age/plugin"
+	"github.com/gopasspw/gopass/internal/out"
 	"github.com/gopasspw/gopass/internal/set"
 	"github.com/gopasspw/gopass/pkg/debug"
 )
@@ -45,46 +47,62 @@ func (a *Age) FindRecipients(ctx context.Context, search ...string) ([]string, e
 }
 
 func (a *Age) parseRecipients(ctx context.Context, recipients []string) ([]age.Recipient, error) {
-	out := make([]age.Recipient, 0, len(recipients))
+	ret := make([]age.Recipient, 0, len(recipients))
 	for _, r := range recipients {
-		if strings.HasPrefix(r, "age1") {
+		switch {
+		case strings.HasPrefix(r, "age1"):
 			id, err := age.ParseX25519Recipient(r)
 			if err != nil {
 				debug.Log("Failed to parse recipient %q as X25519: %s", r, err)
 
+				pid, err := plugin.NewRecipient(r, pluginTerminalUI)
+				if err != nil {
+					debug.Log("Failed to parse recipient %q as an age plugin: %s", out.Secret(r), err)
+
+					continue
+				}
+				ret = append(ret, &wrappedRecipient{rec: pid, encoding: r})
+
 				continue
 			}
-			out = append(out, id)
+			ret = append(ret, id)
 
-			continue
-		}
-		if strings.HasPrefix(r, "ssh-") {
+		case strings.HasPrefix(r, "ssh-"):
 			id, err := agessh.ParseRecipient(r)
 			if err != nil {
 				debug.Log("Failed to parse recipient %q as SSH: %s", r, err)
 
 				continue
 			}
-			out = append(out, id)
+			ret = append(ret, id)
 
-			continue
-		}
-		if strings.HasPrefix(r, "github:") {
+		case strings.HasPrefix(r, "github:"):
+			out.Warning(ctx, "github recipient support has been removed from age, consider switching to native keys")
 			pks, err := a.ghCache.ListKeys(ctx, strings.TrimPrefix(r, "github:"))
 			if err != nil {
-				return out, err
+				return ret, err
 			}
 			for _, pk := range pks {
-				id, err := agessh.ParseRecipient(r)
+				id, err := agessh.ParseRecipient(pk)
 				if err != nil {
-					debug.Log("Failed to parse GitHub recipient %q: %q: %s", r, pk, err)
+					debug.Log("Failed to parse GitHub recipient %q for key %q: %s", r, pk, err)
 
 					continue
 				}
-				out = append(out, id)
+				ret = append(ret, id)
 			}
+		case strings.HasPrefix(r, "AGE-PLUGIN"):
+			pid, err := plugin.NewIdentity(r, pluginTerminalUI)
+			if err != nil {
+				debug.Log("Failed to parse identity as an age plugin: %s", err)
+
+				continue
+			}
+			ret = append(ret, &wrappedRecipient{rec: pid.Recipient(), encoding: r})
+		default:
+			debug.Log("Unknown age recipient %q failed parsing", out.Secret(r))
 		}
 	}
 
-	return out, nil
+	return ret, nil
 }

--- a/internal/backend/crypto/age/recipients.go
+++ b/internal/backend/crypto/age/recipients.go
@@ -91,6 +91,9 @@ func (a *Age) parseRecipients(ctx context.Context, recipients []string) ([]age.R
 				}
 				ret = append(ret, id)
 			}
+
+		// a special case to support the case where plugin users decided to use the plugin identity itself as a recipient
+		// when running the `gopass age identities add` command.
 		case strings.HasPrefix(r, "AGE-PLUGIN"):
 			pid, err := plugin.NewIdentity(r, pluginTerminalUI)
 			if err != nil {
@@ -99,6 +102,7 @@ func (a *Age) parseRecipients(ctx context.Context, recipients []string) ([]age.R
 				continue
 			}
 			ret = append(ret, &wrappedRecipient{rec: pid.Recipient(), encoding: r})
+
 		default:
 			debug.Log("Unknown age recipient %q failed parsing", out.Secret(r))
 		}

--- a/internal/backend/crypto/age/ssh.go
+++ b/internal/backend/crypto/age/ssh.go
@@ -27,9 +27,13 @@ var (
 // getSSHIdentities returns all SSH identities available for the current user.
 func (a *Age) getSSHIdentities(ctx context.Context) (map[string]age.Identity, error) {
 	if sshCache != nil {
+		debug.Log("using sshCache")
+
 		return sshCache, nil
 	}
 
+	// notice that this respects the GOPASS_HOMEDIR env variable, and won't
+	// find a .ssh folder in your home directory if you set GOPASS_HOMEDIR
 	uhd := appdir.UserHome()
 	sshDir := filepath.Join(uhd, ".ssh")
 	if !fsutil.IsDir(sshDir) {
@@ -60,6 +64,7 @@ func (a *Age) getSSHIdentities(ctx context.Context) (map[string]age.Identity, er
 		ids[recp] = id
 	}
 	sshCache = ids
+	debug.Log("returned %d SSH Identities", len(ids))
 
 	return ids, nil
 }

--- a/internal/cache/disk.go
+++ b/internal/cache/disk.go
@@ -75,6 +75,8 @@ func (o *OnDisk) Get(key string) ([]string, error) {
 
 // Set adds an entry to the cache.
 func (o *OnDisk) Set(key string, value []string) error {
+	// we need to make sure not to log things here as plugin Identities' recipients
+	// can contain secret data
 	if err := o.ensureDir(); err != nil {
 		return err
 	}

--- a/internal/cache/ghssh/github.go
+++ b/internal/cache/ghssh/github.go
@@ -22,7 +22,7 @@ var httpClient = &http.Client{
 }
 
 // ListKeys returns the public keys for a github user. It will
-// cache results up the a configurable amount of time (default: 6h).
+// cache results up to a configurable amount of time (default: 6h).
 func (c *Cache) ListKeys(ctx context.Context, user string) ([]string, error) {
 	pk, err := c.disk.Get(user)
 	if err != nil {

--- a/main_test.go
+++ b/main_test.go
@@ -121,6 +121,9 @@ func TestGetCommands(t *testing.T) {
 	ctx = ctxutil.WithTerminal(ctx, false)
 	ctx = ctxutil.WithHidden(ctx, true)
 	ctx = backend.WithCryptoBackendString(ctx, "plain")
+	ctx = ctxutil.WithPasswordCallback(ctx, func(_ string, _ bool) ([]byte, error) {
+		return []byte("foobar"), nil
+	})
 
 	act, err := action.New(cfg, semver.Version{})
 	require.NoError(t, err)


### PR DESCRIPTION
Sorry for this being a big, messy PR; I had to touch quite a few things and the `age` plugin support itself is still experimental, so this is currently based on the [age/plugin feature branch from age](https://github.com/FiloSottile/age/pull/580).

On the bright side: yubikey `age` identities do work really nicely as far as I can tell! 

Closes #2900, closes #2260, and fixes partially #2619.

A few points worth mentioning that might warrant some discussion:
- most notably, I had to edit the format we use for storing identities in our key ring, because plugin identities do not allow to necessarily derive the right recipient easily (or include secret key material when doing so), so I am now storing in our identity file the identities in the following format:
   ```
   AGE-PLUGIN-YUBIKEY-1GK...|age1yubikey1qt2r...
   AGE-SECRET-KEY-10CW...
   ``` 
	using `|` to separate the actual identity encoding from the recipient encoding. This has some trickling effects on how we parse age identities
- I had to add the notion of `wrapped` identities and recipients, because plugin.`Identity` and `Recipient` don't have any easy way to go back to their "encoded" string format with the current proposed `age` plugin interfaces. 
- I had to add a sorting function on the recipients when encrypting with age, because `age` by default tries to decrypt in the order of the stanzas, and if we do have a native identity on our machine, we probably want to use that first before using a hardware token.

On a side node, overall, the `age` backend code is fairly messy and it might warrant some big refactoring at some point.

Disclaimer: I have only tested that on my own machine, not with a team using `age` as a backend, and yeah tests are somewhat lacking, I'll try to add a few tests with example identities and recipients in the coming days.