### PR TITLE
feat: warn when system keyring is unavailable

### DIFF
--- a/internal/backend/crypto/age/askpass.go
+++ b/internal/backend/crypto/age/askpass.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/gopasspw/gopass/internal/cache"
 	"github.com/gopasspw/gopass/internal/config"
+	"github.com/gopasspw/gopass/internal/out"
 	"github.com/gopasspw/gopass/pkg/debug"
 	"github.com/gopasspw/gopass/pkg/pinentry/cli"
 	"github.com/twpayne/go-pinentry/v4"
@@ -16,7 +18,7 @@ import (
 
 type cacher interface {
 	Get(string) (string, bool)
-	Set(string, string)
+	Set(context.Context, string, string)
 	Remove(string)
 	Purge()
 }
@@ -43,9 +45,11 @@ func (o *osKeyring) Get(key string) (string, bool) {
 	return sec, true
 }
 
-func (o *osKeyring) Set(name, value string) {
+func (o *osKeyring) Set(ctx context.Context, name, value string) {
 	if err := keyring.Set("gopass", name, value); err != nil {
 		debug.Log("failed to set %s: %w", name, err)
+		out.Warningf(ctx, "Failed to cache passphrase in OS keyring: %s", err)
+		return
 	}
 	o.knownKeys[name] = true
 }
@@ -77,6 +81,8 @@ type askPass struct {
 	cache   cacher
 }
 
+var keyringWarningOnce sync.Once
+
 func newAskPass(ctx context.Context) *askPass {
 	a := &askPass{
 		cache: cache.NewInMemTTL[string, string](time.Hour, 24*time.Hour),
@@ -86,6 +92,10 @@ func newAskPass(ctx context.Context) *askPass {
 		if err := keyring.Set("gopass", "sentinel", "empty"); err == nil {
 			debug.V(1).Log("using OS keychain to cache age credentials")
 			a.cache = newOsKeyring()
+		} else {
+			keyringWarningOnce.Do(func() {
+				out.Warningf(ctx, "OS keyring is not available. Passphrase caching will not persist. Disable age.usekeychain or install a keyring provider (e.g. gnome-keyring): %s", err)
+			})
 		}
 	}
 
@@ -96,7 +106,7 @@ func (a *askPass) Ping(_ context.Context) error {
 	return nil
 }
 
-func (a *askPass) Passphrase(key string, reason string, repeat bool) (string, error) {
+func (a *askPass) Passphrase(ctx context.Context, key string, reason string, repeat bool) (string, error) {
 	if value, found := a.cache.Get(key); found || a.testing {
 		debug.V(1).Log("Read value for %s from cache", key)
 
@@ -110,7 +120,7 @@ func (a *askPass) Passphrase(key string, reason string, repeat bool) (string, er
 	}
 
 	debug.V(1).Log("Updated value for %s in cache", key)
-	a.cache.Set(key, pw)
+	a.cache.Set(ctx, key, pw)
 
 	return pw, nil
 }

--- a/internal/backend/crypto/age/askpass_test.go
+++ b/internal/backend/crypto/age/askpass_test.go
@@ -1,0 +1,123 @@
+package age
+
+import (
+	"bytes"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/gopasspw/gopass/internal/config"
+	"github.com/gopasspw/gopass/internal/out"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zalando/go-keyring"
+)
+
+func TestNewAskPass_KeychainDisabled(t *testing.T) {
+	keyring.MockInit()
+
+	ctx := config.NewContextInMemory()
+	a := newAskPass(ctx)
+
+	require.NotNil(t, a)
+	_, isOsKeyring := a.cache.(*osKeyring)
+	assert.False(t, isOsKeyring, "cache should be in-memory when keychain is disabled")
+}
+
+func TestNewAskPass_KeychainEnabled_KeyringAvailable(t *testing.T) {
+	keyring.MockInit()
+
+	cfg := config.NewInMemory()
+	require.NoError(t, cfg.Set("", "age.usekeychain", "true"))
+	ctx := cfg.WithConfig(t.Context())
+
+	a := newAskPass(ctx)
+
+	require.NotNil(t, a)
+	_, isOsKeyring := a.cache.(*osKeyring)
+	assert.True(t, isOsKeyring, "cache should be *osKeyring when keychain is enabled and available")
+}
+
+func TestNewAskPass_KeychainEnabled_KeyringUnavailable(t *testing.T) {
+	keyring.MockInitWithError(errors.New("no keyring"))
+	keyringWarningOnce = sync.Once{}
+
+	cfg := config.NewInMemory()
+	require.NoError(t, cfg.Set("", "age.usekeychain", "true"))
+	ctx := cfg.WithConfig(t.Context())
+
+	a := newAskPass(ctx)
+
+	require.NotNil(t, a)
+	_, isOsKeyring := a.cache.(*osKeyring)
+	assert.False(t, isOsKeyring, "cache should fall back to in-memory when keyring is unavailable")
+}
+
+func TestNew_KeychainEnabled_KeyringUnavailable_WarnsUser(t *testing.T) {
+	keyring.MockInitWithError(errors.New("no keyring"))
+	keyringWarningOnce = sync.Once{}
+
+	var buf bytes.Buffer
+	oldStderr := out.Stderr
+	out.Stderr = &buf
+	t.Cleanup(func() { out.Stderr = oldStderr })
+
+	cfg := config.NewInMemory()
+	require.NoError(t, cfg.Set("", "age.usekeychain", "true"))
+	ctx := cfg.WithConfig(t.Context())
+
+	a, err := New(ctx, "")
+	require.NoError(t, err)
+	require.NotNil(t, a)
+
+	assert.Contains(t, buf.String(), "OS keyring is not available")
+}
+
+func TestOsKeyring_Set_Success(t *testing.T) {
+	keyring.MockInit()
+
+	o := newOsKeyring()
+	o.Set(t.Context(), "test-key", "test-value")
+
+	val, err := keyring.Get("gopass", "test-key")
+	require.NoError(t, err)
+	assert.Equal(t, "test-value", val)
+}
+
+func TestOsKeyring_Set_Failure(t *testing.T) {
+	keyring.MockInitWithError(errors.New("no system keyring"))
+
+	var buf bytes.Buffer
+	oldStderr := out.Stderr
+	out.Stderr = &buf
+	t.Cleanup(func() { out.Stderr = oldStderr })
+
+	o := newOsKeyring()
+	o.Set(t.Context(), "test-key", "test-value")
+
+	assert.Contains(t, buf.String(), "Failed to cache passphrase in OS keyring")
+}
+
+func TestOsKeyring_Get_Success(t *testing.T) {
+	keyring.MockInit()
+
+	// Pre-populate the keyring
+	require.NoError(t, keyring.Set("gopass", "my-key", "my-secret"))
+
+	o := newOsKeyring()
+	val, found := o.Get("my-key")
+
+	assert.True(t, found)
+	assert.Equal(t, "my-secret", val)
+}
+
+func TestOsKeyring_Get_Failure(t *testing.T) {
+	keyring.MockInit()
+	// Don't pre-populate — key doesn't exist
+
+	o := newOsKeyring()
+	val, found := o.Get("nonexistent-key")
+
+	assert.False(t, found)
+	assert.Empty(t, val)
+}

--- a/internal/backend/crypto/age/decrypt.go
+++ b/internal/backend/crypto/age/decrypt.go
@@ -30,7 +30,7 @@ func (a *Age) Decrypt(ctx context.Context, ciphertext []byte) ([]byte, error) {
 	if !ctxutil.HasPasswordCallback(ctx) {
 		debug.Log("no password callback found, redirecting to askPass")
 		ctx = ctxutil.WithPasswordCallback(ctx, func(prompt string, _ bool) ([]byte, error) {
-			pw, err := a.askPass.Passphrase(prompt, fmt.Sprintf("to load the keyring at %s", a.identity), false)
+			pw, err := a.askPass.Passphrase(ctx, prompt, fmt.Sprintf("to load the keyring at %s", a.identity), false)
 
 			return []byte(pw), err
 		})

--- a/internal/backend/crypto/age/identities.go
+++ b/internal/backend/crypto/age/identities.go
@@ -76,7 +76,7 @@ func (a *Age) Identities(ctx context.Context) ([]age.Identity, error) {
 	if !ctxutil.HasPasswordCallback(ctx) {
 		debug.V(1).Log("no password callback found, redirecting to askPass")
 		ctx = ctxutil.WithPasswordCallback(ctx, func(prompt string, confirm bool) ([]byte, error) {
-			pw, err := a.askPass.Passphrase(prompt, fmt.Sprintf("to read the age keyring from %s", a.identity), confirm)
+			pw, err := a.askPass.Passphrase(ctx, prompt, fmt.Sprintf("to read the age keyring from %s", a.identity), confirm)
 
 			return []byte(pw), err
 		})
@@ -359,7 +359,7 @@ func (a *Age) saveIdentities(ctx context.Context, ids []string, newFile bool) er
 	if !ctxutil.HasPasswordCallback(ctx) && !ctxutil.IsAlwaysYes(ctx) {
 		debug.Log("no password callback found, redirecting to askPass")
 		ctx = ctxutil.WithPasswordCallback(ctx, func(prompt string, confirm bool) ([]byte, error) {
-			pw, err := a.askPass.Passphrase(prompt, fmt.Sprintf("to save the age keyring to %s", a.identity), confirm)
+			pw, err := a.askPass.Passphrase(ctx, prompt, fmt.Sprintf("to save the age keyring to %s", a.identity), confirm)
 
 			return []byte(pw), err
 		})

--- a/internal/backend/crypto/age/keyring.go
+++ b/internal/backend/crypto/age/keyring.go
@@ -64,7 +64,7 @@ func migrate(ctx context.Context, s backend.Storage) error {
 	if !ctxutil.HasPasswordCallback(ctx) {
 		debug.Log("no password callback found, redirecting to askPass")
 		ctx = ctxutil.WithPasswordCallback(ctx, func(prompt string, _ bool) ([]byte, error) {
-			pw, err := a.askPass.Passphrase(prompt, fmt.Sprintf("to load the age keyring at %s", oldKeyring), false)
+			pw, err := a.askPass.Passphrase(ctx, prompt, fmt.Sprintf("to load the age keyring at %s", oldKeyring), false)
 
 			return []byte(pw), err
 		})

--- a/internal/cache/inmem.go
+++ b/internal/cache/inmem.go
@@ -1,6 +1,7 @@
 package cache
 
 import (
+	"context"
 	"sync"
 	"time"
 )
@@ -79,7 +80,7 @@ func (c *InMemTTL[K, V]) purgeExpired() {
 }
 
 // Set creates or overwrites an entry.
-func (c *InMemTTL[K, V]) Set(key K, value V) {
+func (c *InMemTTL[K, V]) Set(_ context.Context, key K, value V) {
 	c.Lock()
 	defer c.Unlock()
 

--- a/internal/cache/inmem_test.go
+++ b/internal/cache/inmem_test.go
@@ -28,7 +28,7 @@ func TestTTL(t *testing.T) {
 	assert.Empty(t, val)
 	assert.False(t, found)
 
-	c.Set("foo", "bar")
+	c.Set(t.Context(), "foo", "bar")
 	val, found = c.Get("foo")
 	assert.Equal(t, "bar", val)
 	assert.True(t, found)
@@ -45,7 +45,7 @@ func TestTTL(t *testing.T) {
 	assert.Empty(t, val)
 	assert.False(t, found)
 
-	c.Set("bar", "baz")
+	c.Set(t.Context(), "bar", "baz")
 	val, found = c.Get("bar")
 	assert.Equal(t, "baz", val)
 	assert.True(t, found)
@@ -55,8 +55,8 @@ func TestTTL(t *testing.T) {
 	assert.Empty(t, val)
 	assert.False(t, found)
 
-	c.Set("foo", "bar")
-	c.Set("bar", "baz")
+	c.Set(t.Context(), "foo", "bar")
+	c.Set(t.Context(), "bar", "baz")
 	val, found = c.Get("bar")
 	assert.Equal(t, "baz", val)
 	assert.True(t, found)
@@ -77,7 +77,7 @@ func TestPar(t *testing.T) {
 		for range 32 {
 			t.Run("set"+strconv.Itoa(i), func(t *testing.T) {
 				t.Parallel()
-				c.Set(i, i)
+				c.Set(t.Context(), i, i)
 				iv, found := c.Get(i)
 				assert.True(t, found)
 				assert.Equal(t, i, iv)


### PR DESCRIPTION
## Summary

- Emit a one-time warning when `age.usekeychain` is enabled but no OS keyring provider is available, so users understand why passphrase caching won't persist across sessions
- Warn when writing a passphrase to the OS keyring fails at runtime
- The `cacher.Set` and `askPass.Passphrase` signatures now accept a `context.Context` to support the warning output
- Add tests for `askPass` initialization, `osKeyring` get/set paths, and the user-facing warning