### PR TITLE
fix(age): only encrypt for recipients in .age-recipients

### DIFF
--- a/internal/action/clone_test.go
+++ b/internal/action/clone_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/gopasspw/gopass/internal/config"
 	"github.com/gopasspw/gopass/internal/out"
 	"github.com/gopasspw/gopass/pkg/ctxutil"
-	"github.com/gopasspw/gopass/pkg/termio"
 	"github.com/gopasspw/gopass/tests/gptest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -121,10 +120,9 @@ func TestCloneBackendIsStoredForMount(t *testing.T) {
 func TestCloneGetGitConfig(t *testing.T) {
 	u := gptest.NewUnitTester(t)
 
-	r1 := gptest.UnsetVars(termio.NameVars...)
-	defer r1()
-	r2 := gptest.UnsetVars(termio.EmailVars...)
-	defer r2()
+	for _, k := range []string{"GIT_AUTHOR_NAME", "GIT_AUTHOR_EMAIL", "DEBFULLNAME", "DEBEMAIL", "USER", "EMAIL"} {
+		t.Setenv(k, "")
+	}
 
 	ctx := config.NewContextInMemory()
 	ctx = ctxutil.WithAlwaysYes(ctx, true)

--- a/internal/action/commands.go
+++ b/internal/action/commands.go
@@ -401,6 +401,10 @@ func (s *Action) GetCommands() []*cli.Command {
 					Usage:   "Use this editor binary",
 				},
 				&cli.BoolFlag{
+					Name:  "force",
+					Usage: "Force overwriting and encrypting even if none of your local keys is among the recipients",
+				},
+				&cli.BoolFlag{
 					Name:    "create",
 					Aliases: []string{"c"},
 					Usage:   "Create a new secret if none found",

--- a/internal/action/edit.go
+++ b/internal/action/edit.go
@@ -25,6 +25,7 @@ import (
 func (s *secretHandler) Edit(ctx context.Context, cmd *cli.Command) error {
 	ctx = ctxutil.WithGlobalFlags(ctx, cmd)
 	ctx = ctxutil.WithFollowRef(ctx, false)
+	ctx = ctxutil.WithForce(ctx, cmd.Bool("force"))
 
 	name := cmd.Args().First()
 	if name == "" {

--- a/internal/action/history_test.go
+++ b/internal/action/history_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/gopasspw/gopass/internal/config"
 	"github.com/gopasspw/gopass/internal/out"
 	"github.com/gopasspw/gopass/pkg/ctxutil"
-	"github.com/gopasspw/gopass/pkg/termio"
 	"github.com/gopasspw/gopass/tests/gptest"
 	"github.com/stretchr/testify/require"
 )
@@ -18,10 +17,11 @@ import (
 func TestHistory(t *testing.T) {
 	u := gptest.NewUnitTester(t)
 
-	r1 := gptest.UnsetVars(termio.NameVars...)
-	r2 := gptest.UnsetVars(termio.EmailVars...)
-	defer r1()
-	defer r2()
+	for _, k := range []string{"DEBFULLNAME", "DEBEMAIL", "USER", "EMAIL"} {
+		t.Setenv(k, "")
+	}
+	t.Setenv("GIT_AUTHOR_NAME", "foo bar")
+	t.Setenv("GIT_AUTHOR_EMAIL", "foo.bar@example.org")
 
 	ctx := config.NewContextInMemory()
 	ctx = ctxutil.WithAlwaysYes(ctx, true)

--- a/internal/action/insert.go
+++ b/internal/action/insert.go
@@ -27,6 +27,7 @@ func (s *secretHandler) Insert(ctx context.Context, cmd *cli.Command) error {
 	multiline := cmd.Bool("multiline")
 	force := cmd.Bool("force")
 	appending := cmd.Bool("append")
+	ctx = ctxutil.WithForce(ctx, force)
 
 	args, kvps := parseArgs(ctx, cmd)
 	name := args.Get(0)

--- a/internal/backend/crypto/age/encrypt.go
+++ b/internal/backend/crypto/age/encrypt.go
@@ -3,21 +3,24 @@ package age
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"slices"
 
 	"filippo.io/age"
+	"github.com/gopasspw/gopass/pkg/ctxutil"
 	"github.com/gopasspw/gopass/pkg/debug"
 )
 
+// ErrNoLocalIdentity is returned when none of the local identities is among
+// the effective recipients of a store. Encrypting in that situation would
+// create a secret the local user cannot decrypt, so we refuse to do so
+// unless the force flag is set.
+var ErrNoLocalIdentity = errors.New("none of the local age identities is among the recipients of this store; you would not be able to decrypt this secret. Use --force to encrypt anyway")
+
 // Encrypt will encrypt the given payload.
 func (a *Age) Encrypt(ctx context.Context, plaintext []byte, recipients []string) ([]byte, error) {
-	// add our own public keys to the recipients to ensure we can decrypt it later.
-	idRecps, err := a.IdentityRecipients(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to fetch identity recipients for encryption: %w", err)
-	}
 	// parse the most specific recipients file and add it to the final
 	// recipients, too.
 	recp, err := a.parseRecipients(ctx, recipients)
@@ -25,10 +28,48 @@ func (a *Age) Encrypt(ctx context.Context, plaintext []byte, recipients []string
 		return nil, fmt.Errorf("failed to parse recipients file for encryption: %w", err)
 	}
 
+	// fetch the recipients of our own identities. These are NOT added to the
+	// recipients (see https://github.com/gopasspw/gopass/issues/3392), we only
+	// use them to check that we will be able to decrypt the secret later.
+	idRecps, err := a.IdentityRecipients(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch identity recipients for encryption: %w", err)
+	}
+
+	if !ctxutil.IsForce(ctx) && !hasAnyRecipient(recp, idRecps) {
+		return nil, ErrNoLocalIdentity
+	}
+
 	// dedupe also order recipients so that native ones are first
-	recp = dedupe(append(recp, idRecps...))
+	recp = dedupe(recp)
 
 	return a.encrypt(plaintext, recp...)
+}
+
+// hasAnyRecipient returns true if any of the local identity recipients is
+// already among the effective recipients.
+func hasAnyRecipient(recp, idRecps []age.Recipient) bool {
+	if len(idRecps) < 1 {
+		// no local identities, nothing to check.
+		return true
+	}
+
+	effective := make(map[string]struct{}, len(recp))
+	for _, r := range recp {
+		if s, ok := r.(fmt.Stringer); ok {
+			effective[s.String()] = struct{}{}
+		}
+	}
+
+	for _, r := range idRecps {
+		if s, ok := r.(fmt.Stringer); ok {
+			if _, found := effective[s.String()]; found {
+				return true
+			}
+		}
+	}
+
+	return false
 }
 
 // dedupe the recipients, only works for native age recipients.

--- a/internal/backend/crypto/age/encrypt_test.go
+++ b/internal/backend/crypto/age/encrypt_test.go
@@ -1,6 +1,7 @@
 package age
 
 import (
+	"context"
 	"crypto/ed25519"
 	"fmt"
 	"sort"
@@ -8,6 +9,7 @@ import (
 
 	"filippo.io/age"
 	"filippo.io/age/agessh"
+	"github.com/gopasspw/gopass/pkg/ctxutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/ssh"
@@ -50,4 +52,51 @@ func (r Recipients) Swap(i, j int) {
 
 func (r Recipients) Less(i, j int) bool {
 	return fmt.Sprintf("%s", r[i]) < fmt.Sprintf("%s", r[j])
+}
+
+func TestHasAnyRecipient(t *testing.T) {
+	t.Parallel()
+
+	i1, err := age.GenerateX25519Identity()
+	require.NoError(t, err)
+	i2, err := age.GenerateX25519Identity()
+	require.NoError(t, err)
+
+	// no local identities -> nothing to check, must not block.
+	assert.True(t, hasAnyRecipient(nil, nil))
+
+	// local identity is among the recipients.
+	assert.True(t, hasAnyRecipient([]age.Recipient{i1.Recipient()}, []age.Recipient{i1.Recipient()}))
+
+	// local identity is NOT among the recipients.
+	assert.False(t, hasAnyRecipient([]age.Recipient{i2.Recipient()}, []age.Recipient{i1.Recipient()}))
+
+	// no recipients at all, but local identities exist.
+	assert.False(t, hasAnyRecipient(nil, []age.Recipient{i1.Recipient()}))
+}
+
+func TestEncryptNoLocalIdentity(t *testing.T) {
+	ctx := context.Background()
+
+	i1, err := age.GenerateX25519Identity()
+	require.NoError(t, err)
+	i2, err := age.GenerateX25519Identity()
+	require.NoError(t, err)
+
+	a := newTestAge(t)
+	require.NoError(t, a.addIdentity(ctx, i1))
+
+	// encrypting for a recipient we do not have an identity for must fail ...
+	_, err = a.Encrypt(ctx, []byte("foobar"), []string{i2.Recipient().String()})
+	assert.ErrorIs(t, err, ErrNoLocalIdentity)
+
+	// ... unless forced.
+	ctx = ctxutil.WithForce(ctx, true)
+	_, err = a.Encrypt(ctx, []byte("foobar"), []string{i2.Recipient().String()})
+	require.NoError(t, err)
+
+	// encrypting for our own recipient must succeed without force.
+	ctx = context.Background()
+	_, err = a.Encrypt(ctx, []byte("foobar"), []string{i1.Recipient().String()})
+	require.NoError(t, err)
 }

--- a/internal/config/docs_test.go
+++ b/internal/config/docs_test.go
@@ -18,6 +18,9 @@ import (
 var ignoredEnvs = set.Map([]string{
 	// keep-sorted start
 	"APPDATA",
+	"DEBEMAIL",
+	"DEBFULLNAME",
+	"EMAIL",
 	"GIT_AUTHOR_EMAIL",
 	"GIT_AUTHOR_NAME",
 	"GNUPGHOME",
@@ -31,6 +34,7 @@ var ignoredEnvs = set.Map([]string{
 	"HOME",
 	"LOCALAPPDATA",
 	"PASSWORD_STORE_UMASK", // indirect usage
+	"USER",
 	"XDG_CACHE_HOME",
 	"XDG_CONFIG_HOME",
 	"XDG_DATA_HOME",
@@ -144,6 +148,10 @@ func usedOptsInFile(t *testing.T, fn string, opts map[string]bool, re *regexp.Re
 
 			break
 		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return err
 	}
 
 	return nil
@@ -270,6 +278,10 @@ func usedEnvsInFile(t *testing.T, fn string, opts map[string]bool, re *regexp.Re
 		opts[v] = true
 	}
 
+	if err := scanner.Err(); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -305,6 +317,10 @@ func documentedEnvs(t *testing.T) map[string]bool {
 		}
 
 		opts[v] = true
+	}
+
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("failed to scan %s: %s", fn, err)
 	}
 
 	return opts

--- a/pkg/termio/identity.go
+++ b/pkg/termio/identity.go
@@ -3,77 +3,71 @@ package termio
 import (
 	"context"
 	"os"
+	"strings"
 
 	"github.com/gopasspw/gitconfig"
 	"github.com/gopasspw/gopass/pkg/ctxutil"
 	"github.com/urfave/cli/v3"
 )
 
+type strFn func(ctx context.Context, cmd *cli.Command) string
+
 var (
-	// NameVars are the env vars checked for a valid name.
-	NameVars = []string{
-		"GIT_AUTHOR_NAME",
-		"DEBFULLNAME",
-		"USER",
+	nameVars = []strFn{
+		func(ctx context.Context, cmd *cli.Command) string { return ctxutil.GetUsername(ctx) },
+		func(ctx context.Context, cmd *cli.Command) string {
+			if cmd != nil {
+				return cmd.String("name")
+			}
+			return ""
+		},
+		func(ctx context.Context, cmd *cli.Command) string { return os.Getenv("GIT_AUTHOR_NAME") },
+		func(ctx context.Context, cmd *cli.Command) string {
+			cfg := gitconfig.New().LoadAll(GetWorkdir(ctx))
+			return cfg.Get("user.name")
+		},
+		func(ctx context.Context, cmd *cli.Command) string { return os.Getenv("DEBFULLNAME") },
+		func(ctx context.Context, cmd *cli.Command) string { return os.Getenv("USER") },
 	}
-	// EmailVars are the env vars checked for a valid email.
-	EmailVars = []string{
-		"GIT_AUTHOR_EMAIL",
-		"DEBEMAIL",
-		"EMAIL",
+	emailVars = []strFn{
+		func(ctx context.Context, cmd *cli.Command) string { return ctxutil.GetEmail(ctx) },
+		func(ctx context.Context, cmd *cli.Command) string {
+			if cmd != nil {
+				return cmd.String("email")
+			}
+			return ""
+		},
+		func(ctx context.Context, cmd *cli.Command) string { return os.Getenv("GIT_AUTHOR_EMAIL") },
+		func(ctx context.Context, cmd *cli.Command) string {
+			cfg := gitconfig.New().LoadAll(GetWorkdir(ctx))
+			return cfg.Get("user.email")
+		},
+		func(ctx context.Context, cmd *cli.Command) string { return os.Getenv("DEBEMAIL") },
+		func(ctx context.Context, cmd *cli.Command) string { return os.Getenv("EMAIL") },
 	}
 )
 
-// DetectName tries to guess the name of the logged in user.
-// It checks the context, the command line flags, environment variables,
-// and the git config.
-func DetectName(ctx context.Context, cmd *cli.Command) string {
-	cand := make([]string, 0, 10)
-	cand = append(cand, ctxutil.GetUsername(ctx))
-
-	if cmd != nil {
-		cand = append(cand, cmd.String("name"))
-	}
-
-	for _, k := range NameVars {
-		cand = append(cand, os.Getenv(k))
-	}
-
-	cfg := gitconfig.New().LoadAll(GetWorkdir(ctx))
-	cand = append(cand, cfg.Get("user.name"))
-
-	for _, e := range cand {
-		if e != "" {
-			return e
+func detect(ctx context.Context, cmd *cli.Command, vars []strFn) string {
+	for _, fn := range vars {
+		s := strings.TrimSpace(fn(ctx, cmd))
+		if s != "" {
+			return s
 		}
 	}
 
 	return ""
 }
 
+// DetectName tries to guess the name of the logged in user.
+// It checks the context, the command line flags, environment variables,
+// and the git config.
+func DetectName(ctx context.Context, cmd *cli.Command) string {
+	return detect(ctx, cmd, nameVars)
+}
+
 // DetectEmail tries to guess the email of the logged in user.
 // It checks the context, the command line flags, environment variables,
 // and the git config.
 func DetectEmail(ctx context.Context, cmd *cli.Command) string {
-	cand := make([]string, 0, 10)
-	cand = append(cand, ctxutil.GetEmail(ctx))
-
-	if cmd != nil {
-		cand = append(cand, cmd.String("email"))
-	}
-
-	for _, k := range EmailVars {
-		cand = append(cand, os.Getenv(k))
-	}
-
-	cfg := gitconfig.New().LoadAll(GetWorkdir(ctx))
-	cand = append(cand, cfg.Get("user.email"))
-
-	for _, e := range cand {
-		if e != "" {
-			return e
-		}
-	}
-
-	return ""
+	return detect(ctx, cmd, emailVars)
 }

--- a/pkg/termio/identity.go
+++ b/pkg/termio/identity.go
@@ -19,11 +19,13 @@ var (
 			if cmd != nil {
 				return cmd.String("name")
 			}
+
 			return ""
 		},
 		func(ctx context.Context, cmd *cli.Command) string { return os.Getenv("GIT_AUTHOR_NAME") },
 		func(ctx context.Context, cmd *cli.Command) string {
 			cfg := gitconfig.New().LoadAll(GetWorkdir(ctx))
+
 			return cfg.Get("user.name")
 		},
 		func(ctx context.Context, cmd *cli.Command) string { return os.Getenv("DEBFULLNAME") },
@@ -35,11 +37,13 @@ var (
 			if cmd != nil {
 				return cmd.String("email")
 			}
+
 			return ""
 		},
 		func(ctx context.Context, cmd *cli.Command) string { return os.Getenv("GIT_AUTHOR_EMAIL") },
 		func(ctx context.Context, cmd *cli.Command) string {
 			cfg := gitconfig.New().LoadAll(GetWorkdir(ctx))
+
 			return cfg.Get("user.email")
 		},
 		func(ctx context.Context, cmd *cli.Command) string { return os.Getenv("DEBEMAIL") },

--- a/pkg/termio/identity_test.go
+++ b/pkg/termio/identity_test.go
@@ -27,7 +27,7 @@ func TestDetectName(t *testing.T) {
 
 	cmd := &cli.Command{}
 	cmd.Flags = append(cmd.Flags, &cli.StringFlag{Name: "name"})
-	cmd.Set("name", "bar")
+	_ = cmd.Set("name", "bar")
 	assert.Equal(t, "bar", DetectName(ctx, cmd))
 
 	t.Setenv("GIT_AUTHOR_NAME", "Author Name")
@@ -51,7 +51,7 @@ func TestDetectEmail(t *testing.T) {
 
 	cmd := &cli.Command{}
 	cmd.Flags = append(cmd.Flags, &cli.StringFlag{Name: "email"})
-	cmd.Set("email", "bar@baz.de")
+	_ = cmd.Set("email", "bar@baz.de")
 	assert.Equal(t, "bar@baz.de", DetectEmail(ctx, cmd))
 
 	t.Setenv("GIT_AUTHOR_EMAIL", "bar@bar.bar")

--- a/pkg/termio/identity_test.go
+++ b/pkg/termio/identity_test.go
@@ -3,8 +3,11 @@ package termio
 import (
 	"testing"
 
+	"github.com/gopasspw/gitconfig"
 	"github.com/gopasspw/gopass/internal/config"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v3"
 )
 
 func TestDetectName(t *testing.T) {
@@ -21,6 +24,14 @@ func TestDetectName(t *testing.T) {
 
 	t.Setenv("USER", "foo")
 	assert.Equal(t, "foo", DetectName(ctx, nil))
+
+	cmd := &cli.Command{}
+	cmd.Flags = append(cmd.Flags, &cli.StringFlag{Name: "name"})
+	cmd.Set("name", "bar")
+	assert.Equal(t, "bar", DetectName(ctx, cmd))
+
+	t.Setenv("GIT_AUTHOR_NAME", "Author Name")
+	assert.Equal(t, "Author Name", DetectName(ctx, nil))
 }
 
 func TestDetectEmail(t *testing.T) {
@@ -37,4 +48,41 @@ func TestDetectEmail(t *testing.T) {
 
 	t.Setenv("EMAIL", "foo@bar.de")
 	assert.Equal(t, "foo@bar.de", DetectEmail(ctx, nil))
+
+	cmd := &cli.Command{}
+	cmd.Flags = append(cmd.Flags, &cli.StringFlag{Name: "email"})
+	cmd.Set("email", "bar@baz.de")
+	assert.Equal(t, "bar@baz.de", DetectEmail(ctx, cmd))
+
+	t.Setenv("GIT_AUTHOR_EMAIL", "bar@bar.bar")
+	assert.Equal(t, "bar@bar.bar", DetectEmail(ctx, nil))
+}
+
+func TestDetectGitConfig(t *testing.T) {
+	td := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", td)
+	t.Setenv("GOPASS_HOMEDIR", td)
+
+	t.Setenv("GIT_AUTHOR_NAME", "")
+	t.Setenv("GIT_AUTHOR_EMAIL", " ")
+	t.Setenv("DEBFULLNAME", "deb-name")
+	t.Setenv("DEBEMAIL", "deb@example.com")
+	t.Setenv("USER", "user-name")
+	t.Setenv("EMAIL", "user@example.com")
+
+	cfg := gitconfig.New().LoadAll(td)
+	require.NoError(t, cfg.SetLocal("user.name", "Jane Doe"))
+	require.NoError(t, cfg.SetLocal("user.email", "jane@example.com"))
+
+	ctx := WithWorkdir(config.NewContextInMemory(), td)
+
+	// Git config takes precedence over DEBFULLNAME/USER and DEBEMAIL/EMAIL.
+	assert.Equal(t, "Jane Doe", DetectName(ctx, nil))
+	assert.Equal(t, "jane@example.com", DetectEmail(ctx, nil))
+
+	// GIT_AUTHOR_* env vars take precedence over git config.
+	t.Setenv("GIT_AUTHOR_NAME", "Author Name")
+	t.Setenv("GIT_AUTHOR_EMAIL", "author@example.com")
+	assert.Equal(t, "Author Name", DetectName(ctx, nil))
+	assert.Equal(t, "author@example.com", DetectEmail(ctx, nil))
 }


### PR DESCRIPTION
Previously the age backend unconditionally appended the recipients of
all local identities to the effective recipient list when encrypting.
This broke the isolation of stores that intentionally use a different
(sub)set of keys, e.g. a high-security store whose secrets must not be
decryptable by a low-security identity.

Now secrets are encrypted strictly for the recipients configured in the
store's .age-recipients file. To protect users from locking themselves
out, Encrypt returns ErrNoLocalIdentity when none of the local
identities is among the effective recipients. This error can be
overridden with the --force flag, which is now also honored by the
edit and insert commands (generate already supported it).

Fixes https://github.com/gopasspw/gopass/issues/3392