### PR TITLE
fix: eliminate audit, queue, and test initialization races

### DIFF
--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -126,6 +126,12 @@ func (a *Auditor) Batch(ctx context.Context, secrets []string) (*Report, error) 
 	// Spawn workers that run the auditing of all secrets concurrently.
 	debug.Log("launching %d audit workers", maxJobs)
 
+	bar := termio.NewProgressBar(int64(len(secrets)))
+	bar.Hidden = ctxutil.IsHidden(ctx)
+	a.pcb = func() {
+		bar.Inc()
+	}
+
 	done := make(chan struct{}, maxJobs)
 	for range maxJobs {
 		go a.audit(ctx, pending, done)
@@ -137,12 +143,6 @@ func (a *Auditor) Batch(ctx context.Context, secrets []string) (*Report, error) 
 		}
 		close(pending)
 	}()
-
-	bar := termio.NewProgressBar(int64(len(secrets)))
-	bar.Hidden = ctxutil.IsHidden(ctx)
-	a.pcb = func() {
-		bar.Inc()
-	}
 
 	for range maxJobs {
 		<-done

--- a/internal/store/leaf/write.go
+++ b/internal/store/leaf/write.go
@@ -72,7 +72,7 @@ func (s *Store) Set(ctx context.Context, name string, sec gopass.Byter) error {
 		return nil, s.gitCommitAndPush(commitCtx, name)
 	})
 
-	ctx, err = t(ctx)
+	_, err = t(ctx)
 
 	return err
 }

--- a/internal/store/leaf/write.go
+++ b/internal/store/leaf/write.go
@@ -67,8 +67,9 @@ func (s *Store) Set(ctx context.Context, name string, sec gopass.Byter) error {
 
 	// try to enqueue this task, if the queue is not available
 	// it will return the task and we will execute it inline
+	commitCtx := ctx
 	t := queue.GetQueue(ctx).Add(func(_ context.Context) (context.Context, error) {
-		return nil, s.gitCommitAndPush(ctx, name)
+		return nil, s.gitCommitAndPush(commitCtx, name)
 	})
 
 	ctx, err = t(ctx)

--- a/main_test.go
+++ b/main_test.go
@@ -36,8 +36,6 @@ func TestVersionPrinter(t *testing.T) {
 }
 
 func TestGetVersion(t *testing.T) {
-	t.Parallel()
-
 	version = "1.9.0"
 
 	if getVersion().LT(semver.Version{Major: 1, Minor: 9}) {
@@ -46,8 +44,6 @@ func TestGetVersion(t *testing.T) {
 }
 
 func TestSetupApp(t *testing.T) {
-	t.Parallel()
-
 	ctx := config.NewContextInMemory()
 	_, app := setupApp(ctx, semver.Version{})
 	assert.NotNil(t, app)
@@ -226,8 +222,6 @@ func runCmdBefore(ctx context.Context, cmd *cli.Command) (context.Context, error
 }
 
 func TestInitContext(t *testing.T) {
-	t.Parallel()
-
 	ctx := t.Context()
 	cfg := config.NewInMemory()
 


### PR DESCRIPTION
## Summary

- initialize and publish the audit progress callback before starting worker goroutines
- capture the queued commit context before the caller reassigns its local context
- stop running main-package tests that mutate process-global version/color state in parallel

## Race evidence and validation

- `go test -race -shuffle=on .`
- `go test -race ./internal/audit`
- `go test -race -run ^TestConvert$ ./internal/action`

A broader `go test -race ./...` now proceeds beyond these races and exposes separate pre-existing races among parallel `internal/store/leaf` tests that replace shared output globals. Those are not hidden by this PR and should be handled as a separate test-isolation change.