### PR TITLE
fscopy: derive copy direction from the source argument

### DIFF
--- a/internal/action/binary.go
+++ b/internal/action/binary.go
@@ -194,14 +194,17 @@ func (s *binaryHandler) binaryCopy(ctx context.Context, cmd *cli.Command, from, 
 		return fmt.Errorf("usage: %s fs%s from to", cmd.Root().Name, op)
 	}
 
+	// The direction is determined by the source: if "from" is a real file on
+	// disk we copy from the filesystem into the store, otherwise we copy from
+	// the store out to the filesystem. We deliberately key off "from" so that a
+	// destination which happens to share a name with a file in the current
+	// directory (e.g. "gopass fscopy test test") is still treated as a store
+	// entry. fscopy does not support copying between two files, so once the
+	// source is known the destination side is unambiguous. See #3340.
 	switch {
-	case isFilePath(from) && isFilePath(to):
-		// copying from on file to another file is not supported.
-		return fmt.Errorf("ambiguity detected. Only from or to can be a file. Use cp to copy between files")
-	case s.Store.Exists(ctx, from) && s.Store.Exists(ctx, to):
-		// copying from one secret to another secret is not supported.
-		return fmt.Errorf("ambiguity detected. Either from or to must be a file. Use gopass cp to copy between secrets")
-	case isFilePath(from) && !isFilePath(to):
+	case isFilePath(from):
+		// the source is a file on disk, so the destination is a store entry,
+		// even if a same-named file happens to exist in the working directory.
 		if s.isInStore(from) {
 			out.Warningf(ctx, "Ambiguity detected. Source %q is in the store. Use --force if intended", from)
 			if !cmd.Bool("force") {
@@ -210,7 +213,13 @@ func (s *binaryHandler) binaryCopy(ctx context.Context, cmd *cli.Command, from, 
 		}
 
 		return s.binaryCopyFromFileToStore(ctx, from, to, deleteSource)
-	case !isFilePath(from):
+	case s.Store.Exists(ctx, from) && s.Store.Exists(ctx, to):
+		// the source is not a file but both names resolve to secrets, so we
+		// cannot tell which one is meant to be the file. Copying from one
+		// secret to another is not supported here; use cp instead.
+		return fmt.Errorf("ambiguity detected. Either from or to must be a file. Use gopass cp to copy between secrets")
+	case s.Store.Exists(ctx, from):
+		// the source is a store entry, so the destination is a file on disk.
 		if s.isInStore(to) {
 			out.Warningf(ctx, "Ambiguity detected. Destination %q is in the store. Use --force if intended", to)
 			if !cmd.Bool("force") {
@@ -220,7 +229,8 @@ func (s *binaryHandler) binaryCopy(ctx context.Context, cmd *cli.Command, from, 
 
 		return s.binaryCopyFromStoreToFile(ctx, from, to, deleteSource)
 	default:
-		return fmt.Errorf("ambiguity detected. Unhandled case. Please report a bug")
+		// the source is neither a file on disk nor an existing secret.
+		return fmt.Errorf("%q is neither a file nor a secret in the store", from)
 	}
 }
 

--- a/internal/action/binary_test.go
+++ b/internal/action/binary_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gopasspw/gopass/internal/config"
 	"github.com/gopasspw/gopass/internal/out"
 	"github.com/gopasspw/gopass/pkg/ctxutil"
+	"github.com/gopasspw/gopass/pkg/gopass/secrets"
 	"github.com/gopasspw/gopass/tests/gptest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -208,6 +209,82 @@ func TestBinaryCopy(t *testing.T) {
 	t.Run("binary move bar2 tempdir/bar", func(t *testing.T) {
 		defer buf.Reset()
 		require.NoError(t, act.BinaryMove(ctx, gptest.CliCtx(ctx, t, "bar2", outfile)))
+	})
+}
+
+// TestBinaryCopyNameAmbiguity covers https://github.com/gopasspw/gopass/issues/3340:
+// copying a file into the store must work even when the destination secret name
+// matches the basename of an existing file in the current directory, while the
+// genuine "both arguments are secrets" ambiguity is still rejected.
+func TestBinaryCopyNameAmbiguity(t *testing.T) {
+	u := gptest.NewUnitTester(t)
+
+	ctx := config.NewContextInMemory()
+	ctx = ctxutil.WithAlwaysYes(ctx, true)
+	ctx = ctxutil.WithHidden(ctx, true)
+
+	buf := &bytes.Buffer{}
+	out.Stdout = buf
+	defer func() {
+		out.Stdout = os.Stdout
+	}()
+
+	act, err := newMock(ctx, u.StoreDir(""))
+	require.NoError(t, err)
+	require.NotNil(t, act)
+	ctx = act.cfg.WithConfig(ctx)
+
+	// Operate from a directory that holds a file whose name collides with the
+	// destination secret name, reproducing the exact scenario from the issue.
+	workdir := t.TempDir()
+	old, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(workdir))
+	defer func() { require.NoError(t, os.Chdir(old)) }()
+
+	require.NoError(t, os.WriteFile(filepath.Join(workdir, "test"), []byte("0xDEADBEEF\n"), 0o644))
+
+	t.Run("file into same-named store entry succeeds", func(t *testing.T) {
+		defer buf.Reset()
+		// "gopass fscopy test test": source is a real file, destination is the
+		// store entry "test". This used to fail with an ambiguity error.
+		require.NoError(t, act.BinaryCopy(ctx, gptest.CliCtx(ctx, t, "test", "test")))
+		require.True(t, act.Store.Exists(ctx, "test"))
+	})
+
+	t.Run("file into nested same-basename store entry succeeds", func(t *testing.T) {
+		defer buf.Reset()
+		// "gopass fscopy test sub/test": the destination shares the basename of
+		// the on-disk file but is a nested store path. This used to fail with
+		// the ambiguity error too.
+		require.NoError(t, act.BinaryCopy(ctx, gptest.CliCtx(ctx, t, "test", "sub/test")))
+		require.True(t, act.Store.Exists(ctx, "sub/test"))
+	})
+
+	t.Run("file into rooted same-named path no longer reports ambiguity", func(t *testing.T) {
+		defer buf.Reset()
+		// "gopass fscopy test /test": the source is a file so this is routed to
+		// a filesystem-to-store copy. The store rejects a leading-slash secret
+		// name, but the user now gets that clear validation error instead of the
+		// misleading "ambiguity detected" message from #3340.
+		err := act.BinaryCopy(ctx, gptest.CliCtx(ctx, t, "test", "/test"))
+		require.Error(t, err)
+		require.NotContains(t, err.Error(), "ambiguity")
+	})
+
+	t.Run("genuine secret-to-secret ambiguity still errors", func(t *testing.T) {
+		defer buf.Reset()
+		// Set up two secrets that have no matching file on disk, then try to
+		// fscopy between them: this must keep erroring and point at cp.
+		require.NoError(t, act.Store.Set(ctx, "src-secret", secrets.NewAKV()))
+		require.NoError(t, act.Store.Set(ctx, "dst-secret", secrets.NewAKV()))
+		require.Error(t, act.BinaryCopy(ctx, gptest.CliCtx(ctx, t, "src-secret", "dst-secret")))
+	})
+
+	t.Run("unknown source errors", func(t *testing.T) {
+		defer buf.Reset()
+		// Neither a file on disk nor a secret in the store.
+		require.Error(t, act.BinaryCopy(ctx, gptest.CliCtx(ctx, t, "does-not-exist", "dest")))
 	})
 }
 


### PR DESCRIPTION
Fixes #3340

`gopass fscopy <file> <dest>` refused to run whenever the destination
secret name happened to match a file of the same name in the current
directory. The reproduction from the issue:

```
$ touch test
$ gopass fscopy test test
Error: ambiguity detected. Only from or to can be a file. Use cp to copy between files
```

The disambiguation in `binaryCopy` decided the direction by inspecting
both arguments at once. Because `isFilePath` returns true for any real
file in the working directory, a perfectly valid filesystem-to-store
copy where the destination secret shares a basename with the source file
fell into the `isFilePath(from) && isFilePath(to)` branch and was
rejected.

This follows the direction agreed in the issue thread (if `from` is a
real file, treat `to` as a store entry, since fscopy is not meant to copy
between two files): the copy direction is now derived from the source
alone.

- If `from` is a file on disk, copy into the store and treat `to` as a
  secret name, even if a same-named file exists in the working directory.
- Otherwise, if `from` is an existing secret, copy out to a file.

The genuine guards are preserved:

- Both arguments are existing secrets still returns the "use `gopass cp`"
  error.
- A source that already lives inside the store still warns and requires
  `--force`.
- A source that is neither a file nor a secret now returns a clear
  message instead of the previous "unhandled case, please report a bug".

Before / after with the fixed binary:

```
$ gopass fscopy test test          # was: ambiguity detected ...
$ gopass ls
gopass
└── test
$ gopass fscopy test sub/test      # nested destination, also works now
```

Tests: added `TestBinaryCopyNameAmbiguity` covering the same-name and
nested-name copies succeeding, the secret-to-secret case still erroring,
and an unknown source erroring. `go test ./internal/action/...` passes,
`gofmt` and `go vet` are clean. The new test fails against the previous
code with the exact error string from the issue, and passes with this
change.
