### PR TITLE
[fix] skip redundant confirmation when --edit is used

### DIFF
--- a/internal/action/generate.go
+++ b/internal/action/generate.go
@@ -79,7 +79,7 @@ func (s *Action) Generate(c *cli.Context) error {
 	}
 
 	// if requested launch editor to add more data to the generated secret.
-	if edit && termio.AskForConfirmation(ctx, fmt.Sprintf("Do you want to add more data for %s?", name)) {
+	if edit {
 		c.Context = ctx
 		if err := s.Edit(c); err != nil {
 			return exit.Error(exit.Unknown, err, "failed to edit %q: %s", name, err)


### PR DESCRIPTION
When the `--edit` (`-e`) flag is provided, a user has already opted in to edit the entry after password generation. This change removes the redundant confirmation prompt in order to streamline this workflow.