### PR TITLE
chore(termio): Check gitconfig after Git env vars

### DIFF
--- a/internal/action/clone_test.go
+++ b/internal/action/clone_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/gopasspw/gopass/internal/config"
 	"github.com/gopasspw/gopass/internal/out"
 	"github.com/gopasspw/gopass/pkg/ctxutil"
-	"github.com/gopasspw/gopass/pkg/termio"
 	"github.com/gopasspw/gopass/tests/gptest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -121,10 +120,9 @@ func TestCloneBackendIsStoredForMount(t *testing.T) {
 func TestCloneGetGitConfig(t *testing.T) {
 	u := gptest.NewUnitTester(t)
 
-	r1 := gptest.UnsetVars(termio.NameVars...)
-	defer r1()
-	r2 := gptest.UnsetVars(termio.EmailVars...)
-	defer r2()
+	for _, k := range []string{"GIT_AUTHOR_NAME", "GIT_AUTHOR_EMAIL", "DEBFULLNAME", "DEBEMAIL", "USER", "EMAIL"} {
+		t.Setenv(k, "")
+	}
 
 	ctx := config.NewContextInMemory()
 	ctx = ctxutil.WithAlwaysYes(ctx, true)

--- a/internal/action/history_test.go
+++ b/internal/action/history_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/gopasspw/gopass/internal/config"
 	"github.com/gopasspw/gopass/internal/out"
 	"github.com/gopasspw/gopass/pkg/ctxutil"
-	"github.com/gopasspw/gopass/pkg/termio"
 	"github.com/gopasspw/gopass/tests/gptest"
 	"github.com/stretchr/testify/require"
 )
@@ -18,10 +17,11 @@ import (
 func TestHistory(t *testing.T) {
 	u := gptest.NewUnitTester(t)
 
-	r1 := gptest.UnsetVars(termio.NameVars...)
-	r2 := gptest.UnsetVars(termio.EmailVars...)
-	defer r1()
-	defer r2()
+	for _, k := range []string{"DEBFULLNAME", "DEBEMAIL", "USER", "EMAIL"} {
+		t.Setenv(k, "")
+	}
+	t.Setenv("GIT_AUTHOR_NAME", "foo bar")
+	t.Setenv("GIT_AUTHOR_EMAIL", "foo.bar@example.org")
 
 	ctx := config.NewContextInMemory()
 	ctx = ctxutil.WithAlwaysYes(ctx, true)

--- a/internal/config/docs_test.go
+++ b/internal/config/docs_test.go
@@ -18,6 +18,9 @@ import (
 var ignoredEnvs = set.Map([]string{
 	// keep-sorted start
 	"APPDATA",
+	"DEBEMAIL",
+	"DEBFULLNAME",
+	"EMAIL",
 	"GIT_AUTHOR_EMAIL",
 	"GIT_AUTHOR_NAME",
 	"GNUPGHOME",
@@ -31,6 +34,7 @@ var ignoredEnvs = set.Map([]string{
 	"HOME",
 	"LOCALAPPDATA",
 	"PASSWORD_STORE_UMASK", // indirect usage
+	"USER",
 	"XDG_CACHE_HOME",
 	"XDG_CONFIG_HOME",
 	"XDG_DATA_HOME",
@@ -144,6 +148,10 @@ func usedOptsInFile(t *testing.T, fn string, opts map[string]bool, re *regexp.Re
 
 			break
 		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return err
 	}
 
 	return nil
@@ -270,6 +278,10 @@ func usedEnvsInFile(t *testing.T, fn string, opts map[string]bool, re *regexp.Re
 		opts[v] = true
 	}
 
+	if err := scanner.Err(); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -305,6 +317,10 @@ func documentedEnvs(t *testing.T) map[string]bool {
 		}
 
 		opts[v] = true
+	}
+
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("failed to scan %s: %s", fn, err)
 	}
 
 	return opts

--- a/pkg/termio/identity.go
+++ b/pkg/termio/identity.go
@@ -3,77 +3,71 @@ package termio
 import (
 	"context"
 	"os"
+	"strings"
 
 	"github.com/gopasspw/gitconfig"
 	"github.com/gopasspw/gopass/pkg/ctxutil"
 	"github.com/urfave/cli/v3"
 )
 
+type strFn func(ctx context.Context, cmd *cli.Command) string
+
 var (
-	// NameVars are the env vars checked for a valid name.
-	NameVars = []string{
-		"GIT_AUTHOR_NAME",
-		"DEBFULLNAME",
-		"USER",
+	nameVars = []strFn{
+		func(ctx context.Context, cmd *cli.Command) string { return ctxutil.GetUsername(ctx) },
+		func(ctx context.Context, cmd *cli.Command) string {
+			if cmd != nil {
+				return cmd.String("name")
+			}
+			return ""
+		},
+		func(ctx context.Context, cmd *cli.Command) string { return os.Getenv("GIT_AUTHOR_NAME") },
+		func(ctx context.Context, cmd *cli.Command) string {
+			cfg := gitconfig.New().LoadAll(GetWorkdir(ctx))
+			return cfg.Get("user.name")
+		},
+		func(ctx context.Context, cmd *cli.Command) string { return os.Getenv("DEBFULLNAME") },
+		func(ctx context.Context, cmd *cli.Command) string { return os.Getenv("USER") },
 	}
-	// EmailVars are the env vars checked for a valid email.
-	EmailVars = []string{
-		"GIT_AUTHOR_EMAIL",
-		"DEBEMAIL",
-		"EMAIL",
+	emailVars = []strFn{
+		func(ctx context.Context, cmd *cli.Command) string { return ctxutil.GetEmail(ctx) },
+		func(ctx context.Context, cmd *cli.Command) string {
+			if cmd != nil {
+				return cmd.String("email")
+			}
+			return ""
+		},
+		func(ctx context.Context, cmd *cli.Command) string { return os.Getenv("GIT_AUTHOR_EMAIL") },
+		func(ctx context.Context, cmd *cli.Command) string {
+			cfg := gitconfig.New().LoadAll(GetWorkdir(ctx))
+			return cfg.Get("user.email")
+		},
+		func(ctx context.Context, cmd *cli.Command) string { return os.Getenv("DEBEMAIL") },
+		func(ctx context.Context, cmd *cli.Command) string { return os.Getenv("EMAIL") },
 	}
 )
 
-// DetectName tries to guess the name of the logged in user.
-// It checks the context, the command line flags, environment variables,
-// and the git config.
-func DetectName(ctx context.Context, cmd *cli.Command) string {
-	cand := make([]string, 0, 10)
-	cand = append(cand, ctxutil.GetUsername(ctx))
-
-	if cmd != nil {
-		cand = append(cand, cmd.String("name"))
-	}
-
-	for _, k := range NameVars {
-		cand = append(cand, os.Getenv(k))
-	}
-
-	cfg := gitconfig.New().LoadAll(GetWorkdir(ctx))
-	cand = append(cand, cfg.Get("user.name"))
-
-	for _, e := range cand {
-		if e != "" {
-			return e
+func detect(ctx context.Context, cmd *cli.Command, vars []strFn) string {
+	for _, fn := range vars {
+		s := strings.TrimSpace(fn(ctx, cmd))
+		if s != "" {
+			return s
 		}
 	}
 
 	return ""
 }
 
+// DetectName tries to guess the name of the logged in user.
+// It checks the context, the command line flags, environment variables,
+// and the git config.
+func DetectName(ctx context.Context, cmd *cli.Command) string {
+	return detect(ctx, cmd, nameVars)
+}
+
 // DetectEmail tries to guess the email of the logged in user.
 // It checks the context, the command line flags, environment variables,
 // and the git config.
 func DetectEmail(ctx context.Context, cmd *cli.Command) string {
-	cand := make([]string, 0, 10)
-	cand = append(cand, ctxutil.GetEmail(ctx))
-
-	if cmd != nil {
-		cand = append(cand, cmd.String("email"))
-	}
-
-	for _, k := range EmailVars {
-		cand = append(cand, os.Getenv(k))
-	}
-
-	cfg := gitconfig.New().LoadAll(GetWorkdir(ctx))
-	cand = append(cand, cfg.Get("user.email"))
-
-	for _, e := range cand {
-		if e != "" {
-			return e
-		}
-	}
-
-	return ""
+	return detect(ctx, cmd, emailVars)
 }

--- a/pkg/termio/identity.go
+++ b/pkg/termio/identity.go
@@ -19,11 +19,13 @@ var (
 			if cmd != nil {
 				return cmd.String("name")
 			}
+
 			return ""
 		},
 		func(ctx context.Context, cmd *cli.Command) string { return os.Getenv("GIT_AUTHOR_NAME") },
 		func(ctx context.Context, cmd *cli.Command) string {
 			cfg := gitconfig.New().LoadAll(GetWorkdir(ctx))
+
 			return cfg.Get("user.name")
 		},
 		func(ctx context.Context, cmd *cli.Command) string { return os.Getenv("DEBFULLNAME") },
@@ -35,11 +37,13 @@ var (
 			if cmd != nil {
 				return cmd.String("email")
 			}
+
 			return ""
 		},
 		func(ctx context.Context, cmd *cli.Command) string { return os.Getenv("GIT_AUTHOR_EMAIL") },
 		func(ctx context.Context, cmd *cli.Command) string {
 			cfg := gitconfig.New().LoadAll(GetWorkdir(ctx))
+
 			return cfg.Get("user.email")
 		},
 		func(ctx context.Context, cmd *cli.Command) string { return os.Getenv("DEBEMAIL") },

--- a/pkg/termio/identity_test.go
+++ b/pkg/termio/identity_test.go
@@ -27,7 +27,7 @@ func TestDetectName(t *testing.T) {
 
 	cmd := &cli.Command{}
 	cmd.Flags = append(cmd.Flags, &cli.StringFlag{Name: "name"})
-	cmd.Set("name", "bar")
+	_ = cmd.Set("name", "bar")
 	assert.Equal(t, "bar", DetectName(ctx, cmd))
 
 	t.Setenv("GIT_AUTHOR_NAME", "Author Name")
@@ -51,7 +51,7 @@ func TestDetectEmail(t *testing.T) {
 
 	cmd := &cli.Command{}
 	cmd.Flags = append(cmd.Flags, &cli.StringFlag{Name: "email"})
-	cmd.Set("email", "bar@baz.de")
+	_ = cmd.Set("email", "bar@baz.de")
 	assert.Equal(t, "bar@baz.de", DetectEmail(ctx, cmd))
 
 	t.Setenv("GIT_AUTHOR_EMAIL", "bar@bar.bar")

--- a/pkg/termio/identity_test.go
+++ b/pkg/termio/identity_test.go
@@ -3,8 +3,11 @@ package termio
 import (
 	"testing"
 
+	"github.com/gopasspw/gitconfig"
 	"github.com/gopasspw/gopass/internal/config"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v3"
 )
 
 func TestDetectName(t *testing.T) {
@@ -21,6 +24,14 @@ func TestDetectName(t *testing.T) {
 
 	t.Setenv("USER", "foo")
 	assert.Equal(t, "foo", DetectName(ctx, nil))
+
+	cmd := &cli.Command{}
+	cmd.Flags = append(cmd.Flags, &cli.StringFlag{Name: "name"})
+	cmd.Set("name", "bar")
+	assert.Equal(t, "bar", DetectName(ctx, cmd))
+
+	t.Setenv("GIT_AUTHOR_NAME", "Author Name")
+	assert.Equal(t, "Author Name", DetectName(ctx, nil))
 }
 
 func TestDetectEmail(t *testing.T) {
@@ -37,4 +48,41 @@ func TestDetectEmail(t *testing.T) {
 
 	t.Setenv("EMAIL", "foo@bar.de")
 	assert.Equal(t, "foo@bar.de", DetectEmail(ctx, nil))
+
+	cmd := &cli.Command{}
+	cmd.Flags = append(cmd.Flags, &cli.StringFlag{Name: "email"})
+	cmd.Set("email", "bar@baz.de")
+	assert.Equal(t, "bar@baz.de", DetectEmail(ctx, cmd))
+
+	t.Setenv("GIT_AUTHOR_EMAIL", "bar@bar.bar")
+	assert.Equal(t, "bar@bar.bar", DetectEmail(ctx, nil))
+}
+
+func TestDetectGitConfig(t *testing.T) {
+	td := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", td)
+	t.Setenv("GOPASS_HOMEDIR", td)
+
+	t.Setenv("GIT_AUTHOR_NAME", "")
+	t.Setenv("GIT_AUTHOR_EMAIL", " ")
+	t.Setenv("DEBFULLNAME", "deb-name")
+	t.Setenv("DEBEMAIL", "deb@example.com")
+	t.Setenv("USER", "user-name")
+	t.Setenv("EMAIL", "user@example.com")
+
+	cfg := gitconfig.New().LoadAll(td)
+	require.NoError(t, cfg.SetLocal("user.name", "Jane Doe"))
+	require.NoError(t, cfg.SetLocal("user.email", "jane@example.com"))
+
+	ctx := WithWorkdir(config.NewContextInMemory(), td)
+
+	// Git config takes precedence over DEBFULLNAME/USER and DEBEMAIL/EMAIL.
+	assert.Equal(t, "Jane Doe", DetectName(ctx, nil))
+	assert.Equal(t, "jane@example.com", DetectEmail(ctx, nil))
+
+	// GIT_AUTHOR_* env vars take precedence over git config.
+	t.Setenv("GIT_AUTHOR_NAME", "Author Name")
+	t.Setenv("GIT_AUTHOR_EMAIL", "author@example.com")
+	assert.Equal(t, "Author Name", DetectName(ctx, nil))
+	assert.Equal(t, "author@example.com", DetectEmail(ctx, nil))
 }


### PR DESCRIPTION
This changes the name and email lookups to check the Git config right after GIT env vars. If the user has set their git identity in the password store repo we should use that instead of trying to detect a global identity.

Obsoletes #3384