### PR TITLE
[chore] Add keep-sorted linter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -145,7 +145,7 @@ codequality: licensecheck
 	@which keep-sorted > /dev/null; if [ $$? -ne 0 ]; then \
 		$(GO) install github.com/keep-sorted/keep-sorted@latest; \
 	fi
-	@keep-sorted -mode lint $(GOFILES_NOVENDOR) || exit 1
+	@keep-sorted --mode lint $(GOFILES_NOVENDOR) || exit 1
 
 	@printf '%s\n' '$(OK)'
 
@@ -162,7 +162,7 @@ gen:
 	@$(GO) generate ./...
 
 fmt:
-	@keep-sorted -mode fix $(GOFILES_NOVENDOR)
+	@keep-sorted --mode fix $(GOFILES_NOVENDOR)
 	@gofumpt -w $(GOFILES_NOVENDOR)
 	@$(GO) mod tidy
 

--- a/Makefile
+++ b/Makefile
@@ -141,6 +141,12 @@ codequality: licensecheck
 	fi
 	@golangci-lint run --max-issues-per-linter 0 --max-same-issues 0 || exit 1
 
+	@echo -n "      KEEP-SORTED "
+	@which keep-sorted > /dev/null; if [ $$? -ne 0 ]; then \
+		$(GO) install github.com/keep-sorted/keep-sorted@latest; \
+	fi
+	@keep-sorted -mode lint $(GOFILES_NOVENDOR) || exit 1
+
 	@printf '%s\n' '$(OK)'
 
 licensecheck:
@@ -156,6 +162,7 @@ gen:
 	@$(GO) generate ./...
 
 fmt:
+	@keep-sorted -mode fix $(GOFILES_NOVENDOR)
 	@gofumpt -w $(GOFILES_NOVENDOR)
 	@$(GO) mod tidy
 

--- a/internal/config/docs_test.go
+++ b/internal/config/docs_test.go
@@ -16,6 +16,7 @@ import (
 // but originate from elsewhere. They should be well known and properly
 // documented already.
 var ignoredEnvs = set.Map([]string{
+	// keep-sorted start
 	"APPDATA",
 	"GIT_AUTHOR_EMAIL",
 	"GIT_AUTHOR_NAME",
@@ -33,17 +34,20 @@ var ignoredEnvs = set.Map([]string{
 	"XDG_CACHE_HOME",
 	"XDG_CONFIG_HOME",
 	"XDG_DATA_HOME",
+	// keep-sorted end
 })
 
 // ignoredOptions is a list of config options that are used by gopass
 // but may not be covered easily by a regexp.
 var ignoredOptions = set.Map([]string{
+	// keep-sorted start
 	"core.post-hook",
 	"core.pre-hook",
 	"include.path",
 	"recipients.hash",
 	"user.email",
 	"user.name",
+	// keep-sorted end
 })
 
 func TestConfigOptsInDocs(t *testing.T) {

--- a/internal/config/docs_test.go
+++ b/internal/config/docs_test.go
@@ -21,16 +21,16 @@ var ignoredEnvs = set.Map([]string{
 	"GIT_AUTHOR_EMAIL",
 	"GIT_AUTHOR_NAME",
 	"GNUPGHOME",
-	"GOPATH",
 	"GOPASS_CONFIG_NOSYSTEM", // name assembled, tests can't catch it
 	"GOPASS_DEBUG_FILES",     // indirect usage
 	"GOPASS_DEBUG_FUNCS",     // indirect usage
 	"GOPASS_GPG_OPTS",        // indirect usage
 	"GOPASS_UMASK",           // indirect usage
-	"PASSWORD_STORE_UMASK",   // indirect usage
+	"GOPATH",
 	"GPG_TTY",
 	"HOME",
 	"LOCALAPPDATA",
+	"PASSWORD_STORE_UMASK", // indirect usage
 	"XDG_CACHE_HOME",
 	"XDG_CONFIG_HOME",
 	"XDG_DATA_HOME",


### PR DESCRIPTION
This adds a keep-sorted linter that allows to mark certain blocks as having to be sorted.