### PR TITLE
fix: store mount paths relative to home dir for cross-platform portab…

### DIFF
--- a/internal/action/config_test.go
+++ b/internal/action/config_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gopasspw/gopass/internal/config"
 	"github.com/gopasspw/gopass/internal/out"
 	"github.com/gopasspw/gopass/pkg/ctxutil"
+	"github.com/gopasspw/gopass/pkg/fsutil"
 	"github.com/gopasspw/gopass/tests/gptest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -50,7 +51,7 @@ core.nopager = true
 core.notifications = true
 generate.autoclip = true
 `
-		want += "mounts.path = " + u.StoreDir("") + "\n" +
+		want += "mounts.path = " + fsutil.ShrinkPath(u.StoreDir("")) + "\n" +
 			"pwgen.xkcd-lang = en\n"
 		assert.Equal(t, want, buf.String())
 	})
@@ -96,7 +97,7 @@ core.nopager = true
 core.notifications = true
 generate.autoclip = true
 `
-		want += "mounts.path = " + u.StoreDir("") + "\n" +
+		want += "mounts.path = " + fsutil.ShrinkPath(u.StoreDir("")) + "\n" +
 			"pwgen.xkcd-lang = en\n"
 
 		assert.Equal(t, want, buf.String(), "action.printConfigValues")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/gopasspw/gitconfig"
 	"github.com/gopasspw/gopass/pkg/debug"
+	"github.com/gopasspw/gopass/pkg/fsutil"
 )
 
 const (
@@ -123,7 +124,13 @@ func newWithOptions(noWrites bool) *Config {
 		}
 	}
 	// load again, this might add a per-store config from the root store
-	c.root.LoadAll(rootPath)
+	// expand ~ in rootPath before passing to LoadAll since the gitconfig
+	// library does not perform tilde expansion
+	if rootPath != "" {
+		c.root.LoadAll(fsutil.CleanPath(rootPath))
+	} else {
+		c.root.LoadAll("")
+	}
 	c.root.NoWrites = noWrites
 
 	if rootPath := c.root.Get("mounts.path"); rootPath == "" {
@@ -260,22 +267,22 @@ func (c *Config) SetEnv(key, value string) error {
 
 // Path returns the root store path.
 func (c *Config) Path() string {
-	return c.Get("mounts.path")
+	return fsutil.CleanPath(c.Get("mounts.path"))
 }
 
 // MountPath returns the mount store path.
 func (c *Config) MountPath(mountPoint string) string {
-	return c.Get(mpk(mountPoint))
+	return fsutil.CleanPath(c.Get(mpk(mountPoint)))
 }
 
 // SetPath is a shortcut to set the root store path.
 func (c *Config) SetPath(path string) error {
-	return c.Set("", "mounts.path", path)
+	return c.Set("", "mounts.path", fsutil.ShrinkPath(path))
 }
 
 // SetMountPath is a shortcut to set a mount to a path.
 func (c *Config) SetMountPath(mount, path string) error {
-	return c.Set("", mpk(mount), path)
+	return c.Set("", mpk(mount), fsutil.ShrinkPath(path))
 }
 
 // mpk for mountPathKey.

--- a/pkg/fsutil/fsutil.go
+++ b/pkg/fsutil/fsutil.go
@@ -47,7 +47,7 @@ func CleanPath(path string) string {
 	// to the user's homedir to be replaced with one of these two values.
 	if len(path) > 1 && path[:2] == "~/" {
 		if hd := os.Getenv("GOPASS_HOMEDIR"); hd != "" {
-			return filepath.Clean(hd + path[2:])
+			return filepath.Clean(hd + path[1:])
 		}
 
 		if home, err := os.UserHomeDir(); err == nil {
@@ -60,6 +60,28 @@ func CleanPath(path string) string {
 	}
 
 	return filepath.Clean(path)
+}
+
+// ShrinkPath replaces the leading home directory in path with a tilde (~).
+// If GOPASS_HOMEDIR is set it is used as the home directory reference; otherwise
+// os.UserHomeDir is consulted. This makes paths portable across machines when
+// stored in config files that are shared/synced across platforms.
+func ShrinkPath(path string) string {
+	if hd := os.Getenv("GOPASS_HOMEDIR"); hd != "" {
+		if rel, err := filepath.Rel(hd, path); err == nil && !strings.HasPrefix(rel, "..") {
+			return "~/" + filepath.ToSlash(rel)
+		}
+
+		return path
+	}
+
+	if home, err := os.UserHomeDir(); err == nil {
+		if rel, err := filepath.Rel(home, path); err == nil && !strings.HasPrefix(rel, "..") {
+			return "~/" + filepath.ToSlash(rel)
+		}
+	}
+
+	return path
 }
 
 // IsDir checks if a certain path exists and is a directory.

--- a/pkg/fsutil/fsutil_test.go
+++ b/pkg/fsutil/fsutil_test.go
@@ -57,6 +57,39 @@ func TestCleanPath(t *testing.T) {
 	}
 }
 
+func TestCleanPathWithGopassHomedir(t *testing.T) {
+	tempdir := t.TempDir()
+	t.Setenv("GOPASS_HOMEDIR", tempdir)
+
+	// ~/.local/... must expand to $GOPASS_HOMEDIR/.local/..., not $GOPASS_HOMEDIR.local/...
+	assert.Equal(t, filepath.Join(tempdir, ".local", "share"), CleanPath("~/.local/share"))
+	assert.Equal(t, filepath.Join(tempdir, ".password-store"), CleanPath("~/.password-store"))
+}
+
+func TestShrinkPath(t *testing.T) {
+	tempdir := t.TempDir()
+
+	t.Run("with GOPASS_HOMEDIR", func(t *testing.T) {
+		t.Setenv("GOPASS_HOMEDIR", tempdir)
+
+		assert.Equal(t, "~/.local/share/gopass", ShrinkPath(filepath.Join(tempdir, ".local", "share", "gopass")))
+		assert.Equal(t, "~/.password-store", ShrinkPath(filepath.Join(tempdir, ".password-store")))
+		// path outside GOPASS_HOMEDIR should be returned as-is
+		assert.Equal(t, "/tmp/other", ShrinkPath("/tmp/other"))
+	})
+
+	t.Run("without GOPASS_HOMEDIR", func(t *testing.T) {
+		t.Setenv("GOPASS_HOMEDIR", "")
+
+		home, err := os.UserHomeDir()
+		require.NoError(t, err)
+
+		assert.Equal(t, "~/.local/share/gopass", ShrinkPath(filepath.Join(home, ".local", "share", "gopass")))
+		// path outside home dir should be returned as-is
+		assert.Equal(t, "/tmp/other", ShrinkPath("/tmp/other"))
+	})
+}
+
 func TestIsDir(t *testing.T) {
 	t.Parallel()
 

--- a/tests/config_test.go
+++ b/tests/config_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gopasspw/gopass/pkg/fsutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -81,7 +82,7 @@ core.exportkeys = false
 core.follow-references = false
 core.notifications = true
 `
-	wanted += "mounts.mnt/m1.path = " + ts.storeDir("m1") + "\n"
+	wanted += "mounts.mnt/m1.path = " + fsutil.ShrinkPath(ts.storeDir("m1")) + "\n"
 	wanted += "mounts.path = " + ts.storeDir("root") + "\n"
 	wanted += "pwgen.xkcd-lang = en\n"
 	wanted += "recipients.mnt/m1.hash = 9a4c4b1e0eb9ade2e692ff948f43d9668145eca3df88ffff67e0e21426252907\n"


### PR DESCRIPTION
…ility

Fixes #2897.

Two bugs were present:

1. CleanPath in pkg/fsutil incorrectly expanded ~/... when GOPASS_HOMEDIR was set: it used path[2:] (stripping both '~' and '/'), concatenating without a path separator. E.g. '~/.local' with GOPASS_HOMEDIR=/foo became '/foo.local' instead of '/foo/.local'. Fix: use path[1:] to keep the separator, matching the existing os.UserHomeDir branch.

2. Absolute paths were written to config for [mounts] path entries, making configs non-portable across machines/platforms when synced.

Fix:
- Add ShrinkPath() to pkg/fsutil: converts an absolute path back to a ~/... relative form when it falls under GOPASS_HOMEDIR (if set) or the user home directory. This makes stored paths portable.
- Call ShrinkPath() in Config.SetPath() and Config.SetMountPath() so paths are always persisted in ~/... form.
- Apply CleanPath() in Config.Path() and Config.MountPath() so callers always receive a fully-expanded absolute path regardless of what is stored on disk.
- Expand rootPath via CleanPath() in newWithOptions() before passing it to gitconfig.LoadAll(), since the gitconfig library does not perform tilde expansion. Without this the root store local config was loaded from a literal '~/' directory relative to the working directory.