### PR TITLE
Handle referencing in passwords

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -5,7 +5,7 @@
 Some configuration options are only available through setting environment variables.
 
 | **Option**                   | **Type** | **Description**                                                                                                                                                   |
-|------------------------------|----------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ---------------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `CHECKPOINT_DISABLE`         | `bool`   | Set to any non-empty value to disable calling the GitHub API when running `gopass version`.                                                                       |
 | `GOPASS_AGE_PASSWORD`        | `string` | Set to any value (including the empty string) to use as a password for the age identity file containing your secret age identities.                               |
 | `GOPASS_AUTOSYNC_INTERVAL`   | `int`    | Set this to the number of days between autosync runs.                                                                                                             |
@@ -34,7 +34,7 @@ Some configuration options are only available through setting environment variab
 | `GOPASS_NO_NOTIFY`           | `bool`   | Set to any non-empty value to prevent notifications                                                                                                               |
 | `GOPASS_NO_REMINDER`         | `bool`   | Set to any non-empty value to prevent reminders                                                                                                                   |
 | `GOPASS_PW_DEFAULT_LENGTH`   | `int`    | Set to any integer value larger than zero to define a different default length in the `generate` command. By default the length is 24 characters.                 |
-| `GOPASS_SSH_DIR`             | `string` | Set to a filepath that contains ssh keys. Overrides default location. |
+| `GOPASS_SSH_DIR`             | `string` | Set to a filepath that contains ssh keys. Overrides default location.                                                                                             |
 | `GOPASS_UMASK`               | `octal`  | Set to any valid umask to mask bits of files created by gopass                                                                                                    |
 | `GOPASS_UNCLIP_CHECKSUM`     | `string` | (internal) Used between gopass and it's unclip helper.                                                                                                            |
 | `GOPASS_UNCLIP_NAME`         | `string` | (internal) Used between gopass and it's unclip helper.                                                                                                            |
@@ -43,7 +43,7 @@ Some configuration options are only available through setting environment variab
 Variables not exclusively used by gopass:
 
 | **Option**             | **Type** | **Description**                                                                                        |
-|------------------------|----------|--------------------------------------------------------------------------------------------------------|
+| ---------------------- | -------- | ------------------------------------------------------------------------------------------------------ |
 | `PASSWORD_STORE_DIR`   | `string` | absolute path containing the password store (a directory). Only supported during initialization!       |
 | `PASSWORD_STORE_UMASK` | `string` | Set to any valid umask to mask bits of files created by gopass (GOPASS_UMASK has precedence over this) |
 | `EDITOR`               | `string` | command name to execute for editing password entries                                                   |
@@ -58,10 +58,10 @@ During start up, gopass will look for a configuration file at `$HOME/.config/gop
 
 All configuration options are also available for reading and writing through the sub-command `gopass config`.
 
-* To display all values: `gopass config`
-* To display a single value: `gopass config generate.autoclip`
-* To update a single value: `gopass config generate.autoclip false`
-* As many other sub-commands this command accepts a `--store` flag to operate on a given sub-store, provided the sub-store is a remote one.
+- To display all values: `gopass config`
+- To display a single value: `gopass config generate.autoclip`
+- To update a single value: `gopass config generate.autoclip false`
+- As many other sub-commands this command accepts a `--store` flag to operate on a given sub-store, provided the sub-store is a remote one.
 
 ### Configuration format
 
@@ -70,19 +70,19 @@ different configuration sources that take precedence over each other, just like 
 
 #### Configuration precedence
 
-* Hard-coded presets apply if nothing else is set
-* System-wide configuration file allows operators or package maintainers to supply system-wide defaults in `/etc/gopass/config`.
-* User-wide (aka. global) configuration allows to set per-user settings. This is the closest equivalent to the old gopass configs. Located in `$HOME/.config/gopass/config`
-* Per-store (aka. local) configuration allow to set per-store settings, e.g. read-only. Located in `<STORE_DIR>/config`.
-* Per-store unversioned (aka `config.worktree`) configuration allows to override versioned per-store settings, e.g. disabling read-only. Located in `<STORE_DIR>/config.worktree`
-* Environment variables (or command line flags) override all other values. Read from `GOPASS_CONFIG_KEY_n` and `GOPASS_CONFIG_VALUE_n` up to `GOPASS_CONFIG_COUNT`. Command line flags take precedence over environment variables.
+- Hard-coded presets apply if nothing else is set
+- System-wide configuration file allows operators or package maintainers to supply system-wide defaults in `/etc/gopass/config`.
+- User-wide (aka. global) configuration allows to set per-user settings. This is the closest equivalent to the old gopass configs. Located in `$HOME/.config/gopass/config`
+- Per-store (aka. local) configuration allow to set per-store settings, e.g. read-only. Located in `<STORE_DIR>/config`.
+- Per-store unversioned (aka `config.worktree`) configuration allows to override versioned per-store settings, e.g. disabling read-only. Located in `<STORE_DIR>/config.worktree`
+- Environment variables (or command line flags) override all other values. Read from `GOPASS_CONFIG_KEY_n` and `GOPASS_CONFIG_VALUE_n` up to `GOPASS_CONFIG_COUNT`. Command line flags take precedence over environment variables.
 
 ### Configuration options
 
 This is a list of available options:
 
-| **Option**                      | **Type** | Description                                                                                                                                                                                                                        | *Default*                           |
-|---------------------------------|----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------|
+| **Option**                      | **Type** | Description                                                                                                                                                                                                                        | _Default_                           |
+| ------------------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
 | `age.usekeychain`               | `bool`   | Use the OS keychain to cache age passphrases.                                                                                                                                                                                      | `false`                             |
 | `audit.concurrency`             | `int`    | Number of concurrent audit workers.                                                                                                                                                                                                | ``                                  |
 | `audit.hibp-dump-file`          | `string` | Specify to a HIBPv2 Dump file (sorted) if you want `audit` to check password hashes against this file.                                                                                                                             | `None`                              |
@@ -94,6 +94,7 @@ This is a list of available options:
 | `core.cliptimeout`              | `int`    | How many seconds the secret is stored when using `-c`. Setting this to `0` disables auto-clear.                                                                                                                                    | `45`                                |
 | `core.exportkeys`               | `bool`   | Export public keys of all recipients to the store.                                                                                                                                                                                 | `true`                              |
 | `core.nocolor`                  | `bool`   | Do not use color.                                                                                                                                                                                                                  | `false`                             |
+| `core.follow-references`        | `bool`   | Follow references in passwords. You can reference another file using `gopass://path` in store to use that file password.                                                                                                           | `false`                             |
 | `core.nopager`                  | `bool`   | Do not invoke a pager to display long lists.                                                                                                                                                                                       | `false`                             |
 | `core.noreminder`               | `bool`   | Set to true to disable periodic update reminder. Equivalent to setting `GOPASS_NO_REMINDER`.                                                                                                                                       | `false`                             |
 | `core.notifications`            | `bool`   | Enable desktop notifications.                                                                                                                                                                                                      | `true`                              |
@@ -115,15 +116,15 @@ This is a list of available options:
 | `generate.strict`               | `bool`   | Use strict mode for generated password.                                                                                                                                                                                            | `false`                             |
 | `generate.symbols`              | `bool`   | Include symbols in generated password.                                                                                                                                                                                             | `false`                             |
 | `mounts.path`                   | `string` | Path to the root store.                                                                                                                                                                                                            | `$XDG_DATA_HOME/gopass/stores/root` |
-| `notify.disable-icon`           | `bool`   | Do not show notification icon (not available on every platform). |
-| `otp.autoclip`                  | `bool`   | Automatically clip in `gopass otp` by default, while still displaying the codes and timers.                                                                              | `false`                             |
-| `otp.onlyclip`                  | `bool`   | Automatically clip in `gopass otp` by default, without displaying the OTP codes. This takes precedence over `otp.autoclip`. Requires using `gopass otp --clip=false` to force display the codes.                                                                                       | `false`                             |
+| `notify.disable-icon`           | `bool`   | Do not show notification icon (not available on every platform).                                                                                                                                                                   |
+| `otp.autoclip`                  | `bool`   | Automatically clip in `gopass otp` by default, while still displaying the codes and timers.                                                                                                                                        | `false`                             |
+| `otp.onlyclip`                  | `bool`   | Automatically clip in `gopass otp` by default, without displaying the OTP codes. This takes precedence over `otp.autoclip`. Requires using `gopass otp --clip=false` to force display the codes.                                   | `false`                             |
 | `recipients.check`              | `bool`   | Check recipients hash. The global config option takes precedence over local ones here for security reasons.                                                                                                                        | `false`                             |
 | `recipients.hash`               | `string` | SHA256 hash of the recipients file. Used to notify the user when the recipients files change. Not set, nor read at the local level for security reasons.                                                                           | ``                                  |
 | `recipients.remove-extra-keys`  | `bool`   | Remove extra recipients during key import. Not supported at the local level for security reasons.                                                                                                                                  | `false`                             |
 | `show.autoclip`                 | `bool`   | Autoclip in `gopass show` by default.                                                                                                                                                                                              | `false`                             |
 | `show.post-hook`                | `string` | This hook is run right after displaying a secret with `gopass show`.                                                                                                                                                               | `None`                              |
-| `show.safecontent`              | `bool`   | Only output *safe content* (i.e. everything but the first line of a secret) to the terminal. Use *copy* (`-c`) to retrieve the password in the clipboard, or *force* (`-f`) to still print it.                                     | `false`                             |
+| `show.safecontent`              | `bool`   | Only output _safe content_ (i.e. everything but the first line of a secret) to the terminal. Use _copy_ (`-c`) to retrieve the password in the clipboard, or _force_ (`-f`) to still print it.                                     | `false`                             |
 | `updater.check`                 | `bool`   | Check for updates when running `gopass version`. Only supported as a global, system or env config option, not at the local level.                                                                                                  | `true`                              |
 | `output.internal-pager`         | `bool`   | Use the internal pager `ov`.                                                                                                                                                                                                       | `false`                             |
 | `pwgen.xkcd-sep`                | `string` | `xkcd` password generator separator.                                                                                                                                                                                               | ` `                                 |
@@ -136,7 +137,7 @@ Furthermore, the following table list the legacy options (starting with v1.15.9)
 unless you've set them at the system level or using Env variables, in which case you'll need to migrate them manually:
 
 | **Legacy option name** | **New option name** | **Version of migration** |
-|------------------------|---------------------|--------------------------|
+| ---------------------- | ------------------- | ------------------------ |
 | `core.showsafecontent` | `show.safecontent`  | v1.15.9                  |
 | `core.autoclip`        | `generate.autoclip` | v1.15.9                  |
 | `core.showautoclip`    | `show.autoclip`     | v1.15.9                  |

--- a/internal/action/commands.go
+++ b/internal/action/commands.go
@@ -19,10 +19,6 @@ func ShowFlags() []cli.Flag {
 			Usage:   "Always answer yes to yes/no questions",
 		},
 		&cli.BoolFlag{
-			Name:  "no-follow-ref",
-			Usage: "do not following the gopass:// referenced password",
-		},
-		&cli.BoolFlag{
 			Name:    "clip",
 			Aliases: []string{"c"},
 			Usage:   "Copy the password value into the clipboard",

--- a/internal/action/commands.go
+++ b/internal/action/commands.go
@@ -19,6 +19,10 @@ func ShowFlags() []cli.Flag {
 			Usage:   "Always answer yes to yes/no questions",
 		},
 		&cli.BoolFlag{
+			Name:  "no-follow-ref",
+			Usage: "do not following the gopass:// referenced password",
+		},
+		&cli.BoolFlag{
 			Name:    "clip",
 			Aliases: []string{"c"},
 			Usage:   "Copy the password value into the clipboard",

--- a/internal/action/config_test.go
+++ b/internal/action/config_test.go
@@ -42,6 +42,7 @@ core.autopush = true
 core.autosync = true
 core.cliptimeout = 45
 core.exportkeys = true
+core.follow-references = false
 core.nopager = true
 core.notifications = true
 generate.autoclip = true
@@ -84,6 +85,7 @@ core.autopush = true
 core.autosync = true
 core.cliptimeout = 45
 core.exportkeys = true
+core.follow-references = false
 core.nopager = true
 core.notifications = true
 generate.autoclip = true
@@ -119,6 +121,7 @@ core.autopush
 core.autosync
 core.cliptimeout
 core.exportkeys
+core.follow-references
 core.nopager
 core.notifications
 generate.autoclip

--- a/internal/action/edit.go
+++ b/internal/action/edit.go
@@ -24,6 +24,8 @@ import (
 // Edit the content of a password file.
 func (s *Action) Edit(c *cli.Context) error {
 	ctx := ctxutil.WithGlobalFlags(c)
+	ctx = ctxutil.WithFollowRef(ctx, false)
+
 	name := c.Args().First()
 	if name == "" {
 		return exit.Error(exit.Usage, nil, "Usage: %s edit secret", s.Name)

--- a/internal/action/show.go
+++ b/internal/action/show.go
@@ -60,7 +60,7 @@ func showParseArgs(c *cli.Context) context.Context {
 
 	if c.IsSet("chars") {
 		iv := []int{}
-		for _, v := range strings.Split(c.String("chars"), ",") {
+		for v := range strings.SplitSeq(c.String("chars"), ",") {
 			v = strings.TrimSpace(v)
 			if v == "" {
 				continue

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -47,12 +47,13 @@ func newGitconfig() *gitconfig.Configs {
 }
 
 var defaults = map[string]string{
-	"core.autopush":      "true",
-	"core.autosync":      "true",
-	"core.cliptimeout":   "45",
-	"core.exportkeys":    "true",
-	"core.notifications": "true",
-	"pwgen.xkcd-lang":    "en",
+	"core.autopush":          "true",
+	"core.autosync":          "true",
+	"core.cliptimeout":       "45",
+	"core.exportkeys":        "true",
+	"core.notifications":     "true",
+	"core.follow-references": "false",
+	"pwgen.xkcd-lang":        "en",
 }
 
 // Config is a gopass config handler.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -31,7 +31,7 @@ func TestConfig(t *testing.T) {
 	assert.Equal(t, "foo", cfg.Get("env.string"))
 
 	// test default values
-	assert.Equal(t, []string{"core.autopush", "core.autosync", "core.bool", "core.cliptimeout", "core.exportkeys", "core.int", "core.notifications", "core.string", "env.string", "mounts.path", "pwgen.xkcd-lang"}, cfg.Keys(""))
+	assert.Equal(t, []string{"core.autopush", "core.autosync", "core.bool", "core.cliptimeout", "core.exportkeys", "core.follow-references", "core.int", "core.notifications", "core.string", "env.string", "mounts.path", "pwgen.xkcd-lang"}, cfg.Keys(""))
 	for key, expected := range defaults {
 		assert.Equal(t, expected, cfg.Get(key))
 	}

--- a/internal/store/root/rcs.go
+++ b/internal/store/root/rcs.go
@@ -65,6 +65,15 @@ func (r *Store) GetRevision(ctx context.Context, name, revision string) (context
 	store, name := r.getStore(name)
 	sec, err := store.GetRevision(ctx, name, revision)
 
+	if ref, ok := sec.Ref(); ok {
+		refSec, err := store.GetRevision(ctx, ref, revision)
+		if err != nil {
+			return ctx, sec, err
+		}
+
+		sec.SetPassword(refSec.Password())
+	}
+
 	return ctx, sec, err
 }
 

--- a/internal/store/root/rcs.go
+++ b/internal/store/root/rcs.go
@@ -2,6 +2,7 @@ package root
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/gopasspw/gopass/internal/backend"
 	"github.com/gopasspw/gopass/internal/out"
@@ -65,10 +66,10 @@ func (r *Store) GetRevision(ctx context.Context, name, revision string) (context
 	store, name := r.getStore(name)
 	sec, err := store.GetRevision(ctx, name, revision)
 
-	if ref, ok := sec.Ref(); ok {
+	if ref, ok := sec.Ref(); ctxutil.IsFollowRef(ctx) && ok {
 		refSec, err := store.GetRevision(ctx, ref, revision)
 		if err != nil {
-			return ctx, sec, err
+			return ctx, sec, fmt.Errorf("failed to read reference %s by %s: %w", ref, name, err)
 		}
 
 		sec.SetPassword(refSec.Password())

--- a/internal/store/root/read.go
+++ b/internal/store/root/read.go
@@ -2,6 +2,7 @@ package root
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/gopasspw/gopass/pkg/gopass"
 )
@@ -18,7 +19,7 @@ func (r *Store) Get(ctx context.Context, name string) (gopass.Secret, error) {
 	if ref, ok := sec.Ref(); ok {
 		refSec, err := store.Get(ctx, ref)
 		if err != nil {
-			return sec, err
+			return sec, fmt.Errorf("failed to read reference %s by %s: %w", ref, name, err)
 		}
 
 		sec.SetPassword(refSec.Password())

--- a/internal/store/root/read.go
+++ b/internal/store/root/read.go
@@ -10,5 +10,19 @@ import (
 func (r *Store) Get(ctx context.Context, name string) (gopass.Secret, error) {
 	store, name := r.getStore(name)
 
-	return store.Get(ctx, name)
+	sec, err := store.Get(ctx, name)
+	if err != nil {
+		return sec, err
+	}
+
+	if ref, ok := sec.Ref(); ok {
+		refSec, err := store.Get(ctx, ref)
+		if err != nil {
+			return sec, err
+		}
+
+		sec.SetPassword(refSec.Password())
+	}
+
+	return sec, nil
 }

--- a/internal/store/root/read.go
+++ b/internal/store/root/read.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/gopasspw/gopass/pkg/ctxutil"
 	"github.com/gopasspw/gopass/pkg/gopass"
 )
 
@@ -16,7 +17,7 @@ func (r *Store) Get(ctx context.Context, name string) (gopass.Secret, error) {
 		return sec, err
 	}
 
-	if ref, ok := sec.Ref(); ok {
+	if ref, ok := sec.Ref(); ctxutil.IsFollowRef(ctx) && ok {
 		refSec, err := store.Get(ctx, ref)
 		if err != nil {
 			return sec, fmt.Errorf("failed to read reference %s by %s: %w", ref, name, err)

--- a/main.go
+++ b/main.go
@@ -317,6 +317,9 @@ func initContext(ctx context.Context, cfg *config.Config) context.Context {
 		ctx = ctxutil.WithStdin(ctx, true)
 	}
 
+	// enable following references based on the configuration
+	ctx = ctxutil.WithFollowRef(ctx, config.AsBool(cfg.Get("core.follow-references")))
+
 	// disable colored output on windows since cmd.exe doesn't support ANSI color
 	// codes. Other terminal may do, but until we can figure that out better
 	// disable this for all terms on this platform

--- a/pkg/ctxutil/ctxutil.go
+++ b/pkg/ctxutil/ctxutil.go
@@ -33,6 +33,7 @@ const (
 	ctxKeyCommitTimestamp
 	ctxKeyShowParsing
 	ctxKeyHidden
+	ctxFollowRef
 )
 
 // ErrNoCallback is returned when no callback is set in the context.
@@ -43,6 +44,10 @@ var ErrNoCallback = fmt.Errorf("no callback")
 func WithGlobalFlags(c *cli.Context) context.Context {
 	if c.Bool("yes") {
 		return WithAlwaysYes(c.Context, true)
+	}
+
+	if c.Bool("no-follow-ref") {
+		return WithFollowRef(c.Context, false)
 	}
 
 	return c.Context
@@ -156,6 +161,23 @@ func HasGitCommit(ctx context.Context) bool {
 // IsGitCommit returns the value of git commit or the default (true).
 func IsGitCommit(ctx context.Context) bool {
 	return is(ctx, ctxKeyGitCommit, true)
+}
+
+// IsFollowRef returns the value of follow-ref or the default (true).
+func IsFollowRef(ctx context.Context) bool {
+	return is(ctx, ctxFollowRef, true)
+}
+
+// HasFollowRef returns true if a value for follow-ref has been set in this context.
+func HasFollowRef(ctx context.Context) bool {
+	_, ok := ctx.Value(ctxFollowRef).(bool)
+
+	return ok
+}
+
+// WithFollowRef returns a context with the value of follow-ref set.
+func WithFollowRef(ctx context.Context, bv bool) context.Context {
+	return context.WithValue(ctx, ctxFollowRef, bv)
 }
 
 // WithAlwaysYes returns a context with the value of always yes set.

--- a/pkg/ctxutil/ctxutil.go
+++ b/pkg/ctxutil/ctxutil.go
@@ -46,10 +46,6 @@ func WithGlobalFlags(c *cli.Context) context.Context {
 		return WithAlwaysYes(c.Context, true)
 	}
 
-	if c.Bool("no-follow-ref") {
-		return WithFollowRef(c.Context, false)
-	}
-
 	return c.Context
 }
 
@@ -165,7 +161,7 @@ func IsGitCommit(ctx context.Context) bool {
 
 // IsFollowRef returns the value of follow-ref or the default (true).
 func IsFollowRef(ctx context.Context) bool {
-	return is(ctx, ctxFollowRef, true)
+	return is(ctx, ctxFollowRef, false)
 }
 
 // HasFollowRef returns true if a value for follow-ref has been set in this context.

--- a/pkg/gopass/secrets/akv.go
+++ b/pkg/gopass/secrets/akv.go
@@ -11,7 +11,10 @@ import (
 	"github.com/gopasspw/gopass/pkg/set"
 )
 
-var kvSep = ": "
+var (
+	kvSep     = ": "
+	gopassRef = "gopass://"
+)
 
 // AKV is the new Key-Value implementation that will replace KV.
 type AKV struct {
@@ -75,6 +78,17 @@ func (a *AKV) Values(key string) ([]string, bool) {
 	v, found := a.kvp[key]
 
 	return v, found
+}
+
+// Ref returns reference in case of having password of the
+// gopass://ref
+// which references another secret in the store.
+func (a *AKV) Ref() (string, bool) {
+	if strings.HasPrefix(a.password, gopassRef) {
+		return strings.TrimPrefix(a.password, gopassRef), true
+	}
+
+	return "", false
 }
 
 // Set writes a single key.

--- a/pkg/gopass/secrets/yaml.go
+++ b/pkg/gopass/secrets/yaml.go
@@ -85,6 +85,17 @@ func (y *YAML) Set(key string, value any) error {
 	return nil
 }
 
+// Ref returns reference in case of having password of the
+// gopass://ref
+// which references another secret in the store.
+func (y *YAML) Ref() (string, bool) {
+	if strings.HasPrefix(y.password, gopassRef) {
+		return strings.TrimPrefix(y.password, gopassRef), true
+	}
+
+	return "", false
+}
+
 // Add doesn't work since as per YAML specification keys must be unique.
 func (y *YAML) Add(key string, value any) error {
 	return ErrNotSupported

--- a/pkg/gopass/store.go
+++ b/pkg/gopass/store.go
@@ -26,6 +26,11 @@ type Secret interface {
 	// Del removes a single header value
 	Del(key string) bool
 
+	// Ref returns reference in case of having password of the
+	// gopass://ref
+	// which references another secret in the store.
+	Ref() (string, bool)
+
 	// GetBody returns everything except the header. Use Bytes to get everything.
 	Body() string
 	Password() string

--- a/tests/config_test.go
+++ b/tests/config_test.go
@@ -72,8 +72,8 @@ func TestMountConfig(t *testing.T) {
 core.autosync = true
 core.cliptimeout = 45
 core.exportkeys = false
-core.notifications = true
 core.follow-references = false
+core.notifications = true
 `
 	wanted += "mounts.mnt/m1.path = " + ts.storeDir("m1") + "\n"
 	wanted += "mounts.path = " + ts.storeDir("root") + "\n"

--- a/tests/config_test.go
+++ b/tests/config_test.go
@@ -19,8 +19,8 @@ func TestBaseConfig(t *testing.T) {
 core.autosync = true
 core.cliptimeout = 45
 core.exportkeys = false
-core.notifications = true
 core.follow-references = false
+core.notifications = true
 `
 	wanted += "mounts.path = " + ts.storeDir("root") + "\n" +
 		"pwgen.xkcd-lang = en"

--- a/tests/config_test.go
+++ b/tests/config_test.go
@@ -20,6 +20,7 @@ core.autosync = true
 core.cliptimeout = 45
 core.exportkeys = false
 core.notifications = true
+core.follow-references = false
 `
 	wanted += "mounts.path = " + ts.storeDir("root") + "\n" +
 		"pwgen.xkcd-lang = en"
@@ -72,6 +73,7 @@ core.autosync = true
 core.cliptimeout = 45
 core.exportkeys = false
 core.notifications = true
+core.follow-references = false
 `
 	wanted += "mounts.mnt/m1.path = " + ts.storeDir("m1") + "\n"
 	wanted += "mounts.path = " + ts.storeDir("root") + "\n"


### PR DESCRIPTION
Based on the discussion we had in #3148. I've added the referencing feature, so you can defined your passwords as follows:

```
gopass://ws1
username: parham.alvani@snapp.cab
```

Which means password is referencing another secret named `ws1` which you can have another parameters redefined here for example `url`, `username` or `otpauth` could be different.