### PR TITLE
[chore] Run linux builds with multiple Go versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,10 @@ permissions:
 jobs:
   linux:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go: ['1.23', '1.24', '1.25']
+    name: Go ${{ matrix.go }}
     steps:
     - name: Harden Runner
       uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
@@ -43,7 +47,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:
-        go-version: '1.24'
+        go-version: ${{ matrix.go }}
     - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: ~/go/pkg/mod


### PR DESCRIPTION
We want to be able to build using the latest Go version, the one that most large distros ship (e.g. right now that is 1.24) and possibly older versions.

See https://github.com/actions/setup-go?tab=readme-ov-file#matrix-testing