### PR TITLE
docs: point Android clients to the maintained agrahn fork

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -42,7 +42,7 @@ Some examples are available in our [example password store](https://github.com/g
 ## Mobile apps
 
 - [Pass - Password Store](https://apps.apple.com/us/app/pass-password-store/id1205820573) - iOS, [source code](https://github.com/mssun/passforios), [supports only 1 repository now](https://github.com/mssun/passforios/issues/88)
-- [Password Store](https://play.google.com/store/apps/details?id=dev.msfjarvis.aps) - Android, [source code](https://github.com/android-password-store/android-password-store)
+- [Password Store](https://f-droid.org/en/packages/app.passwordstore.agrahn) - Android, [source code](https://github.com/agrahn/Android-Password-Store)
 
 ## Standard Features
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -454,7 +454,7 @@ gopass config mounts.path "~/Google Drive/Password-Store"
 
 Because gopass is fully backwards compatible with pass, you can use some existing graphical user interfaces / frontends:
 
-* Android - [PwdStore](https://github.com/zeapo/Android-Password-Store)
+* Android - [Password Store](https://github.com/agrahn/Android-Password-Store)
 * iOS - [Pass for iOS](https://github.com/davidjb/pass-ios#readme)
 * Windows / MacOS / Linux -  [QtPass](https://qtpass.org/)
 


### PR DESCRIPTION
The original Android Password Store projects ([android-password-store/Android-Password-Store](https://github.com/android-password-store/android-password-store)) are archived and no longer maintained. Update the docs to reference the active fork [agrahn/Android-Password-Store](https://github.com/agrahn/Android-Password-Store/).

Closes #3521