### PR TITLE
ci(updater): move key expiration canary test to dedicated workflow

### DIFF
--- a/.github/workflows/key-canary.yml
+++ b/.github/workflows/key-canary.yml
@@ -1,0 +1,52 @@
+name: Key Canary
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  schedule:
+    - cron: '0 6 * * 1'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  canary:
+    name: Check Updater Key Expiry
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          disable-sudo: true
+          egress-policy: block
+          allowed-endpoints: >
+            github.com:443
+            objects.githubusercontent.com:443
+            proxy.golang.org:443
+            raw.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
+            storage.googleapis.com:443
+            sum.golang.org:443
+            golang.org:443
+            go.dev:443
+            azure.archive.ubuntu.com:443
+            archive.ubuntu.com:443
+            security.ubuntu.com:443
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Run Key Expiry Canary Test
+        run: go test -v -tags canary -run '^TestGPGVerifyIn6Months$' ./internal/updater/...

--- a/internal/updater/README.md
+++ b/internal/updater/README.md
@@ -38,8 +38,7 @@ is available.
 
 The relase signing key is set to expire every other year, so we need to follow a certain key rotation protocol to allow for a seamless key rotation.
 
-* At T-6 Month we should notice that `TestGPGVerifyIn6Months` starts to fail.
-  * There is likely a loss obstrusive way to achieve that, but I'll leave it at that for now.
+* At T-6 Month we should notice that `TestGPGVerifyIn6Months` (run in its own GitHub Action workflow with `-tags canary`) starts to fail.
 * We should then create an issue to track the key rollover (this should never happen in secret). The entire security posture isn't perfect but that's the best I can do with my resources. Help always appreciated.
 * For the actual rollout we first need to generate a new key. That needs to be done by exactly one core maintainer with write access to the repo and the GHA secrets since only they can inject the new key, fingerprint and passphrase.
 * To generate the key run: `gpg --expert --full-generate-key` and select `RSA and RSA`, `3072` (bits) and a validity of `2y`. Use `Gopass Release Signing Key YYYY` as the name, `GitHub Actions only` as the comment and `release@gopass.pw` as the email.

--- a/internal/updater/verify_canary_test.go
+++ b/internal/updater/verify_canary_test.go
@@ -1,0 +1,22 @@
+//go:build canary
+
+package updater
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGPGVerifyIn6Months tests that the signature is still valid in 6 months.
+// This is supposed to act as a canary so we don't forget to roll the key
+// before it expires. See README.md for details.
+func TestGPGVerifyIn6Months(t *testing.T) {
+	t.Parallel()
+
+	ok, err := gpgVerifyAt(testData, testSignature, func() time.Time { return time.Now().AddDate(0, 6, 0) })
+	require.NoError(t, err, "If TestGPGVerify succeeds but this test fails the self-updater key is about to expire. Please open an issue to update the key. Thank you.")
+	assert.True(t, ok)
+}

--- a/internal/updater/verify_test.go
+++ b/internal/updater/verify_test.go
@@ -2,7 +2,6 @@ package updater
 
 import (
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -35,16 +34,5 @@ func TestGPGVerify(t *testing.T) {
 
 	ok, err := gpgVerify(testData, testSignature)
 	require.NoError(t, err)
-	assert.True(t, ok)
-}
-
-// TestGPGVerifyIn6Months tests that the signature is still valid in 6 months.
-// This is supposed to act as a canary so we don't forget to roll the key
-// before it expires. See README.md for details.
-func TestGPGVerifyIn6Months(t *testing.T) {
-	t.Parallel()
-
-	ok, err := gpgVerifyAt(testData, testSignature, func() time.Time { return time.Now().AddDate(0, 6, 0) })
-	require.NoError(t, err, "If TestGPGVerify succeeds but this test fails the self-updater key is about to expire. Please open an issue to update the key. Thank you.")
 	assert.True(t, ok)
 }


### PR DESCRIPTION
Move TestGPGVerifyIn6Months from verify_test.go to verify_canary_test.go behind the canary build tag. This prevents upcoming key expiration from failing the standard test suite and obscuring other test results.

Add a dedicated GitHub Actions workflow (key-canary.yml) that runs the canary test on push, pull request, and a weekly schedule. When the updater signing key is within 6 months of expiration, the canary workflow will fail in isolation, providing a clear indication in the Actions summary.

For #3523