### PR TITLE
[n/a] Correcting mistake in search+replace

### DIFF
--- a/pkg/clipboard/clipboard.go
+++ b/pkg/clipboard/clipboard.go
@@ -46,7 +46,7 @@ func CopyTo(ctx context.Context, name string, content []byte, timeout int) error
 	}
 
 	if timeout < 1 {
-		debug.Log("Auto-clearClip of clipboard disabled.")
+		debug.Log("Auto-clear of clipboard disabled.")
 
 		out.Printf(ctx, "✔ Copied %s to clipboard.", color.YellowString(name))
 		_ = notify.Notify(ctx, "gopass - clipboard", fmt.Sprintf("✔ Copied %s to clipboard.", name))
@@ -55,13 +55,13 @@ func CopyTo(ctx context.Context, name string, content []byte, timeout int) error
 	}
 
 	if err := clearClip(ctx, name, content, timeout); err != nil {
-		_ = notify.Notify(ctx, "gopass - clipboard", "failed to clearClip clipboard")
+		_ = notify.Notify(ctx, "gopass - clipboard", "failed to clear clipboard")
 
-		return fmt.Errorf("failed to clearClip clipboard: %w", err)
+		return fmt.Errorf("failed to clear clipboard: %w", err)
 	}
 
-	out.Printf(ctx, "✔ Copied %s to clipboard. Will clearClip in %d seconds.", color.YellowString(name), timeout)
-	_ = notify.Notify(ctx, "gopass - clipboard", fmt.Sprintf("✔ Copied %s to clipboard. Will clearClip in %d seconds.", name, timeout))
+	out.Printf(ctx, "✔ Copied %s to clipboard. Will clear in %d seconds.", color.YellowString(name), timeout)
+	_ = notify.Notify(ctx, "gopass - clipboard", fmt.Sprintf("✔ Copied %s to clipboard. Will clear in %d seconds.", name, timeout))
 
 	return nil
 }

--- a/pkg/clipboard/clipboard_windows.go
+++ b/pkg/clipboard/clipboard_windows.go
@@ -13,7 +13,7 @@ import (
 	"github.com/gopasspw/gopass/internal/pwschemes/argon2id"
 )
 
-// clearClip will spwan a copy of gopass that waits in a detached background
+// clearClip will spawn a copy of gopass that waits in a detached background
 // process group until the timeout is expired. It will then compare the contents
 // of the clipboard and erase it if it still contains the data gopass copied
 // to it.

--- a/pkg/clipboard/copy_darwin.go
+++ b/pkg/clipboard/copy_darwin.go
@@ -38,7 +38,7 @@ func copyViaOsascript(ctx context.Context, password string) error {
 		"-e", "set type to current application's NSPasteboardTypeString",
 		// pb = a reference to the system's pasteboard
 		"-e", "set pb to current application's NSPasteboard's generalPasteboard()",
-		// Must clearClip contents before adding a new item to pasteboard
+		// Must clear contents before adding a new item to pasteboard
 		"-e", "pb's clearContents()",
 		// Set the flag ConcealedType so clipboard history managers don't record the password.
 		// The first argument can by anything, but an empty string will do fine.

--- a/pkg/clipboard/unclip.go
+++ b/pkg/clipboard/unclip.go
@@ -16,9 +16,9 @@ func Clear(ctx context.Context, name string, checksum string, force bool) error 
 	clipboardClearCMD := os.Getenv("GOPASS_CLIPBOARD_CLEAR_CMD")
 	if clipboardClearCMD != "" {
 		if err := callCommand(ctx, clipboardClearCMD, name, []byte(checksum)); err != nil {
-			_ = notify.Notify(ctx, "gopass - clipboard", "failed to call clipboard clearClip command")
+			_ = notify.Notify(ctx, "gopass - clipboard", "failed to call clipboard clear command")
 
-			return fmt.Errorf("failed to call clipboard clearClip command: %w", err)
+			return fmt.Errorf("failed to call clipboard clear command: %w", err)
 		}
 
 		debug.Log("clipboard cleared (%s)", checksum)
@@ -47,15 +47,15 @@ func Clear(ctx context.Context, name string, checksum string, force bool) error 
 	}
 
 	if err := clipboard.WriteAll(""); err != nil {
-		_ = notify.Notify(ctx, "gopass - clipboard", "Failed to clearClip clipboard")
+		_ = notify.Notify(ctx, "gopass - clipboard", "Failed to clear clipboard")
 
 		return fmt.Errorf("failed to write clipboard: %w", err)
 	}
 
 	if err := clearClipboardHistory(ctx); err != nil {
-		_ = notify.Notify(ctx, "gopass - clipboard", "Failed to clearClip clipboard history")
+		_ = notify.Notify(ctx, "gopass - clipboard", "Failed to clear clipboard history")
 
-		return fmt.Errorf("failed to clearClip clipboard history: %w", err)
+		return fmt.Errorf("failed to clear clipboard history: %w", err)
 	}
 
 	if err := notify.Notify(ctx, "gopass - clipboard", "Clipboard has been cleared"); err != nil {


### PR DESCRIPTION
Seems I was a bit hasty when migrating to Go 1.23 and renaming the function "clear" which is now a builtin into "clearClip".