### PR TITLE
Fix clip flag (-c) for cli/v3 GenericFlag compatibility

### DIFF
--- a/internal/action/show.go
+++ b/internal/action/show.go
@@ -24,6 +24,24 @@ import (
 	"github.com/urfave/cli/v3"
 )
 
+// clipFlagValue returns the string value of the "clip" GenericFlag.
+func clipFlagValue(cmd *cli.Command) string {
+	v := cmd.Value("clip")
+	if v == nil {
+		return ""
+	}
+
+	if s, ok := v.(fmt.Stringer); ok {
+		return s.String()
+	}
+
+	if s, ok := v.(string); ok {
+		return s
+	}
+
+	return ""
+}
+
 func isTrailingFlag(arg string) bool {
 	return arg == "-c" || arg == "--clip" ||
 		strings.HasPrefix(arg, "-c=") || strings.HasPrefix(arg, "--clip=") ||
@@ -71,7 +89,7 @@ func showParseArgs(ctx context.Context, cmd *cli.Command) context.Context {
 	if cmd.IsSet("clip") {
 		ctx = WithOnlyClip(ctx, true)
 
-		if v := cmd.String("clip"); v != "" && v != "true" {
+		if v := clipFlagValue(cmd); v != "" && v != "true" {
 			line, err := strconv.Atoi(v)
 			if err == nil && line >= 0 {
 				ctx = WithClipLine(ctx, line)

--- a/internal/action/show_test.go
+++ b/internal/action/show_test.go
@@ -356,6 +356,43 @@ func TestShowClipLine(t *testing.T) {
 	})
 }
 
+func TestShowParseArgsClipLine(t *testing.T) {
+	t.Run("clip flag with line number sets ClipLine", func(t *testing.T) {
+		ctx := config.NewContextInMemory()
+		cmd := gptest.CliCtxWithFlags(ctx, t, map[string]string{"clip": "2"}, "secret")
+		ctx = showParseArgs(ctx, cmd)
+		assert.True(t, IsOnlyClip(ctx), "OnlyClip should be true when -c=N is given")
+		assert.True(t, IsClip(ctx), "Clip should be true when -c=N is given")
+		assert.Equal(t, 2, GetClipLine(ctx), "ClipLine should be 2 for -c=2")
+	})
+
+	t.Run("clip flag without value sets OnlyClip but not ClipLine", func(t *testing.T) {
+		ctx := config.NewContextInMemory()
+		cmd := gptest.CliCtxWithFlags(ctx, t, map[string]string{"clip": "true"}, "secret")
+		ctx = showParseArgs(ctx, cmd)
+		assert.True(t, IsOnlyClip(ctx), "OnlyClip should be true when -c is given")
+		assert.True(t, IsClip(ctx), "Clip should be true when -c is given")
+		assert.Equal(t, -1, GetClipLine(ctx), "ClipLine should be -1 (unset) for plain -c")
+	})
+
+	t.Run("clip flag with zero sets ClipLine to 0", func(t *testing.T) {
+		ctx := config.NewContextInMemory()
+		cmd := gptest.CliCtxWithFlags(ctx, t, map[string]string{"clip": "0"}, "secret")
+		ctx = showParseArgs(ctx, cmd)
+		assert.True(t, IsOnlyClip(ctx))
+		assert.Equal(t, 0, GetClipLine(ctx), "ClipLine should be 0 for -c=0")
+	})
+
+	t.Run("no clip flag leaves defaults", func(t *testing.T) {
+		ctx := config.NewContextInMemory()
+		cmd := gptest.CliCtxWithFlags(ctx, t, nil, "secret")
+		ctx = showParseArgs(ctx, cmd)
+		assert.False(t, IsOnlyClip(ctx), "OnlyClip should be false without -c")
+		assert.False(t, IsClip(ctx), "Clip should be false without -c")
+		assert.Equal(t, -1, GetClipLine(ctx), "ClipLine should be -1 without -c")
+	})
+}
+
 func TestShowAutoClip(t *testing.T) {
 	// make sure we consistently get the unsupported error message
 	ov := clipboard.ForceUnsupported


### PR DESCRIPTION
After the cli/v2 to v3 migration, `cmd.String()` on a `GenericFlag` always returns `""` because it type-asserts to `string`, which fails for `*OptionalInt`. This caused `show -c=N` (copy a specific line to clipboard) to silently ignore the line number, always copying the password instead.

Fixes #3444