### PR TITLE
[fix] Fix debug.ModuleVersion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ ZSH_COMPLETION_OUTPUT     := zsh.completion
 CLIPHELPERS               ?= ""
 # Support reproducible builds by embedding date according to SOURCE_DATE_EPOCH if present
 DATE                      := $(shell date -u -d "@$(SOURCE_DATE_EPOCH)" '+%FT%T%z' 2>/dev/null || date -u '+%FT%T%z')
-BUILDFLAGS_NOPIE          := -tags=netgo -trimpath -ldflags="-s -w -X main.version=$(GOPASS_VERSION) -X main.commit=$(GOPASS_REVISION) -X main.date=$(DATE) $(CLIPHELPERS)" -gcflags="-trimpath=$(GOPATH)" -asmflags="-trimpath=$(GOPATH)"
+BUILDFLAGS_NOPIE          := -buildvcs=true -tags=netgo -trimpath -ldflags="-s -w -X main.version=$(GOPASS_VERSION) -X main.commit=$(GOPASS_REVISION) -X main.date=$(DATE) $(CLIPHELPERS)" -gcflags="-trimpath=$(GOPATH)" -asmflags="-trimpath=$(GOPATH)"
 BUILDFLAGS                ?= $(BUILDFLAGS_NOPIE) -buildmode=pie
 TESTFLAGS                 ?=
 PWD                       := $(shell pwd)

--- a/helpers/modinfo/main.go
+++ b/helpers/modinfo/main.go
@@ -1,0 +1,29 @@
+// modinfo a small helper to print the build info and module versions.
+//
+// Test builds don't have build info, so this will only work in a real build.
+package main
+
+import (
+	"fmt"
+	rd "runtime/debug"
+
+	_ "github.com/blang/semver/v4"
+	"github.com/gopasspw/gopass/pkg/debug"
+)
+
+func main() {
+	info, ok := rd.ReadBuildInfo()
+	if !ok {
+		panic("could not read build info")
+	}
+
+	fmt.Printf("Build Info: %+v\n", info)
+
+	for _, v := range []string{
+		"github.com/blang/semver/v4",
+		"github.com/gopasspw/gopass/internal/backend/storage/fs",
+	} {
+		mv := debug.ModuleVersion(v)
+		fmt.Printf("Module Version: %s %s\n", v, mv)
+	}
+}

--- a/internal/backend/storage/fs/store.go
+++ b/internal/backend/storage/fs/store.go
@@ -231,7 +231,7 @@ func (s *Store) Name() string {
 
 // Version returns the version of this backend.
 func (s *Store) Version(context.Context) semver.Version {
-	return debug.ModuleVersion("github.com/gopasspw/gopass/internal/backend/fs")
+	return debug.ModuleVersion("github.com/gopasspw/gopass/internal/backend/storage/fs")
 }
 
 // String implements fmt.Stringer.

--- a/pkg/debug/version.go
+++ b/pkg/debug/version.go
@@ -44,6 +44,7 @@ func ModuleVersion(m string) semver.Version {
 
 			// remove invalid characters
 			dv := strings.Trim(strings.TrimPrefix(dep.Version, "v"), "()")
+
 			return semver.Version{
 				Build: []string{dv},
 			}
@@ -62,5 +63,6 @@ func paths(mods []*rdebug.Module) []string {
 	for _, m := range mods {
 		out = append(out, m.Path)
 	}
+
 	return out
 }

--- a/pkg/debug/version.go
+++ b/pkg/debug/version.go
@@ -7,31 +7,60 @@ import (
 	"github.com/blang/semver/v4"
 )
 
+var biFunc func() (*rdebug.BuildInfo, bool) = rdebug.ReadBuildInfo
+
 // ModuleVersion the version of the named import.
 func ModuleVersion(m string) semver.Version {
-	bi, ok := rdebug.ReadBuildInfo()
+	bi, ok := biFunc()
 	if !ok || bi == nil {
 		Log("Failed to read build info")
 
 		return semver.Version{}
 	}
 
+	// special case for gopass
+	if m == "github.com/gopasspw/gopass" || strings.HasPrefix(m, "github.com/gopasspw/gopass/") {
+		sv, err := semver.Parse(strings.TrimPrefix(bi.Main.Version, "v"))
+		if err == nil {
+			return sv
+		}
+		Log("Failed to parse version %q for %q (gopass): %s", bi.Main.Version, m, err)
+	}
+
 	for _, dep := range bi.Deps {
-		if dep.Path != m {
+		// We might be asking for a package that is part of a module
+		// but not the module itself.
+		if !strings.HasPrefix(m, dep.Path) {
 			continue
 		}
 
 		sv, err := semver.Parse(strings.TrimPrefix(dep.Version, "v"))
 		if err != nil {
-			Log("Failed to parse version %s: %s", dep.Version, err)
+			Log("Failed to parse version %q for %q: %s", dep.Version, dep.Path, err)
 
-			return semver.Version{}
+			if dep.Version == "" {
+				return semver.Version{}
+			}
+
+			// remove invalid characters
+			dv := strings.Trim(strings.TrimPrefix(dep.Version, "v"), "()")
+			return semver.Version{
+				Build: []string{dv},
+			}
 		}
 
 		return sv
 	}
 
-	Log("no module %s found", m)
+	Log("no module %s found. Modules: %v", m, paths(bi.Deps))
 
 	return semver.Version{}
+}
+
+func paths(mods []*rdebug.Module) []string {
+	out := make([]string, 0, len(mods))
+	for _, m := range mods {
+		out = append(out, m.Path)
+	}
+	return out
 }

--- a/pkg/debug/version_test.go
+++ b/pkg/debug/version_test.go
@@ -1,0 +1,91 @@
+package debug
+
+import (
+	"testing"
+
+	rdebug "runtime/debug"
+
+	"github.com/blang/semver/v4"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestModuleVersion(t *testing.T) {
+	tests := []struct {
+		name   string
+		pkg    string
+		module string
+		modver string
+		want   semver.Version
+		noBI   bool
+	}{
+		{
+			name:   "valid module version semver",
+			pkg:    "github.com/blang/semver/v4",
+			module: "github.com/blang/semver/",
+			modver: "v4.0.0",
+			want:   semver.MustParse("4.0.0"),
+		},
+		{
+			name:   "valid module version gopass",
+			module: "github.com/gopasspw/gopass",
+			pkg:    "github.com/gopasspw/gopass/internal/backend/storage/fs",
+			modver: "v4.0.0",
+			want:   semver.MustParse("4.0.0"),
+		},
+		{
+			name:   "invalid module version",
+			module: "invalid/module",
+			modver: "",
+			want:   semver.Version{},
+		},
+		{
+			name:   "non-existent module",
+			module: "non/existent/module",
+			modver: "",
+			want:   semver.Version{},
+		},
+		{
+			name:   "build-info failure",
+			module: "non/existent/module",
+			modver: "",
+			want:   semver.Version{},
+			noBI:   true,
+		},
+
+		{
+			name:   "invalid version",
+			module: "some/module/with/invalid/version",
+			modver: "devel",
+			want:   semver.Version{Build: []string{"devel"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			biFunc = func() (*rdebug.BuildInfo, bool) {
+				return &rdebug.BuildInfo{
+					Main: rdebug.Module{
+						Version: "v4.0.0",
+					},
+					Deps: []*rdebug.Module{
+						{
+							Path:    tt.module,
+							Version: tt.modver,
+						},
+					},
+				}, true
+			}
+			if tt.noBI {
+				biFunc = func() (*rdebug.BuildInfo, bool) {
+					return nil, false
+				}
+			}
+			ask := tt.pkg
+			if ask == "" {
+				ask = tt.module
+			}
+			got := ModuleVersion(ask)
+			assert.True(t, got.Equals(tt.want), "ModuleVersion(%s) = %v, want %v", ask, got, tt.want)
+		})
+	}
+}


### PR DESCRIPTION
Add tests, fix parsing issues and add a specical case for the main module.

Logs looking much better now:

```
fs/loader.go:29      fs.loader.New   Using Storage Backend: fs(1.15.16-0.20250304141434-72c5f9454afc+dirty,path:/tmp/gp/.local/share/gopass/stores/root)
```

