### PR TITLE
fix(config): use the config propery generate.strict as default value …

### DIFF
--- a/internal/create/wizard.go
+++ b/internal/create/wizard.go
@@ -403,7 +403,7 @@ func generatePassword(ctx context.Context, hostname, charset string) (string, er
 		return "", err
 	}
 
-	corp, err := termio.AskForBool(ctx, fmtfn(4, "d", "Strict rules?"), false)
+	corp, err := termio.AskForBool(ctx, fmtfn(4, "d", "Strict rules?"), config.Bool(ctx, "generate.strict"))
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Use the config property "generate.strict" as default value for "Strict rules"

The config property "generate.strict" is mentioned in docs/config.md but was not used in the code here, unlike "generate.symbols" where the configuration is loaded and used as the default value, as expected.

The code change follows what is already there for reading and using generate.symbols config property.