### PR TITLE
feat: add a new build job: container

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,6 +68,34 @@ jobs:
     - name: Integration Test
       run: make test-integration
 
+  container:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@4d991eb9b905ef189e4c376166672c3f2f230481 # v2.11.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804
+        env:
+          REGISTRY: ghrc.io
+          IMAGE_NAME: ${{ github.repository }}
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build container image
+        uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4
+        with:
+          context: .
+          push: false
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
   windows:
     runs-on: windows-latest
     defaults:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/golang:1.22-alpine@sha256:0d3653dd6f35159ec6e3d10263a42372f6f194c3dea0b35235d72aabde86486e AS build-env
+FROM docker.io/library/golang:1.23-alpine@sha256:b7486658b87d34ecf95125e5b97e8dfe86c21f712aa36fc0c702e5dc41dc63e1 AS build-env
 
 ENV CGO_ENABLED 0
 


### PR DESCRIPTION
This change adds a new job in `//.github/workflows:build.yml` named
`container`, to build the container image. This is being added as a
quick hack to fix a critical issue with this repository (in regards to
its container image), namely, that it is not built except for releases.

This means that both source code and configuration changes that break
the container build will not be caught until an attempt to create a new
release is made (more specifically, given the current configuration of
the `//.github/workflows:container.yml` pipeline, whenever a new ref is
pushed up matching `refs/tags/v*`).

An example of this is a recent change to the required version of `go`,
made in commit 4c2caf3e9b6f1c65857c0d33208e3273c2ab7eb3 (ca. October
2024), which did not udpate the base `golang` image referenced in
`//:Dockerfile`.
