### PR TITLE
docs(appdir): explain GOPASS_HOMEDIR override in UserHome comment

### DIFF
--- a/pkg/appdir/appdir.go
+++ b/pkg/appdir/appdir.go
@@ -50,8 +50,13 @@ func UserData() string {
 	return DefaultAppdir.UserData()
 }
 
-// UserHome returns the user's home dir.
-// It respects the GOPASS_HOMEDIR environment variable.
+// UserHome returns the user's home directory.
+//
+// If GOPASS_HOMEDIR is set it overrides the OS home dir lookup. This variable
+// exists to allow hermetic test environments and CI runs to redirect all gopass
+// data paths without modifying the real user profile. It should not be set in
+// normal production use; doing so silently redirects every config, cache, and
+// data path to the specified directory.
 func UserHome() string {
 	if hd := os.Getenv("GOPASS_HOMEDIR"); hd != "" {
 		return hd


### PR DESCRIPTION
## Summary

`pkg/appdir/appdir.go` — `UserHome()` silently overrides the OS home directory when `GOPASS_HOMEDIR` is set. The existing one-line comment said only "It respects the GOPASS_HOMEDIR environment variable," giving a security auditor no context for why a password manager binary honours an environment variable that redirects all data paths.

The expanded comment explains:
- The variable exists for hermetic test and CI environments
- It should not be set in normal production use
- Setting it silently redirects every config, cache, and data path

No behaviour change.

## Test plan

- [x] `go build ./pkg/appdir/...` — clean
- [x] `go vet ./pkg/appdir/...` — clean