### PR TITLE
feat(create): support passwordless / SSO login profiles

### DIFF
--- a/internal/create/templates.go
+++ b/internal/create/templates.go
@@ -59,6 +59,37 @@ attributes:
   - name: "comment"
     type: "string"
 `,
+	`---
+priority: 2
+name: "SSO / passwordless login (e.g. Google)"
+prefix: "websites"
+name_from:
+  - "url"
+  - "username"
+welcome: "🧪 Creating SSO / passwordless login"
+attributes:
+  - name: "url"
+    type: "hostname"
+    prompt: "Website URL"
+    min: 1
+    max: 255
+  - name: "username"
+    type: "string"
+    prompt: "Account / email"
+    min: 1
+  - name: "login-method"
+    type: "choice"
+    prompt: "Login via"
+    options:
+      - "google"
+      - "apple"
+      - "github"
+      - "microsoft"
+      - "sso"
+      - "magic-link"
+  - name: "comment"
+    type: "string"
+`,
 }
 
 type storageSetter interface {

--- a/internal/create/wizard.go
+++ b/internal/create/wizard.go
@@ -38,14 +38,16 @@ const (
 // Attribute is a credential attribute that is being asked for
 // when populating a template.
 type Attribute struct {
-	Name         string `yaml:"name"`
-	Type         string `yaml:"type"`
-	Prompt       string `yaml:"prompt"`
-	Charset      string `yaml:"charset"`
-	Min          int    `yaml:"min"`
-	Max          int    `yaml:"max"`
-	AlwaysPrompt bool   `yaml:"always_prompt"` // always prompt for the crendentials
-	Strict       bool   `yaml:"strict"`        // enforce character class rules (all detected classes must be present)
+	Name         string   `yaml:"name"`
+	Type         string   `yaml:"type"`
+	Prompt       string   `yaml:"prompt"`
+	Charset      string   `yaml:"charset"`
+	Min          int      `yaml:"min"`
+	Max          int      `yaml:"max"`
+	AlwaysPrompt bool     `yaml:"always_prompt"` // always prompt for the crendentials
+	Strict       bool     `yaml:"strict"`        // enforce character class rules (all detected classes must be present)
+	Options      []string `yaml:"options"`       // selectable values for the "choice" attribute type
+	Optional     bool     `yaml:"optional"`      // allow skipping a "password" attribute (e.g. SSO / social login accounts)
 }
 
 // Template is an action template for the create wizard.
@@ -234,6 +236,19 @@ func mkActFunc(tpl Template, s *root.Store, cb ActionCallback) func(context.Cont
 					nameParts = append(nameParts, sv)
 				}
 				_ = sec.Set(k, sv)
+			case "choice":
+				if len(v.Options) < 1 {
+					return fmt.Errorf("choice attribute %s has no options", v.Name)
+				}
+				act, sel := cui.GetSelection(ctx, fmtfn(2, strconv.Itoa(step), v.Prompt), v.Options)
+				if act == "aborted" {
+					return exit.Error(exit.Aborted, nil, "user aborted")
+				}
+				choice := v.Options[sel]
+				if wantForName[k] {
+					nameParts = append(nameParts, choice)
+				}
+				_ = sec.Set(k, choice)
 			case "multiline":
 				ed := editor.Path(ctx, cmd)
 
@@ -271,6 +286,20 @@ func mkActFunc(tpl Template, s *root.Store, cb ActionCallback) func(context.Cont
 				_ = sec.Set(k, sv)
 			case "password":
 				var err error
+				// Optional passwords let a single template cover accounts that
+				// authenticate without a stored password (e.g. login via Google /
+				// SSO / social login). When the user declines, we skip prompting
+				// and leave the password empty instead of storing a blank one.
+				if v.Optional {
+					var hasPw bool
+					hasPw, err = termio.AskForBool(ctx, fmtfn(2, strconv.Itoa(step), "Does this account have a password? (No for SSO / social login)"), true)
+					if err != nil {
+						return err
+					}
+					if !hasPw {
+						continue
+					}
+				}
 				if !v.AlwaysPrompt {
 					genPw, err = termio.AskForBool(ctx, fmtfn(2, strconv.Itoa(step), "Generate Password?"), true)
 					if err != nil {

--- a/internal/create/wizard_test.go
+++ b/internal/create/wizard_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gopasspw/gopass/internal/store/mockstore/inmem"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.yaml.in/yaml/v3"
 )
 
 type fakeSetter struct{}
@@ -90,4 +91,67 @@ attributes:
 	assert.Equal(t, 1, w.Templates[0].Attributes[1].Min, "wrong min")
 	assert.Equal(t, "password", w.Templates[0].Attributes[2].Type, "wrong type")
 	assert.True(t, w.Templates[0].Attributes[2].AlwaysPrompt, "wrong always_prompt")
+}
+
+func TestDefaultTemplates(t *testing.T) {
+	t.Parallel()
+
+	ctx := config.NewContextInMemory()
+	w := &Wizard{}
+
+	tpls, err := w.parseTemplatesFallback(ctx)
+	require.NoError(t, err)
+	require.Len(t, tpls, len(defaultTemplates))
+
+	// find the SSO / passwordless template and validate it models a
+	// passwordless account: no password attribute, plus a login-method choice.
+	var sso *Template
+	for i := range tpls {
+		if tpls[i].Prefix == "websites" && len(tpls[i].Attributes) > 0 {
+			for _, a := range tpls[i].Attributes {
+				if a.Name == "login-method" {
+					sso = &tpls[i]
+
+					break
+				}
+			}
+		}
+		if sso != nil {
+			break
+		}
+	}
+	require.NotNil(t, sso, "no SSO / passwordless template found")
+
+	for _, a := range sso.Attributes {
+		assert.NotEqual(t, "password", a.Type, "SSO template must not contain a password attribute")
+	}
+
+	var lm *Attribute
+	for i := range sso.Attributes {
+		if sso.Attributes[i].Name == "login-method" {
+			lm = &sso.Attributes[i]
+
+			break
+		}
+	}
+	require.NotNil(t, lm)
+	assert.Equal(t, "choice", lm.Type, "login-method must be a choice")
+	assert.Contains(t, lm.Options, "google", "login-method must offer google")
+	assert.NotEmpty(t, lm.Options, "choice must have options")
+}
+
+func TestOptionalPasswordParses(t *testing.T) {
+	t.Parallel()
+
+	tpl := Template{}
+	require.NoError(t, yaml.Unmarshal([]byte(`---
+name: "optional pw"
+prefix: "opt"
+attributes:
+  - name: "password"
+    type: "password"
+    optional: true
+`), &tpl))
+	require.Len(t, tpl.Attributes, 1)
+	assert.True(t, tpl.Attributes[0].Optional, "optional flag must round-trip")
 }


### PR DESCRIPTION
## Summary

Adds a way to model accounts that have **no stored password** because login happens through an external provider (e.g. Google, Apple, SSO / social login).

The secret model already tolerates an empty password (first line), so this needs **no changes to the `Secret` interface or the storage format** — everything lives in the `gopass create` wizard.

## Changes

- **New default "SSO / passwordless login" template** (`internal/create/templates.go`). It shows up in `gopass create` and records the provider in a `login-method` field instead of prompting for a password:
  ```
  url: https://accounts.google.com
  username: user@example.com
  login-method: google
  ```
- **New `choice` attribute type** (`internal/create/wizard.go`) so a template can offer a fixed list of options. The SSO template uses it for the provider picker (`google`, `apple`, `github`, `microsoft`, `sso`, `magic-link`). Backed by the existing `cui.GetSelection` helper.
- **Optional / skippable password**: a `password` attribute marked `optional: true` asks *"Does this account have a password?"* and skips password entry entirely when declined (instead of storing a blank one). This lets a single template serve both password and passwordless accounts. Existing templates leave the flag unset, so their behaviour is unchanged.
- Tests covering the new default template, the `choice` type, and the `optional` flag.

## Notes

- The SSO template is filed under the existing `websites` prefix (`2-websites.yml`), so there is no collision with the `0-websites.yml` Website login template. Happy to move it under a dedicated prefix (e.g. `sso/`) if preferred.
- `gopass show` already handles empty-password secrets gracefully (it only errors when both password and body are empty, and guards clipboard/QR on a non-empty password), so passwordless entries display and behave correctly.