### PR TITLE
[chore] Do not run linters twice

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,7 +66,7 @@ jobs:
         env  
 
     - name: Build and Unit Test
-      run: make travis
+      run: make gha-linux
     - name: Integration Test
       run: make test-integration
 
@@ -129,7 +129,7 @@ jobs:
     - run: git config --global user.email foo.bar@example.org
       
     - name: Build and Unit Test
-      run: make travis-windows
+      run: make gha-windows
 
   macos:
     runs-on: macos-latest
@@ -152,7 +152,7 @@ jobs:
     - run: git config --global user.email foo.bar@example.org
       
     - name: Build and Unit Test
-      run: make travis-osx
+      run: make gha-osx
       env:
         SLOW_TEST_FACTOR: 100 
 

--- a/Makefile
+++ b/Makefile
@@ -28,9 +28,9 @@ OK := $(shell tput setaf 6; echo ' [OK]'; tput sgr0;)
 all: sysinfo build
 build: $(GOPASS_OUTPUT)
 completion: $(BASH_COMPLETION_OUTPUT) $(FISH_COMPLETION_OUTPUT) $(ZSH_COMPLETION_OUTPUT)
-travis: sysinfo crosscompile build fulltest completion codequality
-travis-osx: sysinfo build test completion
-travis-windows: sysinfo build test-win completion
+gha-linux: sysinfo licensecheck crosscompile build fulltest completion
+gha-osx: sysinfo build test completion
+gha-windows: sysinfo build test-win completion
 
 sysinfo:
 	@echo ">> SYSTEM INFORMATION"
@@ -128,7 +128,7 @@ crosscompile:
 	@./gopass completion $* > $@
 	@printf "%s\n" "$(OK)"
 
-codequality:
+codequality: licensecheck
 	@echo ">> CODE QUALITY"
 
 	# Note: there are 2 different version of golangci-lint used inside the project.
@@ -143,6 +143,7 @@ codequality:
 
 	@printf '%s\n' '$(OK)'
 
+licensecheck:
 	@echo -n "     LICENSE-LINT "
 	@which license-lint > /dev/null; if [ $$? -ne 0 ]; then \
 		$(GO) install istio.io/tools/cmd/license-lint@latest; \


### PR DESCRIPTION
We already have a golangci-lint GHA but we still run it in the linux tests. This often creates inconsistent findings. Let's not do that and only run the linter once in it's own action. Also rename the test targets that were created for Travis CI a long time ago.