### PR TITLE
chore(deps): bump github.com/twpayne/go-pinentry from v0.3.0 to v4.0.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/schollz/closestmatch v0.0.0-20190308193919-1fbe626be92e
 	github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e
 	github.com/stretchr/testify v1.10.0
-	github.com/twpayne/go-pinentry v0.3.0
+	github.com/twpayne/go-pinentry/v4 v4.0.0
 	github.com/urfave/cli/v2 v2.27.5
 	github.com/xhit/go-str2duration/v2 v2.1.0
 	github.com/zalando/go-keyring v0.2.6

--- a/go.sum
+++ b/go.sum
@@ -191,8 +191,8 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
-github.com/twpayne/go-pinentry v0.3.0 h1:Rr+fEOZXmeItOb4thjeVaBWJKB9Xa/eojolycyF/26c=
-github.com/twpayne/go-pinentry v0.3.0/go.mod h1:iOIZD+9np/2V24OdCGos7Y1/xX90wc6VEAZsgb+r9D4=
+github.com/twpayne/go-pinentry/v4 v4.0.0 h1:8WcNa+UDVRzz7y9OEEU/nRMX+UGFPCAvl5XsqWRxTY4=
+github.com/twpayne/go-pinentry/v4 v4.0.0/go.mod h1:aXvy+awVXqdH+GS0ddQ7AKHZ3tXM6fJ2NK+e16p47PI=
 github.com/ulikunitz/xz v0.5.12 h1:37Nm15o69RwBkXM0J6A5OlE67RZTfzUxTj8fB3dfcsc=
 github.com/ulikunitz/xz v0.5.12/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/urfave/cli/v2 v2.27.5 h1:WoHEJLdsXr6dDWoJgMq/CboDmyY/8HMMH1fTECbih+w=

--- a/internal/backend/crypto/age/askpass.go
+++ b/internal/backend/crypto/age/askpass.go
@@ -11,7 +11,7 @@ import (
 	"github.com/gopasspw/gopass/pkg/debug"
 	"github.com/gopasspw/gopass/pkg/pinentry/cli"
 	"github.com/nbutton23/zxcvbn-go"
-	"github.com/twpayne/go-pinentry"
+	"github.com/twpayne/go-pinentry/v4"
 	"github.com/zalando/go-keyring"
 )
 
@@ -125,7 +125,7 @@ func (a *askPass) getPassphrase(reason string, repeat bool) (string, error) {
 		pinentry.WithTitle("gopass"),
 	}
 	if repeat {
-		opts = append(opts, pinentry.WithOption("REPEAT=Confirm"))
+		opts = append(opts, pinentry.WithRepeat("Confirm"))
 		opts = append(opts, pinentry.WithQualityBar(func(s string) (int, bool) {
 			match := zxcvbn.PasswordStrength(s, nil)
 
@@ -153,12 +153,12 @@ func (a *askPass) getPassphrase(reason string, repeat bool) (string, error) {
 		_ = p.Close()
 	}()
 
-	pw, _, err := p.GetPIN()
+	result, err := p.GetPIN()
 	if err != nil {
 		return "", fmt.Errorf("pinentry error: %w", err)
 	}
 
-	return pw, nil
+	return result.PIN, nil
 }
 
 func (a *askPass) Remove(key string) {


### PR DESCRIPTION
The change is minor, this just updates gopass to use the latest version of go-pinentry.