### PR TITLE
fix: update bash completion flag for urfave/cli/v3 compatibility

### DIFF
--- a/bash.completion
+++ b/bash.completion
@@ -3,7 +3,7 @@ _gopass_bash_autocomplete() {
      COMPREPLY=()
      cur="${COMP_WORDS[COMP_CWORD]}"
      # Use error handling to prevent crashes from invalid flags
-     opts=$( ${COMP_WORDS[@]:0:$COMP_CWORD} --generate-bash-completion 2>/dev/null ) || opts=""
+     opts=$( ${COMP_WORDS[@]:0:$COMP_CWORD} --generate-shell-completion 2>/dev/null ) || opts=""
      local IFS=$'\n'
      COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
      return 0

--- a/internal/action/completion.go
+++ b/internal/action/completion.go
@@ -86,7 +86,7 @@ func (s *miscHandler) CompletionBash(ctx context.Context, cmd *cli.Command) erro
      COMPREPLY=()
      cur="${COMP_WORDS[COMP_CWORD]}"
      # Use error handling to prevent crashes from invalid flags
-     opts=$( ${COMP_WORDS[@]:0:$COMP_CWORD} --generate-bash-completion 2>/dev/null ) || opts=""
+     opts=$( ${COMP_WORDS[@]:0:$COMP_CWORD} --generate-shell-completion 2>/dev/null ) || opts=""
      local IFS=$'\n'
      COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
      return 0

--- a/main.go
+++ b/main.go
@@ -110,7 +110,7 @@ func runApp(ctx context.Context, app *cli.Command) error {
 
 func isShellCompletion() bool {
 	for _, arg := range os.Args {
-		if arg == "--generate-bash-completion" {
+		if arg == "--generate-shell-completion" {
 			return true
 		}
 	}

--- a/tests/completion_test.go
+++ b/tests/completion_test.go
@@ -29,7 +29,7 @@ func TestCompletion(t *testing.T) {
      COMPREPLY=()
      cur="${COMP_WORDS[COMP_CWORD]}"
      # Use error handling to prevent crashes from invalid flags
-     opts=$( ${COMP_WORDS[@]:0:$COMP_CWORD} --generate-bash-completion 2>/dev/null ) || opts=""
+     opts=$( ${COMP_WORDS[@]:0:$COMP_CWORD} --generate-shell-completion 2>/dev/null ) || opts=""
      local IFS=$'\n'
      COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
      return 0


### PR DESCRIPTION
urfave/cli/v3 renamed the shell completion trigger flag from --generate-bash-completion to --generate-shell-completion.

Fixes #3440