### PR TITLE
clone: match GPG recipients by fingerprint, not string equality

### DIFF
--- a/internal/action/clone.go
+++ b/internal/action/clone.go
@@ -214,8 +214,12 @@ func (s *setupHandler) cloneCheckDecryptionKeys(ctx context.Context, mount strin
 	}
 
 	idSet := set.New(ids...)
-	// Check whether any of our usable keys are in recpSet
-	if _, found := recpSet.Choose(idSet.Contains); found {
+	// Check whether any of our usable keys is listed as a recipient. We can not
+	// rely on plain string equality here: .gpg-id may list a recipient in any
+	// GPG-accepted form (short ID, long ID, full fingerprint or email), while
+	// ListIdentities returns our keys in short form. Normalize both sides to a
+	// fingerprint before comparing so every form of the same key matches.
+	if haveDecryptionKey(ctx, crypto.Fingerprint, recpSet.Elements(), idSet.Elements()) {
 		out.Noticef(ctx, "Found valid decryption keys. You can now decrypt your passwords.")
 
 		return nil
@@ -238,6 +242,30 @@ func (s *setupHandler) cloneCheckDecryptionKeys(ctx context.Context, mount strin
 	}
 
 	return nil
+}
+
+// haveDecryptionKey reports whether any of our identities (usable private keys)
+// is listed among the recipients. recipients come from .gpg-id and may be given
+// in any GPG-accepted form (short ID, long ID, fingerprint or email), while ids
+// are our own keys. fpr resolves a key identifier to its fingerprint (returning
+// an empty string for unknown keys). By comparing on the resolved fingerprint we
+// match a recipient regardless of the form it was written in, while a key that
+// is not a recipient at all still does not match.
+func haveDecryptionKey(ctx context.Context, fpr func(context.Context, string) string, recipients, ids []string) bool {
+	recpFprs := set.New[string]()
+	for _, r := range recipients {
+		if fp := fpr(ctx, r); fp != "" {
+			recpFprs.Add(fp)
+		}
+	}
+
+	for _, id := range ids {
+		if fp := fpr(ctx, id); fp != "" && recpFprs.Contains(fp) {
+			return true
+		}
+	}
+
+	return false
 }
 
 func (s *setupHandler) cloneAddMount(ctx context.Context, mount, path string) error {

--- a/internal/action/clone_test.go
+++ b/internal/action/clone_test.go
@@ -181,3 +181,57 @@ func TestCloneCheckDecryptionKeys(t *testing.T) {
 
 	require.Contains(t, act.cfg.Mounts(), "the-project")
 }
+
+func TestHaveDecryptionKey(t *testing.T) {
+	t.Parallel()
+
+	// fpr models gopass's crypto.Fingerprint: it resolves any GPG-accepted form
+	// of a known key (short ID, long ID, fingerprint or email) to the same
+	// fingerprint, and returns an empty string for unknown keys.
+	const fingerprint = "1234567890ABCDEF1234567890AB17F3ED51DADD9393"
+	aliases := map[string]string{
+		"0x17F3ED51DADD9393":                          fingerprint,                                   // short
+		"0x7890AB17F3ED51DADD9393":                    fingerprint,                                   // long
+		fingerprint:                                   fingerprint,                                   // full fingerprint
+		"0x" + fingerprint:                            fingerprint,                                   // 0x-prefixed fingerprint
+		"someone@example.org":                         fingerprint,                                   // email
+		"1111111111111111111111111111111111111111111": "1111111111111111111111111111111111111111111", // unrelated key
+	}
+	fpr := func(_ context.Context, id string) string {
+		return aliases[id]
+	}
+
+	// Our usable key, always reported in short form by ListIdentities.
+	ids := []string{"0x17F3ED51DADD9393"}
+
+	for _, tc := range []struct {
+		name       string
+		recipients []string
+		want       bool
+	}{
+		{name: "short form recipient", recipients: []string{"0x17F3ED51DADD9393"}, want: true},
+		{name: "long form recipient", recipients: []string{"0x7890AB17F3ED51DADD9393"}, want: true},
+		{name: "fingerprint recipient", recipients: []string{fingerprint}, want: true},
+		{name: "0x fingerprint recipient", recipients: []string{"0x" + fingerprint}, want: true},
+		{name: "email recipient", recipients: []string{"someone@example.org"}, want: true},
+		{name: "mixed recipients with a match", recipients: []string{"1111111111111111111111111111111111111111111", "someone@example.org"}, want: true},
+		{name: "non-recipient key is rejected", recipients: []string{"1111111111111111111111111111111111111111111"}, want: false},
+		{name: "no recipients", recipients: nil, want: false},
+		{name: "unknown recipient", recipients: []string{"0xUNKNOWN"}, want: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := haveDecryptionKey(context.Background(), fpr, tc.recipients, ids)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestHaveDecryptionKeyNoIdentities(t *testing.T) {
+	t.Parallel()
+
+	fpr := func(_ context.Context, id string) string { return "FP-" + id }
+
+	assert.False(t, haveDecryptionKey(context.Background(), fpr, []string{"a", "b"}, nil))
+}


### PR DESCRIPTION
## What

`gopass clone` with the GPG backend decides whether the cloning user already has access to the store by comparing the user's usable keys against the recipients listed in `.gpg-id`. That comparison was a plain string equality: usable keys are reported in short form (for example `0x17F3ED51DADD9393`), while `.gpg-id` accepts any GPG-approved key form (short ID, long ID, full fingerprint, or email).

As a result, a recipient written in any form other than the short ID never matched a usable key, and a perfectly valid recipient was told:

> Please ask the owner of the password store to add one of your keys

instead of:

> Found valid decryption keys. You can now decrypt your passwords.

## Fix

In `cloneCheckDecryptionKeys` the match now normalizes both the recipients and the usable identities to their fingerprint before comparing, using the crypto backend's existing `Fingerprint` resolver (`crypto.Fingerprint`, which resolves any key form via the backend's `findKey`). Short ID, long ID, fingerprint, and email forms of the same key all resolve to the same fingerprint and therefore match.

The check is extracted into a small pure helper, `haveDecryptionKey`, that takes the fingerprint resolver as a parameter so it can be tested without a live GPG keyring. The access check is not weakened: a key that is not actually a recipient still does not match, so a non-recipient is still correctly asked to have their key added. Keys the backend cannot resolve (empty fingerprint) are ignored rather than matched.

## Tests

Added `TestHaveDecryptionKey` covering a usable short-form key against a `.gpg-id` recipient written as short ID, long ID, fingerprint, `0x`-prefixed fingerprint, and email (all match), plus negative cases: a non-recipient key, no recipients, an unknown recipient, and no identities (all correctly rejected). `go test ./internal/action/...`, `gofmt`, and `go vet` are clean.

Fixes #3028
