### PR TITLE
fix: warn when recipient key is expired or unusable during encryption

### DIFF
--- a/docs/adr/A-13-expired-gpg-key-handling.md
+++ b/docs/adr/A-13-expired-gpg-key-handling.md
@@ -1,0 +1,165 @@
+# A-13: Expired GPG Key Handling and Recipient Validity Warnings
+
+**Status:** partially implemented — core silent-drop warning shipped; remaining work tracked below  
+**Source:** [GitHub Issue #2885](https://github.com/gopasspw/gopass/issues/2885)
+
+---
+
+## Background
+
+When a recipient's GPG key expires, gopass silently drops that recipient from
+the encryption target list. Secrets written after the key expires can no
+longer be decrypted by that recipient. Neither the writing user nor the
+affected recipient receives any notification that this happened.
+
+The encryption path is:
+
+```
+Set() → useableKeys() → FindRecipients() → [expired key silently filtered]
+      → Encrypt(filtered_list)            [warning in Encrypt() never fires]
+```
+
+`FindRecipients()` calls `KeyList.UseableKeys()`, which returns only keys
+whose `ExpirationDate` is either zero or in the future. The difference between
+the original recipient list and the returned key list was never surfaced to the
+user.
+
+An existing `CheckRecipients()` function in `internal/store/leaf/recipients.go`
+already performs the correct per-recipient check and is called before
+`RecipientsAdd`, but was not called on the write path.
+
+---
+
+## Implemented fix (this branch)
+
+`useableKeys()` in `internal/store/leaf/store.go` now iterates over the
+original recipient list and, for each recipient that `FindRecipients` returns
+no useable key for, emits an `out.Warningf` message naming that recipient.
+The return value (the filtered key list used for encryption) is unchanged.
+
+`Encrypt()` in `internal/backend/crypto/gpg/cli/encrypt.go` was also updated
+to use `out.Warningf` instead of `out.Printf` for its own per-recipient check,
+so the severity is correct if that path is ever reached.
+
+A regression test (`TestSetWarnsAboutInvalidRecipient`) was added to
+`internal/store/leaf/write_test.go`.
+
+---
+
+## Remaining work
+
+### R-1: Add recipient key-expiry check to `gopass audit`
+
+**Problem:** `gopass audit` checks only password strength (crunchy, HIBP). It
+does not check whether any recipient's key is expired or about to expire.
+A team could run `gopass audit` regularly and still have no indication that
+a re-encryption silently excluded a recipient.
+
+**Recommendation:** Add a recipient-validity check to `internal/audit/`. The
+`Auditor` type already has a `secretGetter` interface; a separate
+`RecipientAuditor` (or an additional pass in the existing `Batch` method) could:
+
+1. Collect the union of all recipient IDs across all secrets (or from the
+   `.gpg-id` files) without decrypting anything.
+2. Call `crypto.FindRecipients(ctx, id)` for each one.
+3. Report any ID with no useable key as an error and any ID whose
+   `ExpirationDate` is within a configurable window (default 60 days) as a
+   warning.
+
+This requires plumbing a `Crypto` backend reference into the audit path, which
+the current `secretGetter` interface does not expose. A separate interface or
+an `Auditor` constructor parameter is the cleanest extension point.
+
+**Configuration key (proposed):** `audit.recipient-expiry-warning-days`
+(default `60`; `0` disables the check).
+
+---
+
+### R-2: Proactive expiry warning on sync and fsck
+
+**Problem:** Users learn that a key has expired only when they attempt to
+write a secret. There is no early warning before expiry, and no warning to
+the affected recipient when they pull a store that now contains secrets they
+cannot decrypt.
+
+**Recommendation:**
+
+- In `gopass sync` (`internal/action/sync.go`) and `gopass fsck`
+  (`internal/store/leaf/fsck.go`), call a lightweight
+  `CheckRecipientExpiry(ctx, warningDays int)` helper (to be added to
+  `internal/store/leaf/recipients.go`) that:
+  1. Loads all recipient IDs from the store's `.gpg-id` files.
+  2. Looks up each key via `FindRecipients`.
+  3. For keys that are already expired: `out.Warningf`.
+  4. For keys expiring within `warningDays`: `out.Warningf` including the
+     expiry date and the recovery instructions (see R-3).
+
+- The check must be cheap: it reads only the local keyring and `.gpg-id`
+  files; no network calls or decryption.
+
+**Configuration key (proposed):** `core.recipient-expiry-warning-days`
+(default `60`; `0` disables). Distinct from the audit key so that the two
+features can be tuned independently.
+
+---
+
+### R-3: Document the key-refresh recovery flow
+
+**Problem:** The recovery path when a key has expired is not obvious. The
+issue reporter required a multi-step manual process. A simpler path already
+exists but is undocumented:
+
+1. Recipient L extends the key expiry locally: `gpg --edit-key <L>` → `expire`.
+2. L exports the updated key: `gpg -a --export <L> > L.pub.asc`.
+3. L replaces `.public-keys/<L>` in the store with the new export, commits,
+   and pushes.
+4. Any other recipient A runs `gopass recipients add <L>` (the existing
+   `AddRecipient` handler already asks for confirmation to re-encrypt when the
+   key is already in the store).
+
+Step 4 is the re-encryption trigger. Gopass already supports this workflow;
+it just needs to be documented.
+
+**Recommendation:**
+
+- Add a section "Recipient key expiry" to `docs/commands/recipients.md`
+  describing the flow above.
+- Update the warning message emitted by R-1/R-2 to include a short hint, e.g.:
+  `"Run 'gopass recipients add <id>' after the key is refreshed to re-encrypt."`.
+
+---
+
+### R-4: Detect that the committed public key differs from the local keyring
+
+**Problem:** A recipient may extend their key locally and not update the copy
+in `.public-keys/`. Conversely, another recipient may import an updated key
+from `.public-keys/` while the local keyring still has the old (expired)
+version. In both cases gopass has no way to tell the user that the two copies
+are out of sync.
+
+**Recommendation:** In `gopass fsck` or `gopass recipients`, compare the
+`ExpirationDate` of the key stored in `.public-keys/<id>` against the key
+in the local GPG keyring. If they differ by more than a negligible delta
+(suggest: one day), emit a warning.
+
+This requires parsing the armored public key from `.public-keys/` without
+importing it, which can be done with `golang.org/x/crypto/openpgp` or
+`github.com/ProtonMail/go-crypto/openpgp` (already an indirect dependency via
+the age backend). Care must be taken not to introduce a new direct dependency
+on a CGo package; `go-crypto` is pure Go.
+
+---
+
+## Rejected alternatives
+
+**Return an error from `Set()` when a recipient is dropped:** This would be a
+breaking behaviour change. Existing stores that happen to have stale recipient
+entries (e.g. a team member who has left) would become unwritable. A warning
+is the correct signal; the operator must decide whether to remove the recipient
+or refresh the key.
+
+**Block writes entirely when any recipient has no useable key:** Same objection
+as above. A `--strict` flag could be added later if there is demand.
+
+**Check every recipient on every read (Get):** Unnecessary overhead; expiry
+affects the write path only.

--- a/internal/backend/crypto/gpg/cli/encrypt.go
+++ b/internal/backend/crypto/gpg/cli/encrypt.go
@@ -42,7 +42,7 @@ func (g *GPG) Encrypt(ctx context.Context, plaintext []byte, recipients []string
 			badRecipients = append(badRecipients, r)
 			errmsg := fmt.Sprintf("Not using invalid key %q for encryption. Check its expiration date, its encryption capabilities and trust.", r)
 			debug.Log(errmsg)
-			out.Printf(ctx, errmsg)
+			out.Warningf(ctx, errmsg)
 
 			continue
 		}

--- a/internal/store/leaf/store.go
+++ b/internal/store/leaf/store.go
@@ -189,6 +189,17 @@ func (s *Store) useableKeys(ctx context.Context, name string) ([]string, error) 
 		return rs.IDs(), nil
 	}
 
+	// Warn explicitly about any recipient whose key is expired or otherwise
+	// unusable. Without this check the recipient is silently dropped from the
+	// encryption target list, making newly-written secrets unreadable to them
+	// without any indication that this happened.
+	for _, r := range rs.IDs() {
+		validKeys, err := s.crypto.FindRecipients(ctx, r)
+		if err != nil || len(validKeys) < 1 {
+			out.Warningf(ctx, "Recipient %q has no useable key (key may be expired or untrusted). This secret will NOT be encrypted for %q.", r, r)
+		}
+	}
+
 	debug.Log("useableKeys: %v", kl)
 
 	return kl, nil

--- a/internal/store/leaf/write_test.go
+++ b/internal/store/leaf/write_test.go
@@ -1,11 +1,19 @@
 package leaf
 
 import (
+	"bytes"
+	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/gopasspw/gopass/internal/backend"
+	_ "github.com/gopasspw/gopass/internal/backend/crypto"
 	"github.com/gopasspw/gopass/internal/backend/crypto/gpg"
+	_ "github.com/gopasspw/gopass/internal/backend/storage"
 	"github.com/gopasspw/gopass/internal/config"
+	"github.com/gopasspw/gopass/internal/out"
 	"github.com/gopasspw/gopass/pkg/gopass/secrets"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -24,4 +32,44 @@ func TestSet(t *testing.T) {
 	require.Error(t, s.Set(ctx, "../../../../../etc/passwd", sec))
 
 	require.NoError(t, s.Set(ctx, "zab", sec))
+}
+
+// TestSetWarnsAboutInvalidRecipient verifies that when a recipient has no
+// useable key (e.g. because it is expired or not present in the keyring),
+// gopass emits a visible warning instead of silently omitting that recipient.
+func TestSetWarnsAboutInvalidRecipient(t *testing.T) {
+	buf := &bytes.Buffer{}
+	oldStderr := out.Stderr
+	out.Stderr = buf
+	t.Cleanup(func() { out.Stderr = oldStderr })
+
+	dir := t.TempDir()
+	sd := filepath.Join(dir, "sub")
+
+	// 0xDEADBEEF is in the plain backend's static key list; 0xBADKEY is not.
+	_, _, err := createStore(sd, []string{"0xDEADBEEF", "0xBADKEY"}, nil)
+	require.NoError(t, err)
+
+	t.Setenv("GOPASS_HOMEDIR", dir)
+	t.Setenv("CHECKPOINT_DISABLE", "true")
+	t.Setenv("GOPASS_NO_NOTIFY", "true")
+	t.Setenv("GOPASS_DISABLE_ENCRYPTION", "true")
+	t.Setenv("GNUPGHOME", filepath.Join(dir, ".gnupg"))
+	require.NoError(t, os.Unsetenv("PAGER"))
+
+	ctx := gpg.WithAlwaysTrust(config.NewContextInMemory(), true)
+	ctx, err = backend.WithCryptoBackendString(ctx, "plain")
+	require.NoError(t, err)
+	ctx, err = backend.WithStorageBackendString(ctx, "fs")
+	require.NoError(t, err)
+
+	s, err := New(ctx, "", sd)
+	require.NoError(t, err)
+
+	sec := secrets.NewAKV()
+	sec.SetPassword("hunter2")
+	require.NoError(t, s.Set(ctx, "test/entry", sec))
+
+	// A warning about the recipient with no useable key must have been printed.
+	assert.Contains(t, buf.String(), "0xBADKEY")
 }


### PR DESCRIPTION
When encrypting a secret, gopass silently dropped any recipient whose GPG key was expired, revoked, or otherwise unusable. The affected recipient had no indication that newly written secrets were no longer encrypted for them, and the writing user received no warning either.

Root cause: useableKeys() in internal/store/leaf/store.go delegates to FindRecipients(), which internally calls KeyList.UseableKeys() and returns only valid fingerprints. The difference between the original recipient list and the filtered result was never surfaced.

Fixes:
- useableKeys() now checks each recipient individually after the batch FindRecipients call and emits an out.Warningf for any recipient with no useable key, naming that recipient explicitly.
- Encrypt() in internal/backend/crypto/gpg/cli/encrypt.go now uses out.Warningf instead of out.Printf for its per-recipient guard, so the severity is correct if that code path is ever reached.
- Added TestSetWarnsAboutInvalidRecipient to verify the warning is emitted.
- Added docs/adr/A-13-expired-gpg-key-handling.md tracking the remaining work (audit integration, proactive expiry warnings, recovery docs, and committed-vs-local key sync detection).

Closes #2885