### PR TITLE
[feat] Honor generator options in the create workflow

### DIFF
--- a/internal/action/generate.go
+++ b/internal/action/generate.go
@@ -172,15 +172,6 @@ func (s *Action) generatePassword(ctx context.Context, c *cli.Context, length, n
 
 	cfg, mp := config.FromContext(ctx)
 
-	symbols := false
-	if c.IsSet("symbols") {
-		symbols = c.Bool("symbols")
-	} else {
-		if cfg.GetM(mp, "generate.symbols") != "" {
-			symbols = config.AsBool(cfg.GetM(mp, "generate.symbols"))
-		}
-	}
-
 	generator := cfg.GetM(mp, "generate.generator")
 	if c.IsSet("generator") {
 		generator = c.String("generator")
@@ -188,6 +179,15 @@ func (s *Action) generatePassword(ctx context.Context, c *cli.Context, length, n
 
 	if generator == "xkcd" {
 		return s.generatePasswordXKCD(ctx, c, length)
+	}
+
+	symbols := false
+	if c.IsSet("symbols") {
+		symbols = c.Bool("symbols")
+	} else {
+		if cfg.GetM(mp, "generate.symbols") != "" {
+			symbols = config.AsBool(cfg.GetM(mp, "generate.symbols"))
+		}
 	}
 
 	var pwlen int


### PR DESCRIPTION
This change makes the `gopass create` workflow pick up the config settings for pwgen the same way as the `gopass generate` workflows do. This allows more flexibility and users to override the defaults used in the create wizard.

Fixes #3141