### PR TITLE
[TESTING/CLEANUP] Replace deprecated tenv linter for usetesting

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -73,7 +73,8 @@ linters:
   - sloglint
   - spancheck
   - tagalign
-  - tenv
+  # - tenv # replaced with usetesting
+  - usetesting
   - testableexamples
   - testifylint
   - thelper

--- a/internal/action/find.go
+++ b/internal/action/find.go
@@ -157,6 +157,7 @@ func filter(l []string, needle string, reMatch bool) ([]string, error) {
 				choices = append(choices, value)
 			}
 		}
+
 		return choices, nil
 	}
 
@@ -165,5 +166,6 @@ func filter(l []string, needle string, reMatch bool) ([]string, error) {
 			choices = append(choices, value)
 		}
 	}
+
 	return choices, nil
 }

--- a/internal/updater/update_test.go
+++ b/internal/updater/update_test.go
@@ -48,7 +48,9 @@ func TestIsUpdateable(t *testing.T) {
 		{
 			name: "force update",
 			pre: func() error {
-				return os.Setenv("GOPASS_FORCE_UPDATE", "true")
+				t.Setenv("GOPASS_FORCE_UPDATE", "true")
+
+				return nil
 			},
 			exec: func(context.Context) (string, error) {
 				return "", nil
@@ -61,7 +63,9 @@ func TestIsUpdateable(t *testing.T) {
 		{
 			name: "update in gopath",
 			pre: func() error {
-				return os.Setenv("GOPATH", "/tmp/foo")
+				t.Setenv("GOPATH", "/tmp/foo")
+
+				return nil
 			},
 			exec: func(context.Context) (string, error) {
 				return "/tmp/foo/gopass", nil

--- a/pkg/tempfile/file_test.go
+++ b/pkg/tempfile/file_test.go
@@ -47,6 +47,7 @@ func TestTempdirBase(t *testing.T) {
 	t.Parallel()
 
 	tempdir := t.TempDir()
+	require.NotEmpty(t, tempdir)
 
 	defer func() {
 		_ = os.RemoveAll(tempdir)

--- a/pkg/tempfile/file_test.go
+++ b/pkg/tempfile/file_test.go
@@ -46,8 +46,7 @@ func Example() {
 func TestTempdirBase(t *testing.T) {
 	t.Parallel()
 
-	tempdir, err := os.MkdirTemp(tempdirBase(), "gopass-")
-	require.NoError(t, err)
+	tempdir := t.TempDir()
 
 	defer func() {
 		_ = os.RemoveAll(tempdir)

--- a/tests/tester.go
+++ b/tests/tester.go
@@ -70,7 +70,7 @@ func newTester(t *testing.T) *tester {
 	}
 
 	// create tempDir
-	td, err := os.MkdirTemp("", "gopass-")
+	td := t.TempDir()
 	require.NoError(t, err)
 
 	t.Logf("Tempdir: %s", td)

--- a/tests/tester.go
+++ b/tests/tester.go
@@ -71,6 +71,7 @@ func newTester(t *testing.T) *tester {
 
 	// create tempDir
 	td := t.TempDir()
+	require.NotEmpty(t, td)
 	require.NoError(t, err)
 
 	t.Logf("Tempdir: %s", td)


### PR DESCRIPTION
When I try to run `make codequality` I receive:

`GOLANGCI-LINT WARN The linter 'tenv' is deprecated (since v1.64.0) due to: Duplicate feature in another linter. Replaced by usetesting.`

By recommendation above I replaced linter and it showed me new issues:

```
# https://github.com/gopasspw/gopass/blob/master/Makefile#L136
     GOLANGCI-LINT internal/updater/update_test.go:51:12: os.Setenv() could be replaced by t.Setenv() in TestIsUpdateable (usetesting)
                                return os.Setenv("GOPASS_FORCE_UPDATE", "true")
                                       ^
internal/updater/update_test.go:64:12: os.Setenv() could be replaced by t.Setenv() in TestIsUpdateable (usetesting)
                                return os.Setenv("GOPATH", "/tmp/foo")
                                       ^
pkg/tempfile/file_test.go:49:18: os.MkdirTemp() could be replaced by t.TempDir() in TestTempdirBase (usetesting)
        tempdir, err := os.MkdirTemp(tempdirBase(), "gopass-")
                        ^
tests/tester.go:73:13: os.MkdirTemp() could be replaced by t.TempDir() in newTester (usetesting)
        td, err := os.MkdirTemp("", "gopass-")
                   ^
4 issues:
* usetesting: 4
make: *** [Makefile:139: codequality] Error 1
```

All fixed, I believe the testing's Setenv() and TempDir() is more robust for testing and isolation.
Also there was some problems with find.go file also by codequality test. Fixed them as well.
All tests are passed.