### PR TITLE
feat: allow `-c=N` to copy a specific line to clipboard

### DIFF
--- a/internal/action/commands.go
+++ b/internal/action/commands.go
@@ -2,12 +2,64 @@ package action
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/gopasspw/gopass/internal/backend"
 	"github.com/gopasspw/gopass/pkg/debug"
 	"github.com/gopasspw/gopass/pkg/set"
 	"github.com/urfave/cli/v2"
 )
+
+// OptionalInt is a flag value that acts as a boolean when no value is given,
+// but accepts an integer via the = syntax (e.g. -c=2).
+type OptionalInt struct {
+	IsPresent bool
+	Value     int
+	HasValue  bool
+}
+
+func (o *OptionalInt) Set(s string) error {
+	if s == "false" {
+		o.IsPresent = false
+
+		return nil
+	}
+
+	o.IsPresent = true
+	if s == "true" {
+		o.HasValue = false
+
+		return nil
+	}
+
+	v, err := strconv.Atoi(s)
+	if err != nil {
+		return fmt.Errorf("invalid line number: %q", s)
+	}
+
+	if v < 0 {
+		return fmt.Errorf("line number must be non-negative: %d", v)
+	}
+
+	o.Value = v
+	o.HasValue = true
+
+	return nil
+}
+
+func (o *OptionalInt) String() string {
+	if o == nil || !o.IsPresent {
+		return ""
+	}
+
+	if !o.HasValue {
+		return "true"
+	}
+
+	return strconv.Itoa(o.Value)
+}
+
+func (o *OptionalInt) IsBoolFlag() bool { return true }
 
 // ShowFlags returns the flags for the show command.
 // Exported to re-use in main for the default command.
@@ -18,10 +70,11 @@ func ShowFlags() []cli.Flag {
 			Aliases: []string{"y"},
 			Usage:   "Always answer yes to yes/no questions",
 		},
-		&cli.BoolFlag{
+		&cli.GenericFlag{
 			Name:    "clip",
 			Aliases: []string{"c"},
-			Usage:   "Copy the password value into the clipboard",
+			Usage:   "Copy the password value into the clipboard. Use -c=N to copy line N (0-indexed)",
+			Value:   &OptionalInt{},
 		},
 		&cli.BoolFlag{
 			Name:    "alsoclip",

--- a/internal/action/context.go
+++ b/internal/action/context.go
@@ -14,7 +14,23 @@ const (
 	ctxKeyAlsoClip
 	ctxKeyPrintChars
 	ctxKeyWithQRBody
+	ctxKeyClipLine
 )
+
+// WithClipLine returns a context with the clip line number set.
+func WithClipLine(ctx context.Context, line int) context.Context {
+	return context.WithValue(ctx, ctxKeyClipLine, line)
+}
+
+// GetClipLine returns the clip line number or -1 if not set.
+func GetClipLine(ctx context.Context) int {
+	iv, ok := ctx.Value(ctxKeyClipLine).(int)
+	if !ok {
+		return -1
+	}
+
+	return iv
+}
 
 // WithClip returns a context with the value for clip (for copy to clipboard)
 // set.

--- a/internal/action/context_test.go
+++ b/internal/action/context_test.go
@@ -67,3 +67,11 @@ func TestWithAlsoClip(t *testing.T) {
 	assert.False(t, IsAlsoClip(ctx))
 	assert.True(t, IsAlsoClip(WithAlsoClip(ctx, true)))
 }
+
+func TestWithClipLine(t *testing.T) {
+	ctx := config.NewContextInMemory()
+
+	assert.Equal(t, -1, GetClipLine(ctx))
+	assert.Equal(t, 0, GetClipLine(WithClipLine(ctx, 0)))
+	assert.Equal(t, 2, GetClipLine(WithClipLine(ctx, 2)))
+}

--- a/internal/action/show.go
+++ b/internal/action/show.go
@@ -24,10 +24,59 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
+func isTrailingFlag(arg string) bool {
+	return arg == "-c" || arg == "--clip" ||
+		strings.HasPrefix(arg, "-c=") || strings.HasPrefix(arg, "--clip=") ||
+		arg == "-C" || arg == "--alsoclip"
+}
+
+func showParseTrailingFlags(ctx context.Context, c *cli.Context) context.Context {
+	for i := 1; i < c.Args().Len(); i++ {
+		arg := c.Args().Get(i)
+
+		var clipVal string
+
+		switch {
+		case arg == "-c" || arg == "--clip":
+			clipVal = "true"
+		case strings.HasPrefix(arg, "-c="):
+			clipVal = strings.TrimPrefix(arg, "-c=")
+		case strings.HasPrefix(arg, "--clip="):
+			clipVal = strings.TrimPrefix(arg, "--clip=")
+		case arg == "-C" || arg == "--alsoclip":
+			ctx = WithAlsoClip(ctx, true)
+			ctx = WithClip(ctx, true)
+
+			continue
+		default:
+			continue
+		}
+
+		ctx = WithOnlyClip(ctx, true)
+		ctx = WithClip(ctx, true)
+
+		if clipVal != "true" && clipVal != "" {
+			line, err := strconv.Atoi(clipVal)
+			if err == nil && line >= 0 {
+				ctx = WithClipLine(ctx, line)
+			}
+		}
+	}
+
+	return ctx
+}
+
 func showParseArgs(c *cli.Context) context.Context {
 	ctx := ctxutil.WithGlobalFlags(c)
 	if c.IsSet("clip") {
-		ctx = WithOnlyClip(ctx, c.Bool("clip"))
+		ctx = WithOnlyClip(ctx, true)
+
+		if v := c.String("clip"); v != "" && v != "true" {
+			line, err := strconv.Atoi(v)
+			if err == nil && line >= 0 {
+				ctx = WithClipLine(ctx, line)
+			}
+		}
 	}
 
 	if c.IsSet("unsafe") {
@@ -90,7 +139,10 @@ func (s *secretHandler) Show(c *cli.Context) error {
 
 	ctx := showParseArgs(c)
 
-	if key := c.Args().Get(1); key != "" {
+	// handle flags appearing after the secret name (e.g. "gopass secret -c").
+	ctx = showParseTrailingFlags(ctx, c)
+
+	if key := c.Args().Get(1); key != "" && !isTrailingFlag(key) {
 		debug.Log("Adding key to ctx: %s", key)
 		ctx = WithKey(ctx, key)
 	}
@@ -267,6 +319,16 @@ func (s *secretHandler) showGetContent(ctx context.Context, sec gopass.Secret) (
 	pw := sec.Password()
 	// fallback for old MIME secrets.
 	fullBody := strings.TrimPrefix(string(sec.Bytes()), secrets.Ident+"\n")
+
+	// Select a specific line if -c=N was provided.
+	if line := GetClipLine(ctx); line >= 0 {
+		lines := strings.Split(strings.TrimRight(fullBody, "\n"), "\n")
+		if line >= len(lines) {
+			return "", "", exit.Error(exit.NotFound, nil, "line %d does not exist (valid range: 0-%d)", line, len(lines)-1)
+		}
+
+		pw = lines[line]
+	}
 
 	if IsQRBody(ctx) {
 		return pw, fullBody, nil

--- a/internal/action/show_test.go
+++ b/internal/action/show_test.go
@@ -296,6 +296,66 @@ func TestShowMulti(t *testing.T) {
 	})
 }
 
+func TestShowClipLine(t *testing.T) {
+	u := gptest.NewUnitTester(t)
+
+	ctx := config.NewContextInMemory()
+	ctx = ctxutil.WithAlwaysYes(ctx, true)
+	ctx = ctxutil.WithTerminal(ctx, false)
+	ctx = ctxutil.WithInteractive(ctx, false)
+
+	act, err := newMock(ctx, u.StoreDir(""))
+	require.NoError(t, err)
+	require.NotNil(t, act)
+	ctx = act.cfg.WithConfig(ctx)
+
+	color.NoColor = true
+	buf := &bytes.Buffer{}
+	out.Stdout = buf
+	out.Stderr = buf
+	stdout = buf
+	defer func() {
+		out.Stdout = os.Stdout
+		out.Stderr = os.Stderr
+		stdout = os.Stdout
+	}()
+
+	// Create a multiline secret.
+	sec := secrets.NewAKV()
+	sec.SetPassword("password0")
+	require.NoError(t, sec.Set("user", "admin"))
+	require.NoError(t, act.Store.Set(ctx, "multiline", sec))
+	buf.Reset()
+
+	t.Run("show -c=0 copies line 0 (password)", func(t *testing.T) {
+		c := gptest.CliCtxWithFlags(ctx, t, map[string]string{"clip": "0"}, "multiline")
+		require.NoError(t, act.Show(c))
+		// OnlyClip suppresses output.
+		assert.NotContains(t, buf.String(), "password0")
+		buf.Reset()
+	})
+
+	t.Run("show -c=1 copies line 1", func(t *testing.T) {
+		c := gptest.CliCtxWithFlags(ctx, t, map[string]string{"clip": "1"}, "multiline")
+		require.NoError(t, act.Show(c))
+		assert.NotContains(t, buf.String(), "user")
+		buf.Reset()
+	})
+
+	t.Run("show -c=99 out of range returns error", func(t *testing.T) {
+		c := gptest.CliCtxWithFlags(ctx, t, map[string]string{"clip": "99"}, "multiline")
+		require.Error(t, act.Show(c))
+		buf.Reset()
+	})
+
+	t.Run("show -c (no line number) copies password", func(t *testing.T) {
+		c := gptest.CliCtxWithFlags(ctx, t, map[string]string{"clip": "true"}, "multiline")
+		require.NoError(t, act.Show(c))
+		assert.NotContains(t, buf.String(), "password0")
+		buf.Reset()
+	})
+}
+
 func TestShowAutoClip(t *testing.T) {
 	// make sure we consistently get the unsupported error message
 	ov := clipboard.ForceUnsupported

--- a/tests/gptest/utils.go
+++ b/tests/gptest/utils.go
@@ -54,13 +54,42 @@ func CliCtxWithFlags(ctx context.Context, t *testing.T, flags map[string]string,
 	return c
 }
 
+// optionalIntValue is a test-only flag.Value that mirrors
+// action.OptionalInt for use in test flag sets. It implements
+// IsBoolFlag so the flag parser treats it as a boolean when
+// no value is provided via the = syntax.
+type optionalIntValue struct {
+	raw string
+}
+
+func (o *optionalIntValue) Set(s string) error {
+	o.raw = s
+
+	return nil
+}
+
+func (o *optionalIntValue) String() string {
+	return o.raw
+}
+
+func (o *optionalIntValue) IsBoolFlag() bool { return true }
+
 func flagset(t *testing.T, flags map[string]string, args []string) *flag.FlagSet {
 	t.Helper()
 
 	fs := flag.NewFlagSet("default", flag.ContinueOnError)
 
 	for k, v := range flags {
-		if v == "true" || v == "false" {
+		// The clip flag uses a GenericFlag with OptionalInt in
+		// production. Mirror that here so c.Generic("clip") works.
+		if k == "clip" {
+			f := cli.GenericFlag{
+				Name:  k,
+				Usage: k,
+				Value: &optionalIntValue{},
+			}
+			require.NoError(t, f.Apply(fs))
+		} else if v == "true" || v == "false" {
 			f := cli.BoolFlag{
 				Name:  k,
 				Usage: k,


### PR DESCRIPTION
Allow copying a specific line to the clipboard using `-c=N`.

```bash
gopass show -c secret         # copies password, same as today
gopass show -c=2 secret       # copies line 2
gopass show secret -c=2       # flag after secret also works
```

## Notes

- 0-indexed
- `=` syntax required (`-c=2`, not `-c 2`)
- Reuses `-c` via `GenericFlag` + `IsBoolFlag()` instead of a separate `--line` flag.
- Trailing flags: `gopass secret -c` now works.
- Invalid values: (e.g. `-c=abc`) fall back to bare clip; out-of-range reports the valid range.

Fixes #2884