### PR TITLE
[feat] Add Age custom ssh path options

### DIFF
--- a/internal/backend/crypto/age/age.go
+++ b/internal/backend/crypto/age/age.go
@@ -27,14 +27,15 @@ type githubSSHCacher interface {
 
 // Age is an age backend.
 type Age struct {
-	identity  string
-	ghCache   githubSSHCacher
-	askPass   *askPass
-	recpCache *cache.OnDisk
+	identity   string
+	ghCache    githubSSHCacher
+	askPass    *askPass
+	recpCache  *cache.OnDisk
+	sshKeyPath string // custom SSH key or directory path
 }
 
 // New creates a new Age backend.
-func New(ctx context.Context) (*Age, error) {
+func New(ctx context.Context, sshKeyPath string) (*Age, error) {
 	ghc, err := ghssh.New()
 	if err != nil {
 		return nil, err
@@ -46,13 +47,14 @@ func New(ctx context.Context) (*Age, error) {
 	}
 
 	a := &Age{
-		ghCache:   ghc,
-		recpCache: rc,
-		identity:  filepath.Join(appdir.UserConfig(), "age", "identities"),
-		askPass:   newAskPass(ctx),
+		ghCache:    ghc,
+		recpCache:  rc,
+		identity:   filepath.Join(appdir.UserConfig(), "age", "identities"),
+		askPass:    newAskPass(ctx),
+		sshKeyPath: sshKeyPath,
 	}
 
-	debug.Log("age initialized (ghc: %s, recipients: %s, identity: %s)", a.ghCache.String(), a.recpCache.String(), a.identity)
+	debug.Log("age initialized (ghc: %s, recipients: %s, identity: %s, sshKeyPath: %s)", a.ghCache.String(), a.recpCache.String(), a.identity, a.sshKeyPath)
 
 	return a, nil
 }
@@ -89,4 +91,9 @@ func (a *Age) IDFile() string {
 // Concurrency returns 1 for `age` since otherwise it prompts for the identity password for each worker.
 func (a *Age) Concurrency() int {
 	return 1
+}
+
+// Add a method to get the SSH key path
+func (a *Age) SSHKeyPath() string {
+	return a.sshKeyPath
 }

--- a/internal/backend/crypto/age/age_test.go
+++ b/internal/backend/crypto/age/age_test.go
@@ -10,14 +10,14 @@ import (
 
 func TestNew(t *testing.T) {
 	ctx := t.Context()
-	a, err := New(ctx)
+	a, err := New(ctx, "")
 	require.NoError(t, err)
 	assert.NotNil(t, a)
 }
 
 func TestInitialized(t *testing.T) {
 	ctx := t.Context()
-	a, err := New(ctx)
+	a, err := New(ctx, "")
 	require.NoError(t, err)
 	assert.NotNil(t, a)
 
@@ -27,7 +27,7 @@ func TestInitialized(t *testing.T) {
 
 func TestName(t *testing.T) {
 	ctx := t.Context()
-	a, err := New(ctx)
+	a, err := New(ctx, "")
 	require.NoError(t, err)
 	assert.NotNil(t, a)
 
@@ -37,7 +37,7 @@ func TestName(t *testing.T) {
 
 func TestVersion(t *testing.T) {
 	ctx := t.Context()
-	a, err := New(ctx)
+	a, err := New(ctx, "")
 	require.NoError(t, err)
 	assert.NotNil(t, a)
 
@@ -48,7 +48,7 @@ func TestVersion(t *testing.T) {
 
 func TestExt(t *testing.T) {
 	ctx := t.Context()
-	a, err := New(ctx)
+	a, err := New(ctx, "")
 	require.NoError(t, err)
 	assert.NotNil(t, a)
 
@@ -58,7 +58,7 @@ func TestExt(t *testing.T) {
 
 func TestIDFile(t *testing.T) {
 	ctx := t.Context()
-	a, err := New(ctx)
+	a, err := New(ctx, "")
 	require.NoError(t, err)
 	assert.NotNil(t, a)
 
@@ -68,7 +68,7 @@ func TestIDFile(t *testing.T) {
 
 func TestConcurrency(t *testing.T) {
 	ctx := t.Context()
-	a, err := New(ctx)
+	a, err := New(ctx, "")
 	require.NoError(t, err)
 	assert.NotNil(t, a)
 

--- a/internal/backend/crypto/age/commands.go
+++ b/internal/backend/crypto/age/commands.go
@@ -6,6 +6,7 @@ import (
 
 	"filippo.io/age"
 	"github.com/gopasspw/gopass/internal/action/exit"
+	"github.com/gopasspw/gopass/internal/config"
 	"github.com/gopasspw/gopass/internal/out"
 	"github.com/gopasspw/gopass/pkg/ctxutil"
 	"github.com/gopasspw/gopass/pkg/debug"
@@ -28,6 +29,13 @@ func (l loader) Commands() []*cli.Command {
 				"All age identities, including plugin ones should be supported. We also still support github" +
 				"identities despite them being deprecated by age, we do so by falling back to the ssh identities" +
 				"for these and keeping a local cache of ssh keys for a given github identity.",
+			Flags: []cli.Flag{
+				&cli.StringFlag{
+					Name:    "age-ssh-key-path",
+					Usage:   "Custom path to SSH key or directory for age backend",
+					EnvVars: []string{"GOPASS_SSH_DIR"},
+				},
+			},
 			Subcommands: []*cli.Command{
 				{
 					Name:  "identities",
@@ -36,7 +44,11 @@ func (l loader) Commands() []*cli.Command {
 						"List identities",
 					Action: func(c *cli.Context) error {
 						ctx := ctxutil.WithGlobalFlags(c)
-						a, err := New(ctx)
+						sshKeyPath := config.String(ctx, "age.ssh-key-path")
+						if sv := c.String("age-ssh-key-path"); sv != "" {
+							sshKeyPath = sv
+						}
+						a, err := New(ctx, sshKeyPath)
 						if err != nil {
 							return exit.Error(exit.Unknown, err, "failed to create age backend")
 						}
@@ -64,7 +76,11 @@ func (l loader) Commands() []*cli.Command {
 								"Add an existing age identity, interactively",
 							Action: func(c *cli.Context) error {
 								ctx := ctxutil.WithGlobalFlags(c)
-								a, err := New(ctx)
+								sshKeyPath := config.String(ctx, "age.ssh-key-path")
+								if sv := c.String("age-ssh-key-path"); sv != "" {
+									sshKeyPath = sv
+								}
+								a, err := New(ctx, sshKeyPath)
 								if err != nil {
 									return exit.Error(exit.Unknown, err, "failed to create age backend")
 								}
@@ -111,7 +127,11 @@ func (l loader) Commands() []*cli.Command {
 								"Generate a new age identity",
 							Action: func(c *cli.Context) error {
 								ctx := ctxutil.WithGlobalFlags(c)
-								a, err := New(ctx)
+								sshKeyPath := config.String(ctx, "age.ssh-key-path")
+								if sv := c.String("age-ssh-key-path"); sv != "" {
+									sshKeyPath = sv
+								}
+								a, err := New(ctx, sshKeyPath)
 								if err != nil {
 									return exit.Error(exit.Unknown, err, "failed to create age backend")
 								}
@@ -135,7 +155,11 @@ func (l loader) Commands() []*cli.Command {
 								"Remove all identity matching the argument",
 							Action: func(c *cli.Context) error {
 								ctx := ctxutil.WithGlobalFlags(c)
-								a, err := New(ctx)
+								sshKeyPath := config.String(ctx, "age.ssh-key-path")
+								if sv := c.String("age-ssh-key-path"); sv != "" {
+									sshKeyPath = sv
+								}
+								a, err := New(ctx, sshKeyPath)
 								if err != nil {
 									return exit.Error(exit.Unknown, err, "failed to create age backend")
 								}

--- a/internal/backend/crypto/age/keyring.go
+++ b/internal/backend/crypto/age/keyring.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 
 	"github.com/gopasspw/gopass/internal/backend"
+	"github.com/gopasspw/gopass/internal/config"
 	"github.com/gopasspw/gopass/internal/out"
 	"github.com/gopasspw/gopass/pkg/appdir"
 	"github.com/gopasspw/gopass/pkg/ctxutil"
@@ -54,7 +55,7 @@ func migrate(ctx context.Context, s backend.Storage) error {
 	}
 
 	// create a new instance so we can use decryptFile.
-	a, err := New(ctx)
+	a, err := New(ctx, config.String(ctx, "age.ssh-key-path"))
 	if err != nil {
 		return err
 	}

--- a/internal/backend/crypto/age/loader.go
+++ b/internal/backend/crypto/age/loader.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/gopasspw/gopass/internal/backend"
+	"github.com/gopasspw/gopass/internal/config"
 	"github.com/gopasspw/gopass/internal/out"
 	"github.com/gopasspw/gopass/pkg/debug"
 	"github.com/gopasspw/gopass/pkg/fsutil"
@@ -23,7 +24,7 @@ type loader struct{}
 func (l loader) New(ctx context.Context) (backend.Crypto, error) {
 	debug.Log("Using Crypto Backend: %s", name)
 
-	return New(ctx)
+	return New(ctx, config.String(ctx, "age.ssh-key-path"))
 }
 
 func (l loader) Handles(ctx context.Context, s backend.Storage) error {

--- a/internal/backend/crypto/age/ssh.go
+++ b/internal/backend/crypto/age/ssh.go
@@ -32,33 +32,62 @@ func (a *Age) getSSHIdentities(ctx context.Context) (map[string]age.Identity, er
 		return sshCache, nil
 	}
 
+	ids := make(map[string]age.Identity, 10) // preallocate some space for the cache
+	sshDirs := make([]string, 0, 2)
+
 	sshDir, err := getSSHDir()
 	if err != nil {
-		debug.Log("no .ssh directory found at %s. Ignoring SSH identities", sshDir)
-
-		return nil, fmt.Errorf("no identities found: %w", err)
+		debug.Log("no .ssh directory found at %s.", sshDir)
 	}
-
-	files, err := os.ReadDir(sshDir)
-	if err != nil {
-		debug.Log("unable to read .ssh dir %s: %s", sshDir, err)
-
-		return nil, fmt.Errorf("no identities found: %w", ErrNoSSHDir)
+	if sshDir != "" {
+		debug.Log("found .ssh directory at %s", sshDir)
+		sshDirs = append(sshDirs, sshDir)
 	}
-
-	ids := make(map[string]age.Identity, len(files))
-	for _, file := range files {
-		fn := filepath.Join(sshDir, file.Name())
-		if !strings.HasSuffix(fn, ".pub") {
-			continue
+	// also check the SSH key path, if set
+	if a.sshKeyPath != "" {
+		debug.Log("using custom SSH key path %s", a.sshKeyPath)
+		if fsutil.IsDir(a.sshKeyPath) {
+			sshDirs = append(sshDirs, a.sshKeyPath)
+		} else if fsutil.IsFile(a.sshKeyPath) {
+			debug.Log("using custom SSH key file %s", a.sshKeyPath)
+			recp, id, err := a.parseSSHIdentity(ctx, a.sshKeyPath)
+			if err != nil {
+				debug.Log("unable to parse custom SSH key %s: %s", a.sshKeyPath, err)
+			} else {
+				debug.Log("found custom SSH identity %s", recp)
+				ids[recp] = id
+			}
 		}
+	}
 
-		recp, id, err := a.parseSSHIdentity(ctx, fn)
+	if len(sshDirs) < 1 {
+		return nil, fmt.Errorf("no SSH identities found: %w", ErrNoSSHDir)
+	}
+
+	debug.Log("searching for SSH identities in %d directories: %s", len(sshDirs), strings.Join(sshDirs, ", "))
+
+	for _, sshDir := range sshDirs {
+		debug.Log("searching for SSH identities in %s", sshDir)
+		files, err := os.ReadDir(sshDir)
 		if err != nil {
-			continue
+			debug.Log("unable to read .ssh dir %s: %s", sshDir, err)
+
+			return nil, fmt.Errorf("no identities found: %w", ErrNoSSHDir)
 		}
 
-		ids[recp] = id
+		for _, file := range files {
+			fn := filepath.Join(sshDir, file.Name())
+			if !strings.HasSuffix(fn, ".pub") {
+				continue
+			}
+
+			recp, id, err := a.parseSSHIdentity(ctx, fn)
+			if err != nil {
+				continue
+			}
+
+			ids[recp] = id
+		}
 	}
 	sshCache = ids
 	debug.Log("returned %d SSH Identities", len(ids))


### PR DESCRIPTION
This commit adds a new flag `--age-ssh-key-path` and a new config option `age.ssh-key-path` to specify the path to an additional SSH Key file directory or file.

Fixes #2933