### PR TITLE
[fix] Include git commit hash in tarballs

### DIFF
--- a/main.go
+++ b/main.go
@@ -233,13 +233,13 @@ func parseBuildInfo() (string, string, string) {
 
 	for _, v := range bi.Settings {
 		switch v.Key {
-		case "gitrevision":
+		case "vcs.revision":
 			commit = v.Value[len(v.Value)-8:]
-		case "gitcommittime":
+		case "vcs.time":
 			if bt, err := time.Parse("2006-01-02T15:04:05Z", date); err == nil {
 				date = bt.Format("2006-01-02 15:04:05")
 			}
-		case "gituncommitted":
+		case "vcs.modified":
 			if v.Value == "true" {
 				dirty = " (dirty)"
 			}

--- a/main_test.go
+++ b/main_test.go
@@ -30,7 +30,13 @@ func TestVersionPrinter(t *testing.T) {
 	buf := &bytes.Buffer{}
 	vp := makeVersionPrinter(buf, semver.Version{Major: 1})
 	vp(nil)
-	assert.Equal(t, fmt.Sprintf("gopass 1.0.0 %s %s %s\n", runtime.Version(), runtime.GOOS, runtime.GOARCH), buf.String())
+
+	commitStr := ""
+	if commit, _, _ := parseBuildInfo(); commit != "" {
+		commitStr = " (" + commit + ")"
+	}
+
+	assert.Equal(t, fmt.Sprintf("gopass 1.0.0 %s%s %s %s\n", commitStr, runtime.Version(), runtime.GOOS, runtime.GOARCH), buf.String())
 }
 
 func TestGetVersion(t *testing.T) {

--- a/main_test.go
+++ b/main_test.go
@@ -33,7 +33,7 @@ func TestVersionPrinter(t *testing.T) {
 
 	commitStr := ""
 	if commit, _, _ := parseBuildInfo(); commit != "" {
-		commitStr = " (" + commit + ")"
+		commitStr = "(" + commit + ") "
 	}
 
 	assert.Equal(t, fmt.Sprintf("gopass 1.0.0 %s%s %s %s\n", commitStr, runtime.Version(), runtime.GOOS, runtime.GOARCH), buf.String())


### PR DESCRIPTION
This change should allow builds made from a release tarball to accurately display the git commit hash it was built from.

It does so by rendering the current short hash when packaging the tarball. This workaround is necessary since the tarball won't include the .git directory so we can't extract the commit information from it.