### PR TITLE
docs: add docs/conventions.md and adopt Conventional Commits

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,10 +37,23 @@ The project is specifically targeting users on all major platform, i.e. Linux, U
 - `/pkg/debug`: Contains a debug package with different verbosity levels. Use it to output debug information to a debug log.
 - `/pkg/fsutil`: Contains various helpers for interacting with the filesystem, e.g. checking for presence of files or directories. Prefer those over implementing these checks from scratch.
 - `/pkg/gopass`: Contains the public gopass API to interact with existing password stores. The `api` sub package contains the actual API and the `secrets` sub package the different secret types we support.
+- `/pkg/otp`: Contains functions to handle OTP secrets. It parses OTP secrets from various formats and generates QR codes for them.
+- `/pkg/passkey`: Implements support for WebAuthn credentials for authentication.
+- `/pkg/pinentry/cli`: Contains a pinentry client that uses the terminal for input and output. It is a drop-in replacement for the `pinentry` program, used to ask for a passphrase or PIN. Note that `/pkg/pinentry` itself holds no Go files; `cli` is the only package under it.
+- `/pkg/protect`: Provides an interface to the `pledge` syscall, used to limit the system calls the process can make. `pledge` exists only on OpenBSD; this package is a no-op everywhere else.
 - `/pkg/pwgen`: Contains a pure-Go implementation of the `pwgen` utility.
+- `/pkg/qrcon`: Implements a QR code ANSI printer for displaying QR codes on the console.
 - `/pkg/set`: Contains a generic set type.
 - `/pkg/tempfile`: Contains utility functions for creating and dealing with temp files. It attempts to be more secure than the normal temp file functions from the stdlib. Prefer those over the stdlib.
 - `/pkg/termio`: Contains functions for interacting with the user of the terminal.
+
+## Conventions
+
+Commit messages, versioning, branch and tag names, and file naming are specified in [docs/conventions.md](docs/conventions.md). Observe these three rules in particular:
+
+- Use only the listed commit types: `feat fix security perf refactor revert deps docs test build ci chore`. The list is closed. `otp`, `age`, `fscopy`, `bug` and `openbsd` appear as types in the history; they are scopes and must be written as such.
+- Use `!` and a `BREAKING CHANGE:` footer only for a break in the CLI. Mark a break confined to the `pkg/gopass` Go module with a `PKG-BREAK:` footer and no `!`. The first forces a major release; the second does not.
+- Write the pull request title as a valid Conventional Commit. Pull requests are squash-merged, so the pull request title is the string that reaches `CHANGELOG.md`, not the individual commit subjects.
 
 ## Libraries and Frameworks
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -48,17 +48,28 @@ Semantic versioning applies to the **gopass CLI binary** only. The Go module
 (`github.com/gopasspw/gopass`) does not carry independent semver guarantees:
 a breaking change to `pkg/` interfaces may ship without a major-version bump.
 
-`pkg/gopass/doc.go` carries an explicit instability warning for this reason.
-Until that warning is removed, consumers of `pkg/gopass` should:
+`pkg/gopass` is instead **best-effort stable**, as decided in
+[ADR A-12](docs/adr/A-12-pkg-api-stability.md) and restated in
+`pkg/gopass/doc.go`:
 
-- Pin to a specific commit or tag rather than a `@latest` reference.
-- Review the `CHANGELOG.md` `pkg/` entries before upgrading.
-- Treat any `pkg/` type or function change as potentially breaking.
+- Additive changes (new exported symbols, new functional-option parameters)
+  may appear in any release.
+- Breaking changes (removing or changing the signature of an exported symbol,
+  changing an interface method set or error semantics) require a
+  `[PKG-BREAK]` entry in `CHANGELOG.md` and a deprecation window of two minor
+  releases or three months, whichever is longer.
 
-The intention is to formalise this contract (via a `v2` module path or a
-published compatibility window) once the active contributor base grows
-sufficiently to maintain that commitment. See issue #3414 for the open
-decision on the API stability ADR.
+Consumers of `pkg/gopass` should review the `[PKG-BREAK]` entries in
+`CHANGELOG.md` before upgrading.
+
+A break confined to `pkg/gopass` does **not** trigger a major release of the
+CLI. See [docs/conventions.md](docs/conventions.md) section 2 for how the two
+compatibility surfaces are versioned, and section 1.4 for the commit-message
+markers that distinguish them.
+
+Formalising the contract further (via a `v2` module path or a published
+compatibility window) is deferred until the active contributor base grows
+sufficiently to maintain that commitment.
 
 ### `docs/backends`
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,9 +40,22 @@ will try to clarify it.
 
       Signed-off-by: Your Name <your@email.com>
 
-* The first line of the commit message, the subject line, should be prefix with a tag indicating the type of the change. These tags will be extracted and used to populate the changelog.
-  Valid `[TAG]`s are `[BREAKING]`, `[BUGFIX]`, `[CLEANUP]`, `[DEPRECATION]`,
-  `[DOCUMENTATION]`, `[ENHANCEMENT]`, `[FEATURE]`, `[TESTING]`, and `[UX]`.
+* Write every commit subject as a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/),
+  for example `fix(age): expand ~/ in age.ssh-key-path`. The accepted types and
+  scopes are listed in [docs/conventions.md](docs/conventions.md).
+
+  Conventional Commits governs the subject line; the Developer Certificate of
+  Origin adds a trailer. Both apply to every commit.
+
+* Write the pull request title as a valid Conventional Commit. Pull requests are
+  squash-merged, so the pull request title is the string that reaches the
+  changelog.
+
+## Conventions
+
+Commit messages, versioning, branch and tag names, and file naming are specified
+in [docs/conventions.md](docs/conventions.md). Read it before opening your first
+pull request.
 
 ## Building & Testing
 

--- a/docs/adr/A-03-separate-storage-rcs.md
+++ b/docs/adr/A-03-separate-storage-rcs.md
@@ -1,4 +1,4 @@
-# A-3: Separate `Storage` and `RCS` interfaces
+# A-03: Separate `Storage` and `RCS` interfaces
 
 **Status:** deferred — current implementation intentionally keeps them merged  
 **Source:** CODE_QUALITY_REPORT.md § A-3

--- a/docs/adr/A-04-grep-match-error-counters.md
+++ b/docs/adr/A-04-grep-match-error-counters.md
@@ -1,4 +1,4 @@
-# A-4: Fix `grep` Match and Error Counters
+# A-04: Fix `grep` Match and Error Counters
 
 **Status:** open — not yet fixed  
 **Source:** SECURITY_AUDIT_REPORT.md § M-1, § Q-5

--- a/docs/adr/A-05-template-engine-text-vs-html.md
+++ b/docs/adr/A-05-template-engine-text-vs-html.md
@@ -1,4 +1,4 @@
-# A-5: Template Engine Uses `text/template` Instead of `html/template`
+# A-05: Template Engine Uses `text/template` Instead of `html/template`
 
 **Status:** deferred — current design is acceptable given the constraints  
 **Source:** SECURITY_AUDIT_REPORT.md § M-2

--- a/docs/adr/A-06-minimum-password-length.md
+++ b/docs/adr/A-06-minimum-password-length.md
@@ -1,4 +1,4 @@
-# A-6: Minimum Password Length Enforcement
+# A-06: Minimum Password Length Enforcement
 
 **Status:** deferred — user autonomy preserved; warning to be added  
 **Source:** SECURITY_AUDIT_REPORT.md § M-4

--- a/docs/adr/A-07-hook-system-dead-code.md
+++ b/docs/adr/A-07-hook-system-dead-code.md
@@ -1,4 +1,4 @@
-# A-7: Hook System Dead Code and CVE-2023-24055
+# A-07: Hook System Dead Code and CVE-2023-24055
 
 **Status:** deferred — hooks remain disabled; safe re-enablement path documented  
 **Source:** SECURITY_AUDIT_REPORT.md § M-5

--- a/docs/adr/A-08-shred-modern-storage-limitations.md
+++ b/docs/adr/A-08-shred-modern-storage-limitations.md
@@ -1,4 +1,4 @@
-# A-8: Shred Operation Is Ineffective on Modern Storage
+# A-08: Shred Operation Is Ineffective on Modern Storage
 
 **Status:** accepted — limitation documented; advisory notice to be added  
 **Source:** SECURITY_AUDIT_REPORT.md § M-6

--- a/docs/adr/A-09-low-severity-informational-findings.md
+++ b/docs/adr/A-09-low-severity-informational-findings.md
@@ -1,4 +1,4 @@
-# A-9: Low Severity and Informational Findings
+# A-09: Low Severity and Informational Findings
 
 **Status:** accepted — risks documented; mitigations noted where applicable  
 **Source:** SECURITY_AUDIT_REPORT.md § L-1 through L-6

--- a/docs/adr/A-15-screenshot-build-tag.md
+++ b/docs/adr/A-15-screenshot-build-tag.md
@@ -1,4 +1,4 @@
-# A-13: `noscreenshot` Build Tag for OTP Screen-Capture Feature
+# A-15: `noscreenshot` Build Tag for OTP Screen-Capture Feature
 
 **Status:** accepted  
 **Source:** [GitHub Issue #3415](https://github.com/gopasspw/gopass/issues/3415)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,57 @@
+# Architecture Decision Records
+
+Each record states one architectural decision, the context it was made in, the
+options considered, and the outcome. Amend a record only to update its status.
+Never reuse a number: supersede a decision by writing a new record.
+
+Name records `A-NN-<kebab-slug>.md`, with `NN` zero-padded to two digits. Write
+the H1 as `# A-NN: <Title>`, matching the file name. Open the record with a
+`**Status:**` line — `proposed`, `accepted`, `deferred`, `implemented`,
+`partially implemented`, or `superseded by A-NN` — and a `**Source:**` line.
+Update this index in the same commit that adds or supersedes a record.
+
+## Index
+
+| ADR | Title | Status | Added |
+|---|---|---|---|
+| [A-03](A-03-separate-storage-rcs.md) | Separate `Storage` and `RCS` interfaces | deferred | 2026-04-06 |
+| [A-04](A-04-grep-match-error-counters.md) | Fix `grep` match and error counters | open | 2026-04-06 |
+| [A-05](A-05-template-engine-text-vs-html.md) | Template engine uses `text/template` instead of `html/template` | deferred | 2026-04-06 |
+| [A-06](A-06-minimum-password-length.md) | Minimum password length enforcement | deferred | 2026-04-06 |
+| [A-07](A-07-hook-system-dead-code.md) | Hook system dead code and CVE-2023-24055 | deferred | 2026-04-06 |
+| [A-08](A-08-shred-modern-storage-limitations.md) | Shred operation is ineffective on modern storage | accepted | 2026-04-06 |
+| [A-09](A-09-low-severity-informational-findings.md) | Low severity and informational findings | accepted | 2026-04-06 |
+| [A-10](A-10-code-quality-findings.md) | Code quality findings | open | 2026-04-06 |
+| [A-11](A-11-secret-service.md) | Integrate `org.freedesktop.secrets` D-Bus service | proposed | 2026-05-24 |
+| [A-12](A-12-pkg-api-stability.md) | `pkg/gopass` API stability contract | accepted | 2026-05-24 |
+| [A-13](A-13-expired-gpg-key-handling.md) | Expired GPG key handling and recipient validity warnings | partially implemented | 2026-05-25 |
+| [A-14](A-14-team-workflows.md) | Effortless team workflows | implemented | 2026-06-06 |
+| [A-15](A-15-screenshot-build-tag.md) | `noscreenshot` build tag for OTP screen-capture feature | accepted | 2026-05-25 |
+
+Status values are taken from each record's `**Status:**` line. Dates are the
+authoring commit dates reported by `git log --diff-filter=A --follow`.
+
+## Reserved and renumbered records
+
+**A-01 and A-02 are reserved and have no records.** Both numbers are cited from
+the `CHANGELOG.md` unreleased section: "Split Action handler into focused
+handler types (A-1)" and "Replace context-key config system with typed structs
+(A-2)". No file was written for either. Do not reuse these numbers; the
+changelog citations would then point at unrelated decisions.
+
+**A-15 was renumbered from A-13.** Two records carried the number A-13.
+`A-13-expired-gpg-key-handling.md` keeps it: it is cited from
+`docs/commands/recipients.md`, `docs/usecases/team-workflows.md`, and
+`docs/adr/A-14-team-workflows.md`. The screenshot record had no inbound
+citations and was renumbered to A-15.
+
+**A-03 through A-09 were zero-padded.** Their file names previously used a
+single digit, which sorts them after A-10 in any lexical listing.
+
+## Unavailable sources
+
+`SECURITY_AUDIT_REPORT.md` and `CODE_QUALITY_REPORT.md` are not present in the
+working tree. Records A-03 through A-10 cite them in their `**Source:**` lines.
+Both files were removed in commit `77894053` ("Clean up") and are recoverable
+only from git history. The citations identify which finding each record answers,
+for example "§ M-4", and are therefore retained.

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -1,0 +1,267 @@
+# Conventions
+
+Normative reference for commit messages, versioning, branch and tag names, and
+file naming.
+
+See [CONTRIBUTING.md](../CONTRIBUTING.md) for the contribution workflow and
+[docs/hacking.md](hacking.md) for the development environment.
+
+## 1. Commit messages
+
+Commit subjects follow [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/).
+
+### 1.1 Format
+
+```
+<type>[(<scope>)][!]: <description>
+
+[optional body]
+
+[optional footers]
+```
+
+Rules:
+
+* Limit the subject line to 72 characters.
+* Write the description in the imperative mood: "add", not "adds" or "added".
+* Start the description in lowercase. Do not end it with a period.
+* Include a `Signed-off-by:` footer in every commit, as required by
+  [CONTRIBUTING.md](../CONTRIBUTING.md). Conventional Commits governs the
+  subject line; the Developer Certificate of Origin adds a trailer. Both apply.
+* Write the pull request title as a valid Conventional Commit.
+
+The pull request title requirement follows from the merge strategy. Pull
+requests are squash-merged: pull request #3489, titled `fix: Avoid NPE when
+attempting to edit a non-existing secret`, landed on `master` as the
+single-parent commit `eb1368e4` with the subject `fix: Avoid NPE when
+attempting to edit a non-existing secret (#3489)`. The pull request title, not
+the individual commit subjects, is the string that reaches `CHANGELOG.md`.
+
+### 1.2 Types
+
+This list is exhaustive. Reject any other type.
+
+| Type | Meaning | SemVer impact | Changelog section |
+|---|---|---|---|
+| `feat` | New user-visible capability | MINOR | Added |
+| `fix` | Bug fix | PATCH | Fixed |
+| `security` | Security fix or hardening | PATCH | Security |
+| `perf` | Performance improvement, no behaviour change | PATCH | Changed |
+| `refactor` | Internal restructuring, no behaviour change | PATCH | Changed |
+| `revert` | Reverts a previous commit | PATCH | Changed |
+| `deps` | Dependency version change | PATCH | Changed |
+| `docs` | Documentation only | none | omitted |
+| `test` | Tests only | none | omitted |
+| `build` | Build system: Makefile, goreleaser, Dockerfile | none | omitted |
+| `ci` | GitHub Actions, linter configuration, workflows | none | omitted |
+| `chore` | Housekeeping that fits nothing above | none | omitted |
+
+Two entries extend the set suggested by the specification:
+
+* `security` populates the `Security` section of the changelog, which
+  Keep a Changelog defines as a first-class category. Five commits since
+  2025-01-01 already use it.
+* `deps` is the preferred type for hand-written dependency commits.
+  Accept `chore(deps)` as well: Dependabot emits it, and 147 of the 344
+  commit subjects since 2025-01-01 carry the `chore` type, nearly all of
+  them dependency bumps.
+
+The following appear as commit types in the history and are not types. Use them
+as scopes: `otp` (2 commits since 2025-01-01), `age`, `bug`, `fscopy`, and
+`openbsd` (1 each).
+
+### 1.3 Scopes
+
+The scope is optional. Prefer to supply one. Do not invent scopes; omit the
+scope when none fits. Omit the scope for a change spanning several areas rather
+than listing more than one.
+
+**Commands** — the 41 top-level subcommands: 39 registered by
+`(*Action).GetCommands` in `internal/action/commands.go`, plus `pwgen` from
+`internal/action/pwgen` and `completion`, both added by `getCommands` in
+`main.go`:
+
+```
+alias audit cat clone completion config convert copy create delete doctor edit
+env find fsck fscopy fsmove generate grep history init insert link list merge
+mounts move otp process pwgen rcs recipients reorg setup show sum sync
+templates unclip update version
+```
+
+**Backends:** `age`, `gpg`, `plain`, `cryptfs`, `fossilfs`, `fs`, `gitfs`, `jjfs`
+
+**Subsystems:** `action`, `audit`, `backend`, `cache`, `completion`, `config`,
+`create`, `cui`, `editor`, `hashsum`, `hook`, `notify`, `out`, `queue`,
+`recipients`, `reminder`, `store`, `store/leaf`, `store/root`, `tpl`, `tree`,
+`updater`
+
+**Public API:** `pkg/gopass`, `api`, `secrets`, `appdir`, `clipboard`,
+`ctxutil`, `debug`, `fsutil`, `otp`, `passkey`, `pinentry`, `protect`, `pwgen`,
+`qrcon`, `set`, `tempfile`, `termio`
+
+**Meta:** `deps`, `release`, `changelog`, `docs`, `adr`, `ci`, `build`
+
+Write `pkg/gopass` out in full as a scope. Public-API changes must be greppable
+against the [A-12](adr/A-12-pkg-api-stability.md) stability contract.
+
+### 1.4 Breaking changes
+
+This repository has two independent compatibility surfaces. Mark them
+differently. Do not conflate them.
+
+| Surface broken | Marker | Version impact |
+|---|---|---|
+| gopass CLI: commands, flags, output format, exit codes, config keys, store format | `!` after the type or scope, **and** a `BREAKING CHANGE:` footer | MAJOR |
+| Go module `pkg/gopass` only: an exported symbol removed or changed | a `PKG-BREAK:` footer, **no** `!` | none; MINOR at most |
+| Both | `!` + `BREAKING CHANGE:` + `PKG-BREAK:` | MAJOR |
+
+Do not mark a module-only break with `!`. No CLI user can observe such a
+change, and `!` demands a major release.
+
+Example of a module-only break, per [A-12](adr/A-12-pkg-api-stability.md):
+
+```
+refactor(pkg/gopass): drop Store.GetRevision in favour of Store.History
+
+Deprecated since 1.17.0; the two-minor / three-month window has elapsed.
+
+PKG-BREAK: pkg/gopass: remove Store.GetRevision, use Store.History instead
+Signed-off-by: Your Name <your@example.com>
+```
+
+The `PKG-BREAK:` footer is the machine-readable form of the `[PKG-BREAK]`
+changelog tag mandated by A-12.
+
+### 1.5 Changelog control footers
+
+| Footer | Effect |
+|---|---|
+| `Changelog-Section: Added\|Changed\|Deprecated\|Removed\|Fixed\|Security` | Overrides the type-to-section mapping. Required for `Removed` and `Deprecated`, which have no corresponding commit type. |
+| `RELEASE_NOTES=<text>` or `RELEASE_NOTES=n/a` | Overrides the bullet text, or suppresses the entry. |
+| `PKG-BREAK: <text>` | Emits a `[PKG-BREAK]`-prefixed bullet. |
+
+## 2. Versioning
+
+This project follows [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html).
+
+### 2.1 Covered by SemVer
+
+SemVer applies to the gopass command line interface and its observable
+behaviour: subcommands, flags and their aliases, the stdout and stderr
+contracts, JSON output schemas, exit codes ([docs/exit-codes.md](exit-codes.md)),
+configuration keys ([docs/config.md](config.md)), the on-disk store format, and
+the generated shell completions and man page.
+
+### 2.2 Not covered by SemVer
+
+The Go module `github.com/gopasspw/gopass` carries no independent semver
+guarantees. `pkg/gopass` is governed by [A-12](adr/A-12-pkg-api-stability.md)
+and by the package documentation in `pkg/gopass/doc.go`, which declare it
+best-effort stable:
+
+* Additive changes — new exported symbols, new functional-option parameters —
+  may appear in any release.
+* Breaking changes — removal or signature change of an exported symbol, change
+  to an interface method set or to error semantics — require a `[PKG-BREAK]`
+  entry in `CHANGELOG.md` and a deprecation window of two minor releases or
+  three months, whichever is longer.
+
+### 2.3 Precedence
+
+Release a change that breaks only `pkg/` consumers as MINOR or PATCH. Do not
+bump MAJOR for it. Release a change that breaks CLI users as MAJOR regardless
+of its `pkg/` impact.
+
+### 2.4 Pre-releases
+
+Use `vX.Y.Z-rc.N` only: SemVer pre-release identifiers, dot-separated, numeric.
+Sign the tag. Cut it from the merged `release/vX.Y.Z-rc.N` branch. See
+[docs/releases.md](releases.md).
+
+## 3. Branch names
+
+```
+<type>/<kebab-slug>[-<issue>]
+```
+
+* Use a commit type from §1.2 as `<type>`.
+* Restrict the slug to `[a-z0-9-]`, plus the single `/` separator. Use no spaces
+  and no underscores. Limit the whole name to 60 characters.
+* Append the issue number when one exists:
+  `refactor/separate-storage-rcs-3411`.
+* Do not create these prefixes by hand; the release automation owns them:
+  `release/vX.Y.Z` and `release/vX.Y.Z-rc.N`, created by
+  `helpers/release/main.go`, and `prep/vX.Y.Z`, documented in
+  [docs/releases.md](releases.md).
+* Do not push feature branches to `gopasspw/gopass`. Work on a fork.
+
+## 4. Tag names
+
+* Name releases `vX.Y.Z` and pre-releases `vX.Y.Z-rc.N`.
+* Sign every tag (`git tag -s`).
+* Create no other tags in this repository.
+
+`.github/workflows/autorelease.yml` triggers on `push: tags: 'v*'`.
+`helpers/release/main.go` strips the leading `v` and parses the remainder as
+semver.
+
+## 5. File names
+
+### 5.1 General rules
+
+* Use lowercase kebab-case, restricted to `[a-z0-9._-]`.
+* Use no spaces.
+* Zero-pad any numeric component that participates in lexical ordering.
+* Prefix with `YYYY-MM-DD` when chronological order matters.
+* Order components from most general to most specific, left to right.
+
+### 5.2 Architecture decision records
+
+Name records `docs/adr/A-NN-<kebab-slug>.md`, with `NN` zero-padded to two
+digits.
+
+* Write the H1 as `# A-NN: <Title>`, matching the file name.
+* Open the record with a `**Status:**` line — `proposed`, `accepted`,
+  `deferred`, `implemented`, `partially implemented`, or `superseded by A-NN` —
+  and a `**Source:**` line.
+* Never reuse a number. Supersede a decision by writing a new record.
+* Update [docs/adr/README.md](adr/README.md) in the same commit that adds or
+  supersedes a record.
+
+### 5.3 Other documentation
+
+* Name command specifications `docs/commands/<command>.md`, where the file name
+  is exactly the command name.
+* Name backend documents `docs/backends/<backend>.md` and use cases
+  `docs/usecases/<kebab-slug>.md`.
+* Use lowercase throughout. Keep the SCREAMING_CASE names of root-level
+  documents, which is the GitHub convention.
+
+### 5.4 Go files
+
+* Use lowercase names with no underscores, except for the reserved suffixes
+  below. Prefer a single word matching the primary type or the command.
+* Place a command implementation in `internal/action/<command>.go` with an
+  accompanying `internal/action/<command>_test.go`.
+* Reserved suffixes: `_test.go`; the `GOOS` and `GOARCH` suffixes `_unix.go`,
+  `_windows.go`, `_linux.go`, `_darwin.go`, `_others.go`; `_gen.go` for
+  generated code; `_fuzz.go` for fuzz targets.
+* Give a build-tag variant that is not `GOOS`-based a descriptive suffix and an
+  explicit `//go:build` line, for example `screenshot_supported.go` and
+  `screenshot_stub.go`.
+* Split a file above roughly 600 lines along an existing type or feature seam.
+
+## 6. Changelog
+
+`CHANGELOG.md` follows [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/):
+an `## [Unreleased]` section at the top, then one `## [X.Y.Z] - YYYY-MM-DD`
+section per release, each containing only the non-empty subsections of
+`Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, and `Security`.
+
+`helpers/release` generates the entries from commit subjects at release time,
+using the mapping in §1.2 and the footers in §1.5. Do not edit `CHANGELOG.md`
+by hand, with two exceptions. Add a hand-written `## [Unreleased]` entry for:
+
+* any change to the exported surface of `pkg/`, as required by
+  [A-12](adr/A-12-pkg-api-stability.md); and
+* any `security:` change.

--- a/docs/hacking.md
+++ b/docs/hacking.md
@@ -8,6 +8,8 @@ This document provides an overview on how to develop on gopass.
 
 This project uses [GitHub Flow](https://guides.github.com/introduction/flow/). In other words, create feature branches from master, open an PR against master, and rebase onto master if necessary.
 
+Branch names, tag names, commit message format and file naming are specified in [conventions.md](conventions.md).
+
 We aim for compatibility with the [latest stable Go Release](https://golang.org/dl/) only.
 
 While this project is maintained by volunteers in their free time we aim to triage issues weekly and release a new version at least every quarter.

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -8,7 +8,10 @@ Goreleaser automates most but not all steps of a new release.
 
 Note: We use semantic versioning for the command line interface and tool behaviour
 but not for the API (i.e. `pkg/gopass`). Maintaining both properties in the
-same repository / Go module is too cumbersome.
+same repository / Go module is too cumbersome. `pkg/gopass` is instead governed
+by the best-effort stability contract in [ADR A-12](adr/A-12-pkg-api-stability.md).
+See [conventions.md](conventions.md) section 2 for the full policy, including how
+a break confined to `pkg/` is versioned.
 
 ## Development overview
 

--- a/internal/backend/storage/fs/rcs.go
+++ b/internal/backend/storage/fs/rcs.go
@@ -19,7 +19,7 @@
 // decision to merge them was made to simplify the leaf store and reduce the
 // indirection layer. If the number of pure-storage backends grows, or if the
 // stub overhead becomes a maintenance burden, see
-// docs/adr/A-3-separate-storage-rcs.md for a ready-made plan to split them
+// docs/adr/A-03-separate-storage-rcs.md for a ready-made plan to split them
 // again.
 package fs
 


### PR DESCRIPTION
> Depends on #3502. This branch is stacked on it, so it currently shows two commits. Once #3502 merges, only the conventions commit remains.

## What

Replace the `[TAG]` commit-subject rule in `CONTRIBUTING.md` with Conventional Commits, and add `docs/conventions.md` as the single normative reference for commit messages, versioning, branch and tag names, and file naming.

## Why

`CONTRIBUTING.md:43-45` required a bracketed `[TAG]` prefix and listed nine valid tags. That has not matched practice for some time. Of the 344 commit subjects since 2025-01-01:

```
$ git log --since=2025-01-01 --format='%s' | grep -cE '^[a-z]+(\([^)]*\))?!?: '
225
$ git log --since=2025-01-01 --format='%s' | grep -cE '^\[[A-Za-z-]+\]'
67
```

The `CHANGELOG.md` unreleased section uses a third set including `[SECURITY]` and `[PKG-BREAK]`, neither of which `CONTRIBUTING.md` lists.

## What docs/conventions.md specifies

- **Commit types**, as a closed list, with the SemVer impact and changelog section of each. It documents two extensions to the set suggested by the specification: `security`, which is already used by five commits and populates the Keep a Changelog `Security` section, and `deps`, with `chore(deps)` remaining accepted because Dependabot emits it.
- **Scopes**, derived from the package layout: the 41 top-level subcommands, the backends, the subsystems and the public API packages.
- **The two compatibility surfaces.** A CLI break uses `!` and a `BREAKING CHANGE:` footer and forces a major release. A break confined to `pkg/gopass` uses a `PKG-BREAK:` footer, no `!`, and does not. The `PKG-BREAK:` footer is the machine-readable form of the changelog tag mandated by ADR A-12.
- **Semantic Versioning**, and which surfaces it does and does not cover.
- **Branch and tag names**, including the `release/` and `prep/` prefixes owned by the release automation.
- **File naming** for ADRs, documentation and Go sources.

It also records five values that appear as commit types in the history but are scopes: `otp` (2 commits since 2025-01-01), `age`, `bug`, `fscopy` and `openbsd` (1 each).

## The DCO is unchanged

Conventional Commits governs the subject line; the Developer Certificate of Origin adds a trailer. The two are independent and both continue to apply. `CONTRIBUTING.md:35-41` is untouched.

## Corrections to ARCHITECTURE.md

The API Stability section still described `pkg/gopass/doc.go` as carrying "an explicit instability warning" and instructed consumers to "treat any `pkg/` type or function change as potentially breaking". Both statements predate ADR A-12. `doc.go` now declares the package best-effort stable and permits additive changes in any release. The section also referred to issue #3414 as an open decision; that decision is recorded in A-12 with status `accepted`.

## AGENTS.md

The folder list did not mention five `pkg/` directories that exist: `otp`, `passkey`, `pinentry/cli`, `protect` and `qrcon`. Each is described using its own package doc comment. Note that `pkg/pinentry` itself holds no Go files; `cli` is the only package under it.

## Verification

Every relative link in the changed and added documents resolves. `make test` passes.