### PR TITLE
[ENHANCEMENT] Make it possible to override `show.autoclip`

### DIFF
--- a/internal/action/show.go
+++ b/internal/action/show.go
@@ -51,7 +51,7 @@ func showParseArgs(c *cli.Context) context.Context {
 
 	if c.IsSet("alsoclip") {
 		ctx = WithAlsoClip(ctx, c.Bool("alsoclip"))
-	} else if config.Bool(ctx, "show.autoclip") {
+	} else {
 		ctx = WithAlsoClip(ctx, config.Bool(ctx, "show.autoclip"))
 	}
 

--- a/internal/action/show.go
+++ b/internal/action/show.go
@@ -51,6 +51,8 @@ func showParseArgs(c *cli.Context) context.Context {
 
 	if c.IsSet("alsoclip") {
 		ctx = WithAlsoClip(ctx, c.Bool("alsoclip"))
+	} else if config.Bool(ctx, "show.autoclip") {
+		ctx = WithAlsoClip(ctx, config.Bool(ctx, "show.autoclip"))
 	}
 
 	if c.IsSet("noparsing") {
@@ -214,7 +216,7 @@ func (s *Action) showHandleOutput(ctx context.Context, name string, sec gopass.S
 		}
 	}
 
-	if (IsClip(ctx) || config.Bool(ctx, "show.autoclip")) && pw != "" {
+	if (IsClip(ctx) || IsAlsoClip(ctx)) && pw != "" {
 		if err := clipboard.CopyTo(ctx, name, []byte(pw), config.AsInt(s.cfg.Get("core.cliptimeout"))); err != nil {
 			return err
 		}
@@ -274,7 +276,7 @@ func (s *Action) showGetContent(ctx context.Context, sec gopass.Secret) (string,
 	// everything but the first line.
 	if config.Bool(ctx, "show.safecontent") && !ctxutil.IsForce(ctx) && ctxutil.IsShowParsing(ctx) {
 		body := showSafeContent(sec)
-		if IsAlsoClip(ctx) || config.Bool(ctx, "show.autoclip") {
+		if IsAlsoClip(ctx) {
 			return pw, body, nil
 		}
 

--- a/internal/action/show.go
+++ b/internal/action/show.go
@@ -49,10 +49,9 @@ func showParseArgs(c *cli.Context) context.Context {
 		ctx = WithRevision(ctx, c.String("revision"))
 	}
 
+	ctx = WithAlsoClip(ctx, config.Bool(ctx, "show.autoclip"))
 	if c.IsSet("alsoclip") {
 		ctx = WithAlsoClip(ctx, c.Bool("alsoclip"))
-	} else {
-		ctx = WithAlsoClip(ctx, config.Bool(ctx, "show.autoclip"))
 	}
 
 	if c.IsSet("noparsing") {


### PR DESCRIPTION
With this change is now possible to use `--alsoclip=false` on the command line to override the `show.autoclip` set in the config file.