### PR TITLE
docs: replace retired Go Report Card badge with golangci-lint CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/gopasspw/gopass/badge)](https://securityscorecards.dev/viewer/?uri=github.com/gopasspw/gopass)
 [![Build Status](https://img.shields.io/github/actions/workflow/status/gopasspw/gopass/build.yml?branch=master)](https://github.com/gopasspw/gopass/actions/workflows/build.yml?query=branch%3Amaster)
-[![Go Report Card](https://goreportcard.com/badge/github.com/gopasspw/gopass)](https://goreportcard.com/report/github.com/gopasspw/gopass)
-[![Packaging status](https://repology.org/badge/tiny-repos/gopass-gopasspw.svg)](https://repology.org/project/gopass-gopasspw/versions)
+[![Lint Status](https://img.shields.io/github/actions/workflow/status/gopasspw/gopass/golangci-lint.yml?branch=master&label=lint)](https://github.com/gopasspw/gopass/actions/workflows/golangci-lint.yml?query=branch%3Amaster)
+[![Packaging Status](https://repology.org/badge/tiny-repos/gopass-gopasspw.svg)](https://repology.org/project/gopass-gopasspw/versions)
 [![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/gopasspw/gopass/blob/master/LICENSE)
 [![Github All Releases](https://img.shields.io/github/downloads/gopasspw/gopass/total.svg)](https://github.com/gopasspw/gopass/releases)
 [![Gopass Slack](https://img.shields.io/badge/%23gopass-Slack-brightgreen)](https://join.slack.com/t/gopassworkspace/shared_invite/zt-17jl74b5x-U1OUW4ts4AQ7eAf2V4QaaQ)


### PR DESCRIPTION
<img width="121" height="27" alt="image" src="https://github.com/user-attachments/assets/99858be3-b821-457e-888d-9de7e2655b7a" />

Go Report Card has been retired, so the badge no longer renders useful status. Replace it with a GitHub Actions workflow status badge for our [golangci-lint](https://github.com/gopasspw/gopass/actions/workflows/golangci-lint.yml) workflow, styled like the existing build status badge.

---

New:

<img width="847" height="597" alt="image" src="https://github.com/user-attachments/assets/d8ef121e-fa57-4480-9418-862694bb4dbf" />