### PR TITLE
[CLEANUP] Replace experimental `maps` and `slices` with stdlib

### DIFF
--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -6,7 +6,9 @@ package audit
 import (
 	"context"
 	"fmt"
+	"maps"
 	"path"
+	"slices"
 	"sync"
 	"time"
 
@@ -23,7 +25,6 @@ import (
 	"github.com/gopasspw/gopass/pkg/termio"
 	"github.com/muesli/crunchy"
 	"github.com/nbutton23/zxcvbn-go"
-	"golang.org/x/exp/maps"
 )
 
 type secretGetter interface {
@@ -269,7 +270,7 @@ func (a *Auditor) checkHIBP(ctx context.Context) error {
 
 	// look up all known sha1sums. The LookupBatch method will sort the
 	// input so we don't need to.
-	matches := scanner.LookupBatch(ctx, maps.Keys(a.r.sha1sums))
+	matches := scanner.LookupBatch(ctx, slices.Collect(maps.Keys(a.r.sha1sums)))
 	for _, m := range matches {
 		// map any match back to the secret(s).
 		secs, found := a.r.sha1sums[m]

--- a/internal/backend/registry.go
+++ b/internal/backend/registry.go
@@ -1,12 +1,14 @@
 package backend
 
 import (
+	"cmp"
 	"context"
 	"fmt"
-	"sort"
+	"maps"
+	"slices"
 	"sync"
 
-	"golang.org/x/exp/maps"
+	"github.com/gopasspw/gopass/internal/set"
 )
 
 var (
@@ -73,10 +75,7 @@ func (r *Registry[K, V]) BackendNames() []string {
 	r.RLock()
 	defer r.RUnlock()
 
-	names := maps.Keys(r.nameToBackend)
-	sort.Strings(names)
-
-	return names
+	return set.SortedKeys(r.nameToBackend)
 }
 
 func (r *Registry[K, V]) Backends() []V {
@@ -96,11 +95,10 @@ func (r *Registry[K, V]) Prioritized() []V {
 	defer r.RUnlock()
 
 	bes := maps.Values(r.backends)
-	sort.Slice(bes, func(i, j int) bool {
-		return bes[i].Priority() < bes[j].Priority()
-	})
 
-	return bes
+	return slices.SortedFunc(bes, func(a, b V) int {
+		return cmp.Compare(a.Priority(), b.Priority())
+	})
 }
 
 func (r *Registry[K, V]) Get(key K) (V, error) {

--- a/internal/config/docs_test.go
+++ b/internal/config/docs_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	"github.com/gopasspw/gopass/internal/set"
-	"golang.org/x/exp/maps"
 )
 
 // ignoredEnvs is a list of environment variables that are used by gopass
@@ -186,12 +185,12 @@ func TestEnvVarsInDocs(t *testing.T) {
 	t.Logf("env options documented in doc: %+v", documented)
 	t.Logf("env options used in the code: %+v", used)
 
-	for _, k := range set.Sorted(maps.Keys(documented)) {
+	for _, k := range set.SortedKeys(documented) {
 		if !used[k] {
 			t.Errorf("Documented but not used: %s", k)
 		}
 	}
-	for _, k := range set.Sorted(maps.Keys(used)) {
+	for _, k := range set.SortedKeys(used) {
 		if !documented[k] {
 			t.Errorf("Used but not documented: %s", k)
 		}

--- a/internal/config/legacy/io.go
+++ b/internal/config/legacy/io.go
@@ -5,11 +5,10 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"sort"
 
+	"github.com/gopasspw/gopass/internal/set"
 	"github.com/gopasspw/gopass/pkg/debug"
 	"github.com/gopasspw/gopass/pkg/fsutil"
-	"golang.org/x/exp/maps"
 	"gopkg.in/yaml.v3"
 )
 
@@ -107,8 +106,7 @@ func checkOverflow(m map[string]any) error {
 		return nil
 	}
 
-	keys := maps.Keys(m)
-	sort.Strings(keys)
+	keys := set.SortedKeys(m)
 
 	return fmt.Errorf("unknown fields: %+v", keys)
 }

--- a/internal/recipients/recipients.go
+++ b/internal/recipients/recipients.go
@@ -5,11 +5,9 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
-	"sort"
 	"strings"
 
 	"github.com/gopasspw/gopass/internal/set"
-	"golang.org/x/exp/maps"
 )
 
 // Recipients is a list of Key IDs. It will try to retain the file as much as possible while manipulating the recipients.
@@ -37,10 +35,7 @@ func (r *Recipients) Len() int {
 
 // IDs returns the key IDs.
 func (r *Recipients) IDs() []string {
-	res := maps.Keys(r.r)
-	sort.Strings(res)
-
-	return res
+	return set.SortedKeys(r.r)
 }
 
 // Add adds a new recipients. It returns true if the recipient was added.

--- a/internal/set/sorted.go
+++ b/internal/set/sorted.go
@@ -1,18 +1,18 @@
 package set
 
 import (
+	"maps"
+	"slices"
+
 	"golang.org/x/exp/constraints"
-	"golang.org/x/exp/maps"
-	"golang.org/x/exp/slices"
 )
 
 // SortedKeys returns the sorted keys of the map.
 func SortedKeys[K constraints.Ordered, V any](m map[K]V) []K {
 	// sort
 	keys := maps.Keys(m)
-	slices.Sort(keys)
 
-	return keys
+	return slices.Sorted(keys)
 }
 
 // Sorted returns a sorted set of the input.
@@ -36,9 +36,7 @@ func SortedFiltered[K constraints.Ordered](l []K, want func(K) bool) []K {
 		}
 		m[k] = struct{}{}
 	}
-	// sort
-	keys := maps.Keys(m)
-	slices.Sort(keys)
 
-	return keys
+	// sort
+	return SortedKeys(m)
 }

--- a/internal/store/mockstore/inmem/store.go
+++ b/internal/store/mockstore/inmem/store.go
@@ -4,14 +4,13 @@ package inmem
 import (
 	"context"
 	"fmt"
-	"sort"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/blang/semver/v4"
 	"github.com/gopasspw/gopass/internal/backend"
-	"golang.org/x/exp/maps"
+	"github.com/gopasspw/gopass/internal/set"
 )
 
 // InMem is a thread-safe in-memory store.
@@ -81,10 +80,7 @@ func (m *InMem) List(ctx context.Context, prefix string) ([]string, error) {
 	m.Lock()
 	defer m.Unlock()
 
-	keys := maps.Keys(m.data)
-	sort.Strings(keys)
-
-	return keys, nil
+	return set.SortedKeys(m.data), nil
 }
 
 // IsDir returns true if the entry is a directory.

--- a/pkg/gitconfig/config_test.go
+++ b/pkg/gitconfig/config_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/gopasspw/gopass/internal/set"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/exp/maps"
 )
 
 func TestInsertOnce(t *testing.T) {
@@ -132,7 +131,7 @@ func TestInsertMultiple(t *testing.T) {
 		"core.noshow": "true",
 	}
 
-	for _, k := range set.Sorted(maps.Keys(updates)) {
+	for _, k := range set.SortedKeys(updates) {
 		v := updates[k]
 		require.NoError(t, c.insertValue(k, v))
 	}
@@ -163,7 +162,7 @@ func TestRewriteRaw(t *testing.T) {
 		"show.safecontent": "false",
 		"core.autoimport":  "false",
 	}
-	for _, k := range set.Sorted(maps.Keys(updates)) {
+	for _, k := range set.SortedKeys(updates) {
 		v := updates[k]
 		require.NoError(t, c.Set(k, v))
 	}

--- a/pkg/gitconfig/gitconfig_test.go
+++ b/pkg/gitconfig/gitconfig_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/exp/maps"
 )
 
 // https://mirrors.edge.kernel.org/pub/software/scm/git/docs/git-config.html#EXAMPLES
@@ -343,7 +342,8 @@ func TestParseComplex(t *testing.T) {
 
 	c := ParseConfig(strings.NewReader(configSampleComplex))
 
-	assert.Contains(t, maps.Keys(c.vars), "core.sshCommand")
+	_, ok := c.vars["core.sshCommand"]
+	assert.True(t, ok)
 
 	v, ok := c.Get("core.sshCommand")
 	assert.True(t, ok)

--- a/pkg/gopass/secrets/akv.go
+++ b/pkg/gopass/secrets/akv.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/gopasspw/gopass/internal/set"
 	"github.com/gopasspw/gopass/pkg/debug"
-	"golang.org/x/exp/maps"
 )
 
 var kvSep = ": "
@@ -40,7 +39,7 @@ func NewAKVWithData(pw string, kvps map[string][]string, body string, converted 
 	kv.SetPassword(pw)
 	kv.fromMime = converted
 
-	for _, k := range set.Sorted(maps.Keys(kvps)) {
+	for _, k := range set.SortedKeys(kvps) {
 		vs := kvps[k]
 		for _, v := range vs {
 			_ = kv.Add(k, v)
@@ -59,7 +58,7 @@ func (a *AKV) Bytes() []byte {
 
 // Keys returns all the parsed keys.
 func (a *AKV) Keys() []string {
-	return set.Sorted(maps.Keys(a.kvp))
+	return set.SortedKeys(a.kvp)
 }
 
 // Get returns the value of the requested key, if found.

--- a/pkg/gopass/secrets/yaml.go
+++ b/pkg/gopass/secrets/yaml.go
@@ -6,14 +6,13 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"sort"
 	"strings"
 
 	"github.com/caspr-io/yamlpath"
 	"github.com/gopasspw/gopass/internal/out"
+	"github.com/gopasspw/gopass/internal/set"
 	"github.com/gopasspw/gopass/pkg/debug"
 	"github.com/gopasspw/gopass/pkg/gopass"
-	"golang.org/x/exp/maps"
 	yaml "gopkg.in/yaml.v3"
 )
 
@@ -47,10 +46,7 @@ type YAML struct {
 
 // Keys returns all keys.
 func (y *YAML) Keys() []string {
-	keys := maps.Keys(y.data)
-	sort.Strings(keys)
-
-	return keys
+	return set.SortedKeys(y.data)
 }
 
 // Get returns the first value of a single key.


### PR DESCRIPTION
The experimental functions are now available in the standard library in Go 1.23 [^1].

The only difference is that `maps.Keys` and `maps.Values` in the standard library return an iterator, while `maps.Keys` and `maps.Values` in the `golang.org/x/exp` package return a slice.

[^1]: https://go.dev/doc/go1.23#new-unique-package