### PR TITLE
[BUGFIX] Allow use of trailing slash for cp/mv command

### DIFF
--- a/internal/store/leaf/move.go
+++ b/internal/store/leaf/move.go
@@ -94,6 +94,16 @@ func (s *Store) directMove(ctx context.Context, from, to string, del bool) error
 	pFrom := s.Passfile(from)
 	pTo := s.Passfile(to)
 
+	// if original destination has trailing slash,
+	// it means we should create folder and move/copy source file in it
+	if strings.HasSuffix(to, "/") {
+		// Check if the destination already exists as a file
+		if s.storage.Exists(ctx, to) && !s.storage.IsDir(ctx, to) {
+			return fmt.Errorf("destination %q already exists as a file", to)
+		}
+		pTo = filepath.Join(to, filepath.Base(pFrom))
+	}
+
 	debug.Log("directMove %s (%q) -> %s (%q)", from, to, pFrom, pTo)
 
 	if err := s.storage.Move(ctx, pFrom, pTo, del); err != nil {

--- a/internal/store/root/move.go
+++ b/internal/store/root/move.go
@@ -159,7 +159,9 @@ func (r *Store) directMove(ctx context.Context, from, to string, del bool) error
 
 	// will also remove the store prefix, if applicable
 	subFrom, from := r.getStore(from)
-	subTo, to := r.getStore(to)
+
+	// we don't remove store prefix for destination, as it can be a new folder
+	subTo, _ := r.getStore(to)
 
 	if subFrom.Equals(subTo) {
 		debug.Log("directMove from %q to %q: same store", from, to)


### PR DESCRIPTION
This should fix https://github.com/gopasspw/gopass/issues/3075
Not an elegant solution, but all tests are passed and works as expected