### PR TITLE
fix: recover from panic during shell completion with unknown flags

### DIFF
--- a/main.go
+++ b/main.go
@@ -89,7 +89,7 @@ func main() {
 	ctx = queue.WithQueue(ctx, q)
 	ctx, app := setupApp(ctx, sv)
 
-	if err := app.RunContext(ctx, os.Args); err != nil {
+	if err := runApp(ctx, app); err != nil {
 		log.Fatal(err)
 	}
 
@@ -99,6 +99,27 @@ func main() {
 	writeMemProfile()
 
 	debug.Log("gopass %s shutting down ...\n\n", sv.String())
+}
+
+func runApp(ctx context.Context, app *cli.App) error {
+	// recover from nil pointer panics in urfave/cli during shell completion.
+	if isShellCompletion() {
+		defer func() {
+			recover() //nolint:errcheck
+		}()
+	}
+
+	return app.RunContext(ctx, os.Args)
+}
+
+func isShellCompletion() bool {
+	for _, arg := range os.Args {
+		if arg == "--generate-bash-completion" {
+			return true
+		}
+	}
+
+	return false
 }
 
 //nolint:wrapcheck


### PR DESCRIPTION
Work around a nil `FlagSet` dereference in [`urfave/cli`](https://github.com/urfave/cli) that crashes gopass during tab-completion with unknown flags.

e.g.
```
gopass --something<TAB>
```

The `recover()` only activates during shell completion, normal usage is unaffected. Will submit a follow-up to remove this once the upstream gets fixed.