### PR TITLE
[fix] Correctly handle IsGitCommit false in store.Move

### DIFF
--- a/internal/store/root/move.go
+++ b/internal/store/root/move.go
@@ -46,6 +46,10 @@ func (r *Store) move(ctx context.Context, from, to string, del bool) error {
 		return err
 	}
 
+	if !ctxutil.IsGitCommit(ctx) {
+		return nil
+	}
+
 	commitMsg := ctxutil.GetCommitMessage(ctx)
 	if err := subFrom.Storage().TryCommit(ctx, commitMsg); del && err != nil {
 		return fmt.Errorf("failed to commit changes to git (%s): %w", subFrom.Alias(), err)


### PR DESCRIPTION
The move implementation would always try to commit, even if the caller did set this to false.