### PR TITLE
fix(age): raise agent scanner buffer limit to handle large decrypt payloads

### DIFF
--- a/internal/backend/crypto/age/agent/agent.go
+++ b/internal/backend/crypto/age/agent/agent.go
@@ -114,6 +114,13 @@ func (a *Agent) handleConnection(ctx context.Context, conn net.Conn) {
 	}()
 
 	scanner := bufio.NewScanner(conn)
+	// the decrypt command carries the base64-encoded ciphertext on a single
+	// line, so we need to raise the default 64 KiB token limit to handle
+	// larger secrets (see issue #3508). No buffer is preallocated: the
+	// scanner starts at bufio's small initial size and only doubles as the
+	// longest received line requires, up to this limit. The 16 MiB maximum
+	// matches the privateKeySizeLimit used when parsing identities.
+	scanner.Buffer(nil, 1<<24) // 16 MiB max line size
 	for scanner.Scan() {
 		line := scanner.Text()
 		debug.Log("received: %s", line)
@@ -216,6 +223,9 @@ func (a *Agent) handleConnection(ctx context.Context, conn net.Conn) {
 		default:
 			fmt.Fprintln(conn, "ERR unknown command")
 		}
+	}
+	if err := scanner.Err(); err != nil {
+		debug.Log("agent connection scan error: %s", err)
 	}
 }
 

--- a/internal/backend/crypto/age/agent/agent_test.go
+++ b/internal/backend/crypto/age/agent/agent_test.go
@@ -229,3 +229,48 @@ func TestAgentMultipleIdentities(t *testing.T) {
 	// cleanup
 	require.NoError(t, c.Quit())
 }
+
+func TestAgentLargePayload(t *testing.T) {
+	ctx := t.Context()
+	ctx = termio.WithPassPromptFunc(ctx, func(ctx context.Context, prompt string) (string, error) {
+		return "test", nil
+	})
+
+	// start agent
+	a, err := New()
+	require.NoError(t, err)
+
+	go func() {
+		_ = a.Run(ctx)
+	}()
+	defer a.Shutdown(ctx)
+
+	// wait for it to be ready
+	time.Sleep(time.Second)
+
+	// create client
+	c := NewClient()
+	require.NoError(t, c.Ping())
+
+	// generate identity and encrypt a plaintext large enough that the
+	// base64-encoded ciphertext exceeds the default 64 KiB scanner limit
+	// (see issue #3508)
+	id, err := age.GenerateX25519Identity()
+	require.NoError(t, err)
+
+	plaintext := bytes.Repeat([]byte("a"), 128*1024)
+	buf := &bytes.Buffer{}
+	wc, err := age.Encrypt(buf, id.Recipient())
+	require.NoError(t, err)
+	_, _ = wc.Write(plaintext)
+	require.NoError(t, wc.Close())
+	ciphertext := buf.Bytes()
+
+	require.NoError(t, c.SendIdentities(id.String()))
+
+	decrypted, err := c.Decrypt(ciphertext)
+	require.NoError(t, err)
+	require.Equal(t, plaintext, decrypted)
+
+	require.NoError(t, c.Quit())
+}


### PR DESCRIPTION
The age agent read its line-oriented protocol with a default
bufio.Scanner, which caps lines at 64 KiB (`bufio.MaxScanTokenSize`).
The decrypt command carries the base64-encoded ciphertext on a
single line, so any secret larger than ~48 KiB made scanner.Scan()
fail with `bufio.ErrTooLong`, silently dropping the connection and
leaving the client with EOF (e.g. "failed to send identities to
agent: EOF" from gopass age agent unlock).

Raise the scanner buffer cap to 16 MiB, matching the
`privateKeySizeLimit` already used when parsing identities. No buffer
is preallocated: the scanner starts at bufio's small initial size and
only doubles as the longest line actually received requires, so
this does not allocate anything upfront. Also log
scanner.Err() so future scan failures are no longer silent.

Implements Option 1 from #3508. A chunked or length-prefixed
protocol (Option 2) requires agent protocol versioning first.

Fixes #3508

Assisted-by: Claude-Code:GLM-5.2