### PR TITLE
[BUGFIX] Fixed password not saving to clipboard with safecontent and autoclip true

### DIFF
--- a/internal/action/show.go
+++ b/internal/action/show.go
@@ -273,7 +273,7 @@ func (s *Action) showGetContent(ctx context.Context, sec gopass.Secret) (string,
 	// everything but the first line.
 	if config.Bool(ctx, "show.safecontent") && !ctxutil.IsForce(ctx) && ctxutil.IsShowParsing(ctx) {
 		body := showSafeContent(sec)
-		if IsAlsoClip(ctx) {
+		if IsAlsoClip(ctx) || config.Bool(ctx, "show.autoclip"){
 			return pw, body, nil
 		}
 

--- a/internal/action/show.go
+++ b/internal/action/show.go
@@ -273,7 +273,7 @@ func (s *Action) showGetContent(ctx context.Context, sec gopass.Secret) (string,
 	// everything but the first line.
 	if config.Bool(ctx, "show.safecontent") && !ctxutil.IsForce(ctx) && ctxutil.IsShowParsing(ctx) {
 		body := showSafeContent(sec)
-		if IsAlsoClip(ctx) || config.Bool(ctx, "show.autoclip"){
+		if IsAlsoClip(ctx) || config.Bool(ctx, "show.autoclip") {
 			return pw, body, nil
 		}
 

--- a/internal/action/show_test.go
+++ b/internal/action/show_test.go
@@ -315,6 +315,18 @@ func TestShowAutoClip(t *testing.T) {
 		stdoutBuf.Reset()
 		stderrBuf.Reset()
 	})
+
+	// gopass show foo with show.autoclip and show.safecontent true
+	// -> ONLY Copy to clipboard
+	t.Run("show foo with safecontent and autoclip enabled", func(t *testing.T) {
+		require.NoError(t, act.cfg.Set("", "show.autoclip", "true"))
+		require.NoError(t, act.cfg.Set("", "show.safecontent", "true"))
+		c := gptest.CliCtx(ctx, t, "foo")
+		require.NoError(t, act.Show(c))
+		assert.Contains(t, stderrBuf.String(), "WARNING")
+		assert.NotContains(t, stdoutBuf.String(), "secret")
+		stdoutBuf.Reset()
+	})
 }
 
 func TestShowHandleRevision(t *testing.T) {


### PR DESCRIPTION
Fixed an issue where enabling both AutoClip and SafeContent prevented passwords from being saved to the clipboard. Added tests to cover this case.

Signed-off-by: Alex Wallner <wallneralex7789@gmail.cpm>
