### PR TITLE
fix: Ask user to confirm generated passphrase before invocing pinentry

### DIFF
--- a/internal/action/setup.go
+++ b/internal/action/setup.go
@@ -181,12 +181,6 @@ func (s *Action) initGenerateIdentity(ctx context.Context, crypto backend.Crypto
 		}
 	}
 
-	if err := crypto.GenerateIdentity(ctx, name, email, passphrase); err != nil {
-		return fmt.Errorf("failed to create new private key: %w", err)
-	}
-
-	out.OKf(ctx, "Key pair for %s generated", crypto.Name())
-
 	if pwGenerated {
 		out.Printf(ctx, color.MagentaString("Passphrase: ")+passphrase)
 		out.Noticef(ctx, "You need to remember this very well!")
@@ -196,6 +190,12 @@ func (s *Action) initGenerateIdentity(ctx context.Context, crypto backend.Crypto
 			return fmt.Errorf("user did not confirm saving the passphrase: %w", err)
 		}
 	}
+
+	if err := crypto.GenerateIdentity(ctx, name, email, passphrase); err != nil {
+		return fmt.Errorf("failed to create new private key: %w", err)
+	}
+
+	out.OKf(ctx, "Key pair for %s generated", crypto.Name())
 
 	out.Notice(ctx, "🔐 We need to unlock your newly created private key now! Please enter the passphrase you just generated.")
 

--- a/internal/action/setup.go
+++ b/internal/action/setup.go
@@ -190,6 +190,11 @@ func (s *Action) initGenerateIdentity(ctx context.Context, crypto backend.Crypto
 	if pwGenerated {
 		out.Printf(ctx, color.MagentaString("Passphrase: ")+passphrase)
 		out.Noticef(ctx, "You need to remember this very well!")
+
+		// Prompt to confirm that the user noted their passphrase
+		if want, err := termio.AskForBool(ctx, "Did you save your passphrase?", true); err != nil || !want {
+			return fmt.Errorf("user did not confirm saving the passphrase: %w", err)
+		}
 	}
 
 	out.Notice(ctx, "🔐 We need to unlock your newly created private key now! Please enter the passphrase you just generated.")


### PR DESCRIPTION
This is to avoid users not seeing their generated password if using e.g. pinentry curses UI.

Fixes #3030