### PR TITLE
Maintenance update

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -48,8 +48,7 @@ jobs:
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
           # Note: there are 2 different version of golangci-lint used inside the project.
-          # https://github.com/gopasspw/gopass/blob/master/.github/workflows/build.yml#L65
-          # https://github.com/gopasspw/gopass/blob/master/.github/workflows/golangci-lint.yml#L46
-          # https://github.com/gopasspw/gopass/blob/master/Makefile#L136
-          version: v2.6.1 # we have a list of linters in our .golangci.yml config file
+          # https://github.com/gopasspw/gopass/blob/master/.github/workflows/golangci-lint.yml#L53
+          # https://github.com/gopasspw/gopass/blob/master/Makefile#L137
+          version: v2.11.4 # we have a list of linters in our .golangci.yml config file
           only-new-issues: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,5 @@
 version: "2"
 output:
-  sort-results: true
   sort-order:
     - linter
     - file

--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,7 @@ codequality: licensecheck
 
 	@echo -n "     GOLANGCI-LINT "
 	@which golangci-lint > /dev/null; if [ $$? -ne 0 ]; then \
-		$(GO) install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.6.1; \
+		$(GO) install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4; \
 	fi
 	@golangci-lint run --max-issues-per-linter 0 --max-same-issues 0 || exit 1
 	@printf '%s\n' '$(OK)'
@@ -159,6 +159,9 @@ codequality: licensecheck
 	fi
 	@govulncheck >/dev/null || exit 1
 	@printf '%s\n' '$(OK)'
+
+update-caps:
+	@capslock -packages ./... -output json >.capabilities.json
 
 licensecheck:
 	@echo ">> LICENSE CHECK"
@@ -185,6 +188,9 @@ deps:
 upgrade: gen fmt
 	@$(GO) get -u ./...
 	@$(GO) mod tidy
+
+fix:
+	@$(GO) fix ./...
 
 man:
 	@$(GO) run helpers/man/main.go > gopass.1

--- a/internal/action/recipients.go
+++ b/internal/action/recipients.go
@@ -288,8 +288,8 @@ func (s *Action) recipientsSelectForRemoval(ctx context.Context, store string) (
 func (s *Action) recipientsSelectForAdd(ctx context.Context, store string) ([]string, error) {
 	crypto := s.Store.Crypto(ctx, store)
 
-	choices := []string{}
 	kl, _ := crypto.FindRecipients(ctx)
+	choices := make([]string, 0, len(kl))
 	for _, key := range kl {
 		choices = append(choices, crypto.FormatKey(ctx, key, ""))
 	}

--- a/internal/action/repl.go
+++ b/internal/action/repl.go
@@ -278,14 +278,14 @@ func (g *gopassCompleter) stripFlags(s string) string {
 		return s
 	}
 
-	result := ""
+	var result strings.Builder
 	for i < n {
 		spaceStart := i
 		for i < n && s[i] == ' ' {
 			i++
 		}
 		if i >= n {
-			result += s[spaceStart:]
+			result.WriteString(s[spaceStart:])
 
 			break
 		}
@@ -316,10 +316,10 @@ func (g *gopassCompleter) stripFlags(s string) string {
 			continue
 		}
 
-		result += s[spaceStart:i]
+		result.WriteString(s[spaceStart:i])
 	}
 
-	if result == "" {
+	if result.String() == "" {
 		if n > 0 && s[n-1] == ' ' {
 			return " "
 		}
@@ -327,7 +327,7 @@ func (g *gopassCompleter) stripFlags(s string) string {
 		return ""
 	}
 
-	b.WriteString(result)
+	b.WriteString(result.String())
 
 	return b.String()
 }
@@ -428,7 +428,7 @@ func (s *Action) newGopassCompleter(c *cli.Context) *gopassCompleter {
 		}
 
 		if len(cmd.Subcommands) > 0 {
-			var subs []string
+			subs := make([]string, 0, len(cmd.Subcommands))
 			for _, scmd := range cmd.Subcommands {
 				subs = append(subs, scmd.Name)
 			}

--- a/internal/action/show.go
+++ b/internal/action/show.go
@@ -321,7 +321,7 @@ func showSafeContent(sec gopass.Secret) string {
 
 	for l := range strings.SplitSeq(sec.Body(), "\n") {
 		if strings.HasPrefix(l, "otpauth://") {
-			sb.WriteString(fmt.Sprintf("\notpauth://%s", randAsterisk()))
+			fmt.Fprintf(&sb, "\notpauth://%s", randAsterisk())
 
 			continue
 		}

--- a/internal/audit/output.go
+++ b/internal/audit/output.go
@@ -30,7 +30,7 @@ func (r *Report) PrintResults(ctx context.Context) error {
 	for _, name := range set.SortedKeys(r.Secrets) {
 		s := r.Secrets[name]
 		var sb strings.Builder
-		sb.WriteString(fmt.Sprintf("%s (age: %s) ", name, s.HumanizeAge()))
+		fmt.Fprintf(&sb, "%s (age: %s) ", name, s.HumanizeAge())
 		if !s.HasFindings() {
 			sb.WriteString("OK")
 			out.OK(ctx, sb.String())
@@ -47,7 +47,7 @@ func (r *Report) PrintResults(ctx context.Context) error {
 			case "error":
 				fallthrough
 			case "warning":
-				sb.WriteString(fmt.Sprintf("%s: %s. ", k, v.Message))
+				fmt.Fprintf(&sb, "%s: %s. ", k, v.Message)
 			default:
 				continue
 			}

--- a/internal/backend/crypto/gpg/cli/keyring.go
+++ b/internal/backend/crypto/gpg/cli/keyring.go
@@ -22,7 +22,8 @@ func (g *GPG) listKeys(ctx context.Context, typ string, search ...string) (gpg.K
 	ctx, cancel := context.WithTimeout(ctx, Timeout)
 	defer cancel()
 
-	args := []string{"--with-colons", "--with-fingerprint", "--fixed-list-mode", "--list-" + typ + "-keys"}
+	args := make([]string, 0, 4+len(search))
+	args = append(args, "--with-colons", "--with-fingerprint", "--fixed-list-mode", "--list-"+typ+"-keys")
 	args = append(args, search...)
 	if e, found := g.listCache.Get(strings.Join(args, ",")); found && gpg.UseCache(ctx) {
 		debug.Log("listed cached keys: %q", strings.Join(e.Recipients(), ","))

--- a/internal/backend/crypto/gpg/key.go
+++ b/internal/backend/crypto/gpg/key.go
@@ -69,14 +69,14 @@ func (k Key) String() string {
 	}
 
 	var out strings.Builder
-	out.WriteString(fmt.Sprintf("%s   %dD/0x%s %s", k.KeyType, k.KeyLength, fp, k.CreationDate.Format("2006-01-02")))
+	fmt.Fprintf(&out, "%s   %dD/0x%s %s", k.KeyType, k.KeyLength, fp, k.CreationDate.Format("2006-01-02"))
 	if !k.ExpirationDate.IsZero() {
-		out.WriteString(fmt.Sprintf(" [expires: %s]", k.ExpirationDate.Format("2006-01-02")))
+		fmt.Fprintf(&out, " [expires: %s]", k.ExpirationDate.Format("2006-01-02"))
 	}
 
 	out.WriteString("\n      Key fingerprint = " + k.Fingerprint)
 	for _, id := range k.Identities {
-		out.WriteString(fmt.Sprintf("\n%s", id))
+		fmt.Fprintf(&out, "\n%s", id)
 	}
 
 	return out.String()

--- a/internal/backend/storage/fossilfs/fossil.go
+++ b/internal/backend/storage/fossilfs/fossil.go
@@ -202,7 +202,8 @@ func (f *Fossil) Add(ctx context.Context, files ...string) error {
 		files[i] = strings.TrimPrefix(files[i], f.fs.Path()+"/")
 	}
 
-	args := []string{"add", "--force", "--dotfiles"}
+	args := make([]string, 0, 3+len(files))
+	args = append(args, "add", "--force", "--dotfiles")
 	args = append(args, files...)
 
 	return f.Cmd(ctx, "fossilAdd", args...)

--- a/internal/backend/storage/gitfs/git.go
+++ b/internal/backend/storage/gitfs/git.go
@@ -228,7 +228,8 @@ func (g *Git) Add(ctx context.Context, files ...string) error {
 		files[i] = strings.TrimPrefix(files[i], g.fs.Path()+"/")
 	}
 
-	args := []string{"add", "--all", "--force"}
+	args := make([]string, 0, 3+len(files))
+	args = append(args, "add", "--all", "--force")
 	args = append(args, files...)
 
 	return g.Cmd(ctx, "gitAdd", args...)

--- a/internal/backend/storage/jjfs/jj.go
+++ b/internal/backend/storage/jjfs/jj.go
@@ -126,7 +126,8 @@ func (j *JJFS) Add(ctx context.Context, files ...string) error {
 		files[i] = strings.TrimPrefix(files[i], j.fs.Path()+"/")
 	}
 
-	args := []string{"git", "add"}
+	args := make([]string, 0, 2+len(files))
+	args = append(args, "git", "add")
 	args = append(args, files...)
 
 	return j.Cmd(ctx, "jjGitAdd", args...)

--- a/internal/cui/recipients.go
+++ b/internal/cui/recipients.go
@@ -158,8 +158,10 @@ func AskForStore(ctx context.Context, s mountPointer) string {
 		return ""
 	}
 
-	stores := []string{"<root>"}
-	stores = append(stores, sorted(s.MountPoints())...)
+	mp := s.MountPoints()
+	stores := make([]string, 0, 1+len(mp))
+	stores = append(stores, "<root>")
+	stores = append(stores, sorted(mp)...)
 	if len(stores) < 2 {
 		return ""
 	}

--- a/internal/editor/editor.go
+++ b/internal/editor/editor.go
@@ -54,7 +54,7 @@ func Invoke(ctx context.Context, editor string, content []byte) ([]byte, error) 
 		return []byte{}, fmt.Errorf("failed to close tmpfile to start with %s %v: %w", editor, tmpfile.Name(), err)
 	}
 
-	args := make([]string, 0, 4)
+	args := make([]string, 0, 5)
 	if runtime.GOOS != "windows" {
 		cmdArgs, err := shellquote.Split(editor)
 		if err != nil {
@@ -113,10 +113,8 @@ func vimOptions(editor string) []string {
 		viminfo = `shada=""`
 	}
 
-	args := []string{
-		"-c",
-		fmt.Sprintf("autocmd BufNewFile,BufRead %s setlocal noswapfile nobackup noundofile %s", path, viminfo),
-	}
+	args := make([]string, 0, 5)
+	args = append(args, "-c", fmt.Sprintf("autocmd BufNewFile,BufRead %s setlocal noswapfile nobackup noundofile %s", path, viminfo))
 	args = append(args, "-i", "NONE") // disable viminfo
 	args = append(args, "-n")         // disable swap
 

--- a/internal/notify/notify_darwin_test.go
+++ b/internal/notify/notify_darwin_test.go
@@ -68,7 +68,8 @@ func mockExecLookPathTerminalNotifier(command string) (string, error) {
 }
 
 func mockExecCommand(command string, args ...string) *exec.Cmd {
-	cs := []string{"-test.run=TestHelperProcess", "--", command}
+	cs := make([]string, 0, 3+len(args))
+	cs = append(cs, "-test.run=TestHelperProcess", "--", command)
 	cs = append(cs, args...)
 	cmd := exec.Command(os.Args[0], cs...)
 	cmd.Env = []string{"GO_WANT_HELPER_PROCESS=1"}

--- a/internal/store/leaf/fsck.go
+++ b/internal/store/leaf/fsck.go
@@ -184,7 +184,7 @@ func (s *Store) fsckLoop(ctx context.Context, path string) error {
 
 		msg, err := s.fsckCheckEntry(ctx, name)
 		if err != nil {
-			warnings.WriteString(fmt.Sprintf("failed to check %q:\n    %s\n", name, err))
+			fmt.Fprintf(&warnings, "failed to check %q:\n    %s\n", name, err)
 
 			continue
 		}

--- a/main.go
+++ b/main.go
@@ -154,40 +154,41 @@ func setupApp(ctx context.Context, sv semver.Version) (context.Context, *cli.App
 }
 
 func getCommands(action *ap.Action, app *cli.App) []*cli.Command {
-	cmds := []*cli.Command{
-		{
-			Name:  "completion",
-			Usage: "Bash and ZSH completion",
-			Description: "" +
-				"Source the output of this command with bash or zsh to get auto completion",
-			Subcommands: []*cli.Command{{
-				Name:   "bash",
-				Usage:  "Source for auto completion in bash",
-				Action: action.CompletionBash,
-			}, {
-				Name:  "zsh",
-				Usage: "Source for auto completion in zsh",
-				Action: func(c *cli.Context) error {
-					return action.CompletionZSH(app) //nolint:wrapcheck
-				},
-			}, {
-				Name:  "fish",
-				Usage: "Source for auto completion in fish",
-				Action: func(c *cli.Context) error {
-					return action.CompletionFish(app) //nolint:wrapcheck
-				},
-			}, {
-				Name:  "openbsdksh",
-				Usage: "Source for auto completion in OpenBSD's ksh",
-				Action: func(c *cli.Context) error {
-					return action.CompletionOpenBSDKsh(app) //nolint:wrapcheck
-				},
-			}},
-		},
-	}
+	extra := action.GetCommands()
+	extra2 := pwgen.GetCommands()
+	cmds := make([]*cli.Command, 0, 1+len(extra)+len(extra2))
+	cmds = append(cmds, &cli.Command{
+		Name:  "completion",
+		Usage: "Bash and ZSH completion",
+		Description: "" +
+			"Source the output of this command with bash or zsh to get auto completion",
+		Subcommands: []*cli.Command{{
+			Name:   "bash",
+			Usage:  "Source for auto completion in bash",
+			Action: action.CompletionBash,
+		}, {
+			Name:  "zsh",
+			Usage: "Source for auto completion in zsh",
+			Action: func(c *cli.Context) error {
+				return action.CompletionZSH(app) //nolint:wrapcheck
+			},
+		}, {
+			Name:  "fish",
+			Usage: "Source for auto completion in fish",
+			Action: func(c *cli.Context) error {
+				return action.CompletionFish(app) //nolint:wrapcheck
+			},
+		}, {
+			Name:  "openbsdksh",
+			Usage: "Source for auto completion in OpenBSD's ksh",
+			Action: func(c *cli.Context) error {
+				return action.CompletionOpenBSDKsh(app) //nolint:wrapcheck
+			},
+		}},
+	})
 
-	cmds = append(cmds, action.GetCommands()...)
-	cmds = append(cmds, pwgen.GetCommands()...)
+	cmds = append(cmds, extra...)
+	cmds = append(cmds, extra2...)
 	sort.Slice(cmds, func(i, j int) bool { return cmds[i].Name < cmds[j].Name })
 
 	for i, cmd := range cmds {

--- a/pkg/gopass/secrets/akv.go
+++ b/pkg/gopass/secrets/akv.go
@@ -144,7 +144,7 @@ func (a *AKV) Set(key string, value any) error {
 		k = strings.TrimSpace(k)
 		if k == key {
 			// update the key
-			a.raw.WriteString(fmt.Sprintf("%s: %s\n", key, value))
+			fmt.Fprintf(&a.raw, "%s: %s\n", key, value)
 			written = true
 
 			continue
@@ -167,7 +167,7 @@ func (a *AKV) Add(key string, value any) error {
 	if a.raw.Len() == 0 {
 		a.raw.WriteString("\n")
 	}
-	a.raw.WriteString(fmt.Sprintf("%s: %s\n", key, sv))
+	fmt.Fprintf(&a.raw, "%s: %s\n", key, sv)
 
 	return nil
 }

--- a/tests/gptest/utils.go
+++ b/tests/gptest/utils.go
@@ -81,7 +81,7 @@ func flagset(t *testing.T, flags map[string]string, args []string) *flag.FlagSet
 		}
 	}
 
-	argl := []string{}
+	argl := make([]string, 0, len(flags)+len(args))
 	for k, v := range flags {
 		argl = append(argl, "--"+k+"="+v)
 	}


### PR DESCRIPTION
This commit updates golangci-lint to a new version, rebuilds with Go 1.26 and updates the capslock snapshot. We also apply a fresh go fix run.