### PR TITLE
[chore] Migrate to golangci-lint v2

### DIFF
--- a/.github/workflows/autorelease.yml
+++ b/.github/workflows/autorelease.yml
@@ -30,7 +30,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
-          go-version: '1.23'
+          go-version: '1.24'
       - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: ~/go/pkg/mod

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
       with:
-        go-version: '1.23'
+        go-version: '1.24'
     - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
       with:
         path: ~/go/pkg/mod

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
-          go-version: '1.23'
+          go-version: '1.24'
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: golangci-lint
         uses: golangci/golangci-lint-action@1481404843c368bc19ca9406f87d6e0fc97bdcfd # v7.0.0
@@ -48,5 +48,5 @@ jobs:
           # https://github.com/gopasspw/gopass/blob/master/.github/workflows/build.yml#L65
           # https://github.com/gopasspw/gopass/blob/master/.github/workflows/golangci-lint.yml#L46
           # https://github.com/gopasspw/gopass/blob/master/Makefile#L136
-          version: v1.61.0 # we have a list of linters in our .golangci.yml config file
+          version: v2.1.1 # we have a list of linters in our .golangci.yml config file
           only-new-issues: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -75,8 +75,9 @@ linters:
       min-complexity: 22
     staticcheck:
       checks:
-        - -SA1019
         - all
+        - -SA1019
+        - -ST1000
   exclusions:
     generated: lax
     rules:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,98 +1,105 @@
+version: "2"
 run:
-  timeout: 5m
   go: "1.22"
-
-linters-settings:
-  errcheck:
-    exclude-functions:
-      - fmt.Fprint
-      - fmt.Fprintf
-      - fmt.Fprintln
-  gocyclo:
-    min-complexity: 22
-  cyclop:
-    max-complexity: 22
-    skip-tests: true
-  staticcheck:
-    # https://staticcheck.io/docs/options#checks
-    checks: ["all","-SA1019"]
-  funlen:
-    lines: -1
-    statements: 100
-
-linters:
-  enable:
-  - asasalint
-  - asciicheck
-  - bidichk
-  - bodyclose
-  - containedctx
-  - copyloopvar
-  - cyclop
-  - decorder
-  - dogsled
-  - errcheck
-  - errchkjson
-  - errname
-  - errorlint
-  - exhaustive
-  # - exportloopref # deprecated since Go 1.22
-  - forcetypeassert
-  - funlen
-  - ginkgolinter
-  - gocheckcompilerdirectives
-  - gochecksumtype
-  - godot
-  - gofmt
-  - gofumpt
-  - goheader
-  - goimports
-  - gomoddirectives
-  - gomodguard
-  - goprintffuncname
-  - gosmopolitan
-  - grouper
-  - importas
-  - ineffassign
-  - intrange
-  - loggercheck
-  - makezero
-  - mirror
-  - misspell
-  - nakedret
-  - nestif
-  - nilnil
-  - nlreturn
-  - nonamedreturns
-  - nosprintfhostport
-  - prealloc
-  - predeclared
-  - promlinter
-  - protogetter
-  - reassign
-  - sloglint
-  - spancheck
-  - tagalign
-  # - tenv # replaced with usetesting
-  - usetesting
-  - testableexamples
-  - testifylint
-  - thelper
-  - unconvert
-  - usestdlibvars
-  - whitespace
-  - zerologlint
-
-issues:
-  max-issues-per-linter: 0 # disable limit; report all issues of a linter
-  max-same-issues: 0 # disable limit; report all issues of the same issue
-  exclude-use-default: false # disable filtering of defaults for better zero-issue policy
-  exclude-dirs:
-    - helpers/
-
 output:
-  show-stats: true
-  sort-results: true
   sort-order:
     - linter
     - file
+linters:
+  enable:
+    - asasalint
+    - asciicheck
+    - bidichk
+    - bodyclose
+    - containedctx
+    - copyloopvar
+    - cyclop
+    - decorder
+    - dogsled
+    - errchkjson
+    - errname
+    - errorlint
+    - exhaustive
+    - forcetypeassert
+    - funlen
+    - ginkgolinter
+    - gocheckcompilerdirectives
+    - gochecksumtype
+    - godot
+    - goheader
+    - gomoddirectives
+    - gomodguard
+    - goprintffuncname
+    - gosmopolitan
+    - grouper
+    - importas
+    - intrange
+    - loggercheck
+    - makezero
+    - mirror
+    - misspell
+    - nakedret
+    - nestif
+    - nilnil
+    - nlreturn
+    - nonamedreturns
+    - nosprintfhostport
+    - prealloc
+    - predeclared
+    - promlinter
+    - protogetter
+    - reassign
+    - sloglint
+    - spancheck
+    - tagalign
+    - testableexamples
+    - testifylint
+    - thelper
+    - unconvert
+    - usestdlibvars
+    - usetesting
+    - whitespace
+    - zerologlint
+  settings:
+    cyclop:
+      max-complexity: 22
+    errcheck:
+      exclude-functions:
+        - fmt.Fprint
+        - fmt.Fprintf
+        - fmt.Fprintln
+    funlen:
+      lines: -1
+      statements: 100
+    gocyclo:
+      min-complexity: 22
+    staticcheck:
+      checks:
+        - -SA1019
+        - all
+  exclusions:
+    generated: lax
+    rules:
+      - linters:
+          - cyclop
+        path: (.+)_test\.go
+    paths:
+      - helpers/
+      - third_party$
+      - builtin$
+      - examples$
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
+formatters:
+  enable:
+    - gofmt
+    - gofumpt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - helpers/
+      - third_party$
+      - builtin$
+      - examples$

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/golang:1.23-alpine@sha256:b7486658b87d34ecf95125e5b97e8dfe86c21f712aa36fc0c702e5dc41dc63e1 AS build-env
+FROM docker.io/library/golang:1.24-alpine@sha256:7772cb5322baa875edd74705556d08f0eeca7b9c4b5367754ce3f2f00041ccee AS build-env
 
 ENV CGO_ENABLED 0
 
@@ -59,7 +59,7 @@ RUN go mod download
 RUN make clean
 RUN make git-credential-gopass
 
-FROM docker.io/library/alpine@sha256:c5b1261d6d3e43071626931fc004f70149baeba2c8ec672bd4f27761f8e1ad6b
+FROM docker.io/library/alpine@sha256:a8560b36e8b8210634f77d9f7f9efd7ffa463e380b75e2e74aff4511df3ef88c
 RUN apk add --no-cache ca-certificates git gnupg
 COPY --from=build-env /home/runner/work/gopass/gopass/gopass /usr/local/bin/
 COPY --from=build-env /home/runner/work/gopass/gopass-jsonapi/gopass-jsonapi /usr/local/bin/

--- a/Makefile
+++ b/Makefile
@@ -137,7 +137,7 @@ codequality:
 	# https://github.com/gopasspw/gopass/blob/master/Makefile#L136
 	@echo -n "     GOLANGCI-LINT "
 	@which golangci-lint > /dev/null; if [ $$? -ne 0 ]; then \
-		$(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@latest; \
+		$(GO) install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.1.1; \
 	fi
 	@golangci-lint run --max-issues-per-linter 0 --max-same-issues 0 || exit 1
 

--- a/Makefile
+++ b/Makefile
@@ -139,7 +139,7 @@ codequality:
 	@which golangci-lint > /dev/null; if [ $$? -ne 0 ]; then \
 		$(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@latest; \
 	fi
-	@golangci-lint run --max-issues-per-linter 0 --max-same-issues 0 --sort-results || exit 1
+	@golangci-lint run --max-issues-per-linter 0 --max-same-issues 0 || exit 1
 
 	@printf '%s\n' '$(OK)'
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gopasspw/gopass
 
-go 1.23.2
+go 1.24.0
 
 require (
 	filippo.io/age v1.2.1-0.20240618131852-7eedd929a6cf

--- a/helpers/postrel/main_test.go
+++ b/helpers/postrel/main_test.go
@@ -4,7 +4,6 @@
 package main
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -26,7 +25,7 @@ func TestMustCheckEnv(t *testing.T) {
 // Test createMilestones function
 // TODO: Add test for createMilestones function
 // func TestCreateMilestones(t *testing.T) {
-// 	ctx := context.Background()
+// 	ctx := t.Context()
 // 	ghCl := newMockGHClient(ctx)
 // 	version := semver.MustParse("1.2.3")
 
@@ -85,7 +84,7 @@ func TestUpdateWorkflows(t *testing.T) {
 		goVer: "1.16",
 	}
 
-	err = updater.updateWorkflows(context.Background(), dir)
+	err = updater.updateWorkflows(t.Context(), dir)
 	assert.NoError(t, err)
 
 	content, err := os.ReadFile(filepath.Join(dir, ".github", "workflows", "test.yml"))

--- a/internal/action/binary.go
+++ b/internal/action/binary.go
@@ -195,10 +195,10 @@ func (s *Action) binaryCopy(ctx context.Context, c *cli.Context, from, to string
 	switch {
 	case isFilePath(from) && isFilePath(to):
 		// copying from on file to another file is not supported.
-		return fmt.Errorf("ambiguity detected. Only from or to can be a file. Use cp to copy between files.")
+		return fmt.Errorf("ambiguity detected. Only from or to can be a file. Use cp to copy between files")
 	case s.Store.Exists(ctx, from) && s.Store.Exists(ctx, to):
 		// copying from one secret to another secret is not supported.
-		return fmt.Errorf("ambiguity detected. Either from or to must be a file. Use gopass cp to copy between secrets.")
+		return fmt.Errorf("ambiguity detected. Either from or to must be a file. Use gopass cp to copy between secrets")
 	case isFilePath(from) && !isFilePath(to):
 		if s.isInStore(from) {
 			out.Warningf(ctx, "Ambiguity detected. Source %q is in the store. Use --force if intended", from)

--- a/internal/action/binary.go
+++ b/internal/action/binary.go
@@ -203,7 +203,7 @@ func (s *Action) binaryCopy(ctx context.Context, c *cli.Context, from, to string
 		if s.isInStore(from) {
 			out.Warningf(ctx, "Ambiguity detected. Source %q is in the store. Use --force if intended", from)
 			if !c.Bool("force") {
-				return fmt.Errorf("ambiguity detected. Source is in the store.")
+				return fmt.Errorf("ambiguity detected. Source is in the store")
 			}
 		}
 
@@ -212,7 +212,7 @@ func (s *Action) binaryCopy(ctx context.Context, c *cli.Context, from, to string
 		if s.isInStore(to) {
 			out.Warningf(ctx, "Ambiguity detected. Destination %q is in the store. Use --force if intended", to)
 			if !c.Bool("force") {
-				return fmt.Errorf("ambiguity detected. Destination is in the store.")
+				return fmt.Errorf("ambiguity detected. Destination is in the store")
 			}
 		}
 

--- a/internal/action/context_test.go
+++ b/internal/action/context_test.go
@@ -41,7 +41,7 @@ func TestWithPrintQR(t *testing.T) {
 func TestWithRevision(t *testing.T) {
 	ctx := config.NewContextInMemory()
 
-	assert.Equal(t, "", GetRevision(ctx))
+	assert.Empty(t, GetRevision(ctx))
 	assert.Equal(t, "foo", GetRevision(WithRevision(ctx, "foo")))
 	assert.False(t, HasRevision(ctx))
 	assert.True(t, HasRevision(WithRevision(ctx, "foo")))
@@ -50,7 +50,7 @@ func TestWithRevision(t *testing.T) {
 func TestWithKey(t *testing.T) {
 	ctx := config.NewContextInMemory()
 
-	assert.Equal(t, "", GetKey(ctx))
+	assert.Empty(t, GetKey(ctx))
 	assert.Equal(t, "foo", GetKey(WithKey(ctx, "foo")))
 }
 

--- a/internal/action/fsck_test.go
+++ b/internal/action/fsck_test.go
@@ -47,28 +47,28 @@ func TestFsck(t *testing.T) {
 	require.NoError(t, act.Fsck(gptest.CliCtx(ctx, t)))
 	output := strings.TrimSpace(buf.String())
 	assert.Contains(t, output, "Checking password store integrity ...")
-	assert.Contains(t, output, "Extra recipients on foo: [0xFEEDBEEF]")
+	assert.Contains(t, output, "extra recipients on foo: [0xFEEDBEEF]")
 	buf.Reset()
 
 	// fsck (hidden)
 	require.NoError(t, act.Fsck(gptest.CliCtx(ctxutil.WithHidden(ctx, true), t)))
 	output = strings.TrimSpace(buf.String())
 	assert.NotContains(t, output, "Checking password store integrity ...")
-	assert.NotContains(t, output, "Extra recipients on foo: [0xFEEDBEEF]")
+	assert.NotContains(t, output, "extra recipients on foo: [0xFEEDBEEF]")
 	buf.Reset()
 
 	// fsck --decrypt
 	require.NoError(t, act.Fsck(gptest.CliCtxWithFlags(ctx, t, map[string]string{"decrypt": "true"})))
 	output = strings.TrimSpace(buf.String())
 	assert.Contains(t, output, "Checking password store integrity ...")
-	assert.Contains(t, output, "Extra recipients on foo: [0xFEEDBEEF]")
+	assert.Contains(t, output, "extra recipients on foo: [0xFEEDBEEF]")
 	buf.Reset()
 
 	// fsck foo
 	require.NoError(t, act.Fsck(gptest.CliCtx(ctx, t, "foo")))
 	output = strings.TrimSpace(buf.String())
 	assert.Contains(t, output, "Checking password store integrity ...")
-	assert.Contains(t, output, "Extra recipients on foo: [0xFEEDBEEF]")
+	assert.Contains(t, output, "extra recipients on foo: [0xFEEDBEEF]")
 	buf.Reset()
 }
 

--- a/internal/action/generate_test.go
+++ b/internal/action/generate_test.go
@@ -23,7 +23,7 @@ import (
 
 func TestRuleLookup(t *testing.T) {
 	domain, _ := hasPwRuleForSecret(config.NewContextInMemory(), "foo/gopass.pw")
-	assert.Equal(t, "", domain)
+	assert.Empty(t, domain)
 }
 
 func TestGenerate(t *testing.T) {

--- a/internal/action/generate_test.go
+++ b/internal/action/generate_test.go
@@ -2,7 +2,6 @@ package action
 
 import (
 	"bytes"
-	"context"
 	"flag"
 	"fmt"
 	"os"
@@ -29,7 +28,7 @@ func TestRuleLookup(t *testing.T) {
 func TestGenerate(t *testing.T) {
 	u := gptest.NewUnitTester(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	ctx = ctxutil.WithAlwaysYes(ctx, true)
 	ctx = ctxutil.WithInteractive(ctx, false)
 

--- a/internal/action/mount.go
+++ b/internal/action/mount.go
@@ -117,7 +117,7 @@ func (s *Action) MountAdd(c *cli.Context) error {
 	return nil
 }
 
-// MountsVersion prints the backend versions for each mount.
+// MountsVersions prints the backend versions for each mount.
 func (s *Action) MountsVersions(c *cli.Context) error {
 	ctx := ctxutil.WithGlobalFlags(c)
 

--- a/internal/action/mount_test.go
+++ b/internal/action/mount_test.go
@@ -43,7 +43,7 @@ func TestMounts(t *testing.T) {
 	t.Run("complete mounts", func(t *testing.T) {
 		defer buf.Reset()
 		act.MountsComplete(gptest.CliCtx(ctx, t))
-		assert.Equal(t, "", buf.String())
+		assert.Empty(t, buf.String())
 	})
 
 	t.Run("remove no non-existing mount", func(t *testing.T) {

--- a/internal/action/repl.go
+++ b/internal/action/repl.go
@@ -160,7 +160,7 @@ READ:
 	for {
 		// check for context cancellation
 		select {
-		case <-c.Context.Done():
+		case <-c.Done():
 			return fmt.Errorf("user aborted")
 		default:
 		}

--- a/internal/action/setup.go
+++ b/internal/action/setup.go
@@ -329,7 +329,7 @@ func (s *Action) initLocal(ctx context.Context, remote string) error {
 }
 
 func (s *Action) initDetectPassage(ctx context.Context) error {
-	pIds := age.PassageIdFile()
+	pIds := age.PassageIDFile()
 	if !fsutil.IsFile(pIds) {
 		debug.Log("no passage identities found at %s", pIds)
 

--- a/internal/audit/audit_test.go
+++ b/internal/audit/audit_test.go
@@ -52,7 +52,7 @@ func TestBatch(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.NotNil(t, report)
-	assert.Equal(t, len(secrets), len(report.Secrets))
+	assert.Len(t, len(secrets), len(report.Secrets))
 }
 
 func TestAuditSecret(t *testing.T) {

--- a/internal/audit/audit_test.go
+++ b/internal/audit/audit_test.go
@@ -52,7 +52,7 @@ func TestBatch(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.NotNil(t, report)
-	assert.Len(t, len(secrets), len(report.Secrets))
+	assert.Len(t, secrets, len(report.Secrets))
 }
 
 func TestAuditSecret(t *testing.T) {

--- a/internal/audit/audit_test.go
+++ b/internal/audit/audit_test.go
@@ -32,7 +32,7 @@ func (m *mockSecretGetter) Concurrency() int {
 }
 
 func TestNewAuditor(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	s := &mockSecretGetter{}
 	a := New(ctx, s)
 
@@ -43,7 +43,7 @@ func TestNewAuditor(t *testing.T) {
 }
 
 func TestBatch(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	s := &mockSecretGetter{}
 	a := New(ctx, s)
 
@@ -56,7 +56,7 @@ func TestBatch(t *testing.T) {
 }
 
 func TestAuditSecret(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	s := &mockSecretGetter{}
 	a := New(ctx, s)
 
@@ -67,7 +67,7 @@ func TestAuditSecret(t *testing.T) {
 }
 
 func TestCheckHIBP(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	s := &mockSecretGetter{}
 	a := New(ctx, s)
 

--- a/internal/backend/crypto/age/age_test.go
+++ b/internal/backend/crypto/age/age_test.go
@@ -1,7 +1,6 @@
 package age
 
 import (
-	"context"
 	"testing"
 
 	"github.com/gopasspw/gopass/pkg/debug"
@@ -10,14 +9,14 @@ import (
 )
 
 func TestNew(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	a, err := New(ctx)
 	require.NoError(t, err)
 	assert.NotNil(t, a)
 }
 
 func TestInitialized(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	a, err := New(ctx)
 	require.NoError(t, err)
 	assert.NotNil(t, a)
@@ -27,7 +26,7 @@ func TestInitialized(t *testing.T) {
 }
 
 func TestName(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	a, err := New(ctx)
 	require.NoError(t, err)
 	assert.NotNil(t, a)
@@ -37,7 +36,7 @@ func TestName(t *testing.T) {
 }
 
 func TestVersion(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	a, err := New(ctx)
 	require.NoError(t, err)
 	assert.NotNil(t, a)
@@ -48,7 +47,7 @@ func TestVersion(t *testing.T) {
 }
 
 func TestExt(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	a, err := New(ctx)
 	require.NoError(t, err)
 	assert.NotNil(t, a)
@@ -58,7 +57,7 @@ func TestExt(t *testing.T) {
 }
 
 func TestIDFile(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	a, err := New(ctx)
 	require.NoError(t, err)
 	assert.NotNil(t, a)
@@ -68,7 +67,7 @@ func TestIDFile(t *testing.T) {
 }
 
 func TestConcurrency(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	a, err := New(ctx)
 	require.NoError(t, err)
 	assert.NotNil(t, a)

--- a/internal/backend/crypto/age/context_test.go
+++ b/internal/backend/crypto/age/context_test.go
@@ -1,12 +1,11 @@
 package age
 
 import (
-	"context"
 	"testing"
 )
 
 func TestWithOnlyNative(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	ctx = WithOnlyNative(ctx, true)
 
 	val := ctx.Value(ctxKeyOnlyNative)
@@ -25,7 +24,7 @@ func TestWithOnlyNative(t *testing.T) {
 }
 
 func TestIsOnlyNative(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Test default value
 	if IsOnlyNative(ctx) {

--- a/internal/backend/crypto/age/identities.go
+++ b/internal/backend/crypto/age/identities.go
@@ -423,7 +423,7 @@ func (a *Age) getAllIdentities(ctx context.Context) (map[string]age.Identity, er
 }
 
 func (a *Age) getPassageIdentities(ctx context.Context) (map[string]age.Identity, error) {
-	fn := PassageIdFile()
+	fn := PassageIDFile()
 	fh, err := os.Open(fn)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open %s: %w", fn, err)
@@ -440,8 +440,8 @@ func (a *Age) getPassageIdentities(ctx context.Context) (map[string]age.Identity
 	return idMap(ids), nil
 }
 
-// PassageIdFile returns the location of the passage identities file.
-func PassageIdFile() string {
+// PassageIDFile returns the location of the passage identities file.
+func PassageIDFile() string {
 	return filepath.Join(appdir.UserHome(), ".passage", "identities")
 }
 

--- a/internal/backend/crypto/age/identities_test.go
+++ b/internal/backend/crypto/age/identities_test.go
@@ -44,22 +44,22 @@ func TestParseIdentity(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tId, err := parseIdentity(tt.encoding)
+			tID, err := parseIdentity(tt.encoding)
 			if tt.shouldFail {
 				require.Error(t, err)
 			} else {
 				require.NoError(t, err)
-				require.IsType(t, tt.expectedType, tId)
+				require.IsType(t, tt.expectedType, tID)
 			}
 		})
 	}
 }
 
 func TestIdentityAndRecipient(t *testing.T) {
-	testId, err := age.GenerateX25519Identity()
+	testID, err := age.GenerateX25519Identity()
 	require.NoError(t, err)
 
-	pluginId, err := plugin.NewIdentity("AGE-PLUGIN-YUBIKEY-1GKZKJQYZL98RLMC67F9PJ", nil)
+	pluginID, err := plugin.NewIdentity("AGE-PLUGIN-YUBIKEY-1GKZKJQYZL98RLMC67F9PJ", nil)
 	require.NoError(t, err)
 	pluginRec, err := plugin.NewRecipient("age1yubikey1qt2r3tfk7wvlykudm7ew28dqqm3h8ln9zfsxsq4lcd2w8rh4n4hhz46ur24", nil)
 	require.NoError(t, err)
@@ -74,22 +74,22 @@ func TestIdentityAndRecipient(t *testing.T) {
 	}{
 		{
 			"native identity",
-			testId,
-			testId.Recipient(),
+			testID,
+			testID.Recipient(),
 		},
 		{
 			"wrapped native id",
 			&wrappedIdentity{
-				id:       testId,
-				rec:      testId.Recipient(),
-				encoding: testId.String(),
+				id:       testID,
+				rec:      testID.Recipient(),
+				encoding: testID.String(),
 			},
-			testId.Recipient(),
+			testID.Recipient(),
 		},
 		{
 			"wrapped plugin id",
 			&wrappedIdentity{
-				id:       pluginId,
+				id:       pluginID,
 				rec:      wrRec,
 				encoding: "AGE-PLUGIN-YUBIKEY-1GKZKJQYZL98RLMC67F9PJ",
 			},

--- a/internal/backend/crypto/age/keyring.go
+++ b/internal/backend/crypto/age/keyring.go
@@ -15,12 +15,10 @@ import (
 	"github.com/gopasspw/gopass/pkg/fsutil"
 )
 
-var (
-	// OldIDFile is the old file name for the recipients.
-	OldIDFile = ".age-ids"
-)
+// OldIDFile is the old file name for the recipients.
+var OldIDFile = ".age-ids"
 
-// OldKeyring is the old file name for the keyring.
+// OldKeyringPath is the old file name for the keyring.
 // Must be a func to allow us to honor GOPASS_HOMEDIR in tests.
 // Otherwise it would be read at init time and setting GOPASS_HOMEDIR
 // later would have no effect.

--- a/internal/backend/crypto/age/loader_test.go
+++ b/internal/backend/crypto/age/loader_test.go
@@ -1,7 +1,6 @@
 package age
 
 import (
-	"context"
 	"testing"
 
 	"github.com/gopasspw/gopass/internal/store/mockstore/inmem"
@@ -10,7 +9,7 @@ import (
 )
 
 func TestLoader_New(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	l := loader{}
 
 	crypto, err := l.New(ctx)
@@ -19,7 +18,7 @@ func TestLoader_New(t *testing.T) {
 }
 
 func TestLoader_Handles(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	l := loader{}
 	s := inmem.New()
 	td := t.TempDir()

--- a/internal/backend/crypto/age/recipients_test.go
+++ b/internal/backend/crypto/age/recipients_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestFindRecipients(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	a := &Age{
 		ghCache: &mockGHCache{},
 	}
@@ -51,7 +51,7 @@ func TestFindRecipients(t *testing.T) {
 }
 
 func TestParseRecipients(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	a := &Age{
 		ghCache: &mockGHCache{},
 	}

--- a/internal/backend/crypto/doc.go
+++ b/internal/backend/crypto/doc.go
@@ -1,0 +1,3 @@
+// Package crypto provides a pluggable crypto backend for gopass.
+
+package crypto

--- a/internal/backend/crypto/gpg/cli/encrypt.go
+++ b/internal/backend/crypto/gpg/cli/encrypt.go
@@ -30,7 +30,7 @@ func (g *GPG) Encrypt(ctx context.Context, plaintext []byte, recipients []string
 
 	buf := &bytes.Buffer{}
 	if len(recipients) == 0 {
-		return buf.Bytes(), errors.New("recipients list is empty!")
+		return buf.Bytes(), errors.New("recipients list is empty")
 	}
 	var badRecipients []string
 	for _, r := range recipients {
@@ -49,7 +49,7 @@ func (g *GPG) Encrypt(ctx context.Context, plaintext []byte, recipients []string
 		args = append(args, "--recipient", r)
 	}
 	if len(badRecipients) == len(recipients) {
-		return buf.Bytes(), errors.New("no valid and trusted recipients were found!")
+		return buf.Bytes(), errors.New("no valid and trusted recipients were found")
 	}
 
 	cmd := exec.CommandContext(ctx, g.binary, args...)

--- a/internal/backend/crypto/gpg/cli/gpg_test.go
+++ b/internal/backend/crypto/gpg/cli/gpg_test.go
@@ -9,11 +9,12 @@ import (
 )
 
 func TestGPG(t *testing.T) {
-	t.Parallel()
-
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")
 	}
+
+	td := t.TempDir()
+	t.Setenv("GNUPGHOME", td)
 
 	ctx := config.NewContextInMemory()
 

--- a/internal/backend/crypto/gpg/cli/gpg_test.go
+++ b/internal/backend/crypto/gpg/cli/gpg_test.go
@@ -20,11 +20,11 @@ func TestGPG(t *testing.T) {
 	var err error
 	var g *GPG
 
-	assert.Equal(t, "", g.Binary())
+	assert.Empty(t, g.Binary())
 
 	g, err = New(ctx, Config{})
 	require.NoError(t, err)
-	assert.NotEqual(t, "", g.Binary())
+	assert.NotEmpty(t, g.Binary())
 
 	_, err = g.ListRecipients(ctx)
 	require.NoError(t, err)

--- a/internal/backend/crypto/gpg/cli/keyring_test.go
+++ b/internal/backend/crypto/gpg/cli/keyring_test.go
@@ -73,7 +73,7 @@ func TestReadNamesFromKey(t *testing.T) {
 
 	g, err := New(ctx, Config{})
 	require.NoError(t, err)
-	assert.NotEqual(t, "", g.Binary())
+	assert.NotEmpty(t, g.Binary())
 
 	names, err := g.ReadNamesFromKey(ctx, []byte(pubkey))
 	require.NoError(t, err)

--- a/internal/backend/crypto/gpg/doc.go
+++ b/internal/backend/crypto/gpg/doc.go
@@ -1,0 +1,6 @@
+// Package gpg provides a GPG crypto backend for gopass.
+// It does not provide a full GPG implementation, but rather
+// building blocks used by other packages to provide GPG
+// support.
+
+package gpg

--- a/internal/backend/crypto/gpg/gpgconf/utils_linux_test.go
+++ b/internal/backend/crypto/gpg/gpgconf/utils_linux_test.go
@@ -13,5 +13,5 @@ func TestTTY(t *testing.T) {
 	t.Parallel()
 
 	fd0 = "/tmp/foobar"
-	assert.Equal(t, "", TTY())
+	assert.Empty(t, TTY())
 }

--- a/internal/backend/crypto/gpg/gpgconf/version_test.go
+++ b/internal/backend/crypto/gpg/gpgconf/version_test.go
@@ -44,7 +44,7 @@ func TestSort(t *testing.T) {
 
 			sort.Sort(byVersion(tc.in))
 
-			require.Len(t, len(tc.in), len(tc.out))
+			require.Len(t, tc.in, len(tc.out))
 			for i, v := range tc.out {
 				if !tc.in[i].ver.Equals(v) {
 					t.Errorf("wrong sort order at %d: %s != %s", i, tc.in[i].ver, v)

--- a/internal/backend/crypto/gpg/gpgconf/version_test.go
+++ b/internal/backend/crypto/gpg/gpgconf/version_test.go
@@ -44,7 +44,7 @@ func TestSort(t *testing.T) {
 
 			sort.Sort(byVersion(tc.in))
 
-			require.Equal(t, len(tc.in), len(tc.out))
+			require.Len(t, len(tc.in), len(tc.out))
 			for i, v := range tc.out {
 				if !tc.in[i].ver.Equals(v) {
 					t.Errorf("wrong sort order at %d: %s != %s", i, tc.in[i].ver, v)

--- a/internal/backend/crypto/gpg/key_list_test.go
+++ b/internal/backend/crypto/gpg/key_list_test.go
@@ -50,7 +50,7 @@ func TestKeyList(t *testing.T) {
 	// search for non existing key
 	k, err = kl.FindKey("0x62AF4091C82E2019")
 	require.Error(t, err)
-	assert.Equal(t, "", k.ID())
+	assert.Empty(t, k.ID())
 
 	// search by full name
 	k, err = kl.FindKey("John Doe")

--- a/internal/backend/crypto/gpg/key_test.go
+++ b/internal/backend/crypto/gpg/key_test.go
@@ -81,7 +81,7 @@ func TestKey(t *testing.T) {
 		Identities: map[string]Identity{},
 	}
 	assert.Equal(t, "(invalid:)", k.OneLine())
-	assert.Equal(t, "", k.Identity().Name)
+	assert.Empty(t, k.Identity().Name)
 	k = genTestKey()
 	assert.True(t, k.IsUseable(false))
 	assert.Equal(t, "sec   2048D/0x62AF4031C82E0039 2018-01-01 [expires: 2218-01-01]\n      Key fingerprint = 25FF1614B8F87B52FFFF99B962AF4031C82E0039\nuid                            John Doe (johnny) <john.doe@example.org>", k.String())

--- a/internal/backend/crypto/plain/backend_test.go
+++ b/internal/backend/crypto/plain/backend_test.go
@@ -53,8 +53,8 @@ func TestPlain(t *testing.T) {
 
 	require.NoError(t, m.ImportPublicKey(ctx, buf))
 
-	assert.Equal(t, "", m.FormatKey(ctx, "", ""))
-	assert.Equal(t, "", m.Fingerprint(ctx, ""))
+	assert.Empty(t, m.FormatKey(ctx, "", ""))
+	assert.Empty(t, m.Fingerprint(ctx, ""))
 	require.NoError(t, m.Initialized(ctx))
 	assert.Equal(t, "plain", m.Name())
 	assert.Equal(t, "txt", m.Ext())

--- a/internal/backend/storage/doc.go
+++ b/internal/backend/storage/doc.go
@@ -1,0 +1,3 @@
+// Package storage provides a pluggable storage backend for gopass.
+
+package storage

--- a/internal/backend/storage/fossilfs/context_test.go
+++ b/internal/backend/storage/fossilfs/context_test.go
@@ -1,12 +1,11 @@
 package fossilfs
 
 import (
-	"context"
 	"testing"
 )
 
 func TestWithPathOverride(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	path := "/test/path"
 	ctx = withPathOverride(ctx, path)
 
@@ -16,7 +15,7 @@ func TestWithPathOverride(t *testing.T) {
 }
 
 func TestGetPathOverride(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	defaultPath := "/default/path"
 
 	// Test with no override

--- a/internal/backend/storage/fossilfs/fossil_test.go
+++ b/internal/backend/storage/fossilfs/fossil_test.go
@@ -3,7 +3,6 @@
 package fossilfs
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -27,7 +26,7 @@ func TestNew(t *testing.T) {
 func TestClone(t *testing.T) {
 	dir := t.TempDir()
 
-	ctx := context.Background()
+	ctx := t.Context()
 	repo := "https://example.com/repo.fossil"
 
 	f, err := Clone(ctx, repo, dir)
@@ -38,7 +37,7 @@ func TestClone(t *testing.T) {
 func TestInit(t *testing.T) {
 	dir := t.TempDir()
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	f, err := Init(ctx, dir, "", "")
 	require.NoError(t, err)
@@ -48,7 +47,7 @@ func TestInit(t *testing.T) {
 func TestAdd(t *testing.T) {
 	dir := t.TempDir()
 
-	ctx := context.Background()
+	ctx := t.Context()
 	f, err := Init(ctx, dir, "", "")
 	require.NoError(t, err)
 
@@ -59,7 +58,7 @@ func TestAdd(t *testing.T) {
 func TestCommit(t *testing.T) {
 	dir := t.TempDir()
 
-	ctx := context.Background()
+	ctx := t.Context()
 	f, err := Init(ctx, dir, "", "")
 	require.NoError(t, err)
 
@@ -70,7 +69,7 @@ func TestCommit(t *testing.T) {
 func TestPush(t *testing.T) {
 	dir := t.TempDir()
 
-	ctx := context.Background()
+	ctx := t.Context()
 	f, err := Init(ctx, dir, "", "")
 	require.NoError(t, err)
 
@@ -81,7 +80,7 @@ func TestPush(t *testing.T) {
 func TestPull(t *testing.T) {
 	dir := t.TempDir()
 
-	ctx := context.Background()
+	ctx := t.Context()
 	f, err := Init(ctx, dir, "", "")
 	require.NoError(t, err)
 
@@ -92,7 +91,7 @@ func TestPull(t *testing.T) {
 func TestAddRemote(t *testing.T) {
 	dir := t.TempDir()
 
-	ctx := context.Background()
+	ctx := t.Context()
 	f, err := Init(ctx, dir, "", "")
 	require.NoError(t, err)
 
@@ -103,7 +102,7 @@ func TestAddRemote(t *testing.T) {
 func TestRemoveRemote(t *testing.T) {
 	dir := t.TempDir()
 
-	ctx := context.Background()
+	ctx := t.Context()
 	f, err := Init(ctx, dir, "", "")
 	require.NoError(t, err)
 
@@ -114,7 +113,7 @@ func TestRemoveRemote(t *testing.T) {
 func TestRevisions(t *testing.T) {
 	dir := t.TempDir()
 
-	ctx := context.Background()
+	ctx := t.Context()
 	f, err := Init(ctx, dir, "", "")
 	require.NoError(t, err)
 
@@ -126,7 +125,7 @@ func TestRevisions(t *testing.T) {
 func TestGetRevision(t *testing.T) {
 	dir := t.TempDir()
 
-	ctx := context.Background()
+	ctx := t.Context()
 	f, err := Init(ctx, dir, "", "")
 	require.NoError(t, err)
 
@@ -138,7 +137,7 @@ func TestGetRevision(t *testing.T) {
 func TestStatus(t *testing.T) {
 	dir := t.TempDir()
 
-	ctx := context.Background()
+	ctx := t.Context()
 	f, err := Init(ctx, dir, "", "")
 	require.NoError(t, err)
 
@@ -150,7 +149,7 @@ func TestStatus(t *testing.T) {
 func TestCompact(t *testing.T) {
 	dir := t.TempDir()
 
-	ctx := context.Background()
+	ctx := t.Context()
 	f, err := Init(ctx, dir, "", "")
 	require.NoError(t, err)
 

--- a/internal/backend/storage/fossilfs/loader_test.go
+++ b/internal/backend/storage/fossilfs/loader_test.go
@@ -1,3 +1,8 @@
+// Package fossilfs provides an experimental storage backend for gopass
+// based on the Fossil SCM system.
+//
+// It is not recommended for production use and is only intended for testing
+// purposes.
 package fossilfs
 
 import (

--- a/internal/backend/storage/fossilfs/loader_test.go
+++ b/internal/backend/storage/fossilfs/loader_test.go
@@ -6,7 +6,6 @@
 package fossilfs
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -26,7 +25,7 @@ func createMarker(t *testing.T, path string) {
 
 func TestLoader_New(t *testing.T) {
 	l := loader{}
-	ctx := context.Background()
+	ctx := t.Context()
 	path := t.TempDir()
 	createMarker(t, path)
 
@@ -37,7 +36,7 @@ func TestLoader_New(t *testing.T) {
 
 func TestLoader_Open(t *testing.T) {
 	l := loader{}
-	ctx := context.Background()
+	ctx := t.Context()
 	path := t.TempDir()
 	createMarker(t, path)
 
@@ -50,7 +49,7 @@ func TestLoader_Clone(t *testing.T) {
 	t.Skip("needs fossil binary and valid remote")
 
 	l := loader{}
-	ctx := context.Background()
+	ctx := t.Context()
 	repo := "https://example.com/repo.git"
 	path := t.TempDir()
 	createMarker(t, path)
@@ -64,7 +63,7 @@ func TestLoader_Init(t *testing.T) {
 	t.Skip("needs fossil binary")
 
 	l := loader{}
-	ctx := context.Background()
+	ctx := t.Context()
 	path := t.TempDir()
 	createMarker(t, path)
 
@@ -75,7 +74,7 @@ func TestLoader_Init(t *testing.T) {
 
 func TestLoader_Handles(t *testing.T) {
 	l := loader{}
-	ctx := context.Background()
+	ctx := t.Context()
 	td := t.TempDir()
 
 	err := l.Handles(ctx, td)

--- a/internal/backend/storage/fossilfs/storage_test.go
+++ b/internal/backend/storage/fossilfs/storage_test.go
@@ -3,7 +3,6 @@
 package fossilfs
 
 import (
-	"context"
 	"testing"
 
 	"github.com/gopasspw/gopass/internal/backend/storage/fs"
@@ -14,7 +13,7 @@ import (
 func TestFossil_Get(t *testing.T) {
 	td := t.TempDir()
 	fossil := &Fossil{fs: fs.New(td)}
-	ctx := context.Background()
+	ctx := t.Context()
 	name := "test"
 
 	fossil.fs.Set(ctx, name, []byte("content"))
@@ -27,7 +26,7 @@ func TestFossil_Get(t *testing.T) {
 func TestFossil_Set(t *testing.T) {
 	td := t.TempDir()
 	fossil := &Fossil{fs: fs.New(td)}
-	ctx := context.Background()
+	ctx := t.Context()
 	name := "test"
 	value := []byte("content")
 
@@ -40,7 +39,7 @@ func TestFossil_Delete(t *testing.T) {
 
 	td := t.TempDir()
 	fossil := &Fossil{fs: fs.New(td)}
-	ctx := context.Background()
+	ctx := t.Context()
 	name := "test"
 
 	fossil.fs.Set(ctx, name, []byte("content"))
@@ -52,7 +51,7 @@ func TestFossil_Delete(t *testing.T) {
 func TestFossil_Exists(t *testing.T) {
 	td := t.TempDir()
 	fossil := &Fossil{fs: fs.New(td)}
-	ctx := context.Background()
+	ctx := t.Context()
 	name := "test"
 
 	fossil.fs.Set(ctx, name, []byte("content"))
@@ -64,7 +63,7 @@ func TestFossil_Exists(t *testing.T) {
 func TestFossil_List(t *testing.T) {
 	td := t.TempDir()
 	fossil := &Fossil{fs: fs.New(td)}
-	ctx := context.Background()
+	ctx := t.Context()
 	prefix := "test"
 
 	fossil.fs.Set(ctx, "test/foo", []byte("content"))
@@ -79,7 +78,7 @@ func TestFossil_List(t *testing.T) {
 func TestFossil_IsDir(t *testing.T) {
 	td := t.TempDir()
 	fossil := &Fossil{fs: fs.New(td)}
-	ctx := context.Background()
+	ctx := t.Context()
 	name := "test"
 
 	fossil.fs.Set(ctx, "test/foo", []byte("content"))
@@ -90,7 +89,7 @@ func TestFossil_IsDir(t *testing.T) {
 func TestFossil_Prune(t *testing.T) {
 	td := t.TempDir()
 	fossil := &Fossil{fs: fs.New(td)}
-	ctx := context.Background()
+	ctx := t.Context()
 	prefix := "test"
 
 	fossil.fs.Set(ctx, "test/foo", []byte("content"))
@@ -120,7 +119,7 @@ func TestFossil_Path(t *testing.T) {
 func TestFossil_Fsck(t *testing.T) {
 	td := t.TempDir()
 	fossil := &Fossil{fs: fs.New(td)}
-	ctx := context.Background()
+	ctx := t.Context()
 
 	err := fossil.Fsck(ctx)
 	require.NoError(t, err)
@@ -129,7 +128,7 @@ func TestFossil_Fsck(t *testing.T) {
 func TestFossil_Link(t *testing.T) {
 	td := t.TempDir()
 	fossil := &Fossil{fs: fs.New(td)}
-	ctx := context.Background()
+	ctx := t.Context()
 	from := "from"
 	to := "to"
 
@@ -142,7 +141,7 @@ func TestFossil_Link(t *testing.T) {
 func TestFossil_Move(t *testing.T) {
 	td := t.TempDir()
 	fossil := &Fossil{fs: fs.New(td)}
-	ctx := context.Background()
+	ctx := t.Context()
 	src := "src"
 	dst := "dst"
 	del := true

--- a/internal/backend/storage/fs/rcs_test.go
+++ b/internal/backend/storage/fs/rcs_test.go
@@ -30,6 +30,6 @@ func TestRCS(t *testing.T) {
 	assert.Len(t, revs, 1)
 	body, err := g.GetRevision(ctx, "foo", "latest")
 	require.Error(t, err)
-	assert.Equal(t, "", string(body))
+	assert.Empty(t, string(body))
 	require.Error(t, g.RemoveRemote(ctx, "foo"))
 }

--- a/internal/backend/storage/gitfs/git_test.go
+++ b/internal/backend/storage/gitfs/git_test.go
@@ -37,7 +37,7 @@ func TestGit(t *testing.T) {
 		require.NotNil(t, git)
 
 		sv := git.Version(ctx)
-		assert.NotEqual(t, "", sv.String())
+		assert.NotEmpty(t, sv.String())
 
 		assert.True(t, git.IsInitialized())
 		tf := filepath.Join(gitdir, "some-file")

--- a/internal/cache/disk.go
+++ b/internal/cache/disk.go
@@ -1,3 +1,5 @@
+// Package cache proivdes a simple on disk cache for gopass.
+// It stores the data in a user specific directory.
 package cache
 
 import (

--- a/internal/cache/ghssh/github.go
+++ b/internal/cache/ghssh/github.go
@@ -1,3 +1,5 @@
+// Package ghssh provides a cache for github ssh keys.
+// It fetches the keys from github and caches them on disk.
 package ghssh
 
 import (

--- a/internal/cache/ghssh/github_test.go
+++ b/internal/cache/ghssh/github_test.go
@@ -1,7 +1,6 @@
 package ghssh
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -36,14 +35,14 @@ func TestListKeys(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("valid user", func(t *testing.T) {
-		keys, err := cache.ListKeys(context.Background(), "validuser")
+		keys, err := cache.ListKeys(t.Context(), "validuser")
 		require.NoError(t, err)
 		assert.Len(t, keys, 1)
 		assert.Equal(t, "ssh-rsa AAAAB3Nza... validuser@github", keys[0])
 	})
 
 	t.Run("invalid user", func(t *testing.T) {
-		keys, err := cache.ListKeys(context.Background(), "invaliduser")
+		keys, err := cache.ListKeys(t.Context(), "invaliduser")
 		require.Error(t, err)
 		assert.Nil(t, keys)
 	})
@@ -75,14 +74,14 @@ func TestFetchKeys(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("valid user", func(t *testing.T) {
-		keys, err := cache.fetchKeys(context.Background(), "validuser")
+		keys, err := cache.fetchKeys(t.Context(), "validuser")
 		require.NoError(t, err)
 		assert.Len(t, keys, 1)
 		assert.Equal(t, "ssh-rsa AAAAB3Nza... validuser@github", keys[0])
 	})
 
 	t.Run("invalid user", func(t *testing.T) {
-		keys, err := cache.fetchKeys(context.Background(), "invaliduser")
+		keys, err := cache.fetchKeys(t.Context(), "invaliduser")
 		require.Error(t, err)
 		assert.Nil(t, keys)
 	})

--- a/internal/cache/inmem_test.go
+++ b/internal/cache/inmem_test.go
@@ -25,7 +25,7 @@ func TestTTL(t *testing.T) {
 	c.now = nowFunc(0)
 
 	val, found := c.Get("foo")
-	assert.Equal(t, "", val)
+	assert.Empty(t, val)
 	assert.False(t, found)
 
 	c.Set("foo", "bar")
@@ -42,7 +42,7 @@ func TestTTL(t *testing.T) {
 	c.now = nowFunc(6)
 
 	val, found = c.Get("foo")
-	assert.Equal(t, "", val)
+	assert.Empty(t, val)
 	assert.False(t, found)
 
 	c.Set("bar", "baz")
@@ -52,7 +52,7 @@ func TestTTL(t *testing.T) {
 
 	c.Remove("bar")
 	val, found = c.Get("bar")
-	assert.Equal(t, "", val)
+	assert.Empty(t, val)
 	assert.False(t, found)
 
 	c.Set("foo", "bar")
@@ -63,7 +63,7 @@ func TestTTL(t *testing.T) {
 
 	c.Purge()
 	val, found = c.Get("bar")
-	assert.Equal(t, "", val)
+	assert.Empty(t, val)
 	assert.False(t, found)
 }
 

--- a/internal/completion/fish/completion_test.go
+++ b/internal/completion/fish/completion_test.go
@@ -91,7 +91,7 @@ func TestFormatflagFunc(t *testing.T) {
 	} {
 		sv, err := formatFlagFunc("short")(flag)
 		require.NoError(t, err)
-		assert.Equal(t, "", sv)
+		assert.Empty(t, sv)
 
 		sv, err = formatFlagFunc("long")(flag)
 		require.NoError(t, err)
@@ -104,13 +104,13 @@ func TestFormatflagFunc(t *testing.T) {
 
 	sv, err := formatFlagFunc("short")(&unknownFlag{})
 	require.Error(t, err)
-	assert.Equal(t, "", sv)
+	assert.Empty(t, sv)
 
 	sv, err = formatFlagFunc("long")(&unknownFlag{})
 	require.Error(t, err)
-	assert.Equal(t, "", sv)
+	assert.Empty(t, sv)
 
 	sv, err = formatFlagFunc("usage")(&unknownFlag{})
 	require.Error(t, err)
-	assert.Equal(t, "", sv)
+	assert.Empty(t, sv)
 }

--- a/internal/completion/fish/template.go
+++ b/internal/completion/fish/template.go
@@ -1,3 +1,4 @@
+// Package fish implements a fish completion template for gopass.
 package fish
 
 // see https://fishshell.com/docs/current/commands.html#complete

--- a/internal/completion/zsh/completion.go
+++ b/internal/completion/zsh/completion.go
@@ -1,3 +1,4 @@
+// Package zsh implements a zsh completion script generator.
 package zsh
 
 import (

--- a/internal/completion/zsh/completion_test.go
+++ b/internal/completion/zsh/completion_test.go
@@ -91,5 +91,5 @@ func TestFormatflagFunc(t *testing.T) {
 
 	sv, err := ff(&unknownFlag{})
 	require.Error(t, err)
-	assert.Equal(t, "", sv)
+	assert.Empty(t, sv)
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,3 +1,6 @@
+// Package config provides a way to manage the configuration of gopass.
+// It handles the loading and saving of configuration files,
+// as well as the management of environment variables.
 package config
 
 import (

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"context"
 	"testing"
 
 	"github.com/gopasspw/gopass/tests/gptest"
@@ -39,7 +38,7 @@ func TestConfig(t *testing.T) {
 	require.NoError(t, cfg.Set("", "pwgen.xkcd-lang", "de"))
 	assert.Equal(t, "de", cfg.Get("pwgen.xkcd-lang"))
 
-	ctx := cfg.WithConfig(context.Background())
+	ctx := cfg.WithConfig(t.Context())
 	assert.True(t, Bool(ctx, "core.bool"))
 	assert.Equal(t, "foo", String(ctx, "core.string"))
 	assert.Equal(t, 42, Int(ctx, "core.int"))

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -117,7 +117,7 @@ func TestOptsMigration(t *testing.T) {
 		require.NoError(t, cfg.Set("", "core.showsafecontent", "true"))
 		assert.True(t, cfg.IsSet("core.showsafecontent"))
 		assert.Equal(t, "true", cfg.root.GetGlobal("core.showsafecontent"))
-		assert.Equal(t, "", cfg.root.GetLocal("core.showsafecontent"))
+		assert.Empty(t, cfg.root.GetLocal("core.showsafecontent"))
 		assert.False(t, cfg.IsSet("core.safecontent"))
 		assert.False(t, cfg.IsSet("show.safecontent"))
 
@@ -128,9 +128,9 @@ func TestOptsMigration(t *testing.T) {
 		cfg2 := New()
 		assert.False(t, cfg2.IsSet("core.showsafecontent"))
 		assert.False(t, cfg2.IsSet("core.safecontent"))
-		assert.Equal(t, "", cfg2.root.GetGlobal("core.showsafecontent"))
+		assert.Empty(t, cfg2.root.GetGlobal("core.showsafecontent"))
 		assert.Equal(t, "true", cfg2.root.GetGlobal("show.safecontent"))
-		assert.Equal(t, "", cfg2.root.GetLocal("show.safecontent"))
+		assert.Empty(t, cfg2.root.GetLocal("show.safecontent"))
 	})
 
 	t.Run("migrated config matches test config", func(t *testing.T) {
@@ -169,7 +169,7 @@ func TestOptsMigration(t *testing.T) {
 		// this will write to the local config because of the <root> arg
 		require.NoError(t, cfg.Set("<root>", "core.showsafecontent", "true"))
 		assert.Equal(t, "true", cfg.root.GetLocal("core.showsafecontent"))
-		assert.Equal(t, "", cfg.root.GetGlobal("core.showsafecontent"))
+		assert.Empty(t, cfg.root.GetGlobal("core.showsafecontent"))
 		assert.False(t, cfg.IsSet("show.safecontent"))
 
 		t.Setenv("GOPASS_CONFIG_NO_MIGRATE", "")
@@ -177,7 +177,7 @@ func TestOptsMigration(t *testing.T) {
 		cfg = New()
 		assert.False(t, cfg.IsSet("core.showsafecontent"))
 		assert.Equal(t, "true", cfg.root.GetLocal("show.safecontent"))
-		assert.Equal(t, "", cfg.root.GetGlobal("show.safecontent"))
+		assert.Empty(t, cfg.root.GetGlobal("show.safecontent"))
 	})
 
 	t.Run("env variable are not migrated", func(t *testing.T) {
@@ -214,15 +214,15 @@ func TestOptsMigration(t *testing.T) {
 		// this will write to the local mount config
 		require.NoError(t, cfg.Set("submount", "core.showsafecontent", "true"))
 		assert.Equal(t, "true", cfg.GetM("submount", "core.showsafecontent"))
-		assert.Equal(t, "", cfg.Get("core.showsafecontent"))
-		assert.Equal(t, "", cfg.GetM("submount", "show.safecontent"))
+		assert.Empty(t, cfg.Get("core.showsafecontent"))
+		assert.Empty(t, cfg.GetM("submount", "show.safecontent"))
 
 		t.Setenv("GOPASS_CONFIG_NO_MIGRATE", "")
 		// we test the migration path
 		cfg = New()
 		assert.False(t, cfg.IsSet("core.showsafecontent"))
 		assert.False(t, cfg.IsSet("show.safecontent"))
-		assert.Equal(t, "", cfg.GetM("submount", "core.showsafecontent"))
+		assert.Empty(t, cfg.GetM("submount", "core.showsafecontent"))
 		assert.Equal(t, "true", cfg.GetM("submount", "show.safecontent"))
 	})
 }

--- a/internal/config/legacy/config.go
+++ b/internal/config/legacy/config.go
@@ -1,3 +1,6 @@
+// Package legacy provides the legacy config struct for gopass.
+// It is used for backwards compatibility and should be removed in the future.
+// It is not intended for use in new code.
 package legacy
 
 import (
@@ -88,12 +91,16 @@ func (c *Config) setConfigValue(key, value string) error {
 
 			return nil
 		case reflect.Bool:
-			switch {
-			case value == "true" || value == "on":
+			switch value {
+			case "true":
+				fallthrough
+			case "on":
 				f.SetBool(true)
 
 				return nil
-			case value == "false" || value == "off":
+			case "false":
+				fallthrough
+			case "off":
 				f.SetBool(false)
 
 				return nil

--- a/internal/config/legacy/location_test.go
+++ b/internal/config/legacy/location_test.go
@@ -1,0 +1,39 @@
+package legacy
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConfigLocations(t *testing.T) {
+	gpcfg := filepath.Join(os.TempDir(), "config", ".gopass.yml")
+	xdghome := filepath.Join(os.TempDir(), "xdg")
+	gphome := filepath.Join(os.TempDir(), "home")
+
+	xdgcfg := filepath.Join(xdghome, "gopass", "config.yml")
+	curcfg := filepath.Join(gphome, ".config", "gopass", "config.yml")
+	oldcfg := filepath.Join(gphome, ".gopass.yml")
+
+	t.Run("GOPASS_CONFIG, GOPASS_HOMEDIR set", func(t *testing.T) {
+		t.Setenv("GOPASS_CONFIG", gpcfg)
+		t.Setenv("GOPASS_HOMEDIR", gphome)
+
+		assert.Equal(t, []string{gpcfg, curcfg, curcfg, oldcfg}, ConfigLocations())
+	})
+
+	t.Run("GOPASS_CONFIG, GOPASS_HOMEDIR, XDG_CONFIG_HOME set", func(t *testing.T) {
+		t.Setenv("GOPASS_CONFIG", gpcfg)
+		t.Setenv("GOPASS_HOMEDIR", gphome)
+		t.Setenv("XDG_CONFIG_HOME", xdghome)
+
+		assert.Equal(t, []string{gpcfg, curcfg, curcfg, oldcfg}, ConfigLocations())
+	})
+
+	t.Run("XDG_CONFIG_HOME set only", func(t *testing.T) {
+		t.Setenv("XDG_CONFIG_HOME", xdghome)
+		assert.Equal(t, xdgcfg, ConfigLocations()[0])
+	})
+}

--- a/internal/config/legacy/location_xdg_test.go
+++ b/internal/config/legacy/location_xdg_test.go
@@ -1,3 +1,6 @@
+//go:build !darwin && !windows
+// +build !darwin,!windows
+
 package legacy
 
 import (

--- a/internal/config/location.go
+++ b/internal/config/location.go
@@ -24,20 +24,6 @@ func configLocation() string {
 	return filepath.Join(appdir.UserConfig(), "config.yml")
 }
 
-// configLocations returns the possible locations of gopass config files,
-// in decreasing priority.
-func configLocations() []string {
-	l := []string{}
-	if cf := os.Getenv("GOPASS_CONFIG"); cf != "" {
-		l = append(l, cf)
-	}
-	l = append(l, filepath.Join(appdir.UserConfig(), "config.yml"))
-	l = append(l, filepath.Join(appdir.UserHome(), ".config", "gopass", "config.yml"))
-	l = append(l, filepath.Join(appdir.UserHome(), ".gopass.yml"))
-
-	return l
-}
-
 // PwStoreDir reads the password store dir from the environment
 // or returns the default location if the env is not set.
 func PwStoreDir(mount string) string {

--- a/internal/config/location_xdg_test.go
+++ b/internal/config/location_xdg_test.go
@@ -60,33 +60,3 @@ func TestConfigLocation(t *testing.T) {
 		})
 	}
 }
-
-func TestConfigLocations(t *testing.T) {
-	gpcfg := filepath.Join(os.TempDir(), "config", ".gopass.yml")
-	xdghome := filepath.Join(os.TempDir(), "xdg")
-	gphome := filepath.Join(os.TempDir(), "home")
-
-	xdgcfg := filepath.Join(xdghome, "gopass", "config.yml")
-	curcfg := filepath.Join(gphome, ".config", "gopass", "config.yml")
-	oldcfg := filepath.Join(gphome, ".gopass.yml")
-
-	t.Run("GOPASS_CONFIG, GOPASS_HOMEDIR set", func(t *testing.T) {
-		t.Setenv("GOPASS_CONFIG", gpcfg)
-		t.Setenv("GOPASS_HOMEDIR", gphome)
-
-		assert.Equal(t, []string{gpcfg, curcfg, curcfg, oldcfg}, configLocations())
-	})
-
-	t.Run("GOPASS_CONFIG, GOPASS_HOMEDIR, XDG_CONFIG_HOME set", func(t *testing.T) {
-		t.Setenv("GOPASS_CONFIG", gpcfg)
-		t.Setenv("GOPASS_HOMEDIR", gphome)
-		t.Setenv("XDG_CONFIG_HOME", xdghome)
-
-		assert.Equal(t, []string{gpcfg, curcfg, curcfg, oldcfg}, configLocations())
-	})
-
-	t.Run("XDG_CONFIG_HOME set only", func(t *testing.T) {
-		t.Setenv("XDG_CONFIG_HOME", xdghome)
-		assert.Equal(t, xdgcfg, configLocations()[0])
-	})
-}

--- a/internal/create/wizard.go
+++ b/internal/create/wizard.go
@@ -1,3 +1,4 @@
+// Package create provides a credential creation wizard.
 package create
 
 import (

--- a/internal/cui/cui.go
+++ b/internal/cui/cui.go
@@ -1,3 +1,5 @@
+// Package cui provides a simple command line user interface
+// for gopass. It is used to interact with the user.
 package cui
 
 import (

--- a/internal/cui/recipients_test.go
+++ b/internal/cui/recipients_test.go
@@ -53,21 +53,21 @@ func TestAskForStore(t *testing.T) {
 
 	// test non-interactive
 	ctx = ctxutil.WithInteractive(ctx, false)
-	assert.Equal(t, "", AskForStore(ctx, fakeMountPointer{"foo", "bar"}))
+	assert.Empty(t, AskForStore(ctx, fakeMountPointer{"foo", "bar"}))
 
 	// test interactive
 	ctx = ctxutil.WithInteractive(ctx, true)
 	ctx = ctxutil.WithAlwaysYes(ctx, true)
-	assert.Equal(t, "", AskForStore(ctx, fakeMountPointer{"foo", "bar"}))
+	assert.Empty(t, AskForStore(ctx, fakeMountPointer{"foo", "bar"}))
 
 	// test zero mps
-	assert.Equal(t, "", AskForStore(ctx, fakeMountPointer{}))
+	assert.Empty(t, AskForStore(ctx, fakeMountPointer{}))
 
 	// test one mp
-	assert.Equal(t, "", AskForStore(ctx, fakeMountPointer{"foo"}))
+	assert.Empty(t, AskForStore(ctx, fakeMountPointer{"foo"}))
 
 	// test two mps
-	assert.Equal(t, "", AskForStore(ctx, fakeMountPointer{"foo", "bar"}))
+	assert.Empty(t, AskForStore(ctx, fakeMountPointer{"foo", "bar"}))
 }
 
 func TestSorted(t *testing.T) {

--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -1,3 +1,4 @@
+// Package diff implements diffing of two lists.
 package diff
 
 // Stat returnes the number of items added to and removed from the first to

--- a/internal/editor/editor.go
+++ b/internal/editor/editor.go
@@ -1,3 +1,4 @@
+// Package editor provides a simple wrapper around the EDITOR environment variable.
 package editor
 
 import (

--- a/internal/env/doc.go
+++ b/internal/env/doc.go
@@ -1,0 +1,4 @@
+// Package env provides a way to validate the environment
+// and the configuration of gopass.
+
+package env

--- a/internal/env/env_darwin.go
+++ b/internal/env/env_darwin.go
@@ -20,6 +20,8 @@ var (
 	Stderr io.Writer = os.Stderr
 )
 
+// Check validates the runtime environment on MacOS.
+// It checks if the keychain is used.
 func Check(ctx context.Context) (string, error) {
 	buf := &bytes.Buffer{}
 

--- a/internal/hashsum/hashsums.go
+++ b/internal/hashsum/hashsums.go
@@ -1,3 +1,4 @@
+// Package hashsum provides hash functions for various algorithms.
 package hashsum
 
 import (

--- a/internal/hashsum/hashsums_test.go
+++ b/internal/hashsum/hashsums_test.go
@@ -1,0 +1,60 @@
+package hashsum
+
+import (
+	"testing"
+)
+
+func TestMD5Hex(t *testing.T) {
+	t.Parallel()
+
+	in := "test"
+	want := "098f6bcd4621d373cade4e832627b4f6"
+	got := MD5Hex(in)
+	if got != want {
+		t.Errorf("MD5Hex(%q) = %q, want %q", in, got, want)
+	}
+}
+
+func TestSHA1Hex(t *testing.T) {
+	t.Parallel()
+
+	in := "test"
+	want := "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3"
+	got := SHA1Hex(in)
+	if got != want {
+		t.Errorf("SHA1Hex(%q) = %q, want %q", in, got, want)
+	}
+}
+
+func TestSHA256Hex(t *testing.T) {
+	t.Parallel()
+
+	in := "test"
+	want := "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"
+	got := SHA256Hex(in)
+	if got != want {
+		t.Errorf("SHA256Hex(%q) = %q, want %q", in, got, want)
+	}
+}
+
+func TestSHA512Hex(t *testing.T) {
+	t.Parallel()
+
+	in := "test"
+	want := "ee26b0dd4af7e749aa1a8ee3c10ae9923f618980772e473f8819a5d4940e0db27ac185f8a0e1d5f84f88bc887fd67b143732c304cc5fa9ad8e6f57f50028a8ff"
+	got := SHA512Hex(in)
+	if got != want {
+		t.Errorf("SHA512Hex(%q) = %q, want %q", in, got, want)
+	}
+}
+
+func TestBlake3Hex(t *testing.T) {
+	t.Parallel()
+
+	in := "test"
+	want := "4878ca0425c739fa427f7eda20fe845f6b2e46ba5fe2a14df5b1e32f50603215"
+	got := Blake3Hex(in)
+	if got != want {
+		t.Errorf("Blake3Hex(%q) = %q, want %q", in, got, want)
+	}
+}

--- a/internal/hook/hook.go
+++ b/internal/hook/hook.go
@@ -1,4 +1,4 @@
-// Package hook provides a flexbile hook system for gopass.
+// Package hook provides a flexible hook system for gopass.
 package hook
 
 import (

--- a/internal/hook/hook.go
+++ b/internal/hook/hook.go
@@ -1,3 +1,4 @@
+// Package hook provides a flexbile hook system for gopass.
 package hook
 
 import (

--- a/internal/notify/doc.go
+++ b/internal/notify/doc.go
@@ -1,0 +1,3 @@
+// Package notify provides a notification system for gopass.
+
+package notify

--- a/internal/notify/notify_test.go
+++ b/internal/notify/notify_test.go
@@ -1,7 +1,6 @@
 package notify
 
 import (
-	"context"
 	"image/png"
 	"os"
 	"strings"
@@ -21,7 +20,7 @@ func TestNotify(t *testing.T) {
 func TestIcon(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	fn := strings.TrimPrefix(iconURI(ctx), "file://")
 	require.NoError(t, os.Remove(fn))

--- a/internal/out/context_test.go
+++ b/internal/out/context_test.go
@@ -12,7 +12,7 @@ func TestPrefix(t *testing.T) {
 
 	ctx := config.NewContextInMemory()
 
-	assert.Equal(t, "", Prefix(ctx))
+	assert.Empty(t, Prefix(ctx))
 
 	ctx = AddPrefix(ctx, "[foo] ")
 	assert.Equal(t, "[foo] ", Prefix(ctx))

--- a/internal/out/print.go
+++ b/internal/out/print.go
@@ -1,3 +1,6 @@
+// Package out provides a simple output interface for gopass.
+// It provides functions to print messages to stdout and stderr.
+// These sinks can be replaced by a different implementation, e.g. for testing.
 package out
 
 import (

--- a/internal/out/print_test.go
+++ b/internal/out/print_test.go
@@ -23,7 +23,7 @@ func TestPrint(t *testing.T) {
 	buf.Reset()
 
 	Printf(ctxutil.WithHidden(ctx, true), "%s = %d", "foo", 42)
-	assert.Equal(t, "", buf.String())
+	assert.Empty(t, buf.String())
 	buf.Reset()
 
 	Printf(WithNewline(ctx, false), "%s = %d", "foo", 42)

--- a/internal/pwschemes/argon2i/argon2i.go
+++ b/internal/pwschemes/argon2i/argon2i.go
@@ -1,3 +1,4 @@
+// Package argon2i provides an Argon2i password hashing scheme.
 package argon2i
 
 import (

--- a/internal/pwschemes/argon2id/argon2id.go
+++ b/internal/pwschemes/argon2id/argon2id.go
@@ -1,3 +1,4 @@
+// Package argon2id provides an Argon2id password hashing scheme.
 package argon2id
 
 import (

--- a/internal/pwschemes/bcrypt/bcrypt.go
+++ b/internal/pwschemes/bcrypt/bcrypt.go
@@ -1,3 +1,5 @@
+// Package bcrypt provides a bcrypt password hashing scheme.
+// It is compatible with Dovecot and other systems that use bcrypt.
 package bcrypt
 
 import (

--- a/internal/queue/background_test.go
+++ b/internal/queue/background_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestQueue_Add(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	q := New(ctx)
 
 	task := func(ctx context.Context) (context.Context, error) {
@@ -22,7 +22,7 @@ func TestQueue_Add(t *testing.T) {
 }
 
 func TestQueue_Close(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	q := New(ctx)
 
 	task := func(ctx context.Context) (context.Context, error) {
@@ -41,7 +41,7 @@ func TestQueue_Close(t *testing.T) {
 }
 
 func TestQueue_Idle(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	q := New(ctx)
 
 	task := func(ctx context.Context) (context.Context, error) {
@@ -66,7 +66,7 @@ func TestQueue_Idle(t *testing.T) {
 }
 
 func TestWithQueue(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	q := New(ctx)
 
 	ctxWithQueue := WithQueue(ctx, q)
@@ -76,7 +76,7 @@ func TestWithQueue(t *testing.T) {
 }
 
 func TestGetQueue(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	q := GetQueue(ctx)
 	if _, ok := q.(*noop); !ok {

--- a/internal/recipients/recipients.go
+++ b/internal/recipients/recipients.go
@@ -1,3 +1,5 @@
+// Package recipients provides a datastruct for managing for managinig recipients.
+// It also provides methods for marshalling and unmarshalling the recipients.
 package recipients
 
 import (

--- a/internal/reminder/reminder.go
+++ b/internal/reminder/reminder.go
@@ -1,3 +1,5 @@
+// Package reminder provides a reminder store for gopass.
+// It stores timestamps on disk to remind the user of certain events.
 package reminder
 
 import (

--- a/internal/set/set.go
+++ b/internal/set/set.go
@@ -1,3 +1,4 @@
+// Package set provides a generic set implementation.
 package set
 
 import (

--- a/internal/store/leaf/fsck.go
+++ b/internal/store/leaf/fsck.go
@@ -34,6 +34,8 @@ func (e ErrorSeverity) String() string {
 		return "non-fatal"
 	case errsFatal:
 		return "fatal"
+	case errsNil:
+		return "nil"
 	default:
 		return "nil"
 	}

--- a/internal/store/leaf/fsck.go
+++ b/internal/store/leaf/fsck.go
@@ -29,10 +29,10 @@ const (
 )
 
 func (e ErrorSeverity) String() string {
-	switch {
-	case e == errsNonFatal:
+	switch e {
+	case errsNonFatal:
 		return "non-fatal"
-	case e == errsFatal:
+	case errsFatal:
 		return "fatal"
 	default:
 		return "nil"
@@ -186,7 +186,7 @@ func (s *Store) fsckLoop(ctx context.Context, path string) error {
 
 		msg, err := s.fsckCheckEntry(ctx, name)
 		if err != nil {
-			warnings.WriteString(fmt.Errorf("failed to check %q:\n    %w\n", name, err).Error())
+			warnings.WriteString(fmt.Sprintf("failed to check %q:\n    %s\n", name, err))
 
 			continue
 		}
@@ -252,7 +252,7 @@ func (s *Store) fsckCheckEntry(ctx context.Context, name string) (string, error)
 	merr := s.fsckCheckRecipients(ctx, name)
 	if merr.ErrorOrNil() != nil {
 		if merr.Severity == errsFatal {
-			return "", errs.Append(errsFatal, fmt.Errorf("Checking recipients for %s failed:\n    %w", name, merr)).ErrorOrNil()
+			return "", errs.Append(errsFatal, fmt.Errorf("checking recipients for %s failed:\n    %w", name, merr)).ErrorOrNil()
 		}
 		// the only errsNonFatal error from that function are missing/extra recipients, or unsupported recipient checks
 		// all of which aren't much of an issue since we have yet to correct that by re-encrypting.
@@ -300,7 +300,7 @@ func (s *Store) fsckCheckEntry(ctx context.Context, name string) (string, error)
 	merr = s.fsckCheckRecipients(ctx, name)
 	if merr.ErrorOrNil() != nil {
 		if merr.Severity == errsFatal {
-			_ = errs.Append(merr.Severity, fmt.Errorf("Checking recipients for %s failed:\n    %w", name, merr))
+			_ = errs.Append(merr.Severity, fmt.Errorf("checking recipients for %s failed:\n    %w", name, merr))
 		} else {
 			_ = errs.Append(merr.Severity, merr)
 		}
@@ -347,10 +347,10 @@ func (s *Store) fsckCheckRecipients(ctx context.Context, name string) *fsckMulti
 	// check itemRecps matches storeRecps
 	extra, missing := diff.List(perItemStoreRecps, itemRecps)
 	if len(missing) > 0 {
-		_ = e.Append(errsNonFatal, fmt.Errorf("Missing recipients on %s: %+v\n", name, missing))
+		_ = e.Append(errsNonFatal, fmt.Errorf("missing recipients on %s: %+v", name, missing))
 	}
 	if len(extra) > 0 {
-		_ = e.Append(errsNonFatal, fmt.Errorf("Extra recipients on %s: %+v\n", name, extra))
+		_ = e.Append(errsNonFatal, fmt.Errorf("extra recipients on %s: %+v", name, extra))
 	}
 
 	return e

--- a/internal/store/leaf/store.go
+++ b/internal/store/leaf/store.go
@@ -1,3 +1,6 @@
+// Package leaf provides the leaf store implementation for gopass.
+// It implements the gopass.Store interface and provides methods to
+// interact with the password store.
 package leaf
 
 import (

--- a/internal/store/leaf/write.go
+++ b/internal/store/leaf/write.go
@@ -20,7 +20,7 @@ func (s *Store) Set(ctx context.Context, name string, sec gopass.Byter) error {
 	}
 
 	if cfg, _ := config.FromContext(ctx); cfg.GetM(s.alias, "core.readonly") == "true" {
-		return fmt.Errorf("writing to %s is disabled by `core.readonly`.", s.alias)
+		return fmt.Errorf("writing to %s is disabled by `core.readonly`", s.alias)
 	}
 
 	p := s.Passfile(name)

--- a/internal/store/leaf/write.go
+++ b/internal/store/leaf/write.go
@@ -35,7 +35,7 @@ func (s *Store) Set(ctx context.Context, name string, sec gopass.Byter) error {
 
 	// we can not encrypt without recipients
 	if len(recipients) < 1 {
-		return fmt.Errorf("no useable recipients for %q. can not encrypt without recipients.", name)
+		return fmt.Errorf("no useable recipients for %q. can not encrypt without recipients", name)
 	}
 
 	ciphertext, err := s.crypto.Encrypt(ctx, sec.Bytes(), recipients)

--- a/internal/store/mockstore/store.go
+++ b/internal/store/mockstore/store.go
@@ -1,3 +1,6 @@
+// Package mockstore provides a mock store for testing purposes.
+// It implements the gopass.Store interface and uses an in-memory storage backend.
+
 package mockstore
 
 import (

--- a/internal/store/mockstore/store_test.go
+++ b/internal/store/mockstore/store_test.go
@@ -1,7 +1,6 @@
 package mockstore
 
 import (
-	"context"
 	"testing"
 
 	"github.com/gopasspw/gopass/pkg/gopass/secrets"
@@ -10,7 +9,7 @@ import (
 )
 
 func TestMockStore(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	store := New("test")
 
 	t.Run("String", func(t *testing.T) {

--- a/internal/store/root/fsck.go
+++ b/internal/store/root/fsck.go
@@ -10,10 +10,10 @@ import (
 )
 
 // Fsck checks all stores/entries matching the given prefix.
-func (s *Store) Fsck(ctx context.Context, store, path string) error {
+func (r *Store) Fsck(ctx context.Context, store, path string) error {
 	var result []error
 
-	for alias, sub := range s.mounts {
+	for alias, sub := range r.mounts {
 		if sub == nil {
 			continue
 		}
@@ -41,7 +41,7 @@ func (s *Store) Fsck(ctx context.Context, store, path string) error {
 
 	// check root store
 	debug.Log("Checking root store")
-	if err := s.store.Fsck(ctx, path); err != nil {
+	if err := r.store.Fsck(ctx, path); err != nil {
 		out.Errorf(ctx, "fsck failed on root store: %s", err)
 		result = append(result, err)
 	}

--- a/internal/store/root/mount.go
+++ b/internal/store/root/mount.go
@@ -213,17 +213,11 @@ func (r *Store) checkMounts() error {
 // CleanMountAlias removes all leading and trailing slashes from a mount alias.
 // Note: Slashes inside the alias are valid and will be kept.
 func CleanMountAlias(alias string) string {
-	for {
-		if !strings.HasPrefix(alias, "/") && !strings.HasPrefix(alias, "\\") {
-			break
-		}
+	for strings.HasPrefix(alias, "/") || strings.HasPrefix(alias, "\\") {
 		alias = strings.TrimPrefix(strings.TrimSuffix(alias, "/"), "/")
 		alias = strings.TrimPrefix(strings.TrimSuffix(alias, "\\"), "\\")
 	}
-	for {
-		if !strings.HasSuffix(alias, "/") && !strings.HasSuffix(alias, "\\") {
-			break
-		}
+	for strings.HasSuffix(alias, "/") || strings.HasSuffix(alias, "\\") {
 		alias = strings.TrimSuffix(strings.TrimPrefix(alias, "/"), "/")
 		alias = strings.TrimSuffix(strings.TrimPrefix(alias, "\\"), "\\")
 	}

--- a/internal/store/root/store.go
+++ b/internal/store/root/store.go
@@ -1,3 +1,7 @@
+// Package root provides the root store implementation for gopass.
+// It implements the gopass.Store interface and provides methods to
+// interact with the password store. It is responsible for managing
+// the underlying storage backends and mounting them as needed.
 package root
 
 import (

--- a/internal/store/root/store_test.go
+++ b/internal/store/root/store_test.go
@@ -122,7 +122,7 @@ func TestListNested(t *testing.T) {
 
 	assert.False(t, rs.Exists(ctx, "sub1"))
 	assert.True(t, rs.IsDir(ctx, "sub1"))
-	assert.Equal(t, "", rs.Alias())
+	assert.Empty(t, rs.Alias())
 	assert.NotNil(t, rs.Storage(ctx, "sub1"))
 }
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1,3 +1,5 @@
+// Package store provides the interface for the gopass password store.
+// It defines the methods and types used to interact with the password store.
 package store
 
 import (

--- a/internal/tpl/template.go
+++ b/internal/tpl/template.go
@@ -1,3 +1,5 @@
+// Package tpl provides functions to handle templates.
+// It can parse templates from various formats and generate output for them.
 package tpl
 
 import (

--- a/internal/updater/github_test.go
+++ b/internal/updater/github_test.go
@@ -1,7 +1,6 @@
 package updater
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -78,7 +77,7 @@ func TestFetchLatestRelease(t *testing.T) {
 
 			BaseURL = server.URL + "/repos/%s/%s/releases/latest"
 
-			ctx := context.Background()
+			ctx := t.Context()
 			release, err := FetchLatestRelease(ctx)
 
 			if tt.expectedError {
@@ -131,7 +130,7 @@ func TestDownloadAsset(t *testing.T) {
 				tt.assets[i].URL = server.URL + a.URL
 			}
 
-			ctx := context.Background()
+			ctx := t.Context()
 
 			name, _, err := downloadAsset(ctx, tt.assets, tt.suffix)
 

--- a/internal/updater/update.go
+++ b/internal/updater/update.go
@@ -1,3 +1,6 @@
+// Package updater provides a simple update mechanism for gopass.
+// It will check for updates, download the latest release and
+// verify the GPG signature of the release.
 package updater
 
 import (

--- a/main_test.go
+++ b/main_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"bytes"
-	"context"
 	"flag"
 	"fmt"
 	"os"
@@ -178,7 +177,7 @@ func testCommands(t *testing.T, c *cli.Context, commands []*cli.Command, prefix 
 func TestInitContext(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := t.Context()
 	cfg := config.NewInMemory()
 
 	ctx = initContext(ctx, cfg)

--- a/pkg/appdir/appdir_xdg.go
+++ b/pkg/appdir/appdir_xdg.go
@@ -14,6 +14,7 @@ import (
 func (a *Appdir) UserConfig() string {
 	if hd := os.Getenv("GOPASS_HOMEDIR"); hd != "" {
 		debug.V(3).Log("GOPASS_HOMEDIR is set to %s", hd)
+
 		return filepath.Join(hd, ".config", a.name)
 	}
 

--- a/pkg/clipboard/clipboard.go
+++ b/pkg/clipboard/clipboard.go
@@ -1,3 +1,4 @@
+// Package clipboard provides functions to copy and clear the clipboard.
 package clipboard
 
 import (

--- a/pkg/ctxutil/ctxutil.go
+++ b/pkg/ctxutil/ctxutil.go
@@ -1,3 +1,5 @@
+// Package ctxutil provides a set of functions to manage context values
+// in a gopass application. It allows to set and get values in the context.
 package ctxutil
 
 import (

--- a/pkg/ctxutil/ctxutil_test.go
+++ b/pkg/ctxutil/ctxutil_test.go
@@ -79,8 +79,8 @@ func TestAlias(t *testing.T) {
 
 	ctx := config.NewContextInMemory()
 
-	assert.Equal(t, "", GetAlias(ctx))
-	assert.Equal(t, "", GetAlias(WithAlias(ctx, "")))
+	assert.Empty(t, GetAlias(ctx))
+	assert.Empty(t, GetAlias(WithAlias(ctx, "")))
 }
 
 func TestGitInit(t *testing.T) {
@@ -108,9 +108,9 @@ func TestCommitMessage(t *testing.T) {
 
 	ctx := config.NewContextInMemory()
 
-	assert.Equal(t, "", GetCommitMessage(ctx))
+	assert.Empty(t, GetCommitMessage(ctx))
 	assert.Equal(t, "foo", GetCommitMessage(WithCommitMessage(ctx, "foo")))
-	assert.Equal(t, "", GetCommitMessage(WithCommitMessage(ctx, "")))
+	assert.Empty(t, GetCommitMessage(WithCommitMessage(ctx, "")))
 }
 
 func TestCommitMessageBody(t *testing.T) {
@@ -123,13 +123,13 @@ func TestCommitMessageBody(t *testing.T) {
 	assert.Equal(t, "foo", GetCommitMessage(ctx2))
 	assert.Equal(t, "bar\nbaz", GetCommitMessageBody(ctx2))
 	ctx2 = AddToCommitMessageBody(AddToCommitMessageBody(ctx, "bar"), "baz")
-	assert.Equal(t, "", GetCommitMessage(ctx2))
+	assert.Empty(t, GetCommitMessage(ctx2))
 	assert.Equal(t, "bar\nbaz", GetCommitMessageFull(ctx2))
 	assert.Equal(t, "bar\nbaz", GetCommitMessageBody(ctx2))
 	ctx2 = WithCommitMessage(ctx, "foo")
 	assert.Equal(t, "foo", GetCommitMessage(ctx2))
 	assert.Equal(t, "foo", GetCommitMessageFull(ctx2))
-	assert.Equal(t, "", GetCommitMessageBody(ctx2))
+	assert.Empty(t, GetCommitMessageBody(ctx2))
 }
 
 func TestComposite(t *testing.T) {

--- a/pkg/debug/debug.go
+++ b/pkg/debug/debug.go
@@ -122,10 +122,11 @@ func parseFilter(envname string, pad func(string) string) map[string]bool {
 		t := pad(strings.TrimSpace(fn))
 		val := true
 
-		if t[0] == '-' {
+		switch t[0] {
+		case '-':
 			val = false
 			t = t[1:]
-		} else if t[0] == '+' {
+		case '+':
 			val = true
 			t = t[1:]
 		}

--- a/pkg/fsutil/fsutil.go
+++ b/pkg/fsutil/fsutil.go
@@ -1,11 +1,13 @@
+// Package fsutil provides some common file system utilities
+// for gopass. It is used to handle file paths, directories, and files.
 package fsutil
 
 import (
 	"bufio"
+	"crypto/rand"
 	"errors"
 	"fmt"
 	"io"
-	"math/rand"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -180,12 +182,7 @@ func Shred(path string, runs int) error {
 
 		var written int64
 
-		for {
-			// end of file
-			if written >= flen {
-				break
-			}
-
+		for written < flen {
 			buf := bufFn()
 
 			n, err := fh.Write(buf[0:min(flen-written, int64(len(buf)))])

--- a/pkg/gitconfig/configs_test.go
+++ b/pkg/gitconfig/configs_test.go
@@ -52,10 +52,10 @@ func TestConfigs(t *testing.T) {
 	assert.Equal(t, "env", c.Get("env.key"))
 
 	assert.Equal(t, "global", c.GetGlobal("global.key"))
-	assert.Equal(t, "", c.GetGlobal("local.key"))
+	assert.Empty(t, c.GetGlobal("local.key"))
 
 	assert.Equal(t, "local", c.GetLocal("local.key"))
-	assert.Equal(t, "", c.GetLocal("global.key"))
+	assert.Empty(t, c.GetLocal("global.key"))
 
 	for _, k := range []string{"system.key", "global.key", "local.key", "worktree.key", "env.key"} {
 		assert.True(t, c.IsSet(k))
@@ -64,21 +64,21 @@ func TestConfigs(t *testing.T) {
 	// SetLocal
 	require.NoError(t, c.SetLocal("global.fakekey", "local"))
 	assert.Equal(t, "local", c.GetLocal("global.fakekey"))
-	assert.Equal(t, "", c.GetGlobal("global.fakekey"))
+	assert.Empty(t, c.GetGlobal("global.fakekey"))
 	require.NoError(t, c.UnsetLocal("global.fakekey"))
-	assert.Equal(t, "", c.Get("global.fakekey"))
+	assert.Empty(t, c.Get("global.fakekey"))
 
 	// SetGlobal
 	require.NoError(t, c.SetGlobal("local.fakekey", "global"))
-	assert.Equal(t, "", c.GetLocal("local.fakekey"))
+	assert.Empty(t, c.GetLocal("local.fakekey"))
 	assert.Equal(t, "global", c.GetGlobal("local.fakekey"))
 	require.NoError(t, c.UnsetGlobal("local.fakekey"))
-	assert.Equal(t, "", c.Get("local.fakekey"))
+	assert.Empty(t, c.Get("local.fakekey"))
 
 	// SetEnv
 	require.NoError(t, c.SetEnv("worktree.fakekey", "env"))
-	assert.Equal(t, "", c.GetLocal("worktree.fakekey"))
-	assert.Equal(t, "", c.GetGlobal("worktree.fakekey"))
+	assert.Empty(t, c.GetLocal("worktree.fakekey"))
+	assert.Empty(t, c.GetGlobal("worktree.fakekey"))
 	assert.Equal(t, "env", c.Get("worktree.fakekey"))
 
 	// List

--- a/pkg/gopass/api/api.go
+++ b/pkg/gopass/api/api.go
@@ -1,3 +1,6 @@
+// Package api provides a gopass API implementation.
+// It provides a simple interface to interact with the gopass password store.
+// It is used by the gopass CLI and other tools to access the password store.
 package api
 
 import (

--- a/pkg/gopass/apimock/mock.go
+++ b/pkg/gopass/apimock/mock.go
@@ -1,3 +1,6 @@
+// Package apimock provides a mock implementation of the gopass API.
+// This is useful for testing purposes and allows to simulate different
+// scenarios without relying on a real backend.
 package apimock
 
 import (

--- a/pkg/gopass/secrets/akv_test.go
+++ b/pkg/gopass/secrets/akv_test.go
@@ -27,7 +27,7 @@ password: bar
 
 	v, found := s.Get("Test / test.com")
 	assert.False(t, found)
-	assert.Equal(t, "", v)
+	assert.Empty(t, v)
 
 	t.Logf("Secret:\n%+v\n%s\n", s, string(s.Bytes()))
 
@@ -56,7 +56,7 @@ password: bar
 		s.Del("username")
 		v, ok := s.Get("username")
 		assert.False(t, ok)
-		assert.Equal(t, "", v)
+		assert.Empty(t, v)
 
 		assert.Equal(t, `somepasswd
 Test / test.com

--- a/pkg/gopass/secrets/secparse/parse.go
+++ b/pkg/gopass/secrets/secparse/parse.go
@@ -1,3 +1,5 @@
+// Package secparse provides functions to parse secrets from various formats.
+// It can parse secrets from legacy MIME format, YAML format, and AKV format.
 package secparse
 
 import (

--- a/pkg/gopass/secrets/yaml.go
+++ b/pkg/gopass/secrets/yaml.go
@@ -1,3 +1,4 @@
+// Package secrets provides the different secret types that gopass supports.
 package secrets
 
 import (

--- a/pkg/gopass/secrets/yaml_test.go
+++ b/pkg/gopass/secrets/yaml_test.go
@@ -45,7 +45,7 @@ func TestYAMLKeyFromEmptySecret(t *testing.T) {
 
 	v, ok := s.Get(yamlKey)
 	assert.False(t, ok)
-	assert.Equal(t, "", v)
+	assert.Empty(t, v)
 }
 
 type inlineB struct {
@@ -68,7 +68,7 @@ func TestYAMLEncodingError(t *testing.T) {
 			}{1, inlineB{2, inlineC{3}}},
 		},
 	}
-	assert.Equal(t, "", string(s.Bytes()))
+	assert.Empty(t, string(s.Bytes()))
 }
 
 func TestYAMLKeyToEmptySecret(t *testing.T) {

--- a/pkg/otp/otp.go
+++ b/pkg/otp/otp.go
@@ -1,3 +1,5 @@
+// Package otp provides functions to handle OTP secrets.
+// It can parse OTP secrets from various formats and generate QR codes for them.
 package otp
 
 import (

--- a/pkg/passkey/passkey.go
+++ b/pkg/passkey/passkey.go
@@ -70,7 +70,7 @@ func authDataFlags(options CredentialFlags) uint8 {
 	return flags
 }
 
-// Implementation of the authenticatorMakeCredential Operation: https://www.w3.org/TR/webauthn-2/#sctn-op-make-cred
+// CreateCredential is an implementation of the authenticatorMakeCredential Operation: https://www.w3.org/TR/webauthn-2/#sctn-op-make-cred
 func CreateCredential(rp string, user string, flags CredentialFlags) (*Credential, error) {
 	rawID := make([]byte, 32)
 	_, err := rand.Read(rawID)

--- a/pkg/passkey/passkey.go
+++ b/pkg/passkey/passkey.go
@@ -14,7 +14,7 @@ import (
 	"fmt"
 )
 
-// Flags for the credential parameters: https://www.w3.org/TR/webauthn-2/#flags
+// CredentialFlags for the credential parameters: https://www.w3.org/TR/webauthn-2/#flags
 type CredentialFlags struct {
 	UserPresent     bool
 	UserVerified    bool
@@ -22,9 +22,9 @@ type CredentialFlags struct {
 	ExtensionData   bool
 }
 
-// Structure to store information and key of public key credential.
+// Credential is a structure to store information and key of public key credential.
 type Credential struct {
-	Id        string
+	ID        string
 	Rp        string
 	UserName  string
 	Algorithm string
@@ -33,7 +33,7 @@ type Credential struct {
 	Flags     CredentialFlags
 }
 
-// Client data for signature: https://www.w3.org/TR/webauthn-1/#sec-client-data
+// ClientData for signature: https://www.w3.org/TR/webauthn-1/#sec-client-data
 type ClientData struct {
 	Challenge string `json:"challenge"`
 	Origin    string `json:"origin"`
@@ -72,15 +72,15 @@ func authDataFlags(options CredentialFlags) uint8 {
 
 // Implementation of the authenticatorMakeCredential Operation: https://www.w3.org/TR/webauthn-2/#sctn-op-make-cred
 func CreateCredential(rp string, user string, flags CredentialFlags) (*Credential, error) {
-	rawId := make([]byte, 32)
-	_, err := rand.Read(rawId)
+	rawID := make([]byte, 32)
+	_, err := rand.Read(rawID)
 	if err != nil {
 		return nil, fmt.Errorf("error while generating random ID: %w", err)
 	}
 	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 
 	return &Credential{
-		Id:        base64.RawURLEncoding.EncodeToString(rawId),
+		ID:        base64.RawURLEncoding.EncodeToString(rawID),
 		Rp:        rp,
 		UserName:  user,
 		Algorithm: "ECDSA",
@@ -90,7 +90,7 @@ func CreateCredential(rp string, user string, flags CredentialFlags) (*Credentia
 	}, nil
 }
 
-// Implementation of the authenticatorGetAssertion Operation: https://www.w3.org/TR/webauthn-2/#authenticatorgetassertion
+// GetAssertion is an implementation of the authenticatorGetAssertion Operation: https://www.w3.org/TR/webauthn-2/#authenticatorgetassertion
 func (cred *Credential) GetAssertion(challenge string, origin string) (*Response, error) {
 	credType := "webauthn.get"
 	clientData := ClientData{
@@ -102,15 +102,16 @@ func (cred *Credential) GetAssertion(challenge string, origin string) (*Response
 	if err != nil {
 		return nil, fmt.Errorf("error while reading client data: %w", err)
 	}
+
 	clientDataHash := sha256.Sum256(clientDataJSON)
-	rpIdHash := sha256.Sum256([]byte(cred.Rp))
+	rpIDHash := sha256.Sum256([]byte(cred.Rp))
 	flags := []byte{authDataFlags(cred.Flags)}
 
 	// Signature counter is incremented according to https://www.w3.org/TR/webauthn-2/#signature-counter
 	cred.Counter += 1
 	signCount := make([]byte, 4)
 	binary.BigEndian.PutUint32(signCount, cred.Counter)
-	authData := append(rpIdHash[:], flags...)
+	authData := append(rpIDHash[:], flags...)
 	authData = append(authData[:], signCount[:]...)
 	message := sha256.Sum256(append(authData[:], clientDataHash[:]...))
 	signature, serr := ecdsa.SignASN1(rand.Reader, cred.SecretKey, message[:])

--- a/pkg/pinentry/cli/fallback.go
+++ b/pkg/pinentry/cli/fallback.go
@@ -1,3 +1,7 @@
+// Package cli provides a pinentry client that uses the terminal
+// for input and output. It is a drop-in replacement for the
+// pinentry program. It is used to ask for a passphrase or PIN
+// in the terminal.
 package cli
 
 import (

--- a/pkg/pinentry/cli/fallback_test.go
+++ b/pkg/pinentry/cli/fallback_test.go
@@ -37,7 +37,7 @@ func TestOption(t *testing.T) {
 func TestGetPIN(t *testing.T) {
 	client := New()
 
-	ctx := termio.WithPassPromptFunc(context.Background(), func(ctx context.Context, s string) (string, error) {
+	ctx := termio.WithPassPromptFunc(t.Context(), func(ctx context.Context, s string) (string, error) {
 		return "1234", nil
 	})
 

--- a/pkg/protect/protect.go
+++ b/pkg/protect/protect.go
@@ -1,6 +1,12 @@
 //go:build !openbsd
 // +build !openbsd
 
+// Package protect provides an interface to the pledge syscall.
+// It is used to limit the system calls a process can make.
+// This is used to limit the attack surface of the process.
+// The pledge syscall is only available on OpenBSD.
+// It is not available on other systems.
+// This package is a no-op on other systems.
 package protect
 
 // ProtectEnabled lets us know if we have protection or not.

--- a/pkg/pwgen/cryptic_test.go
+++ b/pkg/pwgen/cryptic_test.go
@@ -34,7 +34,7 @@ func TestCrypticForDomain(t *testing.T) {
 
 				pw := c.Password()
 
-				assert.NotEqual(t, "", pw, tcName)
+				assert.NotEmpty(t, pw, tcName)
 				t.Logf("%s -> %s (%d)", tcName, pw, len(pw))
 			}
 		})

--- a/pkg/pwgen/memorable.go
+++ b/pkg/pwgen/memorable.go
@@ -32,7 +32,7 @@ func GenerateMemorablePassword(minLength int, symbols bool, capitals bool) strin
 	if capitals && !upper {
 		str := sb.String()
 
-		return strings.Title(string(str[0])) + str[1:]
+		return strings.Title(string(str[0])) + str[1:] //nolint:staticcheck
 	}
 
 	return sb.String()

--- a/pkg/pwgen/memorable.go
+++ b/pkg/pwgen/memorable.go
@@ -12,7 +12,8 @@ func GenerateMemorablePassword(minLength int, symbols bool, capitals bool) strin
 	for sb.Len() < minLength {
 		// when requesting uppercase, we randomly uppercase words
 		if capitals && randomInteger(2) == 0 {
-			sb.WriteString(strings.Title(randomWord()))
+			// We control the input so we can safely ignore the linter.
+			sb.WriteString(strings.Title(randomWord())) //nolint:staticcheck
 
 			upper = true
 		} else {

--- a/pkg/pwgen/pwgen_test.go
+++ b/pkg/pwgen/pwgen_test.go
@@ -37,7 +37,7 @@ func TestPwgenCharset(t *testing.T) {
 	t.Setenv("GOPASS_CHARACTER_SET", "a")
 
 	assert.Equal(t, "aaaa", GeneratePassword(4, true))
-	assert.Equal(t, "", GeneratePasswordCharsetCheck(4, "a"))
+	assert.Empty(t, GeneratePasswordCharsetCheck(4, "a"))
 }
 
 func TestPwgenNoCrandFallback(t *testing.T) {

--- a/pkg/pwgen/pwrules/aliases_test.go
+++ b/pkg/pwgen/pwrules/aliases_test.go
@@ -1,7 +1,6 @@
 package pwrules
 
 import (
-	"context"
 	"testing"
 
 	"github.com/gopasspw/gopass/internal/config"
@@ -22,7 +21,7 @@ func TestLoadCustomRules(t *testing.T) {
 		require.NoError(t, cfg.Set("", "domain-alias."+k+".insteadOf", v))
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	ctx = cfg.WithConfig(ctx)
 
 	a := LookupAliases(ctx, "alias.com")

--- a/pkg/pwgen/xkcdgen/pwgen.go
+++ b/pkg/pwgen/xkcdgen/pwgen.go
@@ -1,3 +1,5 @@
+// Package xkcdgen provides a simple wrapper around the xkcdpwgen
+// package to generate random passphrases.
 package xkcdgen
 
 import (

--- a/pkg/tempfile/file_test.go
+++ b/pkg/tempfile/file_test.go
@@ -62,7 +62,7 @@ func TestTempdirBaseEmpty(t *testing.T) {
 
 	shmDir = "/this/should/not/exist"
 
-	assert.Equal(t, "", tempdirBase())
+	assert.Empty(t, tempdirBase())
 }
 
 func TestTempFiler(t *testing.T) {
@@ -84,7 +84,7 @@ func TestTempFiler(t *testing.T) {
 
 	// uninitialized tempfile
 	utf := File{}
-	assert.Equal(t, "", utf.Name())
+	assert.Empty(t, utf.Name())
 	_, err = utf.Write([]byte("foo"))
 	require.Error(t, err)
 	require.NoError(t, utf.Remove(ctx))
@@ -105,7 +105,7 @@ func TestGlobalPrefix(t *testing.T) {
 	}
 	ctx := config.NewContextInMemory()
 
-	assert.Equal(t, "", globalPrefix)
+	assert.Empty(t, globalPrefix)
 
 	// without global prefix
 	withoutGlobalPrefix, err := New(ctx, "some-prefix")

--- a/pkg/termio/ask_test.go
+++ b/pkg/termio/ask_test.go
@@ -248,7 +248,7 @@ foobat
 
 	sv, err = AskForPassword(ctx, "test", true)
 	require.NoError(t, err)
-	assert.Equal(t, "", sv)
+	assert.Empty(t, sv)
 }
 
 func TestAskForPasswordInteractive(t *testing.T) {

--- a/pkg/termio/identity_test.go
+++ b/pkg/termio/identity_test.go
@@ -17,7 +17,7 @@ func TestDetectName(t *testing.T) {
 	t.Setenv("DEBFULLNAME", "")
 	t.Setenv("USER", "")
 
-	assert.Equal(t, "", DetectName(ctx, nil))
+	assert.Empty(t, DetectName(ctx, nil))
 
 	t.Setenv("USER", "foo")
 	assert.Equal(t, "foo", DetectName(ctx, nil))
@@ -33,7 +33,7 @@ func TestDetectEmail(t *testing.T) {
 	t.Setenv("DEBEMAIL", "")
 	t.Setenv("EMAIL", "")
 
-	assert.Equal(t, "", DetectEmail(ctx, nil))
+	assert.Empty(t, DetectEmail(ctx, nil))
 
 	t.Setenv("EMAIL", "foo@bar.de")
 	assert.Equal(t, "foo@bar.de", DetectEmail(ctx, nil))

--- a/pkg/termio/reader.go
+++ b/pkg/termio/reader.go
@@ -1,3 +1,5 @@
+// Package termio provides helpers and functions to work with
+// terminal input and output.
 package termio
 
 import (

--- a/tests/can/can.go
+++ b/tests/can/can.go
@@ -1,3 +1,7 @@
+// Package can provides access to the embedded key material used for testing.
+// The key material is embedded in the binary and is used for testing
+// purposes only.
+
 package can
 
 import (

--- a/tests/can/can.go
+++ b/tests/can/can.go
@@ -46,7 +46,7 @@ func KeyID() string {
 func WriteTo(path string) error {
 	fes, err := can.ReadDir("gnupg")
 	if err != nil {
-		return fmt.Errorf("Failed to read can dir: %w", err)
+		return fmt.Errorf("failed to read can dir: %w", err)
 	}
 	for _, fe := range fes {
 		from := "gnupg/" + fe.Name()

--- a/tests/can/can.go
+++ b/tests/can/can.go
@@ -1,7 +1,6 @@
 // Package can provides access to the embedded key material used for testing.
 // The key material is embedded in the binary and is used for testing
 // purposes only.
-
 package can
 
 import (

--- a/tests/copy_test.go
+++ b/tests/copy_test.go
@@ -47,7 +47,7 @@ func TestCopy(t *testing.T) {
 	t.Run("copy existing secret to non-existing destination", func(t *testing.T) {
 		out, err := ts.run("copy foo/bar foo/baz")
 		require.NoError(t, err)
-		assert.Equal(t, "", out)
+		assert.Empty(t, out)
 
 		orig, err := ts.run("show -f foo/bar")
 		require.NoError(t, err)

--- a/tests/delete_test.go
+++ b/tests/delete_test.go
@@ -28,7 +28,7 @@ func TestDelete(t *testing.T) {
 	for _, secret := range secrets {
 		out, err = ts.run("delete -f " + secret)
 		require.NoError(t, err)
-		assert.Equal(t, "", out)
+		assert.Empty(t, out)
 
 		out, err = ts.run("delete -f " + secret)
 		require.Error(t, err)

--- a/tests/gptest/utils.go
+++ b/tests/gptest/utils.go
@@ -1,3 +1,6 @@
+// Package gptest contains test helpers for gopass, including
+// creating temporary directories, setting up environment variables,
+// and creating CLI contexts for testing.
 package gptest
 
 import (

--- a/tests/insert_test.go
+++ b/tests/insert_test.go
@@ -78,7 +78,7 @@ func TestInsert(t *testing.T) {
 		// This is arguably not a good behaviour: it should not overwrite the password when we are only working on a key:value.
 		out, err = ts.run("insert -f some/other test:inline")
 		require.NoError(t, err)
-		assert.Equal(t, "", out)
+		assert.Empty(t, out)
 
 		out, err = ts.run("show some/other test")
 		require.NoError(t, err)
@@ -94,7 +94,7 @@ func TestInsert(t *testing.T) {
 
 		out, err = ts.run("--yes insert some/other test:inline2")
 		require.NoError(t, err)
-		assert.Equal(t, "", out)
+		assert.Empty(t, out)
 
 		out, err = ts.run("show some/other Test")
 		require.NoError(t, err)

--- a/tests/tester.go
+++ b/tests/tester.go
@@ -1,3 +1,4 @@
+// Package tests contains common test helpers
 package tests
 
 import (


### PR DESCRIPTION
Migrating golangci-lint to the v2 branch. This requires some config changes and a few code changes to make the updated set of checks pass.