### PR TITLE
[BUGFIX] Fixed max length check for strings in create/wizard

### DIFF
--- a/internal/create/wizard.go
+++ b/internal/create/wizard.go
@@ -225,7 +225,7 @@ func mkActFunc(tpl Template, s *root.Store, cb ActionCallback) func(context.Cont
 				if v.Min > 0 && len(sv) < v.Min {
 					return fmt.Errorf("%s is too short (needs %d)", v.Name, v.Min)
 				}
-				if v.Max > 0 && len(sv) > v.Min {
+				if v.Max > 0 && len(sv) > v.Max {
 					return fmt.Errorf("%s is too long (at most %d)", v.Name, v.Max)
 				}
 				if wantForName[k] {


### PR DESCRIPTION
My first real pull request for this project.

tldr: if you create a custom .yaml with max attribute for string, for example:

```
---
priority: 1
name: "Bank Card"
prefix: "cards"
name_from:
  - "bankname"
welcome: "🧪 Creating Bank Card entry"
attributes:
  - name: "bankname"
    type: "string"
    prompt: "Bank Name"
    min: 1
    max: 255

```

It will fail check for max length all the time:

```
🌟 Welcome to the secret creation wizard (gopass create)!
🧪 Hint: Use 'gopass edit -c' for more control!
[ 0] Website login
[ 1] Bank Card

Please select the type of secret you would like to create (q to abort) [0]: 1
1
🧪 Creating Bank Card entry
  [1] Bank Name                              []: Test
❌ bankname is too long (at most 255)
```

Turns out wizard was checking v.Min value instead of v.Max 
Now works as expected.
All internal tests were passed.