### PR TITLE
docs(architecture): add API Stability section clarifying module semver policy

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -42,6 +42,24 @@ change in the API require a major version bump even if nothing about the tool
 apply semantic versioning only to the CLI tool, not the Go module. This is not
 ideal and might change with sufficient active contributors.
 
+## API Stability
+
+Semantic versioning applies to the **gopass CLI binary** only. The Go module
+(`github.com/gopasspw/gopass`) does not carry independent semver guarantees:
+a breaking change to `pkg/` interfaces may ship without a major-version bump.
+
+`pkg/gopass/doc.go` carries an explicit instability warning for this reason.
+Until that warning is removed, consumers of `pkg/gopass` should:
+
+- Pin to a specific commit or tag rather than a `@latest` reference.
+- Review the `CHANGELOG.md` `pkg/` entries before upgrading.
+- Treat any `pkg/` type or function change as potentially breaking.
+
+The intention is to formalise this contract (via a `v2` module path or a
+published compatibility window) once the active contributor base grows
+sufficiently to maintain that commitment. See issue #3414 for the open
+decision on the API stability ADR.
+
 ### `docs/backends`
 
 This folder contains documentation about each of our supported backends. See


### PR DESCRIPTION
## Summary

`ARCHITECTURE.md` already noted that semver applies to the CLI only and called it "not ideal," but gave consumers of `pkg/gopass` no actionable guidance on how to protect themselves from silent breaking changes.

This PR adds an **API Stability** section (inserted between the semver note and `### docs/backends`) that:

- States the current policy explicitly: no module-level semver guarantee
- Points to `pkg/gopass/doc.go`'s existing instability warning as the canonical signal
- Gives three concrete steps for consumers (pin, watch CHANGELOG, treat all pkg/ changes as potentially breaking)
- Links to issue #3414 where the longer-term ADR decision is tracked

No behaviour change. Documentation only.

## Test plan

- [x] Markdown renders correctly — section sits between the semver note and `### docs/backends`
- [x] No broken links