### PR TITLE
[CLEANUP] Remove unnecessary notice for unlocking private key after generation

### DIFF
--- a/internal/action/setup.go
+++ b/internal/action/setup.go
@@ -197,8 +197,6 @@ func (s *Action) initGenerateIdentity(ctx context.Context, crypto backend.Crypto
 
 	out.OKf(ctx, "Key pair for %s generated", crypto.Name())
 
-	out.Notice(ctx, "🔐 We need to unlock your newly created private key now! Please enter the passphrase you just generated.")
-
 	// avoid the gpg cache or we won't find the newly created key
 	kl, err := crypto.ListIdentities(gpg.WithUseCache(ctx, false))
 	if err != nil {


### PR DESCRIPTION
Okay, this will be funny and small PR 

This pull request addresses issue https://github.com/gopasspw/gopass/issues/2862

Basically as I undestand logic of GnuPG and gopass it goes like this:

1. Regardless if user typed his own passphrase or asked gopass to generate it will store it in cache of `gpg-agent`
2. Agent has default 600 seconds of caching time. So user will be prompted after 10 minutes.

It will be highly unlikely that user will be initiating his first store for more than 10 minutes. 
And even so he will prompted by passphrase entry interface (e.g pinentry-curses), so no additional notices needed.