### PR TITLE
test(action): use t.Chdir instead of manual os.Chdir save/restore

### DIFF
--- a/internal/action/binary_test.go
+++ b/internal/action/binary_test.go
@@ -237,10 +237,7 @@ func TestBinaryCopyNameAmbiguity(t *testing.T) {
 	// Operate from a directory that holds a file whose name collides with the
 	// destination secret name, reproducing the exact scenario from the issue.
 	workdir := t.TempDir()
-	old, err := os.Getwd()
-	require.NoError(t, err)
-	require.NoError(t, os.Chdir(workdir))
-	defer func() { require.NoError(t, os.Chdir(old)) }()
+	t.Chdir(workdir)
 
 	require.NoError(t, os.WriteFile(filepath.Join(workdir, "test"), []byte("0xDEADBEEF\n"), 0o644))
 


### PR DESCRIPTION
## What

Replace the manual `os.Getwd` / `os.Chdir` / deferred-restore sequence in `TestBinaryCopyNameAmbiguity` with `t.Chdir`.

## Why

golangci-lint's `usetesting` linter flags both the `os.Chdir` call and its deferred restore:

```
internal/action/binary_test.go:242:21: os.Chdir() could be replaced by t.Chdir() in TestBinaryCopyNameAmbiguity (usetesting)
internal/action/binary_test.go:243:36: os.Chdir() could be replaced by t.Chdir() in TestBinaryCopyNameAmbiguity (usetesting)
```

These are the only two findings golangci-lint reports on the tree.

`t.Chdir` also restores the working directory when the test fails early, which the deferred call does not do if an earlier `require` aborts the goroutine.

## Notes

`t.Chdir` panics if the test calls `t.Parallel`. This test does not, and it already mutates the global `out.Stdout`, so it is inherently serial.

The `os` import is still required at lines 229 and 245.

## Verification

```
$ go test ./internal/action/ -run TestBinaryCopyNameAmbiguity
ok  	github.com/gopasspw/gopass/internal/action

$ go test ./internal/action/
ok  	github.com/gopasspw/gopass/internal/action	9.836s

$ golangci-lint run ./internal/action/...
0 issues.
```

Behaviour change: none.