### PR TITLE
fix: Avoid NPE when attempting to edit a non-existing secret

### DIFF
--- a/internal/action/find.go
+++ b/internal/action/find.go
@@ -56,7 +56,7 @@ func (s *searchHandler) find(ctx context.Context, cmd *cli.Command, needle strin
 	}
 
 	// filter our the ones from the haystack matching the needle.
-	choices, err := filter(haystack, needle, cmd.Bool("regex"))
+	choices, err := filter(haystack, needle, cmd != nil && cmd.Bool("regex"))
 	if err != nil {
 		return exit.Error(exit.Usage, err, "%s", err)
 	}


### PR DESCRIPTION
This was a regression from the CLI lib migration to v3.