### PR TITLE
[fix] Fix test failure due to ambient variables

### DIFF
--- a/internal/config/legacy/location_xdg_test.go
+++ b/internal/config/legacy/location_xdg_test.go
@@ -36,6 +36,7 @@ func TestConfigLocations(t *testing.T) {
 	})
 
 	t.Run("XDG_CONFIG_HOME set only", func(t *testing.T) {
+		t.Setenv("GOPASS_HOMEDIR", "")
 		t.Setenv("XDG_CONFIG_HOME", xdghome)
 		assert.Equal(t, xdgcfg, ConfigLocations()[0])
 	})


### PR DESCRIPTION
The test failed because I had `GOPASS_HOMEDIR` set in my shell. That should not happen, tests should ensure a hermetic env.