### PR TITLE
[fix] Fix recipient check error

### DIFF
--- a/internal/action/edit.go
+++ b/internal/action/edit.go
@@ -35,12 +35,8 @@ func (s *Action) Edit(c *cli.Context) error {
 		return exit.Error(exit.Hook, err, "edit.pre-hook failed: %s", err)
 	}
 
-	if err := s.Store.CheckRecipients(ctx, name); err != nil {
-		return exit.Error(exit.Recipients, err, "Invalid recipients detected: %s", err)
-	}
-
 	if err := s.edit(ctx, c, name); err != nil {
-		return err
+		return exit.Error(exit.Unknown, err, "failed to edit %q: %s", name, err)
 	}
 
 	return hook.InvokeRoot(ctx, "edit.post-hook", name, s.Store)
@@ -105,6 +101,10 @@ func (s *Action) editGetContent(ctx context.Context, name string, create bool) (
 		if err != nil {
 			return "", nil, false, err
 		}
+	}
+
+	if err := s.Store.CheckRecipients(ctx, name); err != nil {
+		return name, nil, false, exit.Error(exit.Recipients, err, "invalid recipients detected for %q: %s", name, err)
 	}
 
 	// edit existing entry.


### PR DESCRIPTION
When using `gopass edit` with the fuzzy match feature the recipients check might incorrectly target the root store when the actual secret would be in a mount (and might have correct recpients).