### PR TITLE
openbsd: allow unix sockets in pledge

### DIFF
--- a/main.go
+++ b/main.go
@@ -52,7 +52,7 @@ func main() {
 	// Example: https://go.dev/play/p/8214zCX6hVq.
 	defer writeCPUProfile()()
 
-	if err := protect.Pledge("stdio rpath wpath cpath tty proc exec fattr"); err != nil {
+	if err := protect.Pledge("stdio rpath wpath cpath tty proc exec fattr unix"); err != nil {
 		panic(err)
 	}
 


### PR DESCRIPTION
Add the `unix` promise to the OpenBSD pledge profile so `gopass age agent` can create its Unix-domain socket.