### PR TITLE
refactor(age): share identity file parsing

### DIFF
--- a/internal/backend/crypto/age/agent/identity.go
+++ b/internal/backend/crypto/age/agent/identity.go
@@ -1,13 +1,13 @@
 package agent
 
 import (
-	"bufio"
 	"fmt"
 	"io"
 	"strings"
 
 	"filippo.io/age"
 	"filippo.io/age/plugin"
+	"github.com/gopasspw/gopass/internal/backend/crypto/age/identityfile"
 )
 
 // parseIdentity parses a single identity string, supporting AGE-PLUGIN-* prefixed plugin
@@ -40,34 +40,8 @@ func parseIdentity(s string) (age.Identity, error) {
 	}
 }
 
-// parseIdentities parses multiple age identities from a reader, supporting plugin identities
-// in addition to native age keys. It replaces age.ParseIdentities() which only handles
-// native keys and rejects AGE-PLUGIN-* identities (causing "malformed secret key: mixed
-// case" errors with e.g. age-plugin-yubikey).
-func parseIdentities(f io.Reader) ([]age.Identity, error) {
-	const privateKeySizeLimit = 1 << 24 // 16 MiB
-	var ids []age.Identity
-	scanner := bufio.NewScanner(io.LimitReader(f, privateKeySizeLimit))
-	var n int
-	for scanner.Scan() {
-		n++
-		line := scanner.Text()
-		if strings.HasPrefix(line, "#") || line == "" {
-			continue
-		}
-
-		i, err := parseIdentity(line)
-		if err != nil {
-			return nil, fmt.Errorf("error at line %d: %w", n, err)
-		}
-		ids = append(ids, i)
-	}
-	if err := scanner.Err(); err != nil {
-		return nil, fmt.Errorf("failed to read secret keys file: %w", err)
-	}
-	if len(ids) == 0 {
-		return nil, fmt.Errorf("no secret keys found")
-	}
-
-	return ids, nil
+// parseIdentities parses native and plugin identities using the shared bounded
+// identity-file scanner and the agent-specific single-line parser.
+func parseIdentities(reader io.Reader) ([]age.Identity, error) {
+	return identityfile.Parse(reader, parseIdentity)
 }

--- a/internal/backend/crypto/age/identities.go
+++ b/internal/backend/crypto/age/identities.go
@@ -1,12 +1,10 @@
 package age
 
 import (
-	"bufio"
 	"bytes"
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"maps"
 	"os"
 	"path/filepath"
@@ -17,6 +15,7 @@ import (
 	"filippo.io/age"
 	"filippo.io/age/agessh"
 	"filippo.io/age/plugin"
+	"github.com/gopasspw/gopass/internal/backend/crypto/age/identityfile"
 	"github.com/gopasspw/gopass/pkg/appdir"
 	"github.com/gopasspw/gopass/pkg/debug"
 )
@@ -86,7 +85,7 @@ func (a *Age) Identities(ctx context.Context) ([]age.Identity, error) {
 		return nil, nil
 	}
 
-	ids, err := parseIdentities(bytes.NewReader(buf))
+	ids, err := identityfile.Parse(bytes.NewReader(buf), parseIdentity)
 	if err != nil {
 		return nil, err
 	}
@@ -138,36 +137,6 @@ func parseIdentity(s string) (age.Identity, error) {
 	default:
 		return nil, fmt.Errorf("unknown identity type")
 	}
-}
-
-// parseIdentities is like age.ParseIdentities, but supports plugin identities,
-// it is a copy of https://github.com/FiloSottile/age/blob/2214a556f60400ad19f2ca43d3cbbb4a5a0fe5ab/cmd/age/parse.go#L123-L126
-func parseIdentities(f io.Reader) ([]age.Identity, error) {
-	const privateKeySizeLimit = 1 << 24 // 16 MiB
-	var ids []age.Identity
-	scanner := bufio.NewScanner(io.LimitReader(f, privateKeySizeLimit))
-	var n int
-	for scanner.Scan() {
-		n++
-		line := scanner.Text()
-		if strings.HasPrefix(line, "#") || line == "" {
-			continue
-		}
-
-		i, err := parseIdentity(line)
-		if err != nil {
-			return nil, fmt.Errorf("error at line %d: %w", n, err)
-		}
-		ids = append(ids, i)
-	}
-	if err := scanner.Err(); err != nil {
-		return nil, fmt.Errorf("failed to read secret keys file: %w", err)
-	}
-	if len(ids) == 0 {
-		return nil, fmt.Errorf("no secret keys found")
-	}
-
-	return ids, nil
 }
 
 // IdentityRecipients returns a slice of recipients derived from our identities.

--- a/internal/backend/crypto/age/identityfile/parse.go
+++ b/internal/backend/crypto/age/identityfile/parse.go
@@ -1,0 +1,44 @@
+// Package identityfile parses bounded age identity files.
+package identityfile
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"strings"
+
+	"filippo.io/age"
+)
+
+const privateKeySizeLimit = 1 << 24 // 16 MiB
+
+// Parser converts one non-empty, non-comment line into an age identity.
+type Parser func(string) (age.Identity, error)
+
+// Parse reads identities and delegates identity-specific decoding to parser.
+func Parse(reader io.Reader, parser Parser) ([]age.Identity, error) {
+	var identities []age.Identity
+	scanner := bufio.NewScanner(io.LimitReader(reader, privateKeySizeLimit))
+	lineNumber := 0
+	for scanner.Scan() {
+		lineNumber++
+		line := scanner.Text()
+		if strings.HasPrefix(line, "#") || line == "" {
+			continue
+		}
+
+		identity, err := parser(line)
+		if err != nil {
+			return nil, fmt.Errorf("error at line %d: %w", lineNumber, err)
+		}
+		identities = append(identities, identity)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("failed to read secret keys file: %w", err)
+	}
+	if len(identities) == 0 {
+		return nil, fmt.Errorf("no secret keys found")
+	}
+
+	return identities, nil
+}

--- a/internal/backend/crypto/age/identityfile/parse_test.go
+++ b/internal/backend/crypto/age/identityfile/parse_test.go
@@ -1,0 +1,47 @@
+package identityfile
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"filippo.io/age"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseSkipsCommentsAndReportsSourceLine(t *testing.T) {
+	wantErr := errors.New("invalid identity")
+	parser := func(line string) (age.Identity, error) {
+		assert.Equal(t, "invalid", line)
+
+		return nil, wantErr
+	}
+
+	_, err := Parse(strings.NewReader("# comment\n\ninvalid\n"), parser)
+	require.ErrorIs(t, err, wantErr)
+	assert.EqualError(t, err, "error at line 3: invalid identity")
+}
+
+func TestParseRejectsEmptyInput(t *testing.T) {
+	_, err := Parse(strings.NewReader("# comment\n\n"), func(string) (age.Identity, error) {
+		t.Fatal("parser must not be called")
+
+		return nil, errors.New("unreachable parser call")
+	})
+	require.EqualError(t, err, "no secret keys found")
+}
+
+func TestParseReturnsAllIdentities(t *testing.T) {
+	first, err := age.GenerateX25519Identity()
+	require.NoError(t, err)
+	second, err := age.GenerateX25519Identity()
+	require.NoError(t, err)
+
+	input := first.String() + "\n" + second.String() + "\n"
+	ids, err := Parse(strings.NewReader(input), func(line string) (age.Identity, error) {
+		return age.ParseX25519Identity(line)
+	})
+	require.NoError(t, err)
+	require.Equal(t, []age.Identity{first, second}, ids)
+}


### PR DESCRIPTION
## Summary

- extract the bounded age identity-file scanner into an internal shared package
- preserve backend-specific single-line parsing through a callback
- remove the exact duplicate implementation from the age backend and age agent
- add focused tests for comments, source line errors, empty input, and multiple identities

The SSA duplicate scan drops from 38 to 37 exact groups; the parseIdentities group is removed.

## Validation

- go test -race -shuffle=on ./internal/backend/crypto/age/...
- go vet ./internal/backend/crypto/age/...
- make test-integration
- git diff --check

Full make test reaches the pre-existing root-only internal/updater TestIsUpdateable failure because root bypasses file permission bits. make codequality reports only pre-existing master findings in internal/action/handler_shims.go (gofumpt) and internal/notify/icon.go (nlreturn). No new findings remain.