### PR TITLE
fix(config): restore sub-store fallback for core.exportkeys

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,6 @@
 version: "2"
 output:
+  sort-results: true
   sort-order:
     - linter
     - file

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -193,10 +193,14 @@ func (c *Config) GetM(mount, key string) string {
 	}
 
 	if cfg := c.cfgs[mount]; cfg != nil {
-		return cfg.Get(key)
+		if v := cfg.Get(key); v != "" {
+			return v
+		}
 	}
 
-	return ""
+	// Fall back to the root config (including defaults) so sub-stores inherit
+	// global settings when not explicitly overridden in their local config.
+	return c.root.Get(key)
 }
 
 // Set tries to set the key to the given value.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -115,6 +115,30 @@ func TestInvalidEnvConfig(t *testing.T) {
 	assert.Equal(t, "true", cfg.Get("core.autosync"))
 }
 
+func TestGetMMountFallbackToRoot(t *testing.T) {
+	// we use our own temp dir
+	td := t.TempDir()
+	t.Setenv("GOPASS_HOMEDIR", td)
+	mountDir := t.TempDir()
+
+	cfg := New()
+	// add it as a mount path to our global config
+	require.NoError(t, cfg.SetMountPath("submount", mountDir))
+	// reload so the submount config is loaded
+	cfg = New()
+
+	// If the key is not set in the mount config, we should inherit from root.
+	assert.Equal(t, defaults["core.exportkeys"], cfg.GetM("submount", "core.exportkeys"))
+
+	// Root local changes should be visible to submounts unless overridden there.
+	require.NoError(t, cfg.Set("<root>", "core.exportkeys", "false"))
+	assert.Equal(t, "false", cfg.GetM("submount", "core.exportkeys"))
+
+	// A mount-local value should override the root value.
+	require.NoError(t, cfg.Set("submount", "core.exportkeys", "true"))
+	assert.Equal(t, "true", cfg.GetM("submount", "core.exportkeys"))
+}
+
 func TestOptsMigration(t *testing.T) {
 	t.Run("migrate global options", func(t *testing.T) {
 		// we use our own temp dir


### PR DESCRIPTION
Fix GetM to fall back to root config when a mount-local key is unset.

Add regression test for mount fallback and override behavior.

Fixes #3366 