### PR TITLE
[BUGFIX]: Respect HTTP proxy environment variables in downloader

### DIFF
--- a/internal/updater/download.go
+++ b/internal/updater/download.go
@@ -25,6 +25,7 @@ var (
 				// enforce TLS 1.3
 				MinVersion: tls.VersionTLS13,
 			},
+			Proxy: http.ProxyFromEnvironment,
 		},
 	}
 )


### PR DESCRIPTION
`gopass update` fails on the hosts behind HTTP proxies and without direct Internet connectivity. Fix is setting up proxy from environment variables similarly to default golang HTTP client.


Before:
```
$ gopass update
⚒ Checking for available updates ...

Error: Failed to update gopass: HTTP request failed: context deadline exceeded
$
```

After: 
```
$ gopass update
⚒ Checking for available updates ...
gopass is up to date (1.15.14)
✅ gopass is up to date
$
```
