### PR TITLE
fix(age): only encrypt for recipients in .age-recipients

### DIFF
--- a/internal/action/commands.go
+++ b/internal/action/commands.go
@@ -401,6 +401,10 @@ func (s *Action) GetCommands() []*cli.Command {
 					Usage:   "Use this editor binary",
 				},
 				&cli.BoolFlag{
+					Name:  "force",
+					Usage: "Force overwriting and encrypting even if none of your local keys is among the recipients",
+				},
+				&cli.BoolFlag{
 					Name:    "create",
 					Aliases: []string{"c"},
 					Usage:   "Create a new secret if none found",

--- a/internal/action/edit.go
+++ b/internal/action/edit.go
@@ -25,6 +25,7 @@ import (
 func (s *secretHandler) Edit(ctx context.Context, cmd *cli.Command) error {
 	ctx = ctxutil.WithGlobalFlags(ctx, cmd)
 	ctx = ctxutil.WithFollowRef(ctx, false)
+	ctx = ctxutil.WithForce(ctx, cmd.Bool("force"))
 
 	name := cmd.Args().First()
 	if name == "" {

--- a/internal/action/insert.go
+++ b/internal/action/insert.go
@@ -27,6 +27,7 @@ func (s *secretHandler) Insert(ctx context.Context, cmd *cli.Command) error {
 	multiline := cmd.Bool("multiline")
 	force := cmd.Bool("force")
 	appending := cmd.Bool("append")
+	ctx = ctxutil.WithForce(ctx, force)
 
 	args, kvps := parseArgs(ctx, cmd)
 	name := args.Get(0)

--- a/internal/backend/crypto/age/encrypt.go
+++ b/internal/backend/crypto/age/encrypt.go
@@ -3,21 +3,24 @@ package age
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"slices"
 
 	"filippo.io/age"
+	"github.com/gopasspw/gopass/pkg/ctxutil"
 	"github.com/gopasspw/gopass/pkg/debug"
 )
 
+// ErrNoLocalIdentity is returned when none of the local identities is among
+// the effective recipients of a store. Encrypting in that situation would
+// create a secret the local user cannot decrypt, so we refuse to do so
+// unless the force flag is set.
+var ErrNoLocalIdentity = errors.New("none of the local age identities is among the recipients of this store; you would not be able to decrypt this secret. Use --force to encrypt anyway")
+
 // Encrypt will encrypt the given payload.
 func (a *Age) Encrypt(ctx context.Context, plaintext []byte, recipients []string) ([]byte, error) {
-	// add our own public keys to the recipients to ensure we can decrypt it later.
-	idRecps, err := a.IdentityRecipients(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to fetch identity recipients for encryption: %w", err)
-	}
 	// parse the most specific recipients file and add it to the final
 	// recipients, too.
 	recp, err := a.parseRecipients(ctx, recipients)
@@ -25,10 +28,48 @@ func (a *Age) Encrypt(ctx context.Context, plaintext []byte, recipients []string
 		return nil, fmt.Errorf("failed to parse recipients file for encryption: %w", err)
 	}
 
+	// fetch the recipients of our own identities. These are NOT added to the
+	// recipients (see https://github.com/gopasspw/gopass/issues/3392), we only
+	// use them to check that we will be able to decrypt the secret later.
+	idRecps, err := a.IdentityRecipients(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch identity recipients for encryption: %w", err)
+	}
+
+	if !ctxutil.IsForce(ctx) && !hasAnyRecipient(recp, idRecps) {
+		return nil, ErrNoLocalIdentity
+	}
+
 	// dedupe also order recipients so that native ones are first
-	recp = dedupe(append(recp, idRecps...))
+	recp = dedupe(recp)
 
 	return a.encrypt(plaintext, recp...)
+}
+
+// hasAnyRecipient returns true if any of the local identity recipients is
+// already among the effective recipients.
+func hasAnyRecipient(recp, idRecps []age.Recipient) bool {
+	if len(idRecps) < 1 {
+		// no local identities, nothing to check.
+		return true
+	}
+
+	effective := make(map[string]struct{}, len(recp))
+	for _, r := range recp {
+		if s, ok := r.(fmt.Stringer); ok {
+			effective[s.String()] = struct{}{}
+		}
+	}
+
+	for _, r := range idRecps {
+		if s, ok := r.(fmt.Stringer); ok {
+			if _, found := effective[s.String()]; found {
+				return true
+			}
+		}
+	}
+
+	return false
 }
 
 // dedupe the recipients, only works for native age recipients.

--- a/internal/backend/crypto/age/encrypt_test.go
+++ b/internal/backend/crypto/age/encrypt_test.go
@@ -1,6 +1,7 @@
 package age
 
 import (
+	"context"
 	"crypto/ed25519"
 	"fmt"
 	"sort"
@@ -8,6 +9,7 @@ import (
 
 	"filippo.io/age"
 	"filippo.io/age/agessh"
+	"github.com/gopasspw/gopass/pkg/ctxutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/ssh"
@@ -50,4 +52,51 @@ func (r Recipients) Swap(i, j int) {
 
 func (r Recipients) Less(i, j int) bool {
 	return fmt.Sprintf("%s", r[i]) < fmt.Sprintf("%s", r[j])
+}
+
+func TestHasAnyRecipient(t *testing.T) {
+	t.Parallel()
+
+	i1, err := age.GenerateX25519Identity()
+	require.NoError(t, err)
+	i2, err := age.GenerateX25519Identity()
+	require.NoError(t, err)
+
+	// no local identities -> nothing to check, must not block.
+	assert.True(t, hasAnyRecipient(nil, nil))
+
+	// local identity is among the recipients.
+	assert.True(t, hasAnyRecipient([]age.Recipient{i1.Recipient()}, []age.Recipient{i1.Recipient()}))
+
+	// local identity is NOT among the recipients.
+	assert.False(t, hasAnyRecipient([]age.Recipient{i2.Recipient()}, []age.Recipient{i1.Recipient()}))
+
+	// no recipients at all, but local identities exist.
+	assert.False(t, hasAnyRecipient(nil, []age.Recipient{i1.Recipient()}))
+}
+
+func TestEncryptNoLocalIdentity(t *testing.T) {
+	ctx := context.Background()
+
+	i1, err := age.GenerateX25519Identity()
+	require.NoError(t, err)
+	i2, err := age.GenerateX25519Identity()
+	require.NoError(t, err)
+
+	a := newTestAge(t)
+	require.NoError(t, a.addIdentity(ctx, i1))
+
+	// encrypting for a recipient we do not have an identity for must fail ...
+	_, err = a.Encrypt(ctx, []byte("foobar"), []string{i2.Recipient().String()})
+	assert.ErrorIs(t, err, ErrNoLocalIdentity)
+
+	// ... unless forced.
+	ctx = ctxutil.WithForce(ctx, true)
+	_, err = a.Encrypt(ctx, []byte("foobar"), []string{i2.Recipient().String()})
+	require.NoError(t, err)
+
+	// encrypting for our own recipient must succeed without force.
+	ctx = context.Background()
+	_, err = a.Encrypt(ctx, []byte("foobar"), []string{i1.Recipient().String()})
+	require.NoError(t, err)
 }

--- a/internal/backend/crypto/age/encrypt_test.go
+++ b/internal/backend/crypto/age/encrypt_test.go
@@ -88,7 +88,7 @@ func TestEncryptNoLocalIdentity(t *testing.T) {
 
 	// encrypting for a recipient we do not have an identity for must fail ...
 	_, err = a.Encrypt(ctx, []byte("foobar"), []string{i2.Recipient().String()})
-	assert.ErrorIs(t, err, ErrNoLocalIdentity)
+	assert.ErrorIs(t, err, ErrNoLocalIdentity) //nolint:testifylint
 
 	// ... unless forced.
 	ctx = ctxutil.WithForce(ctx, true)


### PR DESCRIPTION
Previously the age backend unconditionally appended the recipients of all local identities to the effective recipient list when encrypting. This broke the isolation of stores that intentionally use a different (sub)set of keys, e.g. a high-security store whose secrets must not be decryptable by a low-security identity.

Now secrets are encrypted strictly for the recipients configured in the store's .age-recipients file. To protect users from locking themselves out, Encrypt returns ErrNoLocalIdentity when none of the local identities is among the effective recipients. This error can be overridden with the --force flag, which is now also honored by the edit and insert commands (generate already supported it).

Fixes #3392