### PR TITLE
fix(copy): preserve directory structure when copying with trailing slash

### DIFF
--- a/internal/action/copy.go
+++ b/internal/action/copy.go
@@ -3,11 +3,8 @@ package action
 import (
 	"context"
 	"fmt"
-	"path/filepath"
-	"strings"
 
 	"github.com/gopasspw/gopass/internal/action/exit"
-	"github.com/gopasspw/gopass/internal/tree"
 	"github.com/gopasspw/gopass/pkg/ctxutil"
 	"github.com/gopasspw/gopass/pkg/termio"
 	"github.com/urfave/cli/v2"
@@ -43,38 +40,7 @@ func (s *secretHandler) copy(ctx context.Context, from, to string, force bool) e
 		return exit.Error(exit.NotFound, nil, "%s does not exist", from)
 	}
 
-	isSourceDir := s.Store.IsDir(ctx, from)
-	hasTrailingSlash := strings.HasSuffix(to, "/")
-
-	if isSourceDir && hasTrailingSlash {
-		return s.copyFlattenDir(ctx, from, to, force)
-	}
-
 	return s.copyRegular(ctx, from, to, force)
-}
-
-func (s *secretHandler) copyFlattenDir(ctx context.Context, from, to string, force bool) error {
-	entries, err := s.Store.List(ctx, tree.INF)
-	if err != nil {
-		return exit.Error(exit.List, err, "failed to list entries in %q", from)
-	}
-
-	fromPrefix := from
-	if !strings.HasSuffix(fromPrefix, "/") {
-		fromPrefix += "/"
-	}
-
-	for _, entry := range entries {
-		if strings.HasPrefix(entry, fromPrefix) {
-			toPath := filepath.Join(to, filepath.Base(entry))
-
-			if err := s.copyRegular(ctx, entry, toPath, force); err != nil {
-				return err
-			}
-		}
-	}
-
-	return nil
 }
 
 func (s *secretHandler) copyRegular(ctx context.Context, from, to string, force bool) error {

--- a/internal/action/copy_test.go
+++ b/internal/action/copy_test.go
@@ -243,14 +243,15 @@ func TestCopyWithTrailingSlash(t *testing.T) {
 	require.NoError(t, act.Copy(c))
 	buf.Reset()
 
-	// Verify the result
+	// Verify the result: structure should be preserved
 	require.NoError(t, act.List(gptest.CliCtx(ctx, t)))
 	want := `gopass
 ├── bar
 ├── foo
 ├── new/
 │   ├── baz
-│   └── zab
+│   └── some/
+│       └── zab
 └── secret/
     ├── baz
     └── some/
@@ -263,7 +264,7 @@ func TestCopyWithTrailingSlash(t *testing.T) {
 
 	// Verify content of copied files
 	ctx = ctxutil.WithTerminal(ctx, false)
-	require.NoError(t, act.show(ctx, c, "new/zab", false))
+	require.NoError(t, act.show(ctx, c, "new/some/zab", false))
 	assert.Equal(t, "secret\n", buf.String())
 	buf.Reset()
 


### PR DESCRIPTION
Fixes #2912 