### PR TITLE
fix: use clipboard.WritePassword on darwin

### DIFF
--- a/pkg/clipboard/clipboard.go
+++ b/pkg/clipboard/clipboard.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"runtime"
 
 	"github.com/fatih/color"
 	"github.com/gopasspw/clipboard"
@@ -69,8 +70,15 @@ func CopyTo(ctx context.Context, name string, content []byte, timeout int) error
 }
 
 func copyToClipboard(ctx context.Context, content []byte) error {
-	if err := clipboard.WriteAll(ctx, content); err != nil {
-		return fmt.Errorf("failed to write to clipboard: %w", err)
+	// Prevent leaking password to clipboard history.
+	if runtime.GOOS == "darwin" {
+		if err := clipboard.WritePassword(ctx, content); err != nil {
+			return fmt.Errorf("failed to write to clipboard: %w", err)
+		}
+	} else {
+		if err := clipboard.WriteAll(ctx, content); err != nil {
+			return fmt.Errorf("failed to write to clipboard: %w", err)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
In order to prevent leaking passwords to the clipboard history on darwin, `clipboard.WritePassword` is being used to copy passwords.

Fixes #3305 