### PR TITLE
otp: hide --snip flag when built with noscreenshot tag

### DIFF
--- a/internal/action/commands.go
+++ b/internal/action/commands.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/gopasspw/gopass/internal/backend"
 	"github.com/gopasspw/gopass/pkg/debug"
+	"github.com/gopasspw/gopass/pkg/otp"
 	"github.com/gopasspw/gopass/pkg/set"
 	"github.com/urfave/cli/v3"
 )
@@ -890,7 +891,7 @@ func (s *Action) GetCommands() []*cli.Command {
 			Before:        s.IsInitialized,
 			Action:        s.OTP,
 			ShellComplete: s.Complete,
-			Flags: []cli.Flag{
+			Flags: append([]cli.Flag{
 				&cli.BoolFlag{
 					Name:    "alsoclip",
 					Aliases: []string{"C"},
@@ -916,12 +917,7 @@ func (s *Action) GetCommands() []*cli.Command {
 					Aliases: []string{"o"},
 					Usage:   "Only display the token",
 				},
-				&cli.BoolFlag{
-					Name:    "snip",
-					Aliases: []string{"s"},
-					Usage:   "Scan screen content to insert a OTP QR code into provided entry",
-				},
-			},
+			}, otp.SnipFlags()...),
 		},
 		{
 			Name:  "process",

--- a/pkg/otp/screenshot_others.go
+++ b/pkg/otp/screenshot_others.go
@@ -5,10 +5,17 @@ package otp
 import (
 	"context"
 	"fmt"
+
+	"github.com/urfave/cli/v3"
 )
 
 // ParseScreen will attempt to parse all available screen and will look for otpauth QR codes. It returns the first one
 // it has found.
 func ParseScreen(ctx context.Context) (string, error) {
 	return "", fmt.Errorf("not supported on your platform")
+}
+
+// SnipFlags returns an empty slice because the screen-capture feature is not available in this build.
+func SnipFlags() []cli.Flag {
+	return nil
 }

--- a/pkg/otp/screenshot_supported.go
+++ b/pkg/otp/screenshot_supported.go
@@ -10,7 +10,19 @@ import (
 	"github.com/kbinani/screenshot"
 	"github.com/makiuchi-d/gozxing"
 	"github.com/makiuchi-d/gozxing/qrcode"
+	"github.com/urfave/cli/v3"
 )
+
+// SnipFlags returns the CLI flags for the screen-capture (snip) feature.
+func SnipFlags() []cli.Flag {
+	return []cli.Flag{
+		&cli.BoolFlag{
+			Name:    "snip",
+			Aliases: []string{"s"},
+			Usage:   "Scan screen content to insert a OTP QR code into provided entry",
+		},
+	}
+}
 
 // ParseScreen will attempt to parse all available screen and will look for otpauth QR codes. It returns the first one
 // it has found.


### PR DESCRIPTION
Add otp.SnipFlags() to the build-tagged screenshot files so that the --snip/-s CLI flag is only registered when the screen-capture feature is actually compiled in. Builds with -tags noscreenshot will no longer show --snip in 'gopass otp --help'.

Addresses review comment by AnomalRoil on PR #3442.