### PR TITLE
Revert "[fix] use WritePassword for secure write (#3200)"

### DIFF
--- a/pkg/clipboard/clipboard.go
+++ b/pkg/clipboard/clipboard.go
@@ -68,7 +68,7 @@ func CopyTo(ctx context.Context, name string, content []byte, timeout int) error
 }
 
 func copyToClipboard(ctx context.Context, content []byte) error {
-	if err := clipboard.WritePassword(ctx, content); err != nil {
+	if err := clipboard.WriteAll(ctx, content); err != nil {
 		return fmt.Errorf("failed to write to clipboard: %w", err)
 	}
 


### PR DESCRIPTION
This reverts commit a828cada8f19e946d7db785dd0abfd74caf06a82.

The change of mime-type (away from text/plain) of the clipped text that this causes is problematic, and is not yet supported everywhere. A change like this needs to be tested more thoroughly. See: https://github.com/gopasspw/gopass/issues/3233