### PR TITLE
fix(tempfile): mount macOS ramdisk read-write

### DIFF
--- a/pkg/tempfile/mount_darwin.go
+++ b/pkg/tempfile/mount_darwin.go
@@ -53,7 +53,7 @@ func (t *File) mount(ctx context.Context) error {
 	}
 
 	// mount ramdisk
-	cmd = exec.CommandContext(ctx, "diskutil", "mount", "nobrowse", "-mountOptions", "noatime", "-mountpoint", t.dir, t.dev)
+	cmd = exec.CommandContext(ctx, "diskutil", "mount", "nobrowse", "-mountOptions", "rw,noatime", "-mountpoint", t.dir, t.dev)
 	cmd.Stderr = os.Stderr
 	if debug.IsEnabled() {
 		cmd.Stdout = os.Stdout


### PR DESCRIPTION
## What

`gopass edit` mounts a RAM disk on macOS to hold the decrypted secret
while the editor is open. `diskutil mount` was called with
`-mountOptions noatime`, without an explicit `rw` option.

This changes the mount options to `rw,noatime`, explicitly requesting
a read-write mount.

## Why

On macOS 26.5.2, `gopass edit <secret>` fails with:

read-only file system

because the ramdisk gets mounted read-only, and the temporary file
used to hold the decrypted secret can't be written to it. Passing
`rw` explicitly avoids relying on the default behaviour of
`-mountOptions` and ensures the ramdisk is always writable.

It's unclear whether this is a recent regression in macOS or has
always required an explicit `rw` option; this fix does not depend on
knowing which.

## How was this tested?

- Verified `gopass edit` succeeds on macOS 26.5.2 after the change.
- `go test ./pkg/tempfile/...` passes.
- `make test` also passes, aside from a pre-existing, unrelated
  `TestGPGVerifyIn6Months` failure warning that the self-updater's
  signing key is nearing expiry (unrelated to this change).
