### PR TITLE
chore: remove unecessary variable: REGISTRY

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,10 +83,9 @@ jobs:
         id: meta
         uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804
         env:
-          REGISTRY: ghrc.io
           IMAGE_NAME: ${{ github.repository }}
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.IMAGE_NAME }}
 
       - name: Build container image
         uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4


### PR DESCRIPTION
This change removes the `REGISTRY` variable in the `container` job
defined in `//:.github/workflows:build.yml`. This doesn't matter on a
technical level because the image isn't pushed anywhere, but uh... I
caught the typo and figured getting rid of REGISTRY would be a good
way to make it clear that the image isn't pushed (and get rid of my
typo).
