### PR TITLE
fix(setup): rename --alias/--create to --team/--create-team

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -477,14 +477,17 @@ In order to simplify the setup of gopass for your team members it can be run in 
 
 ```bash
 # First initialize a new shared store and push it to an empty remote
-gopass --yes setup --remote github.com/example/pass.git --alias example --create --name "John Doe" --email "john.doe@example.com"
+gopass --yes setup --remote github.com/example/pass.git --team example --create-team --name "John Doe" --email "john.doe@example.com"
 
 # For every other team member initialize a new store and clone the existing remote
-gopass --yes setup --remote github.com/example/pass.git --alias example --name "Jane Doe" --email "jane.doe@example.com"
+gopass --yes setup --remote github.com/example/pass.git --team example --name "Jane Doe" --email "jane.doe@example.com"
 ```
 
-The first command will create a new mount named `example` and push it to an empty (`--create`) remote.
+The first command will create a new mount named `example` and push it to an empty (`--create-team`) remote.
 It will fail if the remote at `github.com/example/pass.git` is not empty.
 
-The second command will clone the existing (no `--create` flag) remote `github.com/example/pass.git`
+The second command will clone the existing (no `--create-team` flag) remote `github.com/example/pass.git`
 and mount it as the mount point `example`.
+
+N.B. `--team` and `--create-team` used to be named `--alias` and `--create`. The old
+names still work as aliases, but new scripts should prefer the clearer names.

--- a/gopass.1
+++ b/gopass.1
@@ -562,11 +562,9 @@ This command is automatically invoked if gopass is started without any existing 
 
 .B Flags
 .TP
-\fB\-\-alias\fR,
-Local mount point for the given remote
-.TP
+\fB\-\-create-team\fR,
 \fB\-\-create\fR,
-Create a new team (default: false, i.e. join an existing team)
+Create a new team instead of joining an existing one (default: false, i.e. join an existing team)
 .TP
 \fB\-\-crypto\fR,
 Select crypto backend [age gpgcli plain]
@@ -582,6 +580,10 @@ URL to a git remote, will attempt to join this team
 .TP
 \fB\-\-storage\fR,
 Select storage backend [cryptfs fossilfs fs gitfs jjfs]
+.TP
+\fB\-\-team\fR,
+\fB\-\-alias\fR,
+Name of the team to create or join (may contain slashes). Also used as the local mount point.
 .SS show
 Display the content of a secret
 

--- a/internal/action/commands.go
+++ b/internal/action/commands.go
@@ -1192,12 +1192,14 @@ func (s *Action) GetCommands() []*cli.Command {
 					Usage: "URL to a git remote, will attempt to join this team",
 				},
 				&cli.StringFlag{
-					Name:  "alias",
-					Usage: "Local mount point for the given remote",
+					Name:    "team",
+					Aliases: []string{"alias"}, // deprecated, kept for backward compatibility
+					Usage:   "Name of the team to create or join (may contain slashes). Also used as the local mount point.",
 				},
 				&cli.BoolFlag{
-					Name:  "create",
-					Usage: "Create a new team (default: false, i.e. join an existing team)",
+					Name:    "create-team",
+					Aliases: []string{"create"}, // deprecated, kept for backward compatibility
+					Usage:   "Create a new team instead of joining an existing one (default: false, i.e. join an existing team)",
 				},
 				&cli.StringFlag{
 					Name:  "name",

--- a/internal/action/setup.go
+++ b/internal/action/setup.go
@@ -27,8 +27,8 @@ import (
 func (s *setupHandler) Setup(ctx context.Context, cmd *cli.Command) error {
 	ctx = ctxutil.WithGlobalFlags(ctx, cmd)
 	remote := cmd.String("remote")
-	team := cmd.String("alias")
-	create := cmd.Bool("create")
+	team := cmd.String("team")
+	create := cmd.Bool("create-team")
 
 	ctx, err := initParseContext(ctx, cmd)
 	if err != nil {
@@ -90,38 +90,37 @@ func (s *setupHandler) Setup(ctx context.Context, cmd *cli.Command) error {
 		return fmt.Errorf("failed to check private keys: %w", err)
 	}
 
-	// if a git remote is given, clone it and exit
-	if remote != "" && team == "" {
+	switch {
+	case create:
+		// interactive runs fall through to initCreateTeam, which prompts for
+		// a missing team name; non-interactive/unattended runs must fail fast.
+		if team == "" && (!ctxutil.IsInteractive(ctx) || ctxutil.IsAlwaysYes(ctx)) {
+			return fmt.Errorf("can not create a team without a team name; use --team to provide one, or run interactively to be prompted")
+		}
+
+		return s.initCreateTeam(ctx, team, remote)
+	case remote != "" && team != "":
+		// a git remote and a team name are given, attempt unattended team join.
+		return s.initJoinTeam(ctx, team, remote)
+	case remote != "" && team == "":
+		// only a git remote is given, clone it and exit.
 		if err := s.clone(ctx, remote, "", ""); err != nil {
 			return fmt.Errorf("failed to clone remote %q: %w", remote, err)
 		}
 
 		return nil
-	}
+	default:
+		// assume local setup by default, remotes can be added easily later.
+		if err := s.initLocal(ctx, remote); err != nil {
+			debug.Log("Setup failed. initLocal error: %s", err)
 
-	// if a git remote and a team name are given attempt unattended team setup.
-	if remote != "" && team != "" {
-		if create {
-			return s.initCreateTeam(ctx, team, remote)
+			return err
 		}
 
-		return s.initJoinTeam(ctx, team, remote)
+		debug.Log("Setup finished. All systems go. 🚀")
+
+		return nil
 	}
-
-	if team == "" && create {
-		return fmt.Errorf("can not create a team without a team name")
-	}
-
-	// assume local setup by default, remotes can be added easily later.
-	if err := s.initLocal(ctx, remote); err != nil {
-		debug.Log("Setup failed. initLocal error: %s", err)
-
-		return err
-	}
-
-	debug.Log("Setup finished. All systems go. 🚀")
-
-	return nil
 }
 
 func (s *setupHandler) initCheckPrivateKeys(ctx context.Context, crypto backend.Crypto) error {

--- a/internal/action/setup_test.go
+++ b/internal/action/setup_test.go
@@ -14,7 +14,71 @@ import (
 	"github.com/gopasspw/gopass/tests/gptest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v3"
 )
+
+// TestSetupTeamCreateFlagsRegistered verifies the renamed --team/--create-team
+// flags are registered on the setup command with their deprecated aliases
+// (--alias/--create), so existing scripts keep working. See GH-3497.
+func TestSetupTeamCreateFlagsRegistered(t *testing.T) {
+	u := gptest.NewUnitTester(t)
+
+	ctx := config.NewContextInMemory()
+	act, err := newMock(ctx, u.StoreDir(""))
+	require.NoError(t, err)
+	require.NotNil(t, act)
+
+	setupCmd := findCommand(act.GetCommands(), "setup")
+	require.NotNil(t, setupCmd)
+
+	var team *cli.StringFlag
+	var createTeam *cli.BoolFlag
+	for _, f := range setupCmd.Flags {
+		switch v := f.(type) {
+		case *cli.StringFlag:
+			if v.Name == "team" {
+				team = v
+			}
+		case *cli.BoolFlag:
+			if v.Name == "create-team" {
+				createTeam = v
+			}
+		}
+	}
+
+	require.NotNil(t, team)
+	assert.Contains(t, team.Aliases, "alias")
+
+	require.NotNil(t, createTeam)
+	assert.Contains(t, createTeam.Aliases, "create")
+}
+
+// TestSetupCreateTeamRequiresName verifies that requesting team creation
+// without a team name fails fast with an actionable error message when
+// running non-interactively (e.g. scripted setups), instead of the old,
+// confusing "can not create a team without a team name". See GH-3497.
+func TestSetupCreateTeamRequiresName(t *testing.T) {
+	u := gptest.NewUnitTester(t)
+
+	ctx := config.NewContextInMemory()
+	ctx = ctxutil.WithAlwaysYes(ctx, true)
+	ctx = ctxutil.WithInteractive(ctx, false)
+	ctx = backend.WithCryptoBackend(ctx, backend.Age)
+	ctx = backend.WithStorageBackend(ctx, backend.GitFS)
+	ctx = ctxutil.WithAgePassphrase(ctx, "foobar")
+
+	act, err := newMock(ctx, u.StoreDir(""))
+	require.ErrorContains(t, err, "not initialized")
+	require.NotNil(t, act)
+
+	require.NoError(t, os.RemoveAll(u.StoreDir("")))
+	require.NoError(t, os.Remove(u.GPConfig()))
+
+	c := gptest.CliCtxWithFlags(ctx, t, map[string]string{"storage": "gitfs", "crypto": "age", "create-team": "true"})
+	err = act.Setup(ctx, c)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "team name")
+}
 
 func TestSetupAgeGitFS(t *testing.T) {
 	u := gptest.NewUnitTester(t) //nolint:staticcheck

--- a/zsh.completion
+++ b/zsh.completion
@@ -215,7 +215,7 @@ _gopass () {
 	      
 	      ;;
 	  setup)
-	      _arguments : "--remote[URL to a git remote, will attempt to join this team]" "--alias[Local mount point for the given remote]" "--create[Create a new team (default: false, i.e. join an existing team)]" "--name[Firstname and Lastname for unattended GPG key generation]" "--email[EMail for unattended GPG key generation]" "--crypto[Select crypto backend \[age gpgcli plain\]]" "--storage[Select storage backend \[cryptfs fossilfs fs gitfs jjfs\]]"
+	      _arguments : "--remote[URL to a git remote, will attempt to join this team]" "--team[Name of the team to create or join (may contain slashes). Also used as the local mount point.]" "--alias[Name of the team to create or join (may contain slashes). Also used as the local mount point.]" "--create-team[Create a new team instead of joining an existing one (default: false, i.e. join an existing team)]" "--create[Create a new team instead of joining an existing one (default: false, i.e. join an existing team)]" "--name[Firstname and Lastname for unattended GPG key generation]" "--email[EMail for unattended GPG key generation]" "--crypto[Select crypto backend \[age gpgcli plain\]]" "--storage[Select storage backend \[cryptfs fossilfs fs gitfs jjfs\]]"
 	      
 	      
 	      ;;


### PR DESCRIPTION
The `setup` command's team name and team-creation flags were named `--alias` and `--create`, which don't convey their purpose. This led to confusing failures like `can not create a team without a team name` when running `gopass setup --create` with no obvious way to supply a name.

- Rename `--alias` to `--team` and `--create` to `--create-team`, keeping the old names as aliases for backward compatibility.
- Fix `Setup()`'s control flow so `--create-team` is handled consistently: interactive runs are routed through `initCreateTeam`, which already prompts for a missing team name, instead of hard failing. Non-interactive/`--yes` runs still fail fast, with a clearer error message.
- Update docs/setup.md's batch bootstrapping example and the generated man page / zsh completion for the setup command.

Fixes #3497