### PR TITLE
fix: use imperative mood in generated commit messages

### DIFF
--- a/docs/adr/A-14-team-workflows.md
+++ b/docs/adr/A-14-team-workflows.md
@@ -317,7 +317,7 @@ func (s *Store) RemoveRecipient(ctx, id string) error {
     canon := s.matchRecipient(ctx, id)      // existing fuzzy match, returns canonical
     rs.Remove(canon)
     if rs.Len() == 0 { return errLastRecipient }
-    s.saveRecipients(ctx, rs, "Removed Recipient "+canon)
+    s.saveRecipients(ctx, rs, "Remove Recipient "+canon)
     // recipient-scoped cleanup (NOT blanket):
     s.storage.Delete(ctx, filepath.Join(keyDir, canon))
     s.storage.Delete(ctx, filepath.Join(oldKeyDir, canon))  // legacy

--- a/internal/action/binary.go
+++ b/internal/action/binary.go
@@ -250,7 +250,7 @@ func (s *binaryHandler) binaryCopyFromFileToStore(ctx context.Context, from, to 
 		return fmt.Errorf("failed to parse secret from input: %w", err)
 	}
 	if err := s.Store.Set(
-		ctxutil.WithCommitMessage(ctx, fmt.Sprintf("Copied data from %s to %s", from, to)), to, sec); err != nil {
+		ctxutil.WithCommitMessage(ctx, fmt.Sprintf("Copy data from %s to %s", from, to)), to, sec); err != nil {
 		return fmt.Errorf("failed to save buffer to store: %w", err)
 	}
 

--- a/internal/action/copy.go
+++ b/internal/action/copy.go
@@ -23,7 +23,7 @@ func (s *secretHandler) Copy(ctx context.Context, cmd *cli.Command) error {
 	to := cmd.Args().Get(1)
 
 	// Check for custom commit message
-	commitMsg := fmt.Sprintf("Copied %s to %s", from, to)
+	commitMsg := fmt.Sprintf("Copy %s to %s", from, to)
 	if cmd.IsSet("commit-message") {
 		commitMsg = cmd.String("commit-message")
 	}

--- a/internal/action/delete.go
+++ b/internal/action/delete.go
@@ -46,9 +46,9 @@ func (s *secretHandler) Delete(ctx context.Context, cmd *cli.Command) error {
 	}
 
 	// Check for custom commit message
-	commitMsg := fmt.Sprintf("Deleted %s", name)
+	commitMsg := fmt.Sprintf("Delete %s", name)
 	if key != "" {
-		commitMsg = fmt.Sprintf("Deleted key %s from %s", key, name)
+		commitMsg = fmt.Sprintf("Delete key %s from %s", key, name)
 	}
 	if cmd.IsSet("commit-message") {
 		commitMsg = cmd.String("commit-message")

--- a/internal/action/edit.go
+++ b/internal/action/edit.go
@@ -58,7 +58,7 @@ func (s *secretHandler) edit(ctx context.Context, cmd *cli.Command, name string)
 	}
 
 	// Check for custom commit message
-	commitMsg := fmt.Sprintf("Edited with %s", ed)
+	commitMsg := fmt.Sprintf("Edit with %s", ed)
 	if cmd.IsSet("commit-message") {
 		commitMsg = cmd.String("commit-message")
 	}

--- a/internal/action/generate.go
+++ b/internal/action/generate.go
@@ -52,7 +52,7 @@ func (s *generateHandler) Generate(ctx context.Context, cmd *cli.Command) error 
 	}
 
 	// Check for custom commit message
-	commitMsg := "Generated Password"
+	commitMsg := "Generate Password"
 	if cmd.IsSet("commit-message") {
 		commitMsg = cmd.String("commit-message")
 	}

--- a/internal/action/insert.go
+++ b/internal/action/insert.go
@@ -43,7 +43,7 @@ func (s *secretHandler) insert(ctx context.Context, cmd *cli.Command, name, key 
 	var content []byte
 
 	// Check for custom commit message
-	commitMsg := "Inserted user supplied password"
+	commitMsg := "Insert user supplied password"
 	if cmd.IsSet("commit-message") {
 		commitMsg = cmd.String("commit-message")
 	}

--- a/internal/action/merge.go
+++ b/internal/action/merge.go
@@ -79,7 +79,7 @@ func (s *secretHandler) Merge(ctx context.Context, cmd *cli.Command) error {
 	}
 
 	// write result (back) to store
-	if err := s.Store.Set(ctxutil.WithCommitMessage(ctx, fmt.Sprintf("Merged %+v", cmd.Args().Slice())), to, nSec); err != nil {
+	if err := s.Store.Set(ctxutil.WithCommitMessage(ctx, fmt.Sprintf("Merge %+v", cmd.Args().Slice())), to, nSec); err != nil {
 		if !errors.Is(err, store.ErrMeaninglessWrite) {
 			return exit.Error(exit.Encrypt, err, "failed to encrypt secret %s: %s", to, err)
 		}

--- a/internal/action/move.go
+++ b/internal/action/move.go
@@ -28,7 +28,7 @@ func (s *secretHandler) Move(ctx context.Context, cmd *cli.Command) error {
 	}
 
 	// Check for custom commit message
-	commitMsg := fmt.Sprintf("Moved %s to %s", from, to)
+	commitMsg := fmt.Sprintf("Move %s to %s", from, to)
 	if cmd.IsSet("commit-message") {
 		commitMsg = cmd.String("commit-message")
 	}

--- a/internal/action/reorg.go
+++ b/internal/action/reorg.go
@@ -131,7 +131,7 @@ func (s *miscHandler) ReorgAfterEdit(ctx context.Context, initialSecrets, modifi
 	}
 
 	// commit changes
-	if err := storage.TryCommit(ctx, "Reorganized secrets"); err != nil {
+	if err := storage.TryCommit(ctx, "Reorganize secrets"); err != nil {
 		return exit.Error(exit.Git, err, "failed to commit changes: %s", err)
 	}
 

--- a/internal/create/templates.go
+++ b/internal/create/templates.go
@@ -93,7 +93,7 @@ func (w *Wizard) writeTemplates(ctx context.Context, s storageSetter) error {
 		debug.Log("wrote default template to %s", path)
 	}
 
-	if err := s.TryCommit(ctx, "Added default wizard templates"); err != nil {
+	if err := s.TryCommit(ctx, "Add default wizard templates"); err != nil {
 		return fmt.Errorf("failed to commit changes: %w", err)
 	}
 

--- a/internal/create/wizard.go
+++ b/internal/create/wizard.go
@@ -331,7 +331,7 @@ func mkActFunc(tpl Template, s *root.Store, cb ActionCallback) func(context.Cont
 			}
 		}
 
-		if err := s.Set(ctxutil.WithCommitMessage(ctx, "Created new entry"), name, sec); err != nil {
+		if err := s.Set(ctxutil.WithCommitMessage(ctx, "Create new entry"), name, sec); err != nil {
 			return fmt.Errorf("failed to set %q: %w", name, err)
 		}
 		out.OKf(ctx, "Credentials saved to %q", name)

--- a/internal/store/leaf/init.go
+++ b/internal/store/leaf/init.go
@@ -66,7 +66,7 @@ You can add secondary stores with 'gopass init --path <path to secondary store> 
 		return fmt.Errorf("none of the recipients has a secret key. You will not be able to decrypt the secrets you add")
 	}
 
-	if err := s.saveRecipients(ctx, rs, "Initialized Store for "+strings.Join(rs.IDs(), ", ")); err != nil {
+	if err := s.saveRecipients(ctx, rs, "Initialize Store for "+strings.Join(rs.IDs(), ", ")); err != nil {
 		return fmt.Errorf("failed to initialize store: %w", err)
 	}
 	out.OKf(ctx, "Wrote recipients to %s", s.idFile(ctx, ""))

--- a/internal/store/leaf/move.go
+++ b/internal/store/leaf/move.go
@@ -39,7 +39,7 @@ func (s *Store) Copy(ctx context.Context, from, to string) error {
 		return fmt.Errorf("failed to get %q from store: %w", from, err)
 	}
 
-	if err := s.Set(ctxutil.WithCommitMessage(ctx, fmt.Sprintf("Copied from %s to %s", from, to)), to, content); err != nil {
+	if err := s.Set(ctxutil.WithCommitMessage(ctx, fmt.Sprintf("Copy from %s to %s", from, to)), to, content); err != nil {
 		if !errors.Is(err, store.ErrMeaninglessWrite) {
 			return fmt.Errorf("failed to save secret %q to store: %w", to, err)
 		}

--- a/internal/store/leaf/recipients.go
+++ b/internal/store/leaf/recipients.go
@@ -476,7 +476,7 @@ func (s *Store) AddRecipient(ctx context.Context, id string) error {
 	} else {
 		rs.Add(canonID)
 
-		if err := s.saveRecipients(ctx, rs, "Added Recipient "+canonID); err != nil {
+		if err := s.saveRecipients(ctx, rs, "Add Recipient "+canonID); err != nil {
 			return fmt.Errorf("failed to save recipients: %w", err)
 		}
 	}
@@ -485,9 +485,9 @@ func (s *Store) AddRecipient(ctx context.Context, id string) error {
 
 	commitMsg := "Recipient " + canonID
 	if idAlreadyInStore {
-		commitMsg = "Re-encrypted Store for " + commitMsg
+		commitMsg = "Re-encrypt Store for " + commitMsg
 	} else {
-		commitMsg = "Added " + commitMsg
+		commitMsg = "Add " + commitMsg
 	}
 
 	return s.reencrypt(ctxutil.WithCommitMessage(ctx, commitMsg))
@@ -578,7 +578,7 @@ RECIPIENTS:
 		return fmt.Errorf("recipient not in store")
 	}
 
-	if err := s.saveRecipients(ctx, rs, "Removed Recipient "+key); err != nil {
+	if err := s.saveRecipients(ctx, rs, "Remove Recipient "+key); err != nil {
 		return fmt.Errorf("failed to save recipients: %w", err)
 	}
 
@@ -607,7 +607,7 @@ RECIPIENTS:
 		}
 	}
 
-	return s.reencrypt(ctxutil.WithCommitMessage(ctx, "Removed Recipient "+key))
+	return s.reencrypt(ctxutil.WithCommitMessage(ctx, "Remove Recipient "+key))
 }
 
 func (s *Store) ensureOurKeyID(ctx context.Context, recp []string) []string {
@@ -702,7 +702,7 @@ func (s *Store) UpdateExportedPublicKeys(ctx context.Context) (bool, error) {
 	// removal in RemoveRecipient (Stage 3).
 
 	if exported && ctxutil.IsGitCommit(ctx) {
-		if err := s.storage.TryCommit(ctx, "Updated exported Public Keys"); err != nil {
+		if err := s.storage.TryCommit(ctx, "Update exported Public Keys"); err != nil {
 			failed = true
 
 			out.Errorf(ctx, "Failed to git commit: %s", err)
@@ -779,7 +779,7 @@ func (s *Store) UpdateRecipientKeys(ctx context.Context, ids []string) error {
 	}
 
 	if len(exported) > 0 && ctxutil.IsGitCommit(ctx) {
-		if err := s.storage.TryCommit(ctx, "Updated recipient public keys"); err != nil {
+		if err := s.storage.TryCommit(ctx, "Update recipient public keys"); err != nil {
 			out.Errorf(ctx, "Failed to git commit: %s", err)
 			failed = true
 		}
@@ -955,7 +955,7 @@ func (s *Store) CanonicalizeRecipients(ctx context.Context) error {
 		return nil
 	}
 
-	return s.saveRecipients(ctx, newRS, "Canonicalized recipient IDs")
+	return s.saveRecipients(ctx, newRS, "Canonicalize recipient IDs")
 }
 
 // renamePublicKeyFile moves the key file from dir/<oldID> to dir/<newID> and


### PR DESCRIPTION
I am trying gopass as an enhanced alternative to pass and as a backup vault for my primary password manager. I used pass occasionally for many years and noticed that gopass uses the past tense in some generated commit messages.

Even though it is really a nit, I see the usual pass commit messages alongside gopass's slightly off past-tense ones in the same vault as I adapt to using gopass.

This aligns those messages with the imperative-mood convention accepted in #1222.

Most changes were edited and reviewed with AI assistance.