### PR TITLE
fix(secparse): replace panic in MustParse with testing.TB.Fatalf

### DIFF
--- a/pkg/gopass/secrets/secparse/parse.go
+++ b/pkg/gopass/secrets/secparse/parse.go
@@ -4,6 +4,7 @@ package secparse
 
 import (
 	"errors"
+	"testing"
 
 	"github.com/gopasspw/gopass/internal/out"
 	"github.com/gopasspw/gopass/pkg/debug"
@@ -52,12 +53,14 @@ func Parse(in []byte) (gopass.Secret, error) {
 	return s, nil
 }
 
-// MustParse parses a secret from a string or panics if an error occurs.
-// This function should only be used for testing purposes.
-func MustParse(in string) gopass.Secret {
+// MustParse parses a secret from a string and calls tb.Fatal if an error occurs.
+// This function must only be used in tests.
+func MustParse(tb testing.TB, in string) gopass.Secret {
+	tb.Helper()
+
 	sec, err := Parse([]byte(in))
 	if err != nil {
-		panic(err)
+		tb.Fatalf("secparse.MustParse: %v", err)
 	}
 
 	return sec

--- a/pkg/otp/otp_test.go
+++ b/pkg/otp/otp_test.go
@@ -62,17 +62,17 @@ func TestGetOTPURL(t *testing.T) {
 	}{
 		{
 			name: "url-only-in-body",
-			sec:  secparse.MustParse(fmt.Sprintf("%s\n%s", pw, totpURL)),
+			sec:  secparse.MustParse(t, fmt.Sprintf("%s\n%s", pw, totpURL)),
 			url:  totpURL,
 		},
 		{
 			name: "url-and-other-text-in-body",
-			sec:  secparse.MustParse(fmt.Sprintf("%s\n%s\nfoo bar\nbaz\n", pw, totpURL)),
+			sec:  secparse.MustParse(t, fmt.Sprintf("%s\n%s\nfoo bar\nbaz\n", pw, totpURL)),
 			url:  totpURL,
 		},
 		{
 			name: "url-in-kvp",
-			sec:  secparse.MustParse(fmt.Sprintf("%s\notpauth: %s\nfoo bar\nbaz\n", pw, totpURL)),
+			sec:  secparse.MustParse(t, fmt.Sprintf("%s\notpauth: %s\nfoo bar\nbaz\n", pw, totpURL)),
 			url:  totpURL,
 		},
 	} {


### PR DESCRIPTION
## Summary

`secparse.MustParse` was exported from a public package (`pkg/gopass/secrets/secparse`) and contained a `panic(err)` that fires on a `*secrets.PermanentError` from malformed MIME input. Although the function was documented as test-only, the panic was reachable from any caller — including non-test code that imports the package.

- Replace `panic(err)` with `tb.Fatalf(...)`, using a `testing.TB` parameter
- Add `tb.Helper()` so test failure lines point to the call site, not inside `MustParse`
- Update the three call sites in `pkg/otp/otp_test.go` to pass `t`

The `testing.TB` parameter type-enforces test-only use: production code cannot call this function without a `testing.TB` value, making the intent structurally clear rather than just a comment.

## Test plan

- [x] `go build ./pkg/gopass/secrets/secparse/...` — clean
- [x] `go test ./pkg/otp/...` — passes
- [x] `go test ./pkg/gopass/secrets/...` — passes