### PR TITLE
fix(setup): suppress auto-commit in gitfs

### DIFF
--- a/internal/action/setup.go
+++ b/internal/action/setup.go
@@ -318,6 +318,9 @@ func (s *setupHandler) initLocal(ctx context.Context, remote string) error {
 	}
 
 	out.Printf(ctx, "🌟 Configuring your password store ...")
+	if remote != "" {
+		ctx = ctxutil.WithSetupRemote(ctx, remote)
+	}
 	if err := s.init(ctxutil.WithHidden(ctx, true), "", path); err != nil {
 		return fmt.Errorf("failed to init local store: %w", err)
 	}

--- a/internal/backend/storage/gitfs/git.go
+++ b/internal/backend/storage/gitfs/git.go
@@ -126,6 +126,12 @@ func Init(ctx context.Context, path, userName, userEmail string) (*Git, error) {
 		return g, nil
 	}
 
+	if ctxutil.HasSetupRemote(ctx) {
+		debug.Log("Skipping auto-commit during setup with specified remote")
+
+		return g, nil
+	}
+
 	if err := g.Commit(ctx, "Add current content of password store"); err != nil {
 		return g, fmt.Errorf("failed to commit changes to git: %w", err)
 	}

--- a/internal/backend/storage/gitfs/git_test.go
+++ b/internal/backend/storage/gitfs/git_test.go
@@ -121,3 +121,57 @@ func TestParseVersion(t *testing.T) {
 		})
 	}
 }
+
+// TestInitWithSetupRemoteSuppressesCommit verifies that Init does not create
+// an automatic commit when HasSetupRemote is set in the context.
+func TestInitWithSetupRemoteSuppressesCommit(t *testing.T) {
+	td := t.TempDir()
+	gitdir := filepath.Join(td, "git-no-commit")
+	require.NoError(t, os.Mkdir(gitdir, 0o755))
+
+	ctx := config.NewContextInMemory()
+	ctx = ctxutil.WithAlwaysYes(ctx, true)
+	ctx = ctxutil.WithSetupRemote(ctx, "https://example.com/repo.git")
+
+	buf := &bytes.Buffer{}
+	out.Stdout = buf
+	defer func() { out.Stdout = os.Stdout }()
+
+	// Create a file so there would be staged changes to commit.
+	tf := filepath.Join(gitdir, "password")
+	require.NoError(t, os.WriteFile(tf, []byte("hunter2\n"), 0o644))
+
+	git, err := Init(ctx, gitdir, "Test User", "test@example.com")
+	require.NoError(t, err)
+	require.NotNil(t, git)
+
+	// With the flag set, the commit must have been suppressed.
+	// The staged file should still be outstanding (no commit was made).
+	assert.True(t, git.HasStagedChanges(ctx), "expected staged changes to remain when setup remote suppresses commit")
+}
+
+// TestInitWithoutSetupRemoteCreatesCommit verifies the existing (default)
+// behaviour: Init still creates the initial commit when no setup remote is set.
+func TestInitWithoutSetupRemoteCreatesCommit(t *testing.T) {
+	td := t.TempDir()
+	gitdir := filepath.Join(td, "git-with-commit")
+	require.NoError(t, os.Mkdir(gitdir, 0o755))
+
+	ctx := config.NewContextInMemory()
+	ctx = ctxutil.WithAlwaysYes(ctx, true)
+
+	buf := &bytes.Buffer{}
+	out.Stdout = buf
+	defer func() { out.Stdout = os.Stdout }()
+
+	// Create a file so there are staged changes.
+	tf := filepath.Join(gitdir, "password")
+	require.NoError(t, os.WriteFile(tf, []byte("hunter2\n"), 0o644))
+
+	git, err := Init(ctx, gitdir, "Test User", "test@example.com")
+	require.NoError(t, err)
+	require.NotNil(t, git)
+
+	// Without the flag the initial commit should have been created.
+	assert.False(t, git.HasStagedChanges(ctx), "expected no staged changes after automatic commit")
+}

--- a/pkg/ctxutil/ctxutil.go
+++ b/pkg/ctxutil/ctxutil.go
@@ -58,6 +58,9 @@ type ExecConfig struct {
 	// to provide a password for the age encryption backend without interactive
 	// prompts (e.g. in CI/CD pipelines or tests).
 	AgePassphrase string
+	// SetupRemote is set to the remote URL when a git remote is specified during
+	// setup, signalling that the automatic initial commit should be suppressed.
+	SetupRemote string
 }
 
 // WithExecConfig stores e in ctx and returns the updated context.
@@ -470,4 +473,19 @@ func IsHidden(ctx context.Context) bool {
 	}
 
 	return false
+}
+
+// WithSetupRemote returns a context with the remote URL stored for use during
+// "gopass setup". When non-empty it signals that the automatic initial commit
+// in gitfs.Init() should be suppressed.
+func WithSetupRemote(ctx context.Context, remote string) context.Context {
+	e := GetExecConfig(ctx)
+	e.SetupRemote = remote
+
+	return WithExecConfig(ctx, e)
+}
+
+// HasSetupRemote returns true if a non-empty setup remote was stored in ctx.
+func HasSetupRemote(ctx context.Context) bool {
+	return GetExecConfig(ctx).SetupRemote != ""
 }

--- a/pkg/ctxutil/ctxutil_test.go
+++ b/pkg/ctxutil/ctxutil_test.go
@@ -192,3 +192,13 @@ func TestHidden(t *testing.T) {
 	assert.False(t, IsHidden(ctx))
 	assert.True(t, IsHidden(WithHidden(ctx, true)))
 }
+
+func TestSetupRemote(t *testing.T) {
+	t.Parallel()
+
+	ctx := config.NewContextInMemory()
+
+	assert.False(t, HasSetupRemote(ctx))
+	assert.True(t, HasSetupRemote(WithSetupRemote(ctx, "https://example.com/repo.git")))
+	assert.False(t, HasSetupRemote(WithSetupRemote(ctx, "")))
+}


### PR DESCRIPTION
suppress auto-commit in gitfs when setup remote is specified

Fixes #2901