### PR TITLE
[chore] Expose gopass env in help

### DIFF
--- a/internal/action/commands.go
+++ b/internal/action/commands.go
@@ -308,7 +308,6 @@ func (s *Action) GetCommands() []*cli.Command {
 			Before:       s.IsInitialized,
 			Action:       s.Env,
 			BashComplete: s.Complete,
-			Hidden:       true,
 			Flags: []cli.Flag{
 				&cli.BoolFlag{
 					Name:    "keep-case",


### PR DESCRIPTION
This un-hides the env command.

Fixes #3154