### PR TITLE
fix: restore clip flag through fuzzy search in show command

### DIFF
--- a/internal/action/find.go
+++ b/internal/action/find.go
@@ -29,10 +29,11 @@ func (s *searchHandler) FindFuzzy(ctx context.Context, cmd *cli.Command) error {
 
 func (s *searchHandler) findCmd(ctx context.Context, cmd *cli.Command, cb showFunc, fuzzy bool) error {
 	ctx = ctxutil.WithGlobalFlags(ctx, cmd)
-	if cmd.IsSet("clip") {
-		ctx = WithOnlyClip(ctx, cmd.Bool("clip"))
-		ctx = WithClip(ctx, cmd.Bool("clip"))
-	}
+	// Note: do not re-parse the clip flag here. The find command has no clip flag,
+	// and when called via fuzzy search from show, the context already carries the
+	// correct clip state set by showParseArgs. Calling cmd.Bool("clip") on the show
+	// command's GenericFlag (OptionalInt) returns false in cli v3, which would
+	// incorrectly overwrite the clip=true already stored in ctx.
 
 	if cmd.IsSet("unsafe") {
 		ctx = ctxutil.WithForce(ctx, cmd.Bool("unsafe"))


### PR DESCRIPTION
When 'gopass show -c foo' triggers a fuzzy search (because 'foo' does not exist but e.g. 'foozen' does), the -c flag was silently lost.

Root cause: findCmd() re-parsed the clip flag from the cli.Command by calling cmd.Bool("clip"). The show command registers 'clip' as a GenericFlag (*OptionalInt), not a BoolFlag. In urfave/cli v3, cmd.Bool() called on a GenericFlag returns false (the zero value) regardless of what the user passed. This false value overwrote the clip=true that showParseArgs() had already correctly stored in the context.

The find command has no clip flag of its own, so the block was always a no-op for the direct 'gopass find' path. For the fuzzy-search path (called from showHandleError), the context already carries the correct clip state, so removing the re-parse block is the right fix.