### PR TITLE
[feat] Remove expensive and unmaintained zxcvbn-go strength checker

### DIFF
--- a/docs/commands/audit.md
+++ b/docs/commands/audit.md
@@ -26,6 +26,5 @@ test_folder/ignore_this
 
 | Backend                                         | Description                                                            |
 |-------------------------------------------------|------------------------------------------------------------------------|
-| [`zxcvbn`](https://github.com/nbutton23/zxcvbn) | [zxcvbn](https://github.com/dropbox/zxcvbn) password strength checker. |
 | [`crunchy`](https://github.com/muesli/crunchy)  | Crunchy password strength checker                                      |
 | `name`                                          | Checks if password equals the name of the secret                       |

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,6 @@ require (
 	github.com/mattn/go-tty v0.0.7
 	github.com/mitchellh/go-ps v1.0.0
 	github.com/muesli/crunchy v0.4.0
-	github.com/nbutton23/zxcvbn-go v0.0.0-20210217022336-fa2cb2858354
 	github.com/noborus/ov v0.40.1
 	github.com/pquerna/otp v1.4.1-0.20241104074508-c95b6974670c
 	github.com/schollz/closestmatch v0.0.0-20190308193919-1fbe626be92e

--- a/go.sum
+++ b/go.sum
@@ -127,8 +127,6 @@ github.com/mitchellh/go-ps v1.0.0 h1:i6ampVEEF4wQFF+bkYfwYgY+F/uYJDktmvLPf7qIgjc
 github.com/mitchellh/go-ps v1.0.0/go.mod h1:J4lOc8z8yJs6vUwklHw2XEIiT4z4C40KtWVN3nvg8Pg=
 github.com/muesli/crunchy v0.4.0 h1:qdiml8gywULHBsztiSAf6rrE6EyuNasNKZ104mAaahM=
 github.com/muesli/crunchy v0.4.0/go.mod h1:9k4x6xdSbb7WwtAVy0iDjaiDjIk6Wa5AgUIqp+HqOpU=
-github.com/nbutton23/zxcvbn-go v0.0.0-20210217022336-fa2cb2858354 h1:4kuARK6Y6FxaNu/BnU2OAaLF86eTVhP2hjTB6iMvItA=
-github.com/nbutton23/zxcvbn-go v0.0.0-20210217022336-fa2cb2858354/go.mod h1:KSVJerMDfblTH7p5MZaTt+8zaT2iEk3AkVb9PQdZuE8=
 github.com/noborus/guesswidth v0.4.0 h1:+PPh+Z+GM4mKmVrhYR4lpjeyBuLMSVo2arM+VErdHIc=
 github.com/noborus/guesswidth v0.4.0/go.mod h1:ghA6uh9RcK+uSmaDDmBMj/tRZ3BSpspDP6DMF5Xk3bc=
 github.com/noborus/ov v0.40.1 h1:ERWdZaik8sLpH//56YKAi5jMiILYBxVfPxKKufOtvJw=
@@ -174,7 +172,6 @@ github.com/spf13/viper v1.20.1/go.mod h1:P9Mdzt1zoHIG8m2eZQinpiBjo6kCmZSKBClNNqj
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
 github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
-github.com/stretchr/testify v1.1.4/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -24,7 +24,6 @@ import (
 	"github.com/gopasspw/gopass/pkg/gopass"
 	"github.com/gopasspw/gopass/pkg/termio"
 	"github.com/muesli/crunchy"
-	"github.com/nbutton23/zxcvbn-go"
 )
 
 type secretGetter interface {
@@ -63,27 +62,6 @@ func New(ctx context.Context, s secretGetter) *Auditor {
 			Description: "github.com/muesli/crunchy",
 			Validate: func(_ string, sec gopass.Secret) error {
 				return cv.Check(sec.Password())
-			},
-		},
-		{
-			Name:        "zxcvbn",
-			Description: "github.com/nbutton23/zxcvbn-go",
-			Validate: func(name string, sec gopass.Secret) error {
-				ui := make([]string, 0, len(sec.Keys())+1)
-				for _, k := range sec.Keys() {
-					pw, found := sec.Get(k)
-					if !found {
-						continue
-					}
-					ui = append(ui, pw)
-				}
-				ui = append(ui, name)
-				match := zxcvbn.PasswordStrength(sec.Password(), ui)
-				if match.Score < 3 {
-					return fmt.Errorf("weak password (%d / 4)", match.Score)
-				}
-
-				return nil
 			},
 		},
 		{

--- a/internal/backend/crypto/age/askpass.go
+++ b/internal/backend/crypto/age/askpass.go
@@ -10,7 +10,6 @@ import (
 	"github.com/gopasspw/gopass/internal/config"
 	"github.com/gopasspw/gopass/pkg/debug"
 	"github.com/gopasspw/gopass/pkg/pinentry/cli"
-	"github.com/nbutton23/zxcvbn-go"
 	"github.com/twpayne/go-pinentry/v4"
 	"github.com/zalando/go-keyring"
 )
@@ -126,11 +125,6 @@ func (a *askPass) getPassphrase(reason string, repeat bool) (string, error) {
 	}
 	if repeat {
 		opts = append(opts, pinentry.WithRepeat("Confirm"))
-		opts = append(opts, pinentry.WithQualityBar(func(s string) (int, bool) {
-			match := zxcvbn.PasswordStrength(s, nil)
-
-			return match.Score, true
-		}))
 	} else {
 		opts = append(opts,
 			pinentry.WithOption(pinentry.OptionAllowExternalPasswordCache),

--- a/tests/audit_test.go
+++ b/tests/audit_test.go
@@ -18,6 +18,5 @@ func TestAudit(t *testing.T) {
 		out, err := ts.run("audit")
 		require.Error(t, err)
 		assert.Contains(t, out, "crunchy")
-		assert.Contains(t, out, "zxcvbn")
 	})
 }


### PR DESCRIPTION
Fixes #3132.

Improves start-up time by 533%.

Before:

```console
$ time ./gopass --version
gopass 1.15.15-git+HEAD (a27a9cc1) go1.24.2 linux amd64
./gopass --version  0.03s user 0.01s system 130% cpu 0.032 total
```

After:

```console
$ time ./gopass --version
gopass 1.15.15-git+HEAD (3ebb1a7b) go1.24.2 linux amd64
./gopass --version  0.00s user 0.00s system 112% cpu 0.006 total
```