### PR TITLE
[BUGFIX] Check if any usable key matches on clone

### DIFF
--- a/internal/action/clone.go
+++ b/internal/action/clone.go
@@ -204,7 +204,8 @@ func (s *Action) cloneCheckDecryptionKeys(ctx context.Context, mount string) err
 	}
 
 	idSet := set.New(ids...)
-	if idSet.IsSubset(recpSet) {
+	// Check whether any of our usable keys are in recpSet
+	if _, found := recpSet.Choose(idSet.Contains); found {
 		out.Noticef(ctx, "Found valid decryption keys. You can now decrypt your passwords.")
 
 		return nil


### PR DESCRIPTION
This commit changes the check whether we have access to the cloned repository from checking whether *all* of our usable keys are included to whether *any* of our usable keys are included.