### PR TITLE
feat(changelog): migrate to Keep a Changelog 1.1.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,10 +37,23 @@ The project is specifically targeting users on all major platform, i.e. Linux, U
 - `/pkg/debug`: Contains a debug package with different verbosity levels. Use it to output debug information to a debug log.
 - `/pkg/fsutil`: Contains various helpers for interacting with the filesystem, e.g. checking for presence of files or directories. Prefer those over implementing these checks from scratch.
 - `/pkg/gopass`: Contains the public gopass API to interact with existing password stores. The `api` sub package contains the actual API and the `secrets` sub package the different secret types we support.
+- `/pkg/otp`: Contains functions to handle OTP secrets. It parses OTP secrets from various formats and generates QR codes for them.
+- `/pkg/passkey`: Implements support for WebAuthn credentials for authentication.
+- `/pkg/pinentry/cli`: Contains a pinentry client that uses the terminal for input and output. It is a drop-in replacement for the `pinentry` program, used to ask for a passphrase or PIN. Note that `/pkg/pinentry` itself holds no Go files; `cli` is the only package under it.
+- `/pkg/protect`: Provides an interface to the `pledge` syscall, used to limit the system calls the process can make. `pledge` exists only on OpenBSD; this package is a no-op everywhere else.
 - `/pkg/pwgen`: Contains a pure-Go implementation of the `pwgen` utility.
+- `/pkg/qrcon`: Implements a QR code ANSI printer for displaying QR codes on the console.
 - `/pkg/set`: Contains a generic set type.
 - `/pkg/tempfile`: Contains utility functions for creating and dealing with temp files. It attempts to be more secure than the normal temp file functions from the stdlib. Prefer those over the stdlib.
 - `/pkg/termio`: Contains functions for interacting with the user of the terminal.
+
+## Conventions
+
+Commit messages, versioning, branch and tag names, and file naming are specified in [docs/conventions.md](docs/conventions.md). Observe these three rules in particular:
+
+- Use only the listed commit types: `feat fix security perf refactor revert deps docs test build ci chore`. The list is closed. `otp`, `age`, `fscopy`, `bug` and `openbsd` appear as types in the history; they are scopes and must be written as such.
+- Use `!` and a `BREAKING CHANGE:` footer only for a break in the CLI. Mark a break confined to the `pkg/gopass` Go module with a `PKG-BREAK:` footer and no `!`. The first forces a major release; the second does not.
+- Write the pull request title as a valid Conventional Commit. Pull requests are squash-merged, so the pull request title is the string that reaches `CHANGELOG.md`, not the individual commit subjects.
 
 ## Libraries and Frameworks
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -48,17 +48,28 @@ Semantic versioning applies to the **gopass CLI binary** only. The Go module
 (`github.com/gopasspw/gopass`) does not carry independent semver guarantees:
 a breaking change to `pkg/` interfaces may ship without a major-version bump.
 
-`pkg/gopass/doc.go` carries an explicit instability warning for this reason.
-Until that warning is removed, consumers of `pkg/gopass` should:
+`pkg/gopass` is instead **best-effort stable**, as decided in
+[ADR A-12](docs/adr/A-12-pkg-api-stability.md) and restated in
+`pkg/gopass/doc.go`:
 
-- Pin to a specific commit or tag rather than a `@latest` reference.
-- Review the `CHANGELOG.md` `pkg/` entries before upgrading.
-- Treat any `pkg/` type or function change as potentially breaking.
+- Additive changes (new exported symbols, new functional-option parameters)
+  may appear in any release.
+- Breaking changes (removing or changing the signature of an exported symbol,
+  changing an interface method set or error semantics) require a
+  `[PKG-BREAK]` entry in `CHANGELOG.md` and a deprecation window of two minor
+  releases or three months, whichever is longer.
 
-The intention is to formalise this contract (via a `v2` module path or a
-published compatibility window) once the active contributor base grows
-sufficiently to maintain that commitment. See issue #3414 for the open
-decision on the API stability ADR.
+Consumers of `pkg/gopass` should review the `[PKG-BREAK]` entries in
+`CHANGELOG.md` before upgrading.
+
+A break confined to `pkg/gopass` does **not** trigger a major release of the
+CLI. See [docs/conventions.md](docs/conventions.md) section 2 for how the two
+compatibility surfaces are versioned, and section 1.4 for the commit-message
+markers that distinguish them.
+
+Formalising the contract further (via a `v2` module path or a published
+compatibility window) is deferred until the active contributor base grows
+sufficiently to maintain that commitment.
 
 ### `docs/backends`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,39 +1,66 @@
 # Changelog
 
-## Next
+All notable changes to this project will be documented in this file.
 
-* [SECURITY] Fix path traversal vulnerability in fs storage layer (C-1)
-* [SECURITY] Bound symlink traversal to store root (H-2)
-* [SECURITY] Restrict template engine secret access and fix error information leakage (H-1)
-* [SECURITY] Validate editor binary path before invocation (H-3)
-* [SECURITY] Warn on env command secret exposure via environment variables (C-2)
-* [BUGFIX] Add thread safety to SSH identity cache (M-3)
-* [BUGFIX] Fix grep match and error counters in audit summary (B-1)
-* [BUGFIX] Fix autoSync debounce timestamp to update on success instead of failure (B-2)
-* [BUGFIX] Fix create wizard maximum-length check (B-3)
-* [BUGFIX] Fix queue goroutine leak and Add() post-Close() panic (B-8)
-* [BUGFIX] Fix convert backend name in error messages (B-5, B-6)
-* [BUGFIX] Default audit output to summary when no format flag is given (B-7)
-* [FEATURE] Add gopass doctor diagnostic command (I-4)
-* [FEATURE] Add stable structured exit codes; --exit-codes flag lists all codes (I-2)
-* [FEATURE] Add JSON output to audit, list, find, and recipients commands (I-3)
-* [FEATURE] Add show.hidden-keys config option for customizable safecontent redaction (I-5)
-* [FEATURE] Add show.fuzzysearch config and --nofuzzysearch flag to control automatic fuzzy lookup in show
-* [FEATURE] Add --stdin, --file, and --exec modes to gopass env
-* [ENHANCEMENT] Unified secret name validation rejects path traversal and consecutive slashes (I-1)
-* [CLEANUP] Split Action handler into focused handler types (A-1)
-* [CLEANUP] Replace context-key config system with typed structs (A-2)
-* [CLEANUP] Replace sort.Strings with slices.Sort throughout (S-3)
-* [CLEANUP] Protect autosyncLastRun with a mutex (S-6)
-* [UX] Remove misleading --force / -f aliases from --unsafe in show and find (U-1)
-* [UX] Standardize XKCD password generator flag names to --xkcd-sep, --xkcd-lang etc. (U-4)
-* [UX] Remove cryptic -t alias from --force-regen in generate (U-6)
-* [UX] Surface GOPASS_AUTOSYNC_INTERVAL deprecation as a visible warning (U-7)
-* [DOCUMENTATION] Fix documentation vs. implementation mismatches in config.md, show.md, find.md, generate.md, secrets.md, and ARCHITECTURE.md
-* [DOCUMENTATION] Fully document wizard template format, attribute types, and file naming convention (I-7)
-* [DOCUMENTATION] Define pkg/gopass API stability contract: best-effort stable policy with [PKG-BREAK] changelog tag and minimum deprecation window (A-12)
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
+for the gopass command line interface. The Go module `pkg/gopass` follows the
+best-effort stability contract in [ADR A-12](docs/adr/A-12-pkg-api-stability.md);
+breaking changes there are marked `[PKG-BREAK]`. See
+[docs/conventions.md](docs/conventions.md) for the commit message and changelog
+conventions this file is generated from.
 
-## 1.16.1 / 2025-12-13
+## [Unreleased]
+
+### Added
+
+- Add gopass doctor diagnostic command (I-4)
+- Add stable structured exit codes; --exit-codes flag lists all codes (I-2)
+- Add JSON output to audit, list, find, and recipients commands (I-3)
+- Add show.hidden-keys config option for customizable safecontent redaction (I-5)
+- Add show.fuzzysearch config and --nofuzzysearch flag to control automatic fuzzy lookup in show
+- Add --stdin, --file, and --exec modes to gopass env
+
+### Changed
+
+- Unified secret name validation rejects path traversal and consecutive slashes (I-1)
+- Split Action handler into focused handler types (A-1)
+- Replace context-key config system with typed structs (A-2)
+- Replace sort.Strings with slices.Sort throughout (S-3)
+- Protect autosyncLastRun with a mutex (S-6)
+- Standardize XKCD password generator flag names to --xkcd-sep, --xkcd-lang etc. (U-4)
+- Fix documentation vs. implementation mismatches in config.md, show.md, find.md, generate.md, secrets.md, and ARCHITECTURE.md
+- Fully document wizard template format, attribute types, and file naming convention (I-7)
+- Define pkg/gopass API stability contract: best-effort stable policy with [PKG-BREAK] changelog tag and minimum deprecation window (A-12)
+
+### Deprecated
+
+- Surface GOPASS_AUTOSYNC_INTERVAL deprecation as a visible warning (U-7)
+
+### Removed
+
+- Remove misleading --force / -f aliases from --unsafe in show and find (U-1)
+- Remove cryptic -t alias from --force-regen in generate (U-6)
+
+### Fixed
+
+- Add thread safety to SSH identity cache (M-3)
+- Fix grep match and error counters in audit summary (B-1)
+- Fix autoSync debounce timestamp to update on success instead of failure (B-2)
+- Fix create wizard maximum-length check (B-3)
+- Fix queue goroutine leak and Add() post-Close() panic (B-8)
+- Fix convert backend name in error messages (B-5, B-6)
+- Default audit output to summary when no format flag is given (B-7)
+
+### Security
+
+- Fix path traversal vulnerability in fs storage layer (C-1)
+- Bound symlink traversal to store root (H-2)
+- Restrict template engine secret access and fix error information leakage (H-1)
+- Validate editor binary path before invocation (H-3)
+- Warn on env command secret exposure via environment variables (C-2)
+
+## [1.16.1] - 2025-12-13
 
 * chore(deps): bump actions/checkout from 5.0.0 to 6.0.0 (#3299)
 * chore(deps): bump actions/setup-go from 6.0.0 to 6.1.0 (#3300)
@@ -46,7 +73,7 @@
 * fix(config): use the config propery generate.strict as default value for Strict rules (#3303)
 * fix: Fix version check against latest release (#3292)
 
-## 1.16.0 / 2025-11-12
+## [1.16.0] - 2025-11-12
 
 * [BUGFIX] reorg: List all secrets instead of just top-level folders (#3245)
 * [chore] Add capability and vulnerability checks (#3266)
@@ -79,7 +106,7 @@
 * feat: Clone remote on init (#3247)
 * fix: Fix release helper and update capabilities for caplos (#3288)
 
-## 1.15.18 / 2025-09-19
+## [1.15.18] - 2025-09-19
 
 * [fix] Enable Windows builders (#3237)
 * [fix] Fix recipient check error (#3235)
@@ -92,7 +119,7 @@
 * fix(config): Make core.exportkeys handling consistent (#3228)
 * fix(gpg): Opportunistic key comparison on import (#3230)
 
-## 1.15.17 / 2025-09-15
+## [1.15.17] - 2025-09-15
 
 * [BUGFIX] Fix --force flag in recipients add (#3173)
 * [chore] Add tests and comments for hasPwRuleForSecret (#3162)
@@ -113,7 +140,7 @@
 * [fix] use WritePassword for secure write (#3200)
 * [testing] use `/usr/bin/env cat` instead of `/bin/cat` (#3160)
 
-## 1.15.16 / 2025-04-21
+## [1.15.16] - 2025-04-21
 
 * [BUGFIX] Allow use of trailing slash for cp/mv command (#3080)
 * [BUGFIX] Check if any usable key matches on clone (#3027)
@@ -147,7 +174,7 @@
 * [fix] Relase fixes (#3136)
 * [fix] Update Makefile and fix lint violations (#3134)
 
-## 1.15.15 / 2024-11-24
+## [1.15.15] - 2024-11-24
 
 * [BUGFIX] Replace ~ with user homedir if `$GOPASS_HOMEDIR` is not set (#2961)
 * [CLEANUP] Replace experimental `maps` and `slices` with stdlib (#2993)
@@ -160,7 +187,7 @@
 * [bugfix] Copy with trailing slash at destination. (#2966)
 * [chore] use the same version of golangci-lint (#2948)
 
-## 1.15.14 / 2024-08-03
+## [1.15.14] - 2024-08-03
 
 * [bugfix] Fix parsing of key-value pairs according to the gitconfig (#2911)
 * [chore] Update dependency to github.com/cenkalti/backoff/v4 (#2864)
@@ -169,7 +196,7 @@
 * [chore] Update dependency to github.com/xhit/go-str2duration/v2 (#2865)
 * [chore] Update hashicorp/golang-lru to v2 (#2859)
 
-## 1.15.13 / 2024-04-06
+## [1.15.13] - 2024-04-06
 
 * [bugfix] Default to true for core.exportkeys even in substores (#2848)
 * [bugfix] Do not report findings with severity none in audit summary (#2843)
@@ -183,7 +210,7 @@
 * [fix] Disble safecontent parsing if noparsing is requested (#2855)
 * [fix] Pass remote, if given, to local init as well (#2852)
 
-## 1.15.12 / 2024-03-17
+## [1.15.12] - 2024-03-17
 
 * [BUGFIX] Use 'en' as default language for the xkcd generator (#2793)
 * [DOCUMENTATION] Fix typo: initilize -> initialize (#2796)
@@ -198,14 +225,14 @@
 * [ux] Add hint that computing recipients takes some time (#2833)
 * [ux] Do not show create type chooser if only one exists (#2752)
 
-## 1.15.11 / 2023-12-01
+## [1.15.11] - 2023-12-01
 
 * [bugfix] Disable multi-line description for deb packages (#2729)
 * [bugfix] Fix writes to global config from tests (#2727)
 * [bugfix] Workaround for goreleaser/nfpm#742 (#2732)
 * [feature] Allow setting autosync.interval in different time units (#2731)
 
-## 1.15.10 / 2023-11-25
+## [1.15.10] - 2023-11-25
 
 * [BUGFIX] Allow to move shadowed entries into their own folder (#2718)
 * [BUGFIX] Try to always honor local config for mounts (#2724)
@@ -215,7 +242,7 @@
 * [cleanup] Add package description (#2702)
 * [feature] Add new pwgen options to capitalize and include numbers in (#2703)
 
-## 1.15.9 / 2023-11-18
+## [1.15.9] - 2023-11-18
 
 * [BUGFIX] Disabling the OTP snip screenshot feature on OpenBSD (#2685)
 * [CLEANUP] Migration of options to more appropriate sections (#2681)
@@ -224,7 +251,7 @@
 * [enhancement] Add blake3 to the template functions (#2693)
 * [enhancement] Add input validation to block illegal mount points (#2672)
 
-## 1.15.8 / 2023-09-11
+## [1.15.8] - 2023-09-11
 
 * [BUGFIX] Use goreleaser build for crosscompile (#2635)
 * [bugfix] Allow fsck to check a single secret (#2659)
@@ -235,11 +262,11 @@
 * [feat] Add --store option to gopass fsck (#2658)
 * [feat] Add XCKD pwgen config options (#2651)
 
-## 1.15.7 / 2023-08-04
+## [1.15.7] - 2023-08-04
 
 * [BUGFIX] Fix build issues on various non-Linux platforms (#2630, #2633)
 
-## 1.15.6 / 2023-07-30
+## [1.15.6] - 2023-07-30
 
 * [DOCUMENTATION] fix Arch Linux package url (#2598)
 * [BUGFIX] Only show desktop notifications if there are changes (#2627)
@@ -247,12 +274,12 @@
 * [BUGFIX] Correctly handle multiline secrets (#2625)
 * [ENHANCEMENT] Add screen parsing for OTP QR codes (#2597)
 
-## 1.15.5 / 2023-04-07
+## [1.15.5] - 2023-04-07
 
 * [CLEANUP] Use Go1.20 (#2567)
 * [ENHANCEMENT] Add internal pager (ov). (#2510)
 
-## 1.15.4 / 2023-02-12
+## [1.15.4] - 2023-02-12
 
 * [BUGFIX] Also accept lower case CTE headers. (#2539, #2518)
 * [BUGFIX] Commit changes to mount config changes. (#2542, #2530)
@@ -263,7 +290,7 @@
 * [BUGFIX] Improve error handling for gopass convert (#2548, #2520)
 * [ENHANCEMENT] Add edit.auto-create (#2538)
 
-## 1.15.3 / 2023-01-07
+## [1.15.3] - 2023-01-07
 
 * [BUGFIX] Check recipients before launching editor. (#2488, #1565)
 * [BUGFIX] Fix possible concurrency issues in fsck. (#2486, #2459)
@@ -276,13 +303,13 @@
 * [ENHANCEMENT] Rewrite gopass audit. Add HTML and CSV (#2506, #2504)
 * [ENHANCEMENT] gitconfig: Support MultiVars (#2476, #2457)
 
-## 1.15.2 / 2022-12-18
+## [1.15.2] - 2022-12-18
 
 * [BUGFIX] [gitconfig] Properly parse Key-Value pairs with (#2482, #2479)
 * [ENHANCEMENT] Add --force-regen flag to generate (#2475, #2474)
 * [ENHANCEMENT] Add recipients hash checking. (#2481, #2478)
 
-## 1.15.1 / 2022-12-11
+## [1.15.1] - 2022-12-11
 
 * [BUGFIX] Fix domain alias lookup (#2455, #2453)
 * [BUGFIX] Fix vim invocation. (#2456, #2424)
@@ -294,7 +321,7 @@
 * [ENHANCEMENT] Pre-populate ID with git values (#2442, #968)
 * [ENHANCEMENT] Support german language in the password (#2454, #2451)
 
-## 1.15.0 / 2022-12-03
+## [1.15.0] - 2022-12-03
 
 * [BREAKING] New config format based on git config. (#2395, #1567, #1764, #1819, #1878, #2387, #2418)
 * [BUGFIX] Fix symlink deduplication. (#2437, #2402)
@@ -325,7 +352,7 @@ The parsing of the recipients files (`.gpg-id`) has become more flexible and
 can now contain comments. These will be retained when updating these files
 through gopass as well.
 
-## 1.14.11 / 2022-11-25
+## [1.14.11] - 2022-11-25
 
 * [BUGFIX] Fix edit on MacOS Ventura (#2426, #2400)
 * [BUGFIX] Handle nvi (#2414)
@@ -333,7 +360,7 @@ through gopass as well.
 * [BUGFIX] Only pass vim options to vim (#2421, #2412)
 * [ENHANCEMENT] Support combined short flags (#2420, #2419)
 
-## 1.14.10 / 2022-11-09
+## [1.14.10] - 2022-11-09
 
 * [BUGFIX] Correctly handle key removal on Windows (#2372, #2371)
 * [DOCUMENTATION] (#1878)
@@ -341,11 +368,11 @@ through gopass as well.
 * [ENHANCEMENT] Improve key expiration handling (#2383, #2369)
 * [ENHANCEMENT] allow re-encrypting entire directory when (#2373)
 
-## 1.14.9 / 2022-09-28
+## [1.14.9] - 2022-09-28
 
 * [ENHANCEMENT] Make DBus notifications transient (#2364, #2358)
 
-## 1.14.8 / 2022-09-27
+## [1.14.8] - 2022-09-27
 
 * [BUGFIX] Ignore not-existing .ssh dir (#2347, #2333)
 * [BUGFIX] Use Wait() to avoid Zombies (#2354, #1666)
@@ -353,7 +380,7 @@ through gopass as well.
 * [ENHANCEMENT] Improve passage support (#2352, #2059)
 * [ENHANCEMENT] Use OS keychain for age passphrase caching (new config option, off by default). (#2351, #2350)
 
-## 1.14.7 / 2022-09-20
+## [1.14.7] - 2022-09-20
 
 * [BUGFIX] Do not ignore symlinks when listing (#2344, #2173)
 * [BUGFIX] Do not shadow entries behind folders. (#2341, #2338)
@@ -361,18 +388,18 @@ through gopass as well.
 * [BUGFIX] Handle Ctrl+C in TOTP (#2342, #2320)
 * [ENHANCEMENT] Set vim options instead of sniffing (#2343, #2317)
 
-## 1.14.6 / 2022-09-10
+## [1.14.6] - 2022-09-10
 
 * [BUGFIX] Do not show setup message on version (#2327)
 * [BUGFIX] Remove exported public keys of removed (#2328, #2315)
 * [ENHANCEMENT] Document extension model. (#2329, #2290)
 
-## 1.14.5 / 2022-09-03
+## [1.14.5] - 2022-09-03
 
 * [BUGFIX] Fix fsck progress bar. Mostly. (#2303)
 * [DOCUMENTATION] fix in recommended vim setting (#2318)
 
-## 1.14.4 / 2022-08-02
+## [1.14.4] - 2022-08-02
 
 * [BREAKING] gopass otp will automatically update the counter key in HTOP secrets! (#2278)
 * [BUGFIX] Allow removing unknown recipients with --force (#2253)
@@ -384,7 +411,7 @@ through gopass as well.
 * [ENHANCEMENT] Scan for vulnerabilities and add SBOM on (#2268)
 * [ENHANCEMENT] Use packages.gopass.pw for APT packages (#2261)
 
-## 1.14.3 / 2022-05-31
+## [1.14.3] - 2022-05-31
 
 * [BUGFIX] Do not print progress bar on otp --clip (#2243)
 * [BUGFIX] Removing shadowing warning when using -o/--password (#2245)
@@ -392,7 +419,7 @@ through gopass as well.
 * [DOCUMENTATION] Adding doc about YAML entries and unsafe-keys (#2244)
 * [ENHANCEMENT] Allow deleting multiple secrets (#2239)
 
-## 1.14.2 / 2022-05-22
+## [1.14.2] - 2022-05-22
 
 * [BUGFIX] Fix gpg identity detection (#2218, #2179)
 * [BUGFIX] Handle different line breaks in recipient (#2221, #2220)
@@ -400,7 +427,7 @@ through gopass as well.
 * [ENHANCEMENT] Add flag to keep env variable capitalization (#2226, #2225)
 * [ENHANCEMENT] Environment variable GOPASS_PW_DEFAULT_LENGTH can be used to overwrite default password length of 24 characters. (#2219)
 
-## 1.14.1 / 2022-05-02
+## [1.14.1] - 2022-05-02
 
 * [BUGFIX] Do not print missing public key for age. (#2166)
 * [BUGFIX] Improve convert output (#2171)
@@ -409,7 +436,7 @@ through gopass as well.
 * [ENHANCEMENT] Avoid decryption on move or copy (#2183, #2181)
 * [UX] Upgrade xkcdpwgen to a new version that removes German (#2187)
 
-## 1.14.0 / 2022-03-16
+## [1.14.0] - 2022-03-16
 
 * Add --chars option to print subset of secrets (#2155, #2068)
 * [BUGFIX] Always re-encrypt when fsck is invoked with --decrypt. (#2119, #2015)
@@ -451,12 +478,12 @@ through gopass as well.
 * [TESTING] Use a helper to unset env vars in clipboard tests. (#2091, #2042)
 * [UX] OTP code now runs in loop until canceled or used with -o (#2041)
 
-## 1.13.1 / 2022-01-15
+## [1.13.1] - 2022-01-15
 
 * [BUGFIX] Handle from prefix correctly on mv (#2110, #2079)
 * [BUGFIX] Handle unencoded secret on cat
 
-## 1.13.0 / 2021-11-13
+## [1.13.0] - 2021-11-13
 
 * [BUGFIX] Do not print OTP progress bar if not in terminal (#2019)
 * [BUGFIX] Don't prompt to retype password unnecessarily (#1983)
@@ -469,7 +496,7 @@ through gopass as well.
 * [FEATURE] Add capitalized words to memorable passwords (#1985, #1984)
 * [UX] Use new progress bar for OTP expiry time (#2019)
 
-## 1.12.8 / 2021-08-28
+## [1.12.8] - 2021-08-28
 
 * [BUGFIX] Use same default for partial config files (#1968)
 * [CLEANUP] Remove GOPASS_NOCOLOR in favor of NO_COLOR (#1937, #1936)
@@ -477,7 +504,7 @@ through gopass as well.
 * [ENHANCEMENT] Add --symbols to gopass pwgen (#1966)
 * [ENHANCEMENT] Warn on untracked files (#1972)
 
-## 1.12.7 / 2021-07-02
+## [1.12.7] - 2021-07-02
 
 * DOCUMENTATION Fixed Single Line Formating for Clone Documentation (#1943)
 * [BUGFIX] Allow --strict to be chained with --symbols (#1952, #1941)
@@ -485,7 +512,7 @@ through gopass as well.
 * [BUGFIX] Use /tmp for GIT_SSH_COMMAND on Mac (#1951, #1896)
 * [ENHANCEMENT] Add warning when parsing content (#1950)
 
-## 1.12.6 / 2021-05-01
+## [1.12.6] - 2021-05-01
 
 * [BUGFIX] Do not recurse with a key (#1907, #1906)
 * [BUGFIX] Fix SSH control path (#1899, #1896)
@@ -494,7 +521,7 @@ through gopass as well.
 * [BUGFIX] Ignore commented values in gpg config (#1901, #1898)
 * [ENHANCEMENT] Add better usage instructions (#1912)
 
-## 1.12.5 / 2021-03-27
+## [1.12.5] - 2021-03-27
 
 * [BUGFIX] Allow subkeys (#1843, #1841, #1842)
 * [BUGFIX] Avoid logging credentials (#1886, #1883)
@@ -505,12 +532,12 @@ through gopass as well.
 * [ENHANCEMENT] Add proper diff numbers on sync (#1882)
 * [ENHANCEMENT] Update password rules (#1861)
 
-## 1.12.4 / 2021-03-20
+## [1.12.4] - 2021-03-20
 
 * [BUGFIX] Bring back --yes (#1862, #1858)
 * [BUGFIX] Fix make install on BSD (#1859)
 
-## 1.12.3 / 2021-03-20
+## [1.12.3] - 2021-03-20
 
 * [BUGFIX] Fix generate -c (#1846, #1844)
 * [BUGFIX] Fix gopass update (#1838, #1837)
@@ -518,7 +545,7 @@ through gopass as well.
 * [CLEANUP] Remove the custom formula in favour of the official one. (#1847)
 * [ENHANCEMENT] Install manpage when using `make install` (#1845)
 
-## 1.12.2 / 2021-03-13
+## [1.12.2] - 2021-03-13
 
 * [BUGFIX] Do not fail if reminder is unavailable (#1835, #1832)
 * [BUGFIX] Do not shadow directories (#1817, #1813)
@@ -528,7 +555,7 @@ through gopass as well.
 * [ENHANCEMENT] Add gopass.1 man page (#1827, #1824)
 * [UX] Adding the grep command to --help (#1826, #1825)
 
-## 1.12.1 / 2021-02-17
+## [1.12.1] - 2021-02-17
 
 * [BUGFIX] Enable updater on Windows (#1790, #1789)
 * [BUGFIX] Fix progress bar nil pointer access (#1790, #1789)
@@ -537,7 +564,7 @@ through gopass as well.
 * [ENHANCEMENT] Added a env var to disable reminders (#1792)
 * [ENHANCEMENT] Remind to run gopass update/fsck/audit after 90d (#1792)
 
-## 1.12.0 / 2021-02-11
+## [1.12.0] - 2021-02-11
 
 WARNING: The self updater does not support updating from 1.11.0 to 1.12.0. Our
 release infrastructure does not support the key type used in 1.11.0.
@@ -575,7 +602,7 @@ updater and brought it back.
 * [ENHANCEMENT] Use persistent SSH connections (#1755)
 * [TESTING] Adding DI to Github Actions (#1728)
 
-## 1.11.0 / 2020-01-12
+## [1.11.0] - 2020-01-12
 
 This is an important bugfix release that should resolve several outstanding
 issues and concerns. Since 1.10.0 was released was engaged in a lot of
@@ -628,14 +655,14 @@ continue using compatible secrets formats as well as GPG and Git.
 * [ENHANCEMENT] Use 32 byte salt by default
 * [UX] Preserve content across retries
 
-## 1.10.1
+## [1.10.1] - 2020-08-25
 
 * [BUGFIX] Fix the Makefile
 * [BUGFIX] Remove misleading config error message
 * [BUGFIX] Re-use existing root store
 * [BUGFIX] Use standard Unix directories on MacOS
 
-## 1.10.0
+## [1.10.0] - 2020-08-22
 
 WARNING: This release contains a few breaking changes as well as necessary
 packaging changes.
@@ -735,13 +762,13 @@ be included in any binary re-distribution of gopass.
 * [FEATURE] REPL
 * [TESTING] Add a test to detect shadowing issue with mount
 
-## 1.9.2 / 2020-05-13
+## [1.9.2] - 2020-05-13
 
 * [BUGFIX] Bring back the custom fish completion.
 * [BUGFIX] Disable AutoClip when redirecting stdout
 * [ENHANCEMENT] Create new sub stores in XDG compliant locations.
 
-## 1.9.1 / 2020-05-09
+## [1.9.1] - 2020-05-09
 
 * [BUGFIX] Do not copy to clipboard with -f
 * [BUGFIX] Encrypt parent directory if leaf node exists.
@@ -754,7 +781,7 @@ be included in any binary re-distribution of gopass.
 * [ENHANCEMENT] Add memorable password generator
 * [ENHANCEMENT] Add preliminary age encryption support.
 
-## 1.9.0 / 2020-05-01
+## [1.9.0] - 2020-05-01
 
 * [ENHANCEMENT] Proper windows support [#1295]
 * [ENHANCEMENT] Add pwgen subcommand [#1308]
@@ -777,7 +804,7 @@ be included in any binary re-distribution of gopass.
 * [DEPRECATION] Deprecate OTP, Binary, YAML git-credentials and xc support [#1301]
 * [DEPRECATION] Remove support for OpenPGP (library), GoGit, Vault, Consul and encrypted configs [#1290, #1283, #1282, #1279]
 
-## 1.8.6 / 2019-07-26
+## [1.8.6] - 2019-07-26
 
 * [ENHANCEMENT] Add --password to otp command [#1150]
 * [ENHANCEMENT] Support adding key values with colons [#1128]
@@ -786,7 +813,7 @@ be included in any binary re-distribution of gopass.
 * [BUGFIX] Sort recipients by Name not by ID [#1143]
 * [BUGFIX] Handle slashes in recipient names [#1139]
 
-## 1.8.5 / 2019-03-03
+## [1.8.5] - 2019-03-03
 
 * [ENHANCEMENT] Improve template handling [#1029]
 * [ENHANCEMENT] Remove empty directories [#1009]
@@ -796,7 +823,7 @@ be included in any binary re-distribution of gopass.
 * [BUGFIX] Fix bash completion for MSYS on Windows [#1053]
 * [BUGFIX] Git clone failing [#1036]
 
-## 1.8.4 / 2018-12-26
+## [1.8.4] - 2018-12-26
 
 * [ENHANCEMENT] Evaluate templates when inserting single secrets [#1023]
 * [ENHANCEMENT] Add fuzzy search dialog for gopass otp [#1021]
@@ -806,7 +833,7 @@ be included in any binary re-distribution of gopass.
 * [BUGFIX] Abort tests on critical failures [#997]
 * [BUGFIX] Zsh autocompletion [#996]
 
-## 1.8.3 / 2018-11-19
+## [1.8.3] - 2018-11-19
 
 * [ENHANCEMENT] Add zsh autocompletion for insert and generate [#988]
 * [ENHANCEMENT] Set exit code for filtered ls without result [#983]
@@ -828,7 +855,7 @@ be included in any binary re-distribution of gopass.
 * [BUGFIX] Update external dependencies [#884, #932, #981]
 * [BUGFIX] Use valid crypto backend for key selection [#889]
 
-## 1.8.2 / 2018-06-28
+## [1.8.2] - 2018-06-28
 
 * [ENHANCEMENT] Improve fsck output [#859]
 * [ENHANCEMENT] Enable notifications on FreeBSD [#863]
@@ -837,12 +864,12 @@ be included in any binary re-distribution of gopass.
 * [BUGFIX] Fix commit on move [#860]
 * [BUGFIX] Properly check store initialization [#865]
 
-## 1.8.1 / 2018-06-08
+## [1.8.1] - 2018-06-08
 
 * [BUGFIX] Trim fsck path [#856]
 * [BUGFIX] Handle URL parse errors in create [#855]
 
-## 1.8.0 / 2018-06-06
+## [1.8.0] - 2018-06-06
 
 This release includes several possibly breaking changes.
 The `gopass move` implementation was refactored to properly support moving
@@ -875,16 +902,16 @@ the runtime behaviour, but we could not test this on all platforms, yet.
 * [BUGFIX] Properly handle autosync on recipients save [#848]
 * [BUGFIX] Resolve key IDs to fingerprints before adding or removing [#850]
 
-## 1.7.2 / 2018-05-28
+## [1.7.2] - 2018-05-28
 
 * [BUGFIX] Fix tilde expansion [#802]
 
-## 1.7.1 / 2018-05-25
+## [1.7.1] - 2018-05-25
 
 * [BUGFIX] Add nogit compat handler [#792]
 * [BUGFIX] Fix reencrypt [#796]
 
-## 1.7.0 / 2018-05-22
+## [1.7.0] - 2018-05-22
 
 * [FEATURE] Pluggable crypto, storage and RCS backends. Including a pure-Go NaCl based crypto backend [#645] [#680] [#736] [#777]
 * [FEATURE] Password history [#660]
@@ -912,14 +939,14 @@ the runtime behaviour, but we could not test this on all platforms, yet.
 * [BUGFIX] Secret.String() [#738]
 * [BUGFIX] Fix generate --symbols [#742] [#783]
 
-## 1.6.11 / 2018-02-20
+## [1.6.11] - 2018-02-20
 
 * [ENHANCEMENT] Documentation updates [#648] [#656]
 * [ENHANCEMENT] Add secret completions to edit command in zsh [#654]
 * [BUGFIX] Avoid escaping values added to secrets [#658]
 * [BUGFIX] Fix parsing of GPG UIDs [#650]
 
-## 1.6.10 / 2018-01-18
+## [1.6.10] - 2018-01-18
 
 * [ENHANCEMENT] Add Travis MacOS builds [#618]
 * [ENHANCEMENT] Make gopass build on DragonFlyBSD [#619]
@@ -928,11 +955,11 @@ the runtime behaviour, but we could not test this on all platforms, yet.
 * [BUGFIX] Fix Makefile [#615] [#617]
 * [BUGFIX] Fix failing tests on MacOS [#614]
 
-## 1.6.9 / 2018-01-05
+## [1.6.9] - 2018-01-05
 
 * [BUGFIX] Fix update URL check [#610]
 
-## 1.6.8 / 2018-01-05
+## [1.6.8] - 2018-01-05
 
 * [ENHANCEMENT] Add OpenBSD Ksh completion [#586]
 * [ENHANCEMENT] Increase test coverage [#589] [#590] [#592] [#595] [#596] [#597] [#601] [#602] [#603] [#604]
@@ -941,7 +968,7 @@ the runtime behaviour, but we could not test this on all platforms, yet.
 * [BUGFIX] Fix create wizard [#594]
 * [BUGFIX] Use persistent bufio.Reader [#607]
 
-## 1.6.7 / 2017-12-31
+## [1.6.7] - 2017-12-31
 
 * [ENHANCEMENT] Add --sync flag to gopass show [#544]
 * [ENHANCEMENT] Update dependencies [#547]
@@ -952,7 +979,7 @@ the runtime behaviour, but we could not test this on all platforms, yet.
 * [ENHANCEMENT] Add go-fuzz instrumentation [#576]
 * [BUGFIX] Catch URL parse errors [#546]
 
-## 1.6.6 / 2017-12-20
+## [1.6.6] - 2017-12-20
 
 * [FEATURE] Selective Sync [#538]
 * [ENHANCEMENT] Make termwiz honor copy flag [#534]
@@ -960,20 +987,20 @@ the runtime behaviour, but we could not test this on all platforms, yet.
 * [ENHANCEMENT] Refactor [#533] [#540] [#541] [#542]
 * [BUGFIX] Show git output [#529]
 
-## 1.6.5 / 2017-12-15
+## [1.6.5] - 2017-12-15
 
 * [ENHANCEMENT] Handle errors gracefully [#524]
 * [BUGFIX] Follow symlinks [#519]
 * [BUGFIX] Improve GPG binary detection [#520] [#522]
 
-## 1.6.4 / 2017-12-13
+## [1.6.4] - 2017-12-13
 
 * [ENHANCEMENT] Support desktop notifications on Mac and Windows [#513]
 * [BUGFIX] Fix slice out of bounds error [#517]
 * [BUGFIX] Allow .password-store to be a symlink [#516]
 * [BUGFIX] Respect --store flag to git sub command [#512]
 
-## 1.6.3 / 2017-12-12
+## [1.6.3] - 2017-12-12
 
 * [ENHANCEMENT] Avoid altering YAML secrets unless necessary [#508]
 * [ENHANCEMENT] Documentation updates [#493] [#509]
@@ -981,7 +1008,7 @@ the runtime behaviour, but we could not test this on all platforms, yet.
 * [ENHANCEMENT] Support GOPASS_GPG_OPTS and GOPASS_UMASK [#504]
 * [BUGFIX] Create .gpg-keys if it does not exist [#507]
 
-## 1.6.2 / 2017-12-02
+## [1.6.2] - 2017-12-02
 
 * [FEATURE] Add gopass fix command [#471]
 * [ENHANCEMENT] Add pledge support on OpenBSD [#469]
@@ -990,7 +1017,7 @@ the runtime behaviour, but we could not test this on all platforms, yet.
 * [BUGFIX] Default to vi if no other editor is available [#479]
 * [BUGFIX] Avoid auto-search running non-interactively [#483]
 
-## 1.6.1 / 2017-11-15
+## [1.6.1] - 2017-11-15
 
 * [FEATURE] Add generic OTP action [#440]
 * [ENHANCEMENT] Ignore any secret that does not end with .gpg [#461]
@@ -1003,7 +1030,7 @@ the runtime behaviour, but we could not test this on all platforms, yet.
 * [BUGFIX] Fix termbox UI on OpenBSD [#446]
 * [BUGFIX] Fix tests and paths on Windows [#421] [#431] [#442] [#450]
 
-## 1.6.0 / 2017-11-03
+## [1.6.0] - 2017-11-03
 
 * [FEATURE] Add Desktop notifications (Linux/DBus only) [#434] [#435]
 * [ENHANCEMENT] Show public key identities before importing [#427]
@@ -1013,7 +1040,7 @@ the runtime behaviour, but we could not test this on all platforms, yet.
 * [ENHANCEMENT] Refactor git backend [#437]
 * [BUGFIX] Fix recipients remove when using email as identifier [#436]
 
-## 1.5.1 / 2017-10-25
+## [1.5.1] - 2017-10-25
 
 * [ENHANCEMENT] Re-introduce usecolor config option [#414]
 * [ENHANCEMENT] Improve documentation [#407] [#409] [#416] [#417]
@@ -1021,7 +1048,7 @@ the runtime behaviour, but we could not test this on all platforms, yet.
 * [BUGFIX] Fix GPG binary detection [#419]
 * [BUGFIX] Fix tests on windows [#421]
 
-## 1.5.0 / 2017-10-17
+## [1.5.0] - 2017-10-17
 
 * [FEATURE] Add secret creation wizard [#386]
 * [FEATURE] Add onboarding wizard [#387]
@@ -1037,12 +1064,12 @@ the runtime behaviour, but we could not test this on all platforms, yet.
 * [ENHANCEMENT] Automatic GPG key generation [#391]
 * [BUGFIX] Relax YAML document marker handling [#398]
 
-## 1.4.1 / 2017-10-05
+## [1.4.1] - 2017-10-05
 
 * [BUGFIX] Support pre-1.3.0 configs [#382]
 * [BUGFIX] Turn YAML errors into warnings [#380]
 
-## 1.4.0 / 2017-10-04
+## [1.4.0] - 2017-10-04
 
 * [FEATURE] Add fuzzy search [#317]
 * [FEATURE] Allow restricting charset of generated passwords [#270]
@@ -1072,17 +1099,17 @@ the runtime behaviour, but we could not test this on all platforms, yet.
 * [BUGFIX] Do not offer invalid keys [#364]
 * [BUGFIX] Assign path only if resolving symlink succeeds [#370]
 
-## 1.3.2 / 2017-08-22
+## [1.3.2] - 2017-08-22
 
 * [BUGFIX] Fix git version output [#274]
 
-## 1.3.1 / 2017-08-15
+## [1.3.1] - 2017-08-15
 
 * [BUGFIX] Enable AutoSync by default [#267]
 * [BUGFIX] git - do not abort if a store has no remote [#261]
 * [BUGFIX] Fix IFS in bash completion [#268]
 
-## 1.3.0 / 2017-08-11
+## [1.3.0] - 2017-08-11
 
 * [BREAKING] Enforce YAML document markers [#193]
 * [BREAKING] Simplify configuration [#213]
@@ -1111,7 +1138,7 @@ the runtime behaviour, but we could not test this on all platforms, yet.
 * [BUGFIX] Only match mounts on folders [#240]
 * [BUGFIX] Disable checkRecipients as it conflicts with alwaysTrust [#242]
 
-## 1.2.0 / 2017-06-21
+## [1.2.0] - 2017-06-21
 
 * [FEATURE] YAML support [#125]
 * [FEATURE] Binary support [#136]
@@ -1122,19 +1149,19 @@ the runtime behaviour, but we could not test this on all platforms, yet.
 * [BUGFIX] Fix missing recipients on init [#141]
 * [BUGFIX] Fix sorting of mount points [#148]
 
-## 1.1.2 / 2017-06-14
+## [1.1.2] - 2017-06-14
 
 * [BUGFIX] Fix gopass init --store [#129]
 * [BUGFIX] Fix gopass init [#127]
 
-## 1.1.1 / 2017-06-13
+## [1.1.1] - 2017-06-13
 
 * [ENHANCEMENT] Allow files and folders with the same name [#124]
 * [ENHANCEMENT] Improve error messages [#121]
 * [ENHANCEMENT] Add rm aliases to remove commands [#119]
 * [BUGFIX] Several bug fixes for multi-repository handling [#123]
 
-## 1.1.0 / 2017-05-31
+## [1.1.0] - 2017-05-31
 
 * [FEATURE] Support templates [#1]
 * [FEATURE] QR Code output [#64]
@@ -1148,7 +1175,7 @@ the runtime behaviour, but we could not test this on all platforms, yet.
 * [ENHANCEMENT] Accept args for editor [#30]
 * [BUGFIX] Build fixes for Windows [#14]
 
-## 1.0.2 / 2017-03-24
+## [1.0.2] - 2017-03-24
 
 * [ENHANCEMENT] Improve mounts and init commands [#87]
 * [ENHANCEMENT] Document behavior of `-c` [#82]
@@ -1160,7 +1187,7 @@ the runtime behaviour, but we could not test this on all platforms, yet.
 * [BUGFIX] Don't prompt if input from stdin [#58]
 * [BUGFIX] Git add fails to "add" removed files [#57]
 
-## 1.0.1 / 2017-02-13
+## [1.0.1] - 2017-02-13
 
 * [FEATURE] Add dmenu support [#47]
 * [ENHANCEMENT] Extend GOPASS_DEBUG coverage [#31]
@@ -1172,10 +1199,98 @@ the runtime behaviour, but we could not test this on all platforms, yet.
 * [BUGFIX] Only copy the first line to the clipboard [#21]
 * [BUGFIX] Add search alias to find [#8]
 
-## 1.0.0 / 2017-02-02
+## [1.0.0] - 2017-02-02
 
 * [ENHANCEMENT] Support mounted sub-stores
 * [ENHANCEMENT] git auto-push and auto-pull
 * [ENHANCEMENT] git-style config editing
 * [ENHANCEMENT] Simplified recipient management
 * [ENHANCEMENT] Interactive questions for missing parameters
+
+[Unreleased]: https://github.com/gopasspw/gopass/compare/v1.16.1...HEAD
+[1.16.1]: https://github.com/gopasspw/gopass/compare/v1.16.0...v1.16.1
+[1.16.0]: https://github.com/gopasspw/gopass/compare/v1.15.18...v1.16.0
+[1.15.18]: https://github.com/gopasspw/gopass/compare/v1.15.17...v1.15.18
+[1.15.17]: https://github.com/gopasspw/gopass/compare/v1.15.16...v1.15.17
+[1.15.16]: https://github.com/gopasspw/gopass/compare/v1.15.15...v1.15.16
+[1.15.15]: https://github.com/gopasspw/gopass/compare/v1.15.14...v1.15.15
+[1.15.14]: https://github.com/gopasspw/gopass/compare/v1.15.13...v1.15.14
+[1.15.13]: https://github.com/gopasspw/gopass/compare/v1.15.12...v1.15.13
+[1.15.12]: https://github.com/gopasspw/gopass/compare/v1.15.11...v1.15.12
+[1.15.11]: https://github.com/gopasspw/gopass/compare/v1.15.10...v1.15.11
+[1.15.10]: https://github.com/gopasspw/gopass/compare/v1.15.9...v1.15.10
+[1.15.9]: https://github.com/gopasspw/gopass/compare/v1.15.8...v1.15.9
+[1.15.8]: https://github.com/gopasspw/gopass/compare/v1.15.7...v1.15.8
+[1.15.7]: https://github.com/gopasspw/gopass/compare/v1.15.6...v1.15.7
+[1.15.6]: https://github.com/gopasspw/gopass/compare/v1.15.5...v1.15.6
+[1.15.5]: https://github.com/gopasspw/gopass/compare/v1.15.4...v1.15.5
+[1.15.4]: https://github.com/gopasspw/gopass/compare/v1.15.3...v1.15.4
+[1.15.3]: https://github.com/gopasspw/gopass/compare/v1.15.2...v1.15.3
+[1.15.2]: https://github.com/gopasspw/gopass/compare/v1.15.1...v1.15.2
+[1.15.1]: https://github.com/gopasspw/gopass/compare/v1.15.0...v1.15.1
+[1.15.0]: https://github.com/gopasspw/gopass/compare/v1.14.11...v1.15.0
+[1.14.11]: https://github.com/gopasspw/gopass/compare/v1.14.10...v1.14.11
+[1.14.10]: https://github.com/gopasspw/gopass/compare/v1.14.9...v1.14.10
+[1.14.9]: https://github.com/gopasspw/gopass/compare/v1.14.8...v1.14.9
+[1.14.8]: https://github.com/gopasspw/gopass/compare/v1.14.7...v1.14.8
+[1.14.7]: https://github.com/gopasspw/gopass/compare/v1.14.6...v1.14.7
+[1.14.6]: https://github.com/gopasspw/gopass/compare/v1.14.5...v1.14.6
+[1.14.5]: https://github.com/gopasspw/gopass/compare/v1.14.4...v1.14.5
+[1.14.4]: https://github.com/gopasspw/gopass/compare/v1.14.3...v1.14.4
+[1.14.3]: https://github.com/gopasspw/gopass/compare/v1.14.2...v1.14.3
+[1.14.2]: https://github.com/gopasspw/gopass/compare/v1.14.1...v1.14.2
+[1.14.1]: https://github.com/gopasspw/gopass/compare/v1.14.0...v1.14.1
+[1.14.0]: https://github.com/gopasspw/gopass/compare/v1.13.1...v1.14.0
+[1.13.1]: https://github.com/gopasspw/gopass/compare/v1.13.0...v1.13.1
+[1.13.0]: https://github.com/gopasspw/gopass/compare/v1.12.8...v1.13.0
+[1.12.8]: https://github.com/gopasspw/gopass/compare/v1.12.7...v1.12.8
+[1.12.7]: https://github.com/gopasspw/gopass/compare/v1.12.6...v1.12.7
+[1.12.6]: https://github.com/gopasspw/gopass/compare/v1.12.5...v1.12.6
+[1.12.5]: https://github.com/gopasspw/gopass/compare/v1.12.4...v1.12.5
+[1.12.4]: https://github.com/gopasspw/gopass/compare/v1.12.3...v1.12.4
+[1.12.3]: https://github.com/gopasspw/gopass/compare/v1.12.2...v1.12.3
+[1.12.2]: https://github.com/gopasspw/gopass/compare/v1.12.1...v1.12.2
+[1.12.1]: https://github.com/gopasspw/gopass/compare/v1.12.0...v1.12.1
+[1.12.0]: https://github.com/gopasspw/gopass/compare/v1.11.0...v1.12.0
+[1.11.0]: https://github.com/gopasspw/gopass/compare/v1.10.1...v1.11.0
+[1.10.1]: https://github.com/gopasspw/gopass/compare/v1.10.0...v1.10.1
+[1.10.0]: https://github.com/gopasspw/gopass/compare/v1.9.2...v1.10.0
+[1.9.2]: https://github.com/gopasspw/gopass/compare/v1.9.1...v1.9.2
+[1.9.1]: https://github.com/gopasspw/gopass/compare/v1.9.0...v1.9.1
+[1.9.0]: https://github.com/gopasspw/gopass/compare/v1.8.6...v1.9.0
+[1.8.6]: https://github.com/gopasspw/gopass/compare/v1.8.5...v1.8.6
+[1.8.5]: https://github.com/gopasspw/gopass/compare/v1.8.4...v1.8.5
+[1.8.4]: https://github.com/gopasspw/gopass/compare/v1.8.3...v1.8.4
+[1.8.3]: https://github.com/gopasspw/gopass/compare/v1.8.2...v1.8.3
+[1.8.2]: https://github.com/gopasspw/gopass/compare/v1.8.1...v1.8.2
+[1.8.1]: https://github.com/gopasspw/gopass/compare/v1.8.0...v1.8.1
+[1.8.0]: https://github.com/gopasspw/gopass/compare/v1.7.2...v1.8.0
+[1.7.2]: https://github.com/gopasspw/gopass/compare/v1.7.1...v1.7.2
+[1.7.1]: https://github.com/gopasspw/gopass/compare/v1.7.0...v1.7.1
+[1.7.0]: https://github.com/gopasspw/gopass/compare/v1.6.11...v1.7.0
+[1.6.11]: https://github.com/gopasspw/gopass/compare/v1.6.10...v1.6.11
+[1.6.10]: https://github.com/gopasspw/gopass/compare/v1.6.9...v1.6.10
+[1.6.9]: https://github.com/gopasspw/gopass/compare/v1.6.8...v1.6.9
+[1.6.8]: https://github.com/gopasspw/gopass/compare/v1.6.7...v1.6.8
+[1.6.7]: https://github.com/gopasspw/gopass/compare/v1.6.6...v1.6.7
+[1.6.6]: https://github.com/gopasspw/gopass/compare/v1.6.5...v1.6.6
+[1.6.5]: https://github.com/gopasspw/gopass/compare/v1.6.4...v1.6.5
+[1.6.4]: https://github.com/gopasspw/gopass/compare/v1.6.3...v1.6.4
+[1.6.3]: https://github.com/gopasspw/gopass/compare/v1.6.2...v1.6.3
+[1.6.2]: https://github.com/gopasspw/gopass/compare/v1.6.1...v1.6.2
+[1.6.1]: https://github.com/gopasspw/gopass/compare/v1.6.0...v1.6.1
+[1.6.0]: https://github.com/gopasspw/gopass/compare/v1.5.1...v1.6.0
+[1.5.1]: https://github.com/gopasspw/gopass/compare/v1.5.0...v1.5.1
+[1.5.0]: https://github.com/gopasspw/gopass/compare/v1.4.1...v1.5.0
+[1.4.1]: https://github.com/gopasspw/gopass/compare/v1.4.0...v1.4.1
+[1.4.0]: https://github.com/gopasspw/gopass/compare/v1.3.2...v1.4.0
+[1.3.2]: https://github.com/gopasspw/gopass/compare/v1.3.1...v1.3.2
+[1.3.1]: https://github.com/gopasspw/gopass/compare/v1.3.0...v1.3.1
+[1.3.0]: https://github.com/gopasspw/gopass/compare/v1.2.0...v1.3.0
+[1.2.0]: https://github.com/gopasspw/gopass/compare/v1.1.2...v1.2.0
+[1.1.2]: https://github.com/gopasspw/gopass/compare/v1.1.1...v1.1.2
+[1.1.1]: https://github.com/gopasspw/gopass/compare/v1.1.0...v1.1.1
+[1.1.0]: https://github.com/gopasspw/gopass/compare/v1.0.2...v1.1.0
+[1.0.2]: https://github.com/gopasspw/gopass/compare/v1.0.1...v1.0.2
+[1.0.1]: https://github.com/gopasspw/gopass/compare/v1.0.0...v1.0.1
+[1.0.0]: https://github.com/gopasspw/gopass/releases/tag/v1.0.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,9 +40,22 @@ will try to clarify it.
 
       Signed-off-by: Your Name <your@email.com>
 
-* The first line of the commit message, the subject line, should be prefix with a tag indicating the type of the change. These tags will be extracted and used to populate the changelog.
-  Valid `[TAG]`s are `[BREAKING]`, `[BUGFIX]`, `[CLEANUP]`, `[DEPRECATION]`,
-  `[DOCUMENTATION]`, `[ENHANCEMENT]`, `[FEATURE]`, `[TESTING]`, and `[UX]`.
+* Write every commit subject as a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/),
+  for example `fix(age): expand ~/ in age.ssh-key-path`. The accepted types and
+  scopes are listed in [docs/conventions.md](docs/conventions.md).
+
+  Conventional Commits governs the subject line; the Developer Certificate of
+  Origin adds a trailer. Both apply to every commit.
+
+* Write the pull request title as a valid Conventional Commit. Pull requests are
+  squash-merged, so the pull request title is the string that reaches the
+  changelog.
+
+## Conventions
+
+Commit messages, versioning, branch and tag names, and file naming are specified
+in [docs/conventions.md](docs/conventions.md). Read it before opening your first
+pull request.
 
 ## Building & Testing
 

--- a/docs/adr/A-03-separate-storage-rcs.md
+++ b/docs/adr/A-03-separate-storage-rcs.md
@@ -1,4 +1,4 @@
-# A-3: Separate `Storage` and `RCS` interfaces
+# A-03: Separate `Storage` and `RCS` interfaces
 
 **Status:** deferred — current implementation intentionally keeps them merged  
 **Source:** CODE_QUALITY_REPORT.md § A-3

--- a/docs/adr/A-04-grep-match-error-counters.md
+++ b/docs/adr/A-04-grep-match-error-counters.md
@@ -1,4 +1,4 @@
-# A-4: Fix `grep` Match and Error Counters
+# A-04: Fix `grep` Match and Error Counters
 
 **Status:** open — not yet fixed  
 **Source:** SECURITY_AUDIT_REPORT.md § M-1, § Q-5

--- a/docs/adr/A-05-template-engine-text-vs-html.md
+++ b/docs/adr/A-05-template-engine-text-vs-html.md
@@ -1,4 +1,4 @@
-# A-5: Template Engine Uses `text/template` Instead of `html/template`
+# A-05: Template Engine Uses `text/template` Instead of `html/template`
 
 **Status:** deferred — current design is acceptable given the constraints  
 **Source:** SECURITY_AUDIT_REPORT.md § M-2

--- a/docs/adr/A-06-minimum-password-length.md
+++ b/docs/adr/A-06-minimum-password-length.md
@@ -1,4 +1,4 @@
-# A-6: Minimum Password Length Enforcement
+# A-06: Minimum Password Length Enforcement
 
 **Status:** deferred — user autonomy preserved; warning to be added  
 **Source:** SECURITY_AUDIT_REPORT.md § M-4

--- a/docs/adr/A-07-hook-system-dead-code.md
+++ b/docs/adr/A-07-hook-system-dead-code.md
@@ -1,4 +1,4 @@
-# A-7: Hook System Dead Code and CVE-2023-24055
+# A-07: Hook System Dead Code and CVE-2023-24055
 
 **Status:** deferred — hooks remain disabled; safe re-enablement path documented  
 **Source:** SECURITY_AUDIT_REPORT.md § M-5

--- a/docs/adr/A-08-shred-modern-storage-limitations.md
+++ b/docs/adr/A-08-shred-modern-storage-limitations.md
@@ -1,4 +1,4 @@
-# A-8: Shred Operation Is Ineffective on Modern Storage
+# A-08: Shred Operation Is Ineffective on Modern Storage
 
 **Status:** accepted — limitation documented; advisory notice to be added  
 **Source:** SECURITY_AUDIT_REPORT.md § M-6

--- a/docs/adr/A-09-low-severity-informational-findings.md
+++ b/docs/adr/A-09-low-severity-informational-findings.md
@@ -1,4 +1,4 @@
-# A-9: Low Severity and Informational Findings
+# A-09: Low Severity and Informational Findings
 
 **Status:** accepted — risks documented; mitigations noted where applicable  
 **Source:** SECURITY_AUDIT_REPORT.md § L-1 through L-6

--- a/docs/adr/A-12-pkg-api-stability.md
+++ b/docs/adr/A-12-pkg-api-stability.md
@@ -41,8 +41,9 @@ Option D (separate repository) is deferred for the same reasons.
   appear in any release without prior notice.
 * **Breaking changes** (removal or signature change of an exported symbol, change of error
   semantics, change of an interface method set) require:
-  1. A `[PKG-BREAK]` entry in the `## Next` section of `CHANGELOG.md` describing what changed
-     and how consumers should migrate.
+  1. A `PKG-BREAK:` footer on the commit, which produces a `[PKG-BREAK]`-prefixed entry in the
+     `## [Unreleased]` section of `CHANGELOG.md` describing what changed and how consumers
+     should migrate.
   2. A minimum deprecation window of **two minor releases or three months**, whichever is
      longer, between the first deprecation notice and removal. During this window the old
      symbol must remain available (possibly with a `// Deprecated:` GoDoc comment pointing to
@@ -50,15 +51,29 @@ Option D (separate repository) is deferred for the same reasons.
 
 ### Changelog tag convention
 
-Breaking changes to `pkg/` are tagged `[PKG-BREAK]` in `CHANGELOG.md`:
+A breaking change to `pkg/` is declared with a `PKG-BREAK:` commit footer:
 
 ```
-[PKG-BREAK] pkg/gopass: Remove Store.GetRevision — use Store.History instead (deprecated since 1.17.0)
+refactor(pkg/gopass): drop Store.GetRevision in favour of Store.History
+
+Deprecated since 1.17.0; the two-minor / three-month window has elapsed.
+
+PKG-BREAK: pkg/gopass: Remove Store.GetRevision — use Store.History instead
+Signed-off-by: Your Name <your@example.com>
 ```
 
-The existing `helpers/changelog` generator reads `CHANGELOG.md` verbatim; no changes to that
-tool are needed. The `[PKG-BREAK]` tag is a pure text convention, consistent with existing
-tags such as `[SECURITY]`, `[BUGFIX]`, and `[FEATURE]`.
+`helpers/commitmsg` reads that footer and `helpers/release` renders the entry with a
+`[PKG-BREAK]` prefix inside the appropriate Keep a Changelog subsection, normally `Changed`.
+A `Changelog-Section: Removed` footer moves it to `Removed` when the symbol is gone rather
+than changed.
+
+The footer is the machine-readable form of the tag. Writing `[PKG-BREAK]` by hand into
+`## [Unreleased]` also works and is preserved by the release helper.
+
+Note: `CHANGELOG.md` now follows Keep a Changelog 1.1.0, so `[SECURITY]`, `[BUGFIX]` and
+`[FEATURE]` are no longer tags — they are the `Security`, `Fixed` and `Added` subsections.
+`[PKG-BREAK]` remains a bullet prefix because it qualifies an entry rather than categorising
+it. See [docs/conventions.md](../conventions.md).
 
 ### Enforcement
 

--- a/docs/adr/A-15-screenshot-build-tag.md
+++ b/docs/adr/A-15-screenshot-build-tag.md
@@ -1,4 +1,4 @@
-# A-13: `noscreenshot` Build Tag for OTP Screen-Capture Feature
+# A-15: `noscreenshot` Build Tag for OTP Screen-Capture Feature
 
 **Status:** accepted  
 **Source:** [GitHub Issue #3415](https://github.com/gopasspw/gopass/issues/3415)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,57 @@
+# Architecture Decision Records
+
+Each record states one architectural decision, the context it was made in, the
+options considered, and the outcome. Amend a record only to update its status.
+Never reuse a number: supersede a decision by writing a new record.
+
+Name records `A-NN-<kebab-slug>.md`, with `NN` zero-padded to two digits. Write
+the H1 as `# A-NN: <Title>`, matching the file name. Open the record with a
+`**Status:**` line — `proposed`, `accepted`, `deferred`, `implemented`,
+`partially implemented`, or `superseded by A-NN` — and a `**Source:**` line.
+Update this index in the same commit that adds or supersedes a record.
+
+## Index
+
+| ADR | Title | Status | Added |
+|---|---|---|---|
+| [A-03](A-03-separate-storage-rcs.md) | Separate `Storage` and `RCS` interfaces | deferred | 2026-04-06 |
+| [A-04](A-04-grep-match-error-counters.md) | Fix `grep` match and error counters | open | 2026-04-06 |
+| [A-05](A-05-template-engine-text-vs-html.md) | Template engine uses `text/template` instead of `html/template` | deferred | 2026-04-06 |
+| [A-06](A-06-minimum-password-length.md) | Minimum password length enforcement | deferred | 2026-04-06 |
+| [A-07](A-07-hook-system-dead-code.md) | Hook system dead code and CVE-2023-24055 | deferred | 2026-04-06 |
+| [A-08](A-08-shred-modern-storage-limitations.md) | Shred operation is ineffective on modern storage | accepted | 2026-04-06 |
+| [A-09](A-09-low-severity-informational-findings.md) | Low severity and informational findings | accepted | 2026-04-06 |
+| [A-10](A-10-code-quality-findings.md) | Code quality findings | open | 2026-04-06 |
+| [A-11](A-11-secret-service.md) | Integrate `org.freedesktop.secrets` D-Bus service | proposed | 2026-05-24 |
+| [A-12](A-12-pkg-api-stability.md) | `pkg/gopass` API stability contract | accepted | 2026-05-24 |
+| [A-13](A-13-expired-gpg-key-handling.md) | Expired GPG key handling and recipient validity warnings | partially implemented | 2026-05-25 |
+| [A-14](A-14-team-workflows.md) | Effortless team workflows | implemented | 2026-06-06 |
+| [A-15](A-15-screenshot-build-tag.md) | `noscreenshot` build tag for OTP screen-capture feature | accepted | 2026-05-25 |
+
+Status values are taken from each record's `**Status:**` line. Dates are the
+authoring commit dates reported by `git log --diff-filter=A --follow`.
+
+## Reserved and renumbered records
+
+**A-01 and A-02 are reserved and have no records.** Both numbers are cited from
+the `CHANGELOG.md` unreleased section: "Split Action handler into focused
+handler types (A-1)" and "Replace context-key config system with typed structs
+(A-2)". No file was written for either. Do not reuse these numbers; the
+changelog citations would then point at unrelated decisions.
+
+**A-15 was renumbered from A-13.** Two records carried the number A-13.
+`A-13-expired-gpg-key-handling.md` keeps it: it is cited from
+`docs/commands/recipients.md`, `docs/usecases/team-workflows.md`, and
+`docs/adr/A-14-team-workflows.md`. The screenshot record had no inbound
+citations and was renumbered to A-15.
+
+**A-03 through A-09 were zero-padded.** Their file names previously used a
+single digit, which sorts them after A-10 in any lexical listing.
+
+## Unavailable sources
+
+`SECURITY_AUDIT_REPORT.md` and `CODE_QUALITY_REPORT.md` are not present in the
+working tree. Records A-03 through A-10 cite them in their `**Source:**` lines.
+Both files were removed in commit `77894053` ("Clean up") and are recoverable
+only from git history. The citations identify which finding each record answers,
+for example "§ M-4", and are therefore retained.

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -1,0 +1,267 @@
+# Conventions
+
+Normative reference for commit messages, versioning, branch and tag names, and
+file naming.
+
+See [CONTRIBUTING.md](../CONTRIBUTING.md) for the contribution workflow and
+[docs/hacking.md](hacking.md) for the development environment.
+
+## 1. Commit messages
+
+Commit subjects follow [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/).
+
+### 1.1 Format
+
+```
+<type>[(<scope>)][!]: <description>
+
+[optional body]
+
+[optional footers]
+```
+
+Rules:
+
+* Limit the subject line to 72 characters.
+* Write the description in the imperative mood: "add", not "adds" or "added".
+* Start the description in lowercase. Do not end it with a period.
+* Include a `Signed-off-by:` footer in every commit, as required by
+  [CONTRIBUTING.md](../CONTRIBUTING.md). Conventional Commits governs the
+  subject line; the Developer Certificate of Origin adds a trailer. Both apply.
+* Write the pull request title as a valid Conventional Commit.
+
+The pull request title requirement follows from the merge strategy. Pull
+requests are squash-merged: pull request #3489, titled `fix: Avoid NPE when
+attempting to edit a non-existing secret`, landed on `master` as the
+single-parent commit `eb1368e4` with the subject `fix: Avoid NPE when
+attempting to edit a non-existing secret (#3489)`. The pull request title, not
+the individual commit subjects, is the string that reaches `CHANGELOG.md`.
+
+### 1.2 Types
+
+This list is exhaustive. Reject any other type.
+
+| Type | Meaning | SemVer impact | Changelog section |
+|---|---|---|---|
+| `feat` | New user-visible capability | MINOR | Added |
+| `fix` | Bug fix | PATCH | Fixed |
+| `security` | Security fix or hardening | PATCH | Security |
+| `perf` | Performance improvement, no behaviour change | PATCH | Changed |
+| `refactor` | Internal restructuring, no behaviour change | PATCH | Changed |
+| `revert` | Reverts a previous commit | PATCH | Changed |
+| `deps` | Dependency version change | PATCH | Changed |
+| `docs` | Documentation only | none | omitted |
+| `test` | Tests only | none | omitted |
+| `build` | Build system: Makefile, goreleaser, Dockerfile | none | omitted |
+| `ci` | GitHub Actions, linter configuration, workflows | none | omitted |
+| `chore` | Housekeeping that fits nothing above | none | omitted |
+
+Two entries extend the set suggested by the specification:
+
+* `security` populates the `Security` section of the changelog, which
+  Keep a Changelog defines as a first-class category. Five commits since
+  2025-01-01 already use it.
+* `deps` is the preferred type for hand-written dependency commits.
+  Accept `chore(deps)` as well: Dependabot emits it, and 147 of the 344
+  commit subjects since 2025-01-01 carry the `chore` type, nearly all of
+  them dependency bumps.
+
+The following appear as commit types in the history and are not types. Use them
+as scopes: `otp` (2 commits since 2025-01-01), `age`, `bug`, `fscopy`, and
+`openbsd` (1 each).
+
+### 1.3 Scopes
+
+The scope is optional. Prefer to supply one. Do not invent scopes; omit the
+scope when none fits. Omit the scope for a change spanning several areas rather
+than listing more than one.
+
+**Commands** — the 41 top-level subcommands: 39 registered by
+`(*Action).GetCommands` in `internal/action/commands.go`, plus `pwgen` from
+`internal/action/pwgen` and `completion`, both added by `getCommands` in
+`main.go`:
+
+```
+alias audit cat clone completion config convert copy create delete doctor edit
+env find fsck fscopy fsmove generate grep history init insert link list merge
+mounts move otp process pwgen rcs recipients reorg setup show sum sync
+templates unclip update version
+```
+
+**Backends:** `age`, `gpg`, `plain`, `cryptfs`, `fossilfs`, `fs`, `gitfs`, `jjfs`
+
+**Subsystems:** `action`, `audit`, `backend`, `cache`, `completion`, `config`,
+`create`, `cui`, `editor`, `hashsum`, `hook`, `notify`, `out`, `queue`,
+`recipients`, `reminder`, `store`, `store/leaf`, `store/root`, `tpl`, `tree`,
+`updater`
+
+**Public API:** `pkg/gopass`, `api`, `secrets`, `appdir`, `clipboard`,
+`ctxutil`, `debug`, `fsutil`, `otp`, `passkey`, `pinentry`, `protect`, `pwgen`,
+`qrcon`, `set`, `tempfile`, `termio`
+
+**Meta:** `deps`, `release`, `changelog`, `docs`, `adr`, `ci`, `build`
+
+Write `pkg/gopass` out in full as a scope. Public-API changes must be greppable
+against the [A-12](adr/A-12-pkg-api-stability.md) stability contract.
+
+### 1.4 Breaking changes
+
+This repository has two independent compatibility surfaces. Mark them
+differently. Do not conflate them.
+
+| Surface broken | Marker | Version impact |
+|---|---|---|
+| gopass CLI: commands, flags, output format, exit codes, config keys, store format | `!` after the type or scope, **and** a `BREAKING CHANGE:` footer | MAJOR |
+| Go module `pkg/gopass` only: an exported symbol removed or changed | a `PKG-BREAK:` footer, **no** `!` | none; MINOR at most |
+| Both | `!` + `BREAKING CHANGE:` + `PKG-BREAK:` | MAJOR |
+
+Do not mark a module-only break with `!`. No CLI user can observe such a
+change, and `!` demands a major release.
+
+Example of a module-only break, per [A-12](adr/A-12-pkg-api-stability.md):
+
+```
+refactor(pkg/gopass): drop Store.GetRevision in favour of Store.History
+
+Deprecated since 1.17.0; the two-minor / three-month window has elapsed.
+
+PKG-BREAK: pkg/gopass: remove Store.GetRevision, use Store.History instead
+Signed-off-by: Your Name <your@example.com>
+```
+
+The `PKG-BREAK:` footer is the machine-readable form of the `[PKG-BREAK]`
+changelog tag mandated by A-12.
+
+### 1.5 Changelog control footers
+
+| Footer | Effect |
+|---|---|
+| `Changelog-Section: Added\|Changed\|Deprecated\|Removed\|Fixed\|Security` | Overrides the type-to-section mapping. Required for `Removed` and `Deprecated`, which have no corresponding commit type. |
+| `RELEASE_NOTES=<text>` or `RELEASE_NOTES=n/a` | Overrides the bullet text, or suppresses the entry. |
+| `PKG-BREAK: <text>` | Emits a `[PKG-BREAK]`-prefixed bullet. |
+
+## 2. Versioning
+
+This project follows [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html).
+
+### 2.1 Covered by SemVer
+
+SemVer applies to the gopass command line interface and its observable
+behaviour: subcommands, flags and their aliases, the stdout and stderr
+contracts, JSON output schemas, exit codes ([docs/exit-codes.md](exit-codes.md)),
+configuration keys ([docs/config.md](config.md)), the on-disk store format, and
+the generated shell completions and man page.
+
+### 2.2 Not covered by SemVer
+
+The Go module `github.com/gopasspw/gopass` carries no independent semver
+guarantees. `pkg/gopass` is governed by [A-12](adr/A-12-pkg-api-stability.md)
+and by the package documentation in `pkg/gopass/doc.go`, which declare it
+best-effort stable:
+
+* Additive changes — new exported symbols, new functional-option parameters —
+  may appear in any release.
+* Breaking changes — removal or signature change of an exported symbol, change
+  to an interface method set or to error semantics — require a `[PKG-BREAK]`
+  entry in `CHANGELOG.md` and a deprecation window of two minor releases or
+  three months, whichever is longer.
+
+### 2.3 Precedence
+
+Release a change that breaks only `pkg/` consumers as MINOR or PATCH. Do not
+bump MAJOR for it. Release a change that breaks CLI users as MAJOR regardless
+of its `pkg/` impact.
+
+### 2.4 Pre-releases
+
+Use `vX.Y.Z-rc.N` only: SemVer pre-release identifiers, dot-separated, numeric.
+Sign the tag. Cut it from the merged `release/vX.Y.Z-rc.N` branch. See
+[docs/releases.md](releases.md).
+
+## 3. Branch names
+
+```
+<type>/<kebab-slug>[-<issue>]
+```
+
+* Use a commit type from §1.2 as `<type>`.
+* Restrict the slug to `[a-z0-9-]`, plus the single `/` separator. Use no spaces
+  and no underscores. Limit the whole name to 60 characters.
+* Append the issue number when one exists:
+  `refactor/separate-storage-rcs-3411`.
+* Do not create these prefixes by hand; the release automation owns them:
+  `release/vX.Y.Z` and `release/vX.Y.Z-rc.N`, created by
+  `helpers/release/main.go`, and `prep/vX.Y.Z`, documented in
+  [docs/releases.md](releases.md).
+* Do not push feature branches to `gopasspw/gopass`. Work on a fork.
+
+## 4. Tag names
+
+* Name releases `vX.Y.Z` and pre-releases `vX.Y.Z-rc.N`.
+* Sign every tag (`git tag -s`).
+* Create no other tags in this repository.
+
+`.github/workflows/autorelease.yml` triggers on `push: tags: 'v*'`.
+`helpers/release/main.go` strips the leading `v` and parses the remainder as
+semver.
+
+## 5. File names
+
+### 5.1 General rules
+
+* Use lowercase kebab-case, restricted to `[a-z0-9._-]`.
+* Use no spaces.
+* Zero-pad any numeric component that participates in lexical ordering.
+* Prefix with `YYYY-MM-DD` when chronological order matters.
+* Order components from most general to most specific, left to right.
+
+### 5.2 Architecture decision records
+
+Name records `docs/adr/A-NN-<kebab-slug>.md`, with `NN` zero-padded to two
+digits.
+
+* Write the H1 as `# A-NN: <Title>`, matching the file name.
+* Open the record with a `**Status:**` line — `proposed`, `accepted`,
+  `deferred`, `implemented`, `partially implemented`, or `superseded by A-NN` —
+  and a `**Source:**` line.
+* Never reuse a number. Supersede a decision by writing a new record.
+* Update [docs/adr/README.md](adr/README.md) in the same commit that adds or
+  supersedes a record.
+
+### 5.3 Other documentation
+
+* Name command specifications `docs/commands/<command>.md`, where the file name
+  is exactly the command name.
+* Name backend documents `docs/backends/<backend>.md` and use cases
+  `docs/usecases/<kebab-slug>.md`.
+* Use lowercase throughout. Keep the SCREAMING_CASE names of root-level
+  documents, which is the GitHub convention.
+
+### 5.4 Go files
+
+* Use lowercase names with no underscores, except for the reserved suffixes
+  below. Prefer a single word matching the primary type or the command.
+* Place a command implementation in `internal/action/<command>.go` with an
+  accompanying `internal/action/<command>_test.go`.
+* Reserved suffixes: `_test.go`; the `GOOS` and `GOARCH` suffixes `_unix.go`,
+  `_windows.go`, `_linux.go`, `_darwin.go`, `_others.go`; `_gen.go` for
+  generated code; `_fuzz.go` for fuzz targets.
+* Give a build-tag variant that is not `GOOS`-based a descriptive suffix and an
+  explicit `//go:build` line, for example `screenshot_supported.go` and
+  `screenshot_stub.go`.
+* Split a file above roughly 600 lines along an existing type or feature seam.
+
+## 6. Changelog
+
+`CHANGELOG.md` follows [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/):
+an `## [Unreleased]` section at the top, then one `## [X.Y.Z] - YYYY-MM-DD`
+section per release, each containing only the non-empty subsections of
+`Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, and `Security`.
+
+`helpers/release` generates the entries from commit subjects at release time,
+using the mapping in §1.2 and the footers in §1.5. Do not edit `CHANGELOG.md`
+by hand, with two exceptions. Add a hand-written `## [Unreleased]` entry for:
+
+* any change to the exported surface of `pkg/`, as required by
+  [A-12](adr/A-12-pkg-api-stability.md); and
+* any `security:` change.

--- a/docs/hacking.md
+++ b/docs/hacking.md
@@ -8,6 +8,8 @@ This document provides an overview on how to develop on gopass.
 
 This project uses [GitHub Flow](https://guides.github.com/introduction/flow/). In other words, create feature branches from master, open an PR against master, and rebase onto master if necessary.
 
+Branch names, tag names, commit message format and file naming are specified in [conventions.md](conventions.md).
+
 We aim for compatibility with the [latest stable Go Release](https://golang.org/dl/) only.
 
 While this project is maintained by volunteers in their free time we aim to triage issues weekly and release a new version at least every quarter.

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -8,7 +8,10 @@ Goreleaser automates most but not all steps of a new release.
 
 Note: We use semantic versioning for the command line interface and tool behaviour
 but not for the API (i.e. `pkg/gopass`). Maintaining both properties in the
-same repository / Go module is too cumbersome.
+same repository / Go module is too cumbersome. `pkg/gopass` is instead governed
+by the best-effort stability contract in [ADR A-12](adr/A-12-pkg-api-stability.md).
+See [conventions.md](conventions.md) section 2 for the full policy, including how
+a break confined to `pkg/` is versioned.
 
 ## Development overview
 

--- a/helpers/changelog/extract_test.go
+++ b/helpers/changelog/extract_test.go
@@ -1,0 +1,108 @@
+// Copyright 2026 The gopass Authors. All rights reserved.
+// Use of this source code is governed by the MIT license,
+// that can be found in the LICENSE file.
+
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const keepAChangelogFixture = `# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [Unreleased]
+
+## [1.17.0] - 2026-08-01
+
+### Added
+
+- show: add a configurable fuzzy-search fallback toggle (#3449)
+
+### Fixed
+
+- age: expand ~/ in age.ssh-key-path (#3474)
+
+## [1.16.1] - 2025-12-13
+
+* fix: Fix version check against latest release (#3292)
+
+[Unreleased]: https://github.com/gopasspw/gopass/compare/v1.17.0...HEAD
+[1.17.0]: https://github.com/gopasspw/gopass/compare/v1.16.1...v1.17.0
+`
+
+// TestExtractSkipsUnreleased covers the reason this tool needed changing: the
+// previous implementation printed everything between the first and the second
+// "## " heading. After the Keep a Changelog migration the first heading is
+// "## [Unreleased]", which the release helper leaves empty, so the extractor
+// would have produced empty release notes.
+func TestExtractSkipsUnreleased(t *testing.T) {
+	t.Parallel()
+
+	var buf strings.Builder
+
+	require.NoError(t, extract(strings.NewReader(keepAChangelogFixture), &buf))
+
+	got := buf.String()
+
+	assert.Contains(t, got, "## [1.17.0] - 2026-08-01")
+	assert.Contains(t, got, "### Added")
+	assert.Contains(t, got, "age: expand ~/ in age.ssh-key-path (#3474)")
+
+	assert.NotContains(t, got, "[Unreleased]")
+	assert.NotContains(t, got, "1.16.1")
+	assert.NotContains(t, got, "# Changelog")
+	assert.NotContains(t, got, "Keep a Changelog")
+}
+
+// TestExtractLegacyHeadings keeps the tool working against a changelog that has
+// not been migrated.
+func TestExtractLegacyHeadings(t *testing.T) {
+	t.Parallel()
+
+	const fixture = `# Changelog
+
+## 1.16.1 / 2025-12-13
+
+* fix: Fix version check against latest release (#3292)
+
+## 1.16.0 / 2025-11-12
+
+* [BUGFIX] reorg: List all secrets (#3245)
+`
+
+	var buf strings.Builder
+
+	require.NoError(t, extract(strings.NewReader(fixture), &buf))
+
+	got := buf.String()
+
+	assert.Contains(t, got, "## 1.16.1 / 2025-12-13")
+	assert.Contains(t, got, "Fix version check against latest release")
+	assert.NotContains(t, got, "1.16.0")
+}
+
+func TestExtractNoReleasedSection(t *testing.T) {
+	t.Parallel()
+
+	const fixture = `# Changelog
+
+## [Unreleased]
+
+### Added
+
+- something not yet released
+`
+
+	var buf strings.Builder
+
+	require.NoError(t, extract(strings.NewReader(fixture), &buf))
+	assert.Empty(t, buf.String())
+}

--- a/helpers/changelog/main.go
+++ b/helpers/changelog/main.go
@@ -2,23 +2,32 @@
 // Use of this source code is governed by the MIT license,
 // that can be found in the LICENSE file.
 
-// Changelog implements the changelog extractor that is called by the autorelease GitHub action
-// and used to extract the changelog from the CHANGELOG.md file. It's content is then used to
-// populate the release description on GitHub.
+// Changelog implements the changelog extractor that is called by the autorelease
+// GitHub action and used to extract the changelog from the CHANGELOG.md file.
+// It's content is then used to populate the release description on GitHub.
 //
-// This tool will extract every line between the first and the second subheading (##).
-// This way the changelog can have a common header under the top most heading (#) and we
-// still only get the content of the latest release in the GitHub release notes.
+// This tool extracts the most recent *released* section: everything from the
+// first "## [X.Y.Z]" heading up to the next "## " heading. The "## [Unreleased]"
+// section is skipped, because at release time the release helper has already
+// moved its content into the new version's section and left it empty.
 package main
 
 import (
 	"bufio"
 	"fmt"
+	"io"
 	"os"
+	"regexp"
 	"strings"
 )
 
 var filename = "CHANGELOG.md"
+
+// versionHeadingRE matches a released section heading in Keep a Changelog form,
+// for example "## [1.16.1] - 2025-12-13". The legacy form
+// "## 1.16.1 / 2025-12-13" is accepted as well so the tool keeps working on a
+// changelog that has not been migrated.
+var versionHeadingRE = regexp.MustCompile(`^## \[?\d+\.\d+\.\d+`)
 
 func main() {
 	fh, err := os.Open(filename)
@@ -27,14 +36,32 @@ func main() {
 	}
 	defer fh.Close()
 
-	s := bufio.NewScanner(fh)
+	if err := extract(fh, os.Stdout); err != nil {
+		panic(err)
+	}
+}
+
+// extract copies the first released section of a changelog to w.
+func extract(rd io.Reader, w io.Writer) error {
+	s := bufio.NewScanner(rd)
+	out := bufio.NewWriter(w)
+
 	var in bool
+
 	for s.Scan() {
 		line := s.Text()
+
 		if strings.HasPrefix(line, "## ") {
 			if in {
 				break
 			}
+
+			// Skip everything before the first released section: the file
+			// header and the (empty) Unreleased section.
+			if !versionHeadingRE.MatchString(line) {
+				continue
+			}
+
 			in = true
 		}
 
@@ -42,6 +69,16 @@ func main() {
 			continue
 		}
 
-		fmt.Println(line)
+		fmt.Fprintln(out, line)
 	}
+
+	if err := s.Err(); err != nil {
+		return fmt.Errorf("failed to read %s: %w", filename, err)
+	}
+
+	if err := out.Flush(); err != nil {
+		return fmt.Errorf("failed to write release notes: %w", err)
+	}
+
+	return nil
 }

--- a/helpers/commitmsg/commitmsg.go
+++ b/helpers/commitmsg/commitmsg.go
@@ -1,0 +1,303 @@
+// Copyright 2026 The gopass Authors. All rights reserved.
+// Use of this source code is governed by the MIT license,
+// that can be found in the LICENSE file.
+
+// Package commitmsg parses commit subjects and classifies them into Keep a
+// Changelog sections. It is the single source of truth shared by the changelog
+// generator in helpers/release and by any commit message linting, so the two
+// cannot disagree about what a valid subject looks like.
+//
+// The conventions it implements are specified in docs/conventions.md.
+package commitmsg
+
+import (
+	"regexp"
+	"strings"
+)
+
+// Section is a Keep a Changelog 1.1.0 subsection.
+type Section string
+
+// The six sections defined by Keep a Changelog 1.1.0.
+const (
+	Added      Section = "Added"
+	Changed    Section = "Changed"
+	Deprecated Section = "Deprecated"
+	Removed    Section = "Removed"
+	Fixed      Section = "Fixed"
+	Security   Section = "Security"
+
+	// Omit marks a commit type that produces no changelog entry.
+	Omit Section = ""
+)
+
+// Sections lists the sections in the order Keep a Changelog prescribes.
+// Render them in this order and skip the empty ones.
+var Sections = []Section{Added, Changed, Deprecated, Removed, Fixed, Security}
+
+// Types maps every accepted Conventional Commit type to its changelog section.
+// The list is closed: a subject using any other type is not a valid commit
+// message. Types mapping to Omit produce no changelog entry.
+var Types = map[string]Section{
+	"build":    Omit,
+	"chore":    Omit,
+	"ci":       Omit,
+	"deps":     Changed,
+	"docs":     Omit,
+	"feat":     Added,
+	"fix":      Fixed,
+	"perf":     Changed,
+	"refactor": Changed,
+	"revert":   Changed,
+	"security": Security,
+	"test":     Omit,
+}
+
+// legacyTags maps the bracketed tags used before the move to Conventional
+// Commits. They are recognised so that a release spanning the transition
+// classifies its older commits correctly.
+var legacyTags = map[string]Section{
+	"BREAKING":      Changed,
+	"BUGFIX":        Fixed,
+	"CLEANUP":       Changed,
+	"DEPRECATION":   Deprecated,
+	"DOCUMENTATION": Omit,
+	"ENHANCEMENT":   Changed,
+	"FEATURE":       Added,
+	"PKG-BREAK":     Changed,
+	"SECURITY":      Security,
+	"TESTING":       Omit,
+	"UX":            Changed,
+}
+
+// Prefixes applied to an entry's text.
+const (
+	breakingPrefix = "**BREAKING** "
+	pkgBreakPrefix = "[PKG-BREAK] "
+	revertPrefix   = "Revert: "
+)
+
+var (
+	// conventionalRE matches a Conventional Commits 1.0.0 subject.
+	// Groups: type, scope, breaking marker, description.
+	conventionalRE = regexp.MustCompile(`^([a-z]+)(?:\(([^)]*)\))?(!)?: (.+)$`)
+
+	// legacyRE matches the bracketed subject form used before the move to
+	// Conventional Commits, for example "[BUGFIX] reorg: list all secrets".
+	legacyRE = regexp.MustCompile(`^\[([A-Za-z-]+)\]\s+(.+)$`)
+
+	// sectionFooterRE matches the Changelog-Section: footer, which overrides
+	// the type-to-section mapping. It is the only way to reach the Removed and
+	// Deprecated sections, which have no corresponding commit type.
+	sectionFooterRE = regexp.MustCompile(`(?m)^Changelog-Section:\s*(\w+)\s*$`)
+
+	// pkgBreakFooterRE matches the PKG-BREAK: footer mandated by ADR A-12 for a
+	// breaking change confined to the pkg/gopass Go module.
+	pkgBreakFooterRE = regexp.MustCompile(`(?m)^PKG-BREAK:\s*(.+)$`)
+
+	// breakingFooterRE matches the Conventional Commits footer that marks a
+	// break in the CLI.
+	breakingFooterRE = regexp.MustCompile(`(?m)^BREAKING[ -]CHANGE:\s*(.+)$`)
+
+	// releaseNotesRE matches the pre-existing RELEASE_NOTES= override. A value
+	// of "n/a" suppresses the entry entirely.
+	releaseNotesRE = regexp.MustCompile(`(?m)^RELEASE_NOTES=(.*)$`)
+)
+
+// Commit is a parsed commit subject.
+type Commit struct {
+	// Type is the Conventional Commit type, or the empty string for a legacy
+	// bracketed subject.
+	Type string
+	// Scope is the optional parenthesised scope. It is empty when absent.
+	Scope string
+	// Breaking reports whether the subject carried the "!" marker.
+	Breaking bool
+	// Description is the subject with the type, scope and marker removed. For a
+	// legacy subject it is everything after the bracketed tag.
+	Description string
+	// Legacy reports whether the subject used the bracketed form.
+	Legacy bool
+	// Section is the section the type maps to, before any footer override.
+	Section Section
+}
+
+// Entry is one rendered changelog bullet.
+type Entry struct {
+	Section Section
+	Text    string
+}
+
+// Disposition is what Classify decided to do with a commit.
+type Disposition int
+
+const (
+	// Include means the commit produced a changelog entry.
+	Include Disposition = iota
+	// Omitted means the commit was deliberately excluded: its type maps to
+	// Omit, or its body carried RELEASE_NOTES=n/a. This is the expected
+	// outcome for dependency bumps, CI changes and documentation.
+	Omitted
+	// Unrecognised means the subject is not a valid commit message, so no
+	// section could be chosen. Callers must surface these rather than drop
+	// them silently: a real user-facing change written as "otp: hide --snip
+	// flag" -- a scope used as a type -- would otherwise vanish from the
+	// changelog without a trace.
+	Unrecognised
+)
+
+// Parse splits a commit subject into its parts. It reports false when the
+// subject is neither a Conventional Commit with a known type nor a legacy
+// bracketed subject with a known tag.
+func Parse(subject string) (Commit, bool) {
+	subject = strings.TrimSpace(subject)
+
+	if m := conventionalRE.FindStringSubmatch(subject); m != nil {
+		sec, ok := Types[m[1]]
+		if !ok {
+			return Commit{}, false
+		}
+
+		return Commit{
+			Type:        m[1],
+			Scope:       m[2],
+			Breaking:    m[3] == "!",
+			Description: m[4],
+			Section:     sec,
+		}, true
+	}
+
+	if m := legacyRE.FindStringSubmatch(subject); m != nil {
+		if sec, ok := legacyTags[strings.ToUpper(m[1])]; ok {
+			return Commit{
+				Description: m[2],
+				Legacy:      true,
+				Section:     sec,
+				Breaking:    strings.EqualFold(m[1], "BREAKING"),
+			}, true
+		}
+
+		// The history also contains a hybrid form that puts a Conventional
+		// Commit type in brackets, for example "[fix] Support HW Age
+		// identities" and "[chore] Update gopasspw/clipboard". Accept it so a
+		// release spanning the transition does not lose those entries.
+		if sec, ok := Types[strings.ToLower(m[1])]; ok {
+			return Commit{
+				Type:        strings.ToLower(m[1]),
+				Description: m[2],
+				Legacy:      true,
+				Section:     sec,
+			}, true
+		}
+
+		return Commit{}, false
+	}
+
+	return Commit{}, false
+}
+
+// Text renders the changelog bullet text for a parsed commit: the description,
+// prefixed with the scope when there is one. The type is dropped because the
+// section heading already carries it -- "fix(age): expand ~/" under a "Fixed"
+// heading renders as "age: expand ~/".
+func (c Commit) Text() string {
+	if c.Scope == "" {
+		return c.Description
+	}
+
+	return c.Scope + ": " + c.Description
+}
+
+// Classify turns a commit subject and body into a changelog entry, and reports
+// why it did so.
+//
+// Precedence, highest first: RELEASE_NOTES=n/a suppresses everything;
+// RELEASE_NOTES=<text> replaces the text; Changelog-Section: replaces the
+// section; PKG-BREAK: forces an entry and adds a prefix; "!" or
+// BREAKING CHANGE: adds a prefix.
+func Classify(subject, body string) (Entry, Disposition) {
+	notes, hasNotes := releaseNotes(body)
+	if hasNotes && notes == "" {
+		// RELEASE_NOTES=n/a: an explicit request to stay out of the changelog.
+		return Entry{}, Omitted
+	}
+
+	c, ok := Parse(subject)
+	if !ok && !hasNotes {
+		return Entry{}, Unrecognised
+	}
+
+	sec := c.Section
+	text := c.Text()
+
+	if hasNotes {
+		text = notes
+		if !ok {
+			// An unparseable subject with an explicit release note still
+			// deserves an entry; Changed is the least surprising home for it.
+			sec = Changed
+		}
+	}
+
+	pkgBreak := pkgBreakFooterRE.FindStringSubmatch(body)
+	if pkgBreak != nil && sec == Omit {
+		// A pkg/gopass break must always be visible, whatever the type says.
+		sec = Changed
+	}
+
+	if m := sectionFooterRE.FindStringSubmatch(body); m != nil {
+		if s, valid := parseSection(m[1]); valid {
+			sec = s
+		}
+	}
+
+	if sec == Omit {
+		return Entry{}, Omitted
+	}
+
+	if c.Breaking || breakingFooterRE.MatchString(body) {
+		text = breakingPrefix + text
+	}
+
+	if pkgBreak != nil {
+		text = pkgBreakPrefix + text
+	}
+
+	if c.Type == "revert" {
+		text = revertPrefix + text
+	}
+
+	return Entry{Section: sec, Text: text}, Include
+}
+
+// parseSection resolves a Changelog-Section: footer value, case-insensitively.
+func parseSection(in string) (Section, bool) {
+	for _, s := range Sections {
+		if strings.EqualFold(in, string(s)) {
+			return s, true
+		}
+	}
+
+	return Omit, false
+}
+
+// releaseNotes extracts the RELEASE_NOTES= override from a commit body. It
+// returns an empty string with ok set when the value is "n/a", which means the
+// commit is deliberately excluded from the changelog.
+func releaseNotes(body string) (string, bool) {
+	m := releaseNotesRE.FindStringSubmatch(body)
+	if m == nil {
+		return "", false
+	}
+
+	val := strings.TrimSpace(m[1])
+	if strings.EqualFold(val, "n/a") {
+		return "", true
+	}
+
+	if val == "" {
+		return "", false
+	}
+
+	return val, true
+}

--- a/helpers/commitmsg/commitmsg_test.go
+++ b/helpers/commitmsg/commitmsg_test.go
@@ -344,7 +344,8 @@ func TestEveryTypeHasASection(t *testing.T) {
 func TestSectionsAreKeepAChangelogOrder(t *testing.T) {
 	t.Parallel()
 
-	assert.Equal(t,
+	assert.Equal(
+		t,
 		[]Section{Added, Changed, Deprecated, Removed, Fixed, Security},
 		Sections,
 	)

--- a/helpers/commitmsg/commitmsg_test.go
+++ b/helpers/commitmsg/commitmsg_test.go
@@ -1,0 +1,400 @@
+// Copyright 2026 The gopass Authors. All rights reserved.
+// Use of this source code is governed by the MIT license,
+// that can be found in the LICENSE file.
+
+package commitmsg
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseConventional(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name    string
+		subject string
+		want    Commit
+	}{
+		{
+			name:    "type only",
+			subject: "fix: avoid NPE when editing a non-existing secret",
+			want: Commit{
+				Type:        "fix",
+				Description: "avoid NPE when editing a non-existing secret",
+				Section:     Fixed,
+			},
+		},
+		{
+			name:    "type and scope",
+			subject: "fix(age): expand ~/ in age.ssh-key-path",
+			want: Commit{
+				Type:        "fix",
+				Scope:       "age",
+				Description: "expand ~/ in age.ssh-key-path",
+				Section:     Fixed,
+			},
+		},
+		{
+			name:    "breaking marker",
+			subject: "feat(show)!: drop the -f alias",
+			want: Commit{
+				Type:        "feat",
+				Scope:       "show",
+				Breaking:    true,
+				Description: "drop the -f alias",
+				Section:     Added,
+			},
+		},
+		{
+			name:    "slash in scope",
+			subject: "refactor(pkg/gopass): drop Store.GetRevision",
+			want: Commit{
+				Type:        "refactor",
+				Scope:       "pkg/gopass",
+				Description: "drop Store.GetRevision",
+				Section:     Changed,
+			},
+		},
+		{
+			name:    "dependabot subject",
+			subject: "chore(deps): bump actions/checkout from 6.0.3 to 7.0.0 (#3485)",
+			want: Commit{
+				Type:        "chore",
+				Scope:       "deps",
+				Description: "bump actions/checkout from 6.0.3 to 7.0.0 (#3485)",
+				Section:     Omit,
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, ok := Parse(tc.subject)
+			require.True(t, ok, tc.subject)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestParseLegacy(t *testing.T) {
+	t.Parallel()
+
+	got, ok := Parse("[BUGFIX] reorg: List all secrets instead of just top-level folders (#3245)")
+	require.True(t, ok)
+	assert.True(t, got.Legacy)
+	assert.Equal(t, Fixed, got.Section)
+	assert.Equal(t, "reorg: List all secrets instead of just top-level folders (#3245)", got.Description)
+	assert.Empty(t, got.Type)
+}
+
+func TestParseRejects(t *testing.T) {
+	t.Parallel()
+
+	// These appear as commit types in the history but are scopes, so they must
+	// not parse as Conventional Commits.
+	for _, subject := range []string{
+		"otp: hide --snip flag when built with noscreenshot tag (#3445)",
+		"age: fix YubiKey identity persistence via raw-append (ADR-0002) (#3399)",
+		"bug: reload identities on unlock command (#3430)",
+		"fscopy: derive copy direction from the source argument (#3462)",
+		"openbsd: something",
+		"[NOSUCHTAG] whatever",
+		"Improve Team Workflows (#3460)",
+		"",
+	} {
+		_, ok := Parse(subject)
+		assert.False(t, ok, subject)
+	}
+}
+
+func TestText(t *testing.T) {
+	t.Parallel()
+
+	c, ok := Parse("fix(age): expand ~/ in age.ssh-key-path")
+	require.True(t, ok)
+	assert.Equal(t, "age: expand ~/ in age.ssh-key-path", c.Text())
+
+	c, ok = Parse("fix: restore clip flag through fuzzy search")
+	require.True(t, ok)
+	assert.Equal(t, "restore clip flag through fuzzy search", c.Text())
+}
+
+func TestClassify(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name     string
+		subject  string
+		body     string
+		want     Entry
+		wantOK   bool
+		wantDisp Disposition
+	}{
+		{
+			name:    "feat to Added",
+			subject: "feat(show): add configurable fuzzy-search fallback toggle",
+			want:    Entry{Section: Added, Text: "show: add configurable fuzzy-search fallback toggle"},
+			wantOK:  true,
+		},
+		{
+			name:    "fix to Fixed",
+			subject: "fix: restore clip flag through fuzzy search",
+			want:    Entry{Section: Fixed, Text: "restore clip flag through fuzzy search"},
+			wantOK:  true,
+		},
+		{
+			name:    "security to Security",
+			subject: "security: bound symlink traversal to the store root",
+			want:    Entry{Section: Security, Text: "bound symlink traversal to the store root"},
+			wantOK:  true,
+		},
+		{
+			name:    "refactor to Changed",
+			subject: "refactor(store): split the leaf recipient handling",
+			want:    Entry{Section: Changed, Text: "store: split the leaf recipient handling"},
+			wantOK:  true,
+		},
+		{
+			name:    "deps to Changed",
+			subject: "deps: bump golang.org/x/crypto to 0.54.0",
+			want:    Entry{Section: Changed, Text: "bump golang.org/x/crypto to 0.54.0"},
+			wantOK:  true,
+		},
+		{
+			name:     "docs omitted",
+			wantDisp: Omitted,
+			subject:  "docs(adr): add the MCP server record",
+			wantOK:   false,
+		},
+		{
+			name:     "chore omitted",
+			wantDisp: Omitted,
+			subject:  "chore(deps): bump actions/checkout from 6.0.3 to 7.0.0",
+			wantOK:   false,
+		},
+		{
+			name:     "ci omitted",
+			wantDisp: Omitted,
+			subject:  "ci: bump golangci-lint to v2.12.2",
+			wantOK:   false,
+		},
+		{
+			name:    "breaking marker prefixes the text",
+			subject: "feat(show)!: drop the -f alias",
+			want:    Entry{Section: Added, Text: "**BREAKING** show: drop the -f alias"},
+			wantOK:  true,
+		},
+		{
+			name:    "breaking footer prefixes the text",
+			subject: "feat(show): drop the -f alias",
+			body:    "BREAKING CHANGE: -f no longer aliases --unsafe\n",
+			want:    Entry{Section: Added, Text: "**BREAKING** show: drop the -f alias"},
+			wantOK:  true,
+		},
+		{
+			name:    "hyphenated breaking footer is accepted",
+			subject: "feat(show): drop the -f alias",
+			body:    "BREAKING-CHANGE: -f no longer aliases --unsafe\n",
+			want:    Entry{Section: Added, Text: "**BREAKING** show: drop the -f alias"},
+			wantOK:  true,
+		},
+		{
+			name:    "pkg break prefixes the text without forcing a major",
+			subject: "refactor(pkg/gopass): drop Store.GetRevision",
+			body:    "PKG-BREAK: pkg/gopass: remove Store.GetRevision, use Store.History\n",
+			want:    Entry{Section: Changed, Text: "[PKG-BREAK] pkg/gopass: drop Store.GetRevision"},
+			wantOK:  true,
+		},
+		{
+			name:    "pkg break forces an entry for an otherwise omitted type",
+			subject: "chore(pkg/gopass): tidy up",
+			body:    "PKG-BREAK: pkg/gopass: remove Store.Foo\n",
+			want:    Entry{Section: Changed, Text: "[PKG-BREAK] pkg/gopass: tidy up"},
+			wantOK:  true,
+		},
+		{
+			name:    "section footer overrides the type",
+			subject: "refactor(hook): delete the dead hook system",
+			body:    "Changelog-Section: Removed\n",
+			want:    Entry{Section: Removed, Text: "hook: delete the dead hook system"},
+			wantOK:  true,
+		},
+		{
+			name:    "section footer reaches Deprecated",
+			subject: "refactor(env): mark GOPASS_AUTOSYNC_INTERVAL as going away",
+			body:    "Changelog-Section: Deprecated\n",
+			want:    Entry{Section: Deprecated, Text: "env: mark GOPASS_AUTOSYNC_INTERVAL as going away"},
+			wantOK:  true,
+		},
+		{
+			name:    "section footer rescues an omitted type",
+			subject: "chore(env): drop the legacy variable",
+			body:    "Changelog-Section: Removed\n",
+			want:    Entry{Section: Removed, Text: "env: drop the legacy variable"},
+			wantOK:  true,
+		},
+		{
+			name:    "invalid section footer falls back to the type",
+			subject: "fix(env): correct the lookup order",
+			body:    "Changelog-Section: Nonsense\n",
+			want:    Entry{Section: Fixed, Text: "env: correct the lookup order"},
+			wantOK:  true,
+		},
+		{
+			name:    "release notes override the text",
+			subject: "fix: something terse",
+			body:    "RELEASE_NOTES=A much better description\n",
+			want:    Entry{Section: Fixed, Text: "A much better description"},
+			wantOK:  true,
+		},
+		{
+			name:     "release notes n/a suppresses the entry",
+			wantDisp: Omitted,
+			subject:  "feat(show): add a thing",
+			body:     "RELEASE_NOTES=n/a\n",
+			wantOK:   false,
+		},
+		{
+			name:    "release notes rescue an unparseable subject",
+			subject: "Improve Team Workflows (#3460)",
+			body:    "RELEASE_NOTES=Improve team workflows\n",
+			want:    Entry{Section: Changed, Text: "Improve team workflows"},
+			wantOK:  true,
+		},
+		{
+			name:    "revert is prefixed",
+			subject: "revert: undo the fuzzy search toggle",
+			want:    Entry{Section: Changed, Text: "Revert: undo the fuzzy search toggle"},
+			wantOK:  true,
+		},
+		{
+			name:    "legacy BUGFIX to Fixed",
+			subject: "[BUGFIX] reorg: List all secrets instead of just top-level folders",
+			want:    Entry{Section: Fixed, Text: "reorg: List all secrets instead of just top-level folders"},
+			wantOK:  true,
+		},
+		{
+			name:    "legacy SECURITY to Security",
+			subject: "[SECURITY] Fix path traversal vulnerability in fs storage layer (C-1)",
+			want:    Entry{Section: Security, Text: "Fix path traversal vulnerability in fs storage layer (C-1)"},
+			wantOK:  true,
+		},
+		{
+			name:     "legacy DOCUMENTATION omitted",
+			wantDisp: Omitted,
+			subject:  "[DOCUMENTATION] Fix documentation vs. implementation mismatches",
+			wantOK:   false,
+		},
+		{
+			name:    "legacy BREAKING is prefixed",
+			subject: "[BREAKING] Remove the old config format",
+			want:    Entry{Section: Changed, Text: "**BREAKING** Remove the old config format"},
+			wantOK:  true,
+		},
+		{
+			name:     "unrecognised subject produces nothing",
+			wantDisp: Unrecognised,
+			subject:  "Improve Team Workflows (#3460)",
+			wantOK:   false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, disp := Classify(tc.subject, tc.body)
+			assert.Equal(t, tc.wantOK, disp == Include, tc.subject)
+			if !tc.wantOK {
+				assert.Equal(t, tc.wantDisp, disp, tc.subject)
+
+				return
+			}
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestEveryTypeHasASection guards against adding a type to docs/conventions.md
+// without deciding where its entries go.
+func TestEveryTypeHasASection(t *testing.T) {
+	t.Parallel()
+
+	want := []string{
+		"build", "chore", "ci", "deps", "docs", "feat",
+		"fix", "perf", "refactor", "revert", "security", "test",
+	}
+
+	assert.Len(t, Types, len(want))
+
+	for _, ty := range want {
+		sec, ok := Types[ty]
+		require.True(t, ok, ty)
+
+		if sec == Omit {
+			continue
+		}
+
+		assert.Contains(t, Sections, sec, ty)
+	}
+}
+
+func TestSectionsAreKeepAChangelogOrder(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t,
+		[]Section{Added, Changed, Deprecated, Removed, Fixed, Security},
+		Sections,
+	)
+}
+
+// TestParseBracketedType covers the hybrid form found in the history, which
+// puts a Conventional Commit type in brackets rather than a legacy tag.
+func TestParseBracketedType(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		subject string
+		wantSec Section
+		wantTxt string
+	}{
+		{"[fix] Support HW Age identities (#3389)", Fixed, "Support HW Age identities (#3389)"},
+		{"[feat] Add --safe flag to set safecontent on demand (#3318)", Added, "Add --safe flag to set safecontent on demand (#3318)"},
+		{"[chore] Update gopasspw/clipboard (#3436)", Omit, ""},
+	} {
+		c, ok := Parse(tc.subject)
+		require.True(t, ok, tc.subject)
+		assert.Equal(t, tc.wantSec, c.Section, tc.subject)
+
+		e, disp := Classify(tc.subject, "")
+		if tc.wantSec == Omit {
+			assert.Equal(t, Omitted, disp, tc.subject)
+
+			continue
+		}
+		require.Equal(t, Include, disp, tc.subject)
+		assert.Equal(t, tc.wantTxt, e.Text)
+	}
+}
+
+// TestUnrecognisedIsReported guards the distinction that keeps real changes
+// from vanishing: a scope written where a type belongs must be reported, not
+// silently dropped like an intentional omission.
+func TestUnrecognisedIsReported(t *testing.T) {
+	t.Parallel()
+
+	for _, subject := range []string{
+		"otp: hide --snip flag when built with noscreenshot tag (#3445)",
+		"fscopy: derive copy direction from the source argument (#3462)",
+		"Improve Team Workflows (#3460)",
+	} {
+		_, disp := Classify(subject, "")
+		assert.Equal(t, Unrecognised, disp, subject)
+	}
+
+	// An intentional omission must not be reported.
+	_, disp := Classify("chore(deps): bump actions/checkout from 6.0.3 to 7.0.0", "")
+	assert.Equal(t, Omitted, disp)
+}

--- a/helpers/release/changelog.go
+++ b/helpers/release/changelog.go
@@ -1,0 +1,246 @@
+// Copyright 2026 The gopass Authors. All rights reserved.
+// Use of this source code is governed by the MIT license,
+// that can be found in the LICENSE file.
+
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"regexp"
+	"slices"
+	"strings"
+
+	"github.com/blang/semver/v4"
+	"github.com/gopasspw/gopass/helpers/commitmsg"
+)
+
+// repoURL is the base for the compare links at the foot of CHANGELOG.md.
+const repoURL = "https://github.com/gopasspw/gopass"
+
+var (
+	// unreleasedHeadingRE matches the Keep a Changelog unreleased heading.
+	unreleasedHeadingRE = regexp.MustCompile(`^## \[Unreleased\]\s*$`)
+
+	// versionHeadingRE matches a released section heading.
+	versionHeadingRE = regexp.MustCompile(`^## \[(\d+\.\d+\.\d+[^\]]*)\]`)
+
+	// subsectionRE matches one of the six Keep a Changelog subsections.
+	subsectionRE = regexp.MustCompile(`^### (\w+)\s*$`)
+
+	// bulletRE matches a changelog bullet in either the "-" or the legacy "*"
+	// form. CHANGELOG.md uses "*" throughout its history.
+	bulletRE = regexp.MustCompile(`^[-*]\s+(.*)$`)
+
+	// linkRefRE matches a markdown link reference definition, which Keep a
+	// Changelog places in a block at the foot of the file.
+	linkRefRE = regexp.MustCompile(`^\[[^\]]+\]:\s+\S+`)
+)
+
+// changelog is a parsed CHANGELOG.md.
+type changelog struct {
+	// header is every line before the first "## " heading.
+	header []string
+	// unreleased holds the entries of the "## [Unreleased]" section, keyed by
+	// subsection. Entries outside any subsection are keyed by commitmsg.Omit.
+	unreleased map[commitmsg.Section][]string
+	// released is every line from the first versioned heading up to the link
+	// reference block, copied through unchanged.
+	released []string
+	// links is the link reference block at the foot of the file.
+	links []string
+}
+
+// parseChangelog reads a CHANGELOG.md into its four parts.
+//
+// It is deliberately tolerant: a file that has not been migrated to Keep a
+// Changelog yet still parses, with everything from the first heading onwards
+// landing in released.
+func parseChangelog(rd io.Reader) (*changelog, error) {
+	cl := &changelog{unreleased: map[commitmsg.Section][]string{}}
+
+	const (
+		inHeader = iota
+		inUnreleased
+		inReleased
+	)
+
+	state := inHeader
+	section := commitmsg.Omit
+
+	s := bufio.NewScanner(rd)
+	for s.Scan() {
+		line := s.Text()
+
+		switch {
+		case unreleasedHeadingRE.MatchString(line):
+			state = inUnreleased
+			section = commitmsg.Omit
+
+			continue
+
+		case strings.HasPrefix(line, "## "):
+			// Any other second-level heading starts the released body. Keep the
+			// heading itself.
+			state = inReleased
+
+		case state == inHeader:
+			cl.header = append(cl.header, line)
+
+			continue
+		}
+
+		if state == inUnreleased {
+			if m := subsectionRE.FindStringSubmatch(line); m != nil {
+				if sec, ok := parseSectionName(m[1]); ok {
+					section = sec
+				}
+
+				continue
+			}
+
+			if m := bulletRE.FindStringSubmatch(line); m != nil {
+				cl.unreleased[section] = append(cl.unreleased[section], m[1])
+			}
+
+			continue
+		}
+
+		if linkRefRE.MatchString(line) {
+			cl.links = append(cl.links, line)
+
+			continue
+		}
+
+		cl.released = append(cl.released, line)
+	}
+
+	if err := s.Err(); err != nil {
+		return nil, fmt.Errorf("failed to read changelog: %w", err)
+	}
+
+	trimTrailingBlanks(&cl.header)
+	trimTrailingBlanks(&cl.released)
+
+	return cl, nil
+}
+
+// parseSectionName resolves a "### Foo" heading to a section.
+func parseSectionName(in string) (commitmsg.Section, bool) {
+	for _, sec := range commitmsg.Sections {
+		if strings.EqualFold(in, string(sec)) {
+			return sec, true
+		}
+	}
+
+	return commitmsg.Omit, false
+}
+
+func trimTrailingBlanks(lines *[]string) {
+	for len(*lines) > 0 && strings.TrimSpace((*lines)[len(*lines)-1]) == "" {
+		*lines = (*lines)[:len(*lines)-1]
+	}
+}
+
+// release folds the unreleased entries together with the generated ones and
+// writes them out as a new released section, leaving an empty Unreleased
+// section behind and refreshing the link reference block.
+//
+// Merging the two sources is what makes the hand-written entries in
+// "## [Unreleased]" survive a release. The previous implementation inserted the
+// new section before the first "## " heading, which is the unreleased heading,
+// so those entries were orphaned below the release and never consumed.
+func (c *changelog) release(prev, next semver.Version, date string, generated []commitmsg.Entry) {
+	merged := map[commitmsg.Section][]string{}
+
+	for sec, texts := range c.unreleased {
+		target := sec
+		if target == commitmsg.Omit {
+			// A bullet that sat outside any subsection. Changed is the least
+			// surprising home for it.
+			target = commitmsg.Changed
+		}
+		merged[target] = append(merged[target], texts...)
+	}
+
+	for _, e := range generated {
+		merged[e.Section] = append(merged[e.Section], e.Text)
+	}
+
+	for sec := range merged {
+		slices.Sort(merged[sec])
+		merged[sec] = slices.Compact(merged[sec])
+	}
+
+	section := []string{fmt.Sprintf("## [%s] - %s", next.String(), date), ""}
+
+	for _, sec := range commitmsg.Sections {
+		if len(merged[sec]) == 0 {
+			// Keep a Changelog: omit empty subsections.
+			continue
+		}
+
+		section = append(section, "### "+string(sec), "")
+		for _, t := range merged[sec] {
+			section = append(section, "- "+t)
+		}
+		section = append(section, "")
+	}
+
+	c.released = append(section, c.released...)
+	c.unreleased = map[commitmsg.Section][]string{}
+	c.updateLinks(prev, next)
+}
+
+// updateLinks rewrites the two link references a release changes: Unreleased
+// now compares against the new tag, and the new version gets its own compare
+// link against the previous one. Every other reference is left alone.
+func (c *changelog) updateLinks(prev, next semver.Version) {
+	unreleased := fmt.Sprintf("[Unreleased]: %s/compare/v%s...HEAD", repoURL, next.String())
+	version := fmt.Sprintf("[%s]: %s/compare/v%s...v%s", next.String(), repoURL, prev.String(), next.String())
+
+	links := []string{unreleased, version}
+
+	for _, l := range c.links {
+		if strings.HasPrefix(l, "[Unreleased]:") {
+			continue
+		}
+		if strings.HasPrefix(l, "["+next.String()+"]:") {
+			continue
+		}
+		links = append(links, l)
+	}
+
+	c.links = links
+}
+
+// render writes the changelog back out.
+func (c *changelog) render(w io.Writer) error {
+	out := bufio.NewWriter(w)
+
+	for _, l := range c.header {
+		fmt.Fprintln(out, l)
+	}
+
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "## [Unreleased]")
+	fmt.Fprintln(out)
+
+	for _, l := range c.released {
+		fmt.Fprintln(out, l)
+	}
+
+	if len(c.links) > 0 {
+		fmt.Fprintln(out)
+		for _, l := range c.links {
+			fmt.Fprintln(out, l)
+		}
+	}
+
+	if err := out.Flush(); err != nil {
+		return fmt.Errorf("failed to write changelog: %w", err)
+	}
+
+	return nil
+}

--- a/helpers/release/changelog.go
+++ b/helpers/release/changelog.go
@@ -170,7 +170,7 @@ func (c *changelog) release(prev, next semver.Version, date string, generated []
 
 	for sec := range merged {
 		slices.Sort(merged[sec])
-		merged[sec] = slices.Compact(merged[sec])
+		merged[sec] = dedupeFold(merged[sec])
 	}
 
 	section := []string{fmt.Sprintf("## [%s] - %s", next.String(), date), ""}
@@ -191,6 +191,32 @@ func (c *changelog) release(prev, next semver.Version, date string, generated []
 	c.released = append(section, c.released...)
 	c.unreleased = map[commitmsg.Section][]string{}
 	c.updateLinks(prev, next)
+}
+
+// dedupeFold removes entries that differ only in case from one already kept.
+// The input must be sorted.
+//
+// A hand-written unreleased entry and the subject of the commit that
+// implemented it often describe the same change with a different capital
+// letter, for example "Add gopass doctor diagnostic command (I-4)" against
+// "add gopass doctor diagnostic command (I-4)". It cannot catch two genuinely
+// different wordings of the same change; those still need a human pass before
+// the release.
+func dedupeFold(in []string) []string {
+	out := in[:0]
+	seen := make(map[string]struct{}, len(in))
+
+	for _, s := range in {
+		k := strings.ToLower(s)
+		if _, ok := seen[k]; ok {
+			continue
+		}
+
+		seen[k] = struct{}{}
+		out = append(out, s)
+	}
+
+	return out
 }
 
 // updateLinks rewrites the two link references a release changes: Unreleased

--- a/helpers/release/changelog_test.go
+++ b/helpers/release/changelog_test.go
@@ -1,0 +1,256 @@
+// Copyright 2026 The gopass Authors. All rights reserved.
+// Use of this source code is governed by the MIT license,
+// that can be found in the LICENSE file.
+
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/blang/semver/v4"
+	"github.com/gopasspw/gopass/helpers/commitmsg"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const migratedFixture = `# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [Unreleased]
+
+### Security
+
+- fix path traversal in the fs storage layer (C-1)
+
+### Added
+
+- add the gopass doctor diagnostic command (I-4)
+
+## [1.16.1] - 2025-12-13
+
+* fix: Fix version check against latest release (#3292)
+
+## [1.16.0] - 2025-11-12
+
+* [BUGFIX] reorg: List all secrets (#3245)
+
+[Unreleased]: https://github.com/gopasspw/gopass/compare/v1.16.1...HEAD
+[1.16.1]: https://github.com/gopasspw/gopass/compare/v1.16.0...v1.16.1
+[1.16.0]: https://github.com/gopasspw/gopass/compare/v1.15.18...v1.16.0
+`
+
+func TestParseChangelog(t *testing.T) {
+	t.Parallel()
+
+	cl, err := parseChangelog(strings.NewReader(migratedFixture))
+	require.NoError(t, err)
+
+	assert.Contains(t, strings.Join(cl.header, "\n"), "# Changelog")
+	assert.NotContains(t, strings.Join(cl.header, "\n"), "## [")
+
+	assert.Equal(t,
+		[]string{"fix path traversal in the fs storage layer (C-1)"},
+		cl.unreleased[commitmsg.Security])
+	assert.Equal(t,
+		[]string{"add the gopass doctor diagnostic command (I-4)"},
+		cl.unreleased[commitmsg.Added])
+
+	released := strings.Join(cl.released, "\n")
+	assert.Contains(t, released, "## [1.16.1] - 2025-12-13")
+	assert.Contains(t, released, "## [1.16.0] - 2025-11-12")
+	assert.NotContains(t, released, "[Unreleased]:")
+
+	require.Len(t, cl.links, 3)
+	assert.Equal(t, "[Unreleased]: https://github.com/gopasspw/gopass/compare/v1.16.1...HEAD", cl.links[0])
+}
+
+// TestReleaseConsumesUnreleased is the regression this change exists for.
+//
+// The previous writeChangelog inserted the new section before the first "## "
+// heading. Once an unreleased section existed, that heading was the unreleased
+// one, so the release landed *above* it and the hand-written entries below were
+// orphaned: never published, and silently carried into every later release.
+func TestReleaseConsumesUnreleased(t *testing.T) {
+	t.Parallel()
+
+	cl, err := parseChangelog(strings.NewReader(migratedFixture))
+	require.NoError(t, err)
+
+	cl.release(
+		semver.MustParse("1.16.1"),
+		semver.MustParse("1.17.0"),
+		"2026-08-01",
+		[]commitmsg.Entry{
+			{Section: commitmsg.Fixed, Text: "age: expand ~/ in age.ssh-key-path (#3474)"},
+			{Section: commitmsg.Added, Text: "show: add a fuzzy-search toggle (#3449)"},
+		},
+	)
+
+	var buf strings.Builder
+
+	require.NoError(t, cl.render(&buf))
+
+	got := buf.String()
+
+	// The hand-written entries are now part of the release, not stranded.
+	assert.Contains(t, got, "- fix path traversal in the fs storage layer (C-1)")
+	assert.Contains(t, got, "- add the gopass doctor diagnostic command (I-4)")
+
+	// ... together with the generated ones.
+	assert.Contains(t, got, "- age: expand ~/ in age.ssh-key-path (#3474)")
+	assert.Contains(t, got, "- show: add a fuzzy-search toggle (#3449)")
+
+	// The release heading precedes the previous release.
+	relIdx := strings.Index(got, "## [1.17.0] - 2026-08-01")
+	prevIdx := strings.Index(got, "## [1.16.1] - 2025-12-13")
+	require.Positive(t, relIdx)
+	require.Positive(t, prevIdx)
+	assert.Less(t, relIdx, prevIdx)
+
+	// The unreleased section survives, empty, above the release.
+	unrelIdx := strings.Index(got, "## [Unreleased]")
+	require.Positive(t, unrelIdx)
+	assert.Less(t, unrelIdx, relIdx)
+	assert.NotContains(t, got[unrelIdx:relIdx], "- ")
+}
+
+func TestReleaseOrdersAndOmitsSections(t *testing.T) {
+	t.Parallel()
+
+	cl, err := parseChangelog(strings.NewReader(migratedFixture))
+	require.NoError(t, err)
+
+	cl.release(
+		semver.MustParse("1.16.1"),
+		semver.MustParse("1.17.0"),
+		"2026-08-01",
+		[]commitmsg.Entry{{Section: commitmsg.Fixed, Text: "a fix"}},
+	)
+
+	var buf strings.Builder
+
+	require.NoError(t, cl.render(&buf))
+
+	got := buf.String()
+
+	// Keep a Changelog order: Added, Changed, Deprecated, Removed, Fixed, Security.
+	addedIdx := strings.Index(got, "### Added")
+	fixedIdx := strings.Index(got, "### Fixed")
+	securityIdx := strings.Index(got, "### Security")
+	require.Positive(t, addedIdx)
+	require.Positive(t, fixedIdx)
+	require.Positive(t, securityIdx)
+	assert.Less(t, addedIdx, fixedIdx)
+	assert.Less(t, fixedIdx, securityIdx)
+
+	// Empty subsections are omitted.
+	assert.NotContains(t, got, "### Changed")
+	assert.NotContains(t, got, "### Deprecated")
+	assert.NotContains(t, got, "### Removed")
+}
+
+func TestReleaseDeduplicates(t *testing.T) {
+	t.Parallel()
+
+	cl, err := parseChangelog(strings.NewReader(migratedFixture))
+	require.NoError(t, err)
+
+	// The same text arrives both by hand and from a commit subject.
+	cl.release(
+		semver.MustParse("1.16.1"),
+		semver.MustParse("1.17.0"),
+		"2026-08-01",
+		[]commitmsg.Entry{
+			{Section: commitmsg.Added, Text: "add the gopass doctor diagnostic command (I-4)"},
+		},
+	)
+
+	var buf strings.Builder
+
+	require.NoError(t, cl.render(&buf))
+
+	assert.Equal(t, 1, strings.Count(buf.String(), "add the gopass doctor diagnostic command (I-4)"))
+}
+
+func TestReleaseUpdatesLinks(t *testing.T) {
+	t.Parallel()
+
+	cl, err := parseChangelog(strings.NewReader(migratedFixture))
+	require.NoError(t, err)
+
+	cl.release(semver.MustParse("1.16.1"), semver.MustParse("1.17.0"), "2026-08-01", nil)
+
+	var buf strings.Builder
+
+	require.NoError(t, cl.render(&buf))
+
+	got := buf.String()
+
+	assert.Contains(t, got, "[Unreleased]: https://github.com/gopasspw/gopass/compare/v1.17.0...HEAD")
+	assert.Contains(t, got, "[1.17.0]: https://github.com/gopasspw/gopass/compare/v1.16.1...v1.17.0")
+	// Existing references are preserved.
+	assert.Contains(t, got, "[1.16.1]: https://github.com/gopasspw/gopass/compare/v1.16.0...v1.16.1")
+	assert.Contains(t, got, "[1.16.0]: https://github.com/gopasspw/gopass/compare/v1.15.18...v1.16.0")
+	// The stale Unreleased reference is replaced, not duplicated.
+	assert.Equal(t, 1, strings.Count(got, "[Unreleased]: "))
+}
+
+// TestParseUnmigratedChangelog covers the transitional state: a file that still
+// uses "## Next" and the legacy headings must still parse, with everything from
+// the first heading onwards treated as released body.
+func TestParseUnmigratedChangelog(t *testing.T) {
+	t.Parallel()
+
+	const fixture = `# Changelog
+
+## Next
+
+* [BUGFIX] something not yet released
+
+## 1.16.1 / 2025-12-13
+
+* fix: Fix version check (#3292)
+`
+
+	cl, err := parseChangelog(strings.NewReader(fixture))
+	require.NoError(t, err)
+
+	assert.Empty(t, cl.unreleased)
+	assert.Contains(t, strings.Join(cl.released, "\n"), "## Next")
+	assert.Contains(t, strings.Join(cl.released, "\n"), "## 1.16.1 / 2025-12-13")
+	assert.Empty(t, cl.links)
+}
+
+// TestReleaseBulletOutsideSubsection places an unreleased bullet that sits under
+// no "###" heading into Changed rather than dropping it.
+func TestReleaseBulletOutsideSubsection(t *testing.T) {
+	t.Parallel()
+
+	const fixture = `# Changelog
+
+## [Unreleased]
+
+- a bullet with no subsection
+
+## [1.16.1] - 2025-12-13
+
+* fix: something
+`
+
+	cl, err := parseChangelog(strings.NewReader(fixture))
+	require.NoError(t, err)
+
+	cl.release(semver.MustParse("1.16.1"), semver.MustParse("1.17.0"), "2026-08-01", nil)
+
+	var buf strings.Builder
+
+	require.NoError(t, cl.render(&buf))
+
+	got := buf.String()
+	assert.Contains(t, got, "### Changed")
+	assert.Contains(t, got, "- a bullet with no subsection")
+}

--- a/helpers/release/changelog_test.go
+++ b/helpers/release/changelog_test.go
@@ -254,3 +254,41 @@ func TestReleaseBulletOutsideSubsection(t *testing.T) {
 	assert.Contains(t, got, "### Changed")
 	assert.Contains(t, got, "- a bullet with no subsection")
 }
+
+// TestReleaseDeduplicatesCaseInsensitively covers the common transitional case:
+// a hand-written unreleased entry and the commit subject that implemented it
+// differ only in their first letter.
+func TestReleaseDeduplicatesCaseInsensitively(t *testing.T) {
+	t.Parallel()
+
+	const fixture = `# Changelog
+
+## [Unreleased]
+
+### Added
+
+- Add gopass doctor diagnostic command (I-4)
+
+## [1.16.1] - 2025-12-13
+
+* fix: something
+`
+
+	cl, err := parseChangelog(strings.NewReader(fixture))
+	require.NoError(t, err)
+
+	cl.release(
+		semver.MustParse("1.16.1"),
+		semver.MustParse("1.17.0"),
+		"2026-08-01",
+		[]commitmsg.Entry{
+			{Section: commitmsg.Added, Text: "add gopass doctor diagnostic command (I-4)"},
+		},
+	)
+
+	var buf strings.Builder
+
+	require.NoError(t, cl.render(&buf))
+
+	assert.Equal(t, 1, strings.Count(strings.ToLower(buf.String()), "gopass doctor diagnostic command (i-4)"))
+}

--- a/helpers/release/main.go
+++ b/helpers/release/main.go
@@ -10,30 +10,26 @@
 package main
 
 import (
-	"bufio"
 	"fmt"
 	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"regexp"
-	"sort"
+	"slices"
 	"strings"
 	"text/template"
 	"time"
 
 	"github.com/blang/semver/v4"
+	"github.com/gopasspw/gopass/helpers/commitmsg"
 	"github.com/gopasspw/gopass/helpers/gitutils"
 )
 
 var (
 	sleep   = time.Second
 	issueRE = regexp.MustCompile(`#(\d+)\b`)
-	// Supported formats:
-	// [TAG] description
-	// TAG: description
-	subjectRE = regexp.MustCompile(`^(\[\w+\]\s+.*|\S+:\s.*)$`)
-	verTmpl   = `package main
+	verTmpl = `package main
 
 import (
 	"strings"
@@ -311,7 +307,7 @@ func parseReleaseArgs(args []string) releaseArgs {
 }
 
 func printDryRun(prevVer, nextVer semver.Version, patchRelease bool) error {
-	notes, err := changelogEntries(prevVer)
+	notes, unrecognised, err := changelogEntries(prevVer)
 	if err != nil {
 		return err
 	}
@@ -350,15 +346,32 @@ func printDryRun(prevVer, nextVer semver.Version, patchRelease bool) error {
 	fmt.Printf("Would later tag and push: v%s\n", nextVer.String())
 	fmt.Println()
 	fmt.Println("Planned changelog entries:")
+
 	if len(notes) < 1 {
 		fmt.Println("- none")
-
-		return nil
 	}
 
-	for _, note := range notes {
-		fmt.Printf("- %s\n", note)
+	// Group by section so the dry run shows exactly the shape that will be
+	// written, rather than a flat list the release then rearranges.
+	for _, sec := range commitmsg.Sections {
+		var printed bool
+
+		for _, note := range notes {
+			if note.Section != sec {
+				continue
+			}
+
+			if !printed {
+				fmt.Printf("\n### %s\n", sec)
+
+				printed = true
+			}
+
+			fmt.Printf("- %s\n", note.Text)
+		}
 	}
+
+	reportUnrecognised(unrecognised)
 
 	return nil
 }
@@ -450,52 +463,66 @@ func gitCommit(v semver.Version) error {
 }
 
 func writeChangelog(prev, next semver.Version) error {
-	cl, err := changelogEntries(prev)
-	if err != nil {
-		panic(err)
-	}
-
-	// prepend the new changelog entries by first writing the
-	// new content in a new file ...
-	fh, err := os.Create("CHANGELOG.new")
+	entries, unrecognised, err := changelogEntries(prev)
 	if err != nil {
 		return err
 	}
-	defer fh.Close()
+
+	reportUnrecognised(unrecognised)
 
 	ofh, err := os.Open("CHANGELOG.md")
 	if err != nil {
 		return err
 	}
-	defer ofh.Close()
 
-	scanner := bufio.NewScanner(ofh)
+	cl, err := parseChangelog(ofh)
+	_ = ofh.Close()
 
-	var written bool
-	for scanner.Scan() {
-		line := scanner.Text()
-
-		// insert the new section before the last entry
-		if strings.HasPrefix(line, "## ") && !written {
-			fmt.Fprintf(fh, "## %s / %s\n\n", next.String(), time.Now().UTC().Format("2006-01-02"))
-			for _, e := range cl {
-				fmt.Fprint(fh, "* ")
-				fmt.Fprintln(fh, e)
-			}
-			fmt.Fprintln(fh)
-
-			written = true
-		}
-
-		// all existing lines are just copied over
-		fmt.Fprintln(fh, line)
-	}
-	if err := scanner.Err(); err != nil {
+	if err != nil {
 		return err
 	}
 
-	// renaming the new file to the old file
+	cl.release(prev, next, time.Now().UTC().Format("2006-01-02"), entries)
+
+	// write the new content to a new file first, then rename over the old one
+	fh, err := os.Create("CHANGELOG.new")
+	if err != nil {
+		return err
+	}
+
+	if err := cl.render(fh); err != nil {
+		_ = fh.Close()
+
+		return err
+	}
+
+	if err := fh.Close(); err != nil {
+		return err
+	}
+
 	return os.Rename("CHANGELOG.new", "CHANGELOG.md")
+}
+
+// reportUnrecognised prints the commit subjects that could not be classified.
+//
+// These are not the same as the deliberately omitted ones. A subject such as
+// "otp: hide --snip flag" uses a scope where a type belongs, so it names a real
+// user-facing change that no section can be chosen for. Printing them is what
+// keeps such a change from disappearing from the release notes unnoticed.
+func reportUnrecognised(subjects []string) {
+	if len(subjects) == 0 {
+		return
+	}
+
+	fmt.Printf("\n⚠ %d commit(s) could not be classified and produced no changelog entry.\n", len(subjects))
+	fmt.Println("  Their subjects are not valid commit messages. See docs/conventions.md.")
+	fmt.Println("  Add a RELEASE_NOTES= line to the commit body, or add the entry by hand:")
+
+	for _, s := range subjects {
+		fmt.Printf("  - %s\n", s)
+	}
+
+	fmt.Println()
 }
 
 func updateCompletion() error {
@@ -646,7 +673,10 @@ func gitVersion() (semver.Version, error) {
 	return semver.Version{}, fmt.Errorf("no valid version found")
 }
 
-func changelogEntries(since semver.Version) ([]string, error) {
+// changelogEntries collects the changelog entries for every commit since the
+// given version. It returns the classified entries and, separately, the
+// subjects it could not classify, so the caller can report them.
+func changelogEntries(since semver.Version) ([]commitmsg.Entry, []string, error) {
 	// set up a custom output format for the git log command to make it easier to parse here.
 	gitSep := "@@@GIT-SEP@@@"
 	gitDelim := "@@@GIT-DELIM@@@"
@@ -660,11 +690,14 @@ func changelogEntries(since semver.Version) ([]string, error) {
 	}
 	buf, err := exec.Command("git", args...).CombinedOutput()
 	if err != nil {
-		return nil, fmt.Errorf("failed to run git %+v with error %w: %s", args, err, string(buf))
+		return nil, nil, fmt.Errorf("failed to run git %+v with error %w: %s", args, err, string(buf))
 	}
 
 	// gitSep separates each commit from the next
-	notes := make([]string, 0, 10)
+	entries := make([]commitmsg.Entry, 0, 10)
+
+	var unrecognised []string
+
 	commits := strings.SplitSeq(string(buf), gitSep)
 	for commit := range commits {
 		commit := strings.TrimSpace(commit)
@@ -684,48 +717,63 @@ func changelogEntries(since semver.Version) ([]string, error) {
 
 		subject := strings.TrimSpace(p[1])
 
-		// extract github issue numbers from the subject
-		issues := []string{}
-		if m := issueRE.FindStringSubmatch(strings.TrimSpace(subject)); len(m) > 1 {
-			issues = append(issues, m[1])
-		}
-
-		// try to extract the release note from the subject
-		if m := subjectRE.FindStringSubmatch(subject); len(m) > 1 {
-			notes = append(notes, m[1])
-
-			continue
-		}
-
-		// if no suitable subject was parsed, try to parse the body as well
-		for line := range strings.SplitSeq(p[2], "\n") {
-			line := strings.TrimSpace(line)
-
-			if m := issueRE.FindStringSubmatch(line); len(m) > 1 {
-				issues = append(issues, m[1])
-			}
-
-			if !strings.HasPrefix(line, "RELEASE_NOTES=") {
-				continue
-			}
-			p := strings.Split(line, "=")
-			if len(p) < 2 {
-				continue
-			}
-			val := p[1]
-			if strings.ToLower(val) == "n/a" {
-				continue
-			}
-			if len(issues) > 0 {
-				val += " (#" + strings.Join(issues, ", #") + ")"
-			}
-			notes = append(notes, val)
+		entry, disp := commitmsg.Classify(subject, p[2])
+		switch disp {
+		case commitmsg.Include:
+			entry.Text = appendIssues(entry.Text, subject, p[2])
+			entries = append(entries, entry)
+		case commitmsg.Unrecognised:
+			unrecognised = append(unrecognised, subject)
+		case commitmsg.Omitted:
+			// deliberately excluded: dependency bumps, CI, docs, tests
 		}
 	}
 
-	sort.Strings(notes)
+	slices.SortFunc(entries, func(a, b commitmsg.Entry) int {
+		if a.Section != b.Section {
+			return slices.Index(commitmsg.Sections, a.Section) - slices.Index(commitmsg.Sections, b.Section)
+		}
 
-	return notes, nil
+		return strings.Compare(a.Text, b.Text)
+	})
+
+	return entries, unrecognised, nil
+}
+
+// appendIssues appends the referenced issue numbers to an entry, unless the
+// text already carries them. A squash-merged subject usually ends in "(#1234)"
+// already, so this only fires for entries whose text came from a
+// RELEASE_NOTES= override or from a body reference.
+func appendIssues(text, subject, body string) string {
+	issues := []string{}
+
+	if m := issueRE.FindStringSubmatch(subject); len(m) > 1 {
+		issues = append(issues, m[1])
+	}
+
+	for line := range strings.SplitSeq(body, "\n") {
+		if m := issueRE.FindStringSubmatch(strings.TrimSpace(line)); len(m) > 1 {
+			issues = append(issues, m[1])
+		}
+	}
+
+	slices.Sort(issues)
+	issues = slices.Compact(issues)
+
+	missing := make([]string, 0, len(issues))
+
+	for _, i := range issues {
+		if strings.Contains(text, "#"+i) {
+			continue
+		}
+		missing = append(missing, i)
+	}
+
+	if len(missing) == 0 {
+		return text
+	}
+
+	return text + " (#" + strings.Join(missing, ", #") + ")"
 }
 
 func usage() {

--- a/helpers/release/main.go
+++ b/helpers/release/main.go
@@ -258,8 +258,8 @@ Will use
 `,
 		gitVer,
 		vfVer,
-		prevVerFlag,
 		nextVerFlag,
+		prevVerFlag,
 		prevVer,
 		nextVer)
 

--- a/internal/backend/storage/fs/rcs.go
+++ b/internal/backend/storage/fs/rcs.go
@@ -19,7 +19,7 @@
 // decision to merge them was made to simplify the leaf store and reduce the
 // indirection layer. If the number of pure-storage backends grows, or if the
 // stub overhead becomes a maintenance burden, see
-// docs/adr/A-3-separate-storage-rcs.md for a ready-made plan to split them
+// docs/adr/A-03-separate-storage-rcs.md for a ready-made plan to split them
 // again.
 package fs
 


### PR DESCRIPTION
> Depends on #3502 and #3503. This branch is stacked on them, so it shows five commits; three are its own. Once those merge only `feat(changelog)`, `fix(release)` and `docs(adr): align A-12` remain.

## Why

`CHANGELOG.md` carried three overlapping entry conventions at once: the bracketed `[TAG]` prefixes `CONTRIBUTING.md` mandated, the Conventional Commit subjects in use since 2025, and a third set in `## Next` including `[SECURITY]` and `[PKG-BREAK]` that appeared in neither. Release 1.16.0 contains the first two mixed together.

**There is also a live defect in the release automation.** `helpers/release/main.go` inserted the new release section before the *first* `## ` heading. Once an unreleased section existed that heading was `## Next`, so the release landed **above** it and the 30 hand-written entries below were orphaned — never published, and silently carried into every subsequent release. That is the current state of `master`.

## What this does

### `helpers/commitmsg` (new)

Parses and classifies commit subjects. Single source of truth for the changelog generator and for any future commit linting, so the two cannot disagree about what a valid subject is. It implements the closed type list, the `Changelog-Section:`, `PKG-BREAK:`, `BREAKING CHANGE:` and `RELEASE_NOTES=` footers, and the legacy `[TAG]` and bracketed-type forms so a release spanning the transition still classifies its older commits.

`Classify` returns a **disposition**, not a boolean. It distinguishes a deliberate omission — a dependency bump, a CI change — from a subject it could not recognise. Over the 137 commits since `v1.16.1` it classifies 47, omits 60, and cannot recognise 30. Among those 30:

```
otp: hide --snip flag when built with noscreenshot tag (#3445)
fscopy: derive copy direction from the source argument (#3462)
bug: reload identities on unlock command (#3430)
```

These are real user-facing changes written with a scope where a type belongs. The release helper now **prints them** rather than dropping them silently, so they can be added by hand or given a `RELEASE_NOTES=` line.

### `helpers/release`

`helpers/release/changelog.go` parses the file into header, unreleased block, released body and link references; merges the hand-written entries with the generated ones and de-duplicates; renders the release with only its non-empty subsections in Keep a Changelog order; leaves an empty `## [Unreleased]` behind; and rewrites the two link references a release changes.

Two smaller fixes found while verifying: the "Version overview" block passed `prevVerFlag, nextVerFlag` under labels reading "Next version flag" then "Prev version flag" — swapped, so a release run misreported its own arguments. And entries are now de-duplicated case-insensitively, because a hand-written entry and the commit subject that implemented it commonly differ only in their first letter.

### `helpers/changelog`

The extractor printed everything between the first and second `## ` heading. After the migration the first heading is an empty `## [Unreleased]`, which would have produced **empty GitHub release notes**. It now extracts the first *versioned* section, and still handles the legacy `## 1.16.1 / 2025-12-13` form.

### `CHANGELOG.md`

The 30 entries under `## Next` move into `## [Unreleased]`, distributed by their existing tags. **Three are placed by meaning rather than by tag**, because Keep a Changelog has sections their tags do not: the two `[UX]` entries that remove a CLI alias go to `Removed`, and the `[UX]` entry about the `GOPASS_AUTOSYNC_INTERVAL` deprecation goes to `Deprecated`. Bracketed prefixes are dropped; the trailing audit identifiers such as `(A-1)` and `(B-8)` are kept, since they are the only trace back to the audit that produced those entries.

All 86 released headings become `## [X.Y.Z] - YYYY-MM-DD` with their entry text untouched. The two headings that carried no date, `1.10.0` and `1.10.1`, take theirs from their git tags (2020-08-22 and 2020-08-25). A link reference block is appended; all 86 versions have a matching tag.

**The bullet count is unchanged at 837.** Nothing was dropped.

### ADR A-12

Three statements in it no longer hold. The entry goes in `## [Unreleased]`, not `## Next`. "The existing `helpers/changelog` generator reads `CHANGELOG.md` verbatim; no changes to that tool are needed" is false. And `[SECURITY]`, `[BUGFIX]`, `[FEATURE]` are no longer tags but subsections. `[PKG-BREAK]` survives as a bullet *prefix*, because it qualifies an entry rather than categorising it — which is exactly what a subsection cannot express.

## Verification

`go test ./helpers/...` passes. New tests cover the parser, every footer, all six sections, the legacy forms, the ordering defect, de-duplication and the link rewrite.

End to end against the real file, in a throwaway copy:

```
$ go run ./helpers/release --dry-run v1.17.0
...
### Security
- bound symlink walk to store root (H-2)
- document and warn on env command secret exposure (C-2)
- fix path traversal in fs storage layer (C-1)
- restrict template engine secret access and fix error leakage (H-1)
- validate editor binary exists before invocation (H-3)

⚠ 30 commit(s) could not be classified and produced no changelog entry.
  Their subjects are not valid commit messages. See docs/conventions.md.
  Add a RELEASE_NOTES= line to the commit body, or add the entry by hand:
  - fscopy: derive copy direction from the source argument (#3462)
  - otp: hide --snip flag when built with noscreenshot tag (#3445)
  ...
```

```
$ go run ./helpers/changelog | head -3
## [1.16.1] - 2025-12-13

* chore(deps): bump actions/checkout from 5.0.0 to 6.0.0 (#3299)
```

`make test` passes except `TestIsUpdateable`, which also fails on unmodified `master` in my container: it writes a file with mode `0555` and asserts it is not writable, but the test runs as uid 0 and root bypasses DAC. The compiled test binary passes as an unprivileged user.

`make codequality` reports only the two pre-existing `usetesting` findings and the `gomodguard` deprecation warning, both addressed in #3499 and #3498. `helpers/` is excluded from golangci-lint by `.golangci.yml:89`, but its tests do run under `make test`; `gofmt`, `gofumpt` and `go vet` are clean on the new code.

## One thing to expect

The first release cut after this will contain some near-duplicate entries, because the current `## [Unreleased]` was hand-written to describe commits that are also in the range — for example "Add JSON output to audit, list, find, and recipients commands (I-3)" alongside "machine-readable JSON output (I-3)". Case-insensitive folding catches the identical pairs; two different wordings of the same change need one manual pass. This is a one-time artefact of the transition: from here on, entries come from commits only.

## Open question

Mapping `deps` to `Changed` puts every Dependabot entry in `### Changed`; release 1.16.1 consisted entirely of them. I would suggest a `### Dependencies` section documented as an explicit extension to Keep a Changelog, but that is your call and I have not implemented it. Alternatives are to accept the noise, or to omit `deps` entirely since the GitHub release page already links the pull requests.