### PR TITLE
[BUGFIX] replace return of wrong error variable

### DIFF
--- a/internal/notify/notify_dbus.go
+++ b/internal/notify/notify_dbus.go
@@ -31,7 +31,7 @@ func Notify(ctx context.Context, subj, msg string) error {
 	if call.Err != nil {
 		debug.Log("DBus notification failure: %s", call.Err)
 
-		return err
+		return call.Err
 	}
 
 	return nil


### PR DESCRIPTION
This fixes the issue #3012 where the error returned by the `Notify()` call would incorrectly return a nil value (from `dbus.SessionBus()`), instead of the correct non-nil value (from `call.Err`).