### PR TITLE
fix: Remove gci

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -156,7 +156,6 @@ gen:
 
 fmt:
 	@gofumpt -w $(GOFILES_NOVENDOR)
-	@gci write $(GOFILES_NOVENDOR)
 	@$(GO) mod tidy
 
 deps:


### PR DESCRIPTION
gci would sometimes mess with gofumpt and cause lint issues.