### PR TITLE
[FEATURE] Add option -r/--regex to find

### DIFF
--- a/internal/action/commands.go
+++ b/internal/action/commands.go
@@ -336,6 +336,11 @@ func (s *Action) GetCommands() []*cli.Command {
 					Aliases: []string{"u", "force", "f"},
 					Usage:   "In the case of an exact match, display the password even if safecontent is enabled",
 				},
+				&cli.BoolFlag{
+					Name:    "regex",
+					Aliases: []string{"r"},
+					Usage:   "Interpret pattern as regular expression",
+				},
 			},
 		},
 		{

--- a/internal/action/find.go
+++ b/internal/action/find.go
@@ -56,7 +56,10 @@ func (s *Action) find(ctx context.Context, c *cli.Context, needle string, cb sho
 	}
 
 	// filter our the ones from the haystack matching the needle.
-	choices := filter(haystack, needle, c.Bool("regex"))
+	choices, err := filter(haystack, needle, c.Bool("regex"))
+	if err != nil {
+		return exit.Error(exit.Usage, err, "%s", err)
+	}
 
 	// if we have an exact match print it.
 	if len(choices) == 1 {
@@ -141,12 +144,15 @@ func (s *Action) findSelection(ctx context.Context, c *cli.Context, choices []st
 	}
 }
 
-func filter(l []string, needle string, regex bool) []string {
+func filter(l []string, needle string, regex bool) ([]string, error) {
 	choices := make([]string, 0, 10)
 	for _, value := range l {
 		if regex {
 			matched, err := regexp.MatchString(needle, value)
-			if err == nil && matched {
+			if err != nil {
+				return nil, err
+			}
+			if matched {
 				choices = append(choices, value)
 			}
 		} else if strings.Contains(strings.ToLower(value), strings.ToLower(needle)) {
@@ -154,5 +160,5 @@ func filter(l []string, needle string, regex bool) []string {
 		}
 	}
 
-	return choices
+	return choices, nil
 }

--- a/internal/action/find.go
+++ b/internal/action/find.go
@@ -146,19 +146,24 @@ func (s *Action) findSelection(ctx context.Context, c *cli.Context, choices []st
 
 func filter(l []string, needle string, reMatch bool) ([]string, error) {
 	choices := make([]string, 0, 10)
-	for _, value := range l {
-		if reMatch {
-			matched, err := regexp.MatchString(needle, value)
-			if err != nil {
-				return nil, err
-			}
-			if matched {
+
+	if reMatch {
+		compiledRE, err := regexp.Compile(needle)
+		if err != nil {
+			return nil, err
+		}
+		for _, value := range l {
+			if compiledRE.MatchString(value) {
 				choices = append(choices, value)
 			}
-		} else if strings.Contains(strings.ToLower(value), strings.ToLower(needle)) {
+		}
+		return choices, nil
+	}
+
+	for _, value := range l {
+		if strings.Contains(strings.ToLower(value), strings.ToLower(needle)) {
 			choices = append(choices, value)
 		}
 	}
-
 	return choices, nil
 }

--- a/internal/action/find.go
+++ b/internal/action/find.go
@@ -3,6 +3,7 @@ package action
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -55,8 +56,7 @@ func (s *Action) find(ctx context.Context, c *cli.Context, needle string, cb sho
 	}
 
 	// filter our the ones from the haystack matching the needle.
-	needle = strings.ToLower(needle)
-	choices := filter(haystack, needle)
+	choices := filter(haystack, needle, c.Bool("regex"))
 
 	// if we have an exact match print it.
 	if len(choices) == 1 {
@@ -141,10 +141,15 @@ func (s *Action) findSelection(ctx context.Context, c *cli.Context, choices []st
 	}
 }
 
-func filter(l []string, needle string) []string {
+func filter(l []string, needle string, regex bool) []string {
 	choices := make([]string, 0, 10)
 	for _, value := range l {
-		if strings.Contains(strings.ToLower(value), needle) {
+		if regex {
+			matched, err := regexp.MatchString(needle, value)
+			if err == nil && matched {
+				choices = append(choices, value)
+			}
+		} else if strings.Contains(strings.ToLower(value), strings.ToLower(needle)) {
 			choices = append(choices, value)
 		}
 	}

--- a/internal/action/find.go
+++ b/internal/action/find.go
@@ -144,10 +144,10 @@ func (s *Action) findSelection(ctx context.Context, c *cli.Context, choices []st
 	}
 }
 
-func filter(l []string, needle string, regex bool) ([]string, error) {
+func filter(l []string, needle string, reMatch bool) ([]string, error) {
 	choices := make([]string, 0, 10)
 	for _, value := range l {
-		if regex {
+		if reMatch {
 			matched, err := regexp.MatchString(needle, value)
 			if err != nil {
 				return nil, err

--- a/internal/action/find_test.go
+++ b/internal/action/find_test.go
@@ -121,4 +121,21 @@ func TestFind(t *testing.T) {
 	// findSelection w/o options
 	c = gptest.CliCtx(ctx, t)
 	require.Error(t, act.findSelection(ctx, c, nil, "fo", func(_ context.Context, _ *cli.Context, _ string, _ bool) error { return nil }))
+
+	// Test regex matching
+	// Add a secret with a pattern that can be matched by a regex
+	require.NoError(t, act.Store.Set(ctx, "test/regex123", sec))
+	require.NoError(t, act.Store.Set(ctx, "test/no-match", sec))
+	buf.Reset()
+
+	// find using regex pattern
+	c = gptest.CliCtxWithFlags(ctx, t, map[string]string{"regex": "true"}, "regex.*")
+	require.NoError(t, act.Find(c))
+	assert.Equal(t, "test/regex123", strings.TrimSpace(buf.String()))
+	buf.Reset()
+
+	// find using regex pattern with no match
+	c = gptest.CliCtxWithFlags(ctx, t, map[string]string{"regex": "true"}, "nomatch.*")
+	require.Error(t, act.Find(c))
+	buf.Reset()
 }


### PR DESCRIPTION
If the option `-r/--regex` is supplied to `gopass find`, the argument is treated as a regex pattern instead of a substring.