### PR TITLE
chore: Remove vendor directory before calling go clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,7 @@ sysinfo:
 
 clean:
 	@echo -n ">> CLEAN"
+	@rm -rf vendor/
 	@$(GO) clean -i ./...
 	@rm -f ./coverage-all.html
 	@rm -f ./coverage-all.out


### PR DESCRIPTION
This avoid issues when the vendor directory is not canonical. Those might be relevant for other operations but not for the clean target.