### PR TITLE
feat(gpg): support v5/v6 post-quantum PGP keys with 64-character fingerprints

### DIFF
--- a/internal/backend/crypto/gpg/cli/keyring.go
+++ b/internal/backend/crypto/gpg/cli/keyring.go
@@ -3,13 +3,11 @@ package cli
 import (
 	"bytes"
 	"context"
-	"encoding/hex"
 	"fmt"
 	"os/exec"
 	"strings"
 	"text/template"
 
-	"github.com/ProtonMail/go-crypto/openpgp"
 	"github.com/gopasspw/gopass/internal/backend/crypto/gpg"
 	"github.com/gopasspw/gopass/internal/backend/crypto/gpg/colons"
 	"github.com/gopasspw/gopass/internal/out"
@@ -104,18 +102,29 @@ func (g *GPG) FormatKey(ctx context.Context, id, tpl string) string {
 
 // ReadNamesFromKey unmarshals and returns the names associated with the given public key.
 func (g *GPG) ReadNamesFromKey(ctx context.Context, buf []byte) ([]string, error) {
-	el, err := openpgp.ReadArmoredKeyRing(bytes.NewReader(buf))
-	if err != nil {
-		return nil, fmt.Errorf("failed to read key ring: %w", err)
+	if len(buf) < 1 {
+		return nil, fmt.Errorf("empty input")
 	}
 
-	if len(el) != 1 {
+	args := append(g.args, "--with-colons", "--show-keys")
+	cmd := exec.CommandContext(ctx, g.binary, args...)
+	cmd.Stdin = bytes.NewReader(buf)
+	errBuf := &bytes.Buffer{}
+	cmd.Stderr = errBuf
+
+	cmdout, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("failed to run command '%s %+v': %w - %s", cmd.Path, cmd.Args, err, errBuf.String())
+	}
+
+	kl := colons.Parse(bytes.NewBuffer(cmdout))
+	if len(kl) != 1 {
 		return nil, fmt.Errorf("public Key must contain exactly one Entity")
 	}
 
-	names := make([]string, 0, len(el[0].Identities))
-	for _, v := range el[0].Identities {
-		names = append(names, v.Name)
+	names := make([]string, 0, len(kl[0].Identities))
+	for _, v := range kl[0].Identities {
+		names = append(names, v.ID())
 	}
 
 	return names, nil
@@ -155,20 +164,23 @@ func (g *GPG) GetFingerprint(ctx context.Context, buf []byte) (string, error) {
 		return "", fmt.Errorf("empty input")
 	}
 
-	el, err := openpgp.ReadArmoredKeyRing(bytes.NewReader(buf))
+	args := append(g.args, "--with-colons", "--show-keys")
+	cmd := exec.CommandContext(ctx, g.binary, args...)
+	cmd.Stdin = bytes.NewReader(buf)
+	errBuf := &bytes.Buffer{}
+	cmd.Stderr = errBuf
+
+	cmdout, err := cmd.Output()
 	if err != nil {
-		// maybe it's a non-armored key?
-		el, err = openpgp.ReadKeyRing(bytes.NewReader(buf))
-		if err != nil {
-			return "", fmt.Errorf("failed to read key ring: %w", err)
-		}
+		return "", fmt.Errorf("failed to run command '%s %+v': %w - %s", cmd.Path, cmd.Args, err, errBuf.String())
 	}
 
-	if len(el) != 1 {
+	kl := colons.Parse(bytes.NewBuffer(cmdout))
+	if len(kl) != 1 {
 		return "", fmt.Errorf("public Key must contain exactly one Entity")
 	}
 
-	return strings.ToUpper(hex.EncodeToString(el[0].PrimaryKey.Fingerprint[:])), nil
+	return strings.ToUpper(kl[0].Fingerprint), nil
 }
 
 // ExportPublicKey will export the named public key to the location given.

--- a/internal/backend/crypto/gpg/cli/keyring_test.go
+++ b/internal/backend/crypto/gpg/cli/keyring_test.go
@@ -1,9 +1,12 @@
 package cli
 
 import (
+	"bytes"
+	"io"
 	"runtime"
 	"testing"
 
+	"github.com/ProtonMail/go-crypto/openpgp/armor"
 	"github.com/gopasspw/gopass/internal/config"
 	"github.com/gopasspw/gopass/pkg/ctxutil"
 	"github.com/stretchr/testify/assert"
@@ -65,6 +68,19 @@ oLGNPe8bErLNfny6AWU0Enam6a13BxwbBrtr
 -----END PGP PUBLIC KEY BLOCK-----
 `
 
+const pubkeyV5 = `-----BEGIN PGP PUBLIC KEY BLOCK-----
+
+mEkFamRhtRYAAAA/AytlcQHGJY4S2Za1gwFCd82T22Ul4EmqBVrYixcVWjEgpEB1
+e8M2dG7ED5VcKt85elLa2gqU/gzMx1CORDgAtBtUZXN0IEVkNDQ4IDx0ZXN0QGVk
+NDQ4Lm9yZz6I6QUTFgoAaSIhBWvLYkhPMeI0e+KOsnvpdbiIgIXCuhCjdJqDej4n
+0cGeBQJqZGG1GxSAAAAAAAQADm1hbnUyLDIuNSsxLjEyLDIsMgIbAQUJBaOagAUL
+CQgHAgIiAgYVCgkICwIEFgIDAQIeBwIXgAAAWfUByOC5k0FSpuzsOzFyF//3glgr
+Jx49bL7wEYvsUKaDr7JIk8nTBpoNbonTbySWKNQUchPgNBYm9tDtAAHHekxQXTFI
+KCmDZWKk9AszRJ8HME6UpUgRL+7StRu3auYkcQ54B+iId7BXFg117fiELKScOm/j
+JA0A
+=sVFJ
+-----END PGP PUBLIC KEY BLOCK-----`
+
 func TestReadNamesFromKey(t *testing.T) {
 	t.Parallel()
 
@@ -106,4 +122,76 @@ func TestImport(t *testing.T) {
 
 	g.binary = ""
 	require.Error(t, g.ImportPublicKey(ctx, []byte("foobar")))
+}
+
+func TestReadNamesFromKeyBinary(t *testing.T) {
+	t.Parallel()
+
+	ctx := config.NewContextInMemory()
+	ctx = ctxutil.WithAlwaysYes(ctx, true)
+
+	g, err := New(ctx, Config{})
+	require.NoError(t, err)
+	assert.NotEmpty(t, g.Binary())
+
+	block, err := armor.Decode(bytes.NewReader([]byte(pubkey)))
+	require.NoError(t, err)
+
+	binKey, err := io.ReadAll(block.Body)
+	require.NoError(t, err)
+
+	names, err := g.ReadNamesFromKey(ctx, binKey)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"Gopass Archive Signing Key <gopass@justwatch.com>"}, names)
+}
+
+func TestGetFingerprint(t *testing.T) {
+	t.Parallel()
+
+	ctx := config.NewContextInMemory()
+	ctx = ctxutil.WithAlwaysYes(ctx, true)
+
+	g, err := New(ctx, Config{})
+	require.NoError(t, err)
+	assert.NotEmpty(t, g.Binary())
+
+	fpr, err := g.GetFingerprint(ctx, []byte(pubkey))
+	require.NoError(t, err)
+	assert.Equal(t, "7379880F3D29A3B03F44B73D0C92225A97F6B666", fpr)
+}
+
+func TestGetFingerprintBinary(t *testing.T) {
+	t.Parallel()
+
+	ctx := config.NewContextInMemory()
+	ctx = ctxutil.WithAlwaysYes(ctx, true)
+
+	g, err := New(ctx, Config{})
+	require.NoError(t, err)
+	assert.NotEmpty(t, g.Binary())
+
+	block, err := armor.Decode(bytes.NewReader([]byte(pubkey)))
+	require.NoError(t, err)
+
+	binKey, err := io.ReadAll(block.Body)
+	require.NoError(t, err)
+
+	fpr, err := g.GetFingerprint(ctx, binKey)
+	require.NoError(t, err)
+	assert.Equal(t, "7379880F3D29A3B03F44B73D0C92225A97F6B666", fpr)
+}
+
+func TestGetFingerprintV5(t *testing.T) {
+	t.Parallel()
+
+	ctx := config.NewContextInMemory()
+	ctx = ctxutil.WithAlwaysYes(ctx, true)
+
+	g, err := New(ctx, Config{})
+	require.NoError(t, err)
+	assert.NotEmpty(t, g.Binary())
+
+	fpr, err := g.GetFingerprint(ctx, []byte(pubkeyV5))
+	require.NoError(t, err)
+	assert.Equal(t, "6BCB62484F31E2347BE28EB27BE975B8888085C2BA10A3749A837A3E27D1C19E", fpr)
 }

--- a/internal/backend/crypto/gpg/key.go
+++ b/internal/backend/crypto/gpg/key.go
@@ -63,13 +63,8 @@ func (k Key) IsUseable(alwaysTrust bool) bool {
 // String implement fmt.Stringer. This method produces output that is close to, but
 // not exactly the same, as the output from GPG itself.
 func (k Key) String() string {
-	fp := ""
-	if len(k.Fingerprint) > 24 {
-		fp = k.Fingerprint[24:]
-	}
-
 	var out strings.Builder
-	fmt.Fprintf(&out, "%s   %dD/0x%s %s", k.KeyType, k.KeyLength, fp, k.CreationDate.Format("2006-01-02"))
+	fmt.Fprintf(&out, "%s   %dD/%s %s", k.KeyType, k.KeyLength, k.ID(), k.CreationDate.Format("2006-01-02"))
 	if !k.ExpirationDate.IsZero() {
 		fmt.Fprintf(&out, " [expires: %s]", k.ExpirationDate.Format("2006-01-02"))
 	}
@@ -85,11 +80,12 @@ func (k Key) String() string {
 // OneLine prints a terse representation of this key on one line (includes only
 // the first identity!).
 func (k Key) OneLine() string {
-	if len(k.Fingerprint) < 24 {
+	id := k.ID()
+	if id == "" {
 		return fmt.Sprintf("(invalid:%s)", k.Fingerprint)
 	}
 
-	return fmt.Sprintf("0x%s - %s", k.Fingerprint[24:], k.Identity().ID())
+	return fmt.Sprintf("%s - %s", id, k.Identity().ID())
 }
 
 // Identity returns the first identity.
@@ -112,9 +108,15 @@ func (k Key) Identity() Identity {
 
 // ID returns the short fingerprint.
 func (k Key) ID() string {
-	if len(k.Fingerprint) < 25 {
-		return ""
+	if len(k.Fingerprint) == 64 {
+		return fmt.Sprintf("0x%s", k.Fingerprint[:16])
+	}
+	if len(k.Fingerprint) >= 40 {
+		return fmt.Sprintf("0x%s", k.Fingerprint[len(k.Fingerprint)-16:])
+	}
+	if len(k.Fingerprint) >= 24 {
+		return fmt.Sprintf("0x%s", k.Fingerprint[24:])
 	}
 
-	return fmt.Sprintf("0x%s", k.Fingerprint[24:])
+	return ""
 }

--- a/internal/backend/crypto/gpg/key_list.go
+++ b/internal/backend/crypto/gpg/key_list.go
@@ -73,7 +73,7 @@ func (kl KeyList) FindKey(id string) (Key, error) {
 			return k, nil
 		}
 
-		if strings.HasSuffix(k.Fingerprint, id) {
+		if strings.HasSuffix(k.Fingerprint, id) || strings.HasPrefix(k.Fingerprint, id) {
 			return k, nil
 		}
 
@@ -88,7 +88,7 @@ func (kl KeyList) FindKey(id string) (Key, error) {
 		}
 
 		for sk := range k.SubKeys {
-			if strings.HasSuffix(sk, id) {
+			if strings.HasSuffix(sk, id) || strings.HasPrefix(sk, id) {
 				return k, nil
 			}
 		}

--- a/internal/backend/crypto/gpg/key_test.go
+++ b/internal/backend/crypto/gpg/key_test.go
@@ -74,6 +74,13 @@ func genTestKey(args ...string) Key {
 	}
 }
 
+func genTestKeyV5() Key {
+	k := genTestKey()
+	k.Fingerprint = "70B42A46DB33A9F24177F0BCA2CD28D5D0DB013CBDFDE8A66324CAAC83E67468"
+
+	return k
+}
+
 func TestKey(t *testing.T) {
 	t.Parallel()
 
@@ -87,6 +94,11 @@ func TestKey(t *testing.T) {
 	assert.Equal(t, "sec   2048D/0x62AF4031C82E0039 2018-01-01 [expires: 2218-01-01]\n      Key fingerprint = 25FF1614B8F87B52FFFF99B962AF4031C82E0039\nuid                            John Doe (johnny) <john.doe@example.org>", k.String())
 	assert.Equal(t, "0x62AF4031C82E0039 - John Doe (johnny) <john.doe@example.org>", k.OneLine())
 	assert.Equal(t, "0x62AF4031C82E0039", k.ID())
+
+	v5 := genTestKeyV5()
+	assert.Equal(t, "sec   2048D/0x70B42A46DB33A9F2 2018-01-01 [expires: 2218-01-01]\n      Key fingerprint = 70B42A46DB33A9F24177F0BCA2CD28D5D0DB013CBDFDE8A66324CAAC83E67468\nuid                            John Doe (johnny) <john.doe@example.org>", v5.String())
+	assert.Equal(t, "0x70B42A46DB33A9F2 - John Doe (johnny) <john.doe@example.org>", v5.OneLine())
+	assert.Equal(t, "0x70B42A46DB33A9F2", v5.ID())
 }
 
 func TestIdentitySort(t *testing.T) {


### PR DESCRIPTION
GnuPG 2.5+ can produce v5 keys (e.g. with PQC algorithms like `ky768_cv25519`) whose fingerprints are 64 hex characters instead of the traditional 40. This PR updates key parsing, ID extraction, and key lookup to handle both v4 and v5 fingerprint lengths.

### Changes

- **`Key.ID()`**: Add a branch for 64-char fingerprints, taking the first 16 characters as the short ID (matching GnuPG's own implementation).
- **`ReadNamesFromKey` / `GetFingerprint`**: Replace `ProtonMail/go-crypto` openpgp calls with `gpg --show-keys --with-colons`, since `go-crypto` does not support v5 key packets and fails to parse them.
- **`key_list.go`**: Match key IDs by prefix in addition to suffix, since v5 short IDs are derived from the start of the fingerprint.

### Tests

- `key_test.go`: Unit tests for v5 key ID extraction from 64-char fingerprints.
- `keyring_test.go`: Unit tests for v5 key parsing via `--show-keys --with-colons` output.