### PR TITLE
test(gpg): isolate package GnuPG home

### DIFF
--- a/internal/backend/crypto/gpg/cli/main_test.go
+++ b/internal/backend/crypto/gpg/cli/main_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -23,7 +25,7 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 
-	if err := os.Setenv("GNUPGHOME", home); err != nil {
+	if err := os.Setenv("GNUPGHOME", gpgHomeEnv(home, runtime.GOOS)); err != nil {
 		cleanup()
 		_ = os.RemoveAll(base)
 		_, _ = fmt.Fprintf(os.Stderr, "set GNUPGHOME for tests: %v\n", err)
@@ -45,6 +47,19 @@ func prepareTestGPGHome(base string) (string, func(), error) {
 	return home, func() { _ = os.RemoveAll(home) }, nil
 }
 
+func gpgHomeEnv(home, goos string) string {
+	if goos != "windows" {
+		return home
+	}
+
+	home = strings.ReplaceAll(home, `\`, "/")
+	if len(home) >= 2 && home[1] == ':' {
+		return "/" + strings.ToLower(home[:1]) + home[2:]
+	}
+
+	return home
+}
+
 func TestPrepareTestGPGHome(t *testing.T) {
 	base := t.TempDir()
 	home, cleanup, err := prepareTestGPGHome(base)
@@ -56,5 +71,12 @@ func TestPrepareTestGPGHome(t *testing.T) {
 	info, err := os.Stat(home)
 	require.NoError(t, err)
 	require.True(t, info.IsDir())
-	require.Equal(t, os.FileMode(0o700), info.Mode().Perm())
+	if runtime.GOOS != "windows" {
+		require.Equal(t, os.FileMode(0o700), info.Mode().Perm())
+	}
+}
+
+func TestGPGHomeEnv(t *testing.T) {
+	require.Equal(t, "/c/msys64/tmp/gopass/.gnupg", gpgHomeEnv(`C:\msys64\tmp\gopass\.gnupg`, "windows"))
+	require.Equal(t, "/tmp/gopass/.gnupg", gpgHomeEnv("/tmp/gopass/.gnupg", "linux"))
 }

--- a/internal/backend/crypto/gpg/cli/main_test.go
+++ b/internal/backend/crypto/gpg/cli/main_test.go
@@ -1,0 +1,60 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMain(m *testing.M) {
+	base, err := os.MkdirTemp("", "gopass-gpg-test-")
+	if err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "create GnuPG test base directory: %v\n", err)
+		os.Exit(1)
+	}
+
+	home, cleanup, err := prepareTestGPGHome(base)
+	if err != nil {
+		_ = os.RemoveAll(base)
+		_, _ = fmt.Fprintf(os.Stderr, "prepare GnuPG test home: %v\n", err)
+		os.Exit(1)
+	}
+
+	if err := os.Setenv("GNUPGHOME", home); err != nil {
+		cleanup()
+		_ = os.RemoveAll(base)
+		_, _ = fmt.Fprintf(os.Stderr, "set GNUPGHOME for tests: %v\n", err)
+		os.Exit(1)
+	}
+
+	code := m.Run()
+	cleanup()
+	_ = os.RemoveAll(base)
+	os.Exit(code)
+}
+
+func prepareTestGPGHome(base string) (string, func(), error) {
+	home := filepath.Join(base, ".gnupg")
+	if err := os.Mkdir(home, 0o700); err != nil {
+		return "", func() {}, fmt.Errorf("create %s: %w", home, err)
+	}
+
+	return home, func() { _ = os.RemoveAll(home) }, nil
+}
+
+func TestPrepareTestGPGHome(t *testing.T) {
+	base := t.TempDir()
+	home, cleanup, err := prepareTestGPGHome(base)
+	require.NoError(t, err)
+	t.Cleanup(cleanup)
+
+	require.Equal(t, filepath.Join(base, ".gnupg"), home)
+
+	info, err := os.Stat(home)
+	require.NoError(t, err)
+	require.True(t, info.IsDir())
+	require.Equal(t, os.FileMode(0o700), info.Mode().Perm())
+}


### PR DESCRIPTION
## Summary

- create a package-scoped temporary `GNUPGHOME` before parallel GPG CLI tests start
- pre-create it with mode `0700` to remove the concurrent GnuPG home-creation race
- preserve existing parallel test execution and production behavior

Fixes the recurring `gpg: Fatal: can't create directory ~/.gnupg: File exists` failure reported in #3118.

## Validation

- `go test -count=20 ./internal/backend/crypto/gpg/cli`
- `go test -race -shuffle=on -count=5 ./internal/backend/crypto/gpg/cli`
- `make test` reaches the pre-existing root-only `TestIsUpdateable` failure after the GPG package passes
- master codequality has the pre-existing `internal/notify/icon.go` nlreturn finding addressed by #3498