### PR TITLE
[fix] Fix version check

### DIFF
--- a/internal/action/version.go
+++ b/internal/action/version.go
@@ -84,7 +84,7 @@ func (s *Action) checkVersion(ctx context.Context, u chan string) {
 		return
 	}
 
-	if s.version.GTE(r.Version) {
+	if r.Version.GT(s.version) {
 		_ = s.rem.Reset("update")
 		debug.Log("gopass is up-to-date (local: %q, GitHub: %q)", s.version, r.Version)
 


### PR DESCRIPTION
Previously `gopass version` would always print an upgrade notice when build from source even if there were no newer releases.