### PR TITLE
feat: add export command to dump secrets as JSON

### DIFF
--- a/docs/commands/export.md
+++ b/docs/commands/export.md
@@ -1,0 +1,47 @@
+# `export` command
+
+The `export` command decrypts secrets and writes them to a portable JSON
+document. It is meant to help migrate a store into another password manager:
+the JSON keeps the password, the body and all key/value attributes so nothing
+is lost, and you can transform it into whatever format the target expects.
+
+By default the whole store is exported. Provide one or more folder prefixes to
+export only those subfolders.
+
+The output contains your secrets in **plaintext**, so treat the file (or the
+terminal it is printed to) with the same care as the secrets themselves.
+
+## Synopsis
+
+```
+$ gopass export
+$ gopass export websites/
+$ gopass export --out backup.json
+```
+
+## Flags
+
+| Flag    | Aliases | Description                                     |
+|---------|---------|-------------------------------------------------|
+| `--out` | `-o`    | Write the export to this file instead of stdout. When writing to a file the mode is set to `0600`. |
+
+## Output format
+
+The document is a JSON array of objects:
+
+```json
+[
+  {
+    "name": "websites/example",
+    "password": "correct horse battery staple",
+    "body": "some notes",
+    "attributes": {
+      "url": ["https://example.com"],
+      "user": ["alice"]
+    }
+  }
+]
+```
+
+Empty fields are omitted. Attributes are encoded as lists because a key can
+hold more than one value.

--- a/internal/action/commands.go
+++ b/internal/action/commands.go
@@ -454,6 +454,27 @@ func (s *Action) GetCommands() []*cli.Command {
 			},
 		},
 		{
+			Name:      "export",
+			Usage:     "Export secrets to a portable JSON format",
+			ArgsUsage: "[prefix]...",
+			Description: "" +
+				"This command exports secrets to a portable JSON document that can be " +
+				"transformed for import into another password manager. Provide one or " +
+				"more folder prefixes to export only those subfolders, otherwise the " +
+				"whole store is exported. The output contains unencrypted secrets, so " +
+				"handle it with care.",
+			Before:        s.IsInitialized,
+			Action:        s.Export,
+			ShellComplete: s.Complete,
+			Flags: []cli.Flag{
+				&cli.StringFlag{
+					Name:    "out",
+					Aliases: []string{"o"},
+					Usage:   "Write the export to this file instead of stdout",
+				},
+			},
+		},
+		{
 			Name:      "find",
 			Usage:     "Search for secrets",
 			ArgsUsage: "<pattern>",

--- a/internal/action/export.go
+++ b/internal/action/export.go
@@ -1,0 +1,114 @@
+package action
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/gopasspw/gopass/internal/action/exit"
+	"github.com/gopasspw/gopass/internal/out"
+	"github.com/gopasspw/gopass/internal/tree"
+	"github.com/gopasspw/gopass/pkg/ctxutil"
+	"github.com/urfave/cli/v3"
+)
+
+// exportedSecret is the JSON representation of a single secret. It keeps the
+// password, the free-form body and all key/value attributes so the dump is
+// lossless and can be transformed into whatever format another password
+// manager expects on import.
+type exportedSecret struct {
+	Name       string              `json:"name"`
+	Password   string              `json:"password,omitempty"`
+	Body       string              `json:"body,omitempty"`
+	Attributes map[string][]string `json:"attributes,omitempty"`
+}
+
+// Export writes all secrets, or those below the given prefixes, to a portable
+// JSON document. The document goes to stdout unless --out names a file.
+func (s *searchHandler) Export(ctx context.Context, cmd *cli.Command) error {
+	ctx = ctxutil.WithGlobalFlags(ctx, cmd)
+
+	names, err := s.Store.List(ctx, tree.INF)
+	if err != nil {
+		return exit.Error(exit.List, err, "failed to list store: %s", err)
+	}
+	sort.Strings(names)
+
+	prefixes := cmd.Args().Slice()
+
+	// The output is plaintext, so make sure the user understands that before
+	// it ends up in a file or the shell history.
+	out.Warningf(ctx, "Exported secrets are stored UNENCRYPTED. Handle the output with care.")
+
+	exported := make([]exportedSecret, 0, len(names))
+	var failed int
+	for _, name := range names {
+		if !hasAnyPrefix(name, prefixes) {
+			continue
+		}
+
+		sec, err := s.Store.Get(ctx, name)
+		if err != nil {
+			out.Errorf(ctx, "Failed to decrypt %s: %v", name, err)
+			failed++
+
+			continue
+		}
+
+		es := exportedSecret{
+			Name:     name,
+			Password: sec.Password(),
+			Body:     sec.Body(),
+		}
+		if keys := sec.Keys(); len(keys) > 0 {
+			es.Attributes = make(map[string][]string, len(keys))
+			for _, k := range keys {
+				if vs, ok := sec.Values(k); ok {
+					es.Attributes[k] = vs
+				}
+			}
+		}
+		exported = append(exported, es)
+	}
+
+	buf, err := json.MarshalIndent(exported, "", "  ")
+	if err != nil {
+		return exit.Error(exit.Unknown, err, "failed to encode secrets: %s", err)
+	}
+	buf = append(buf, '\n')
+
+	if fn := cmd.String("out"); fn != "" {
+		if err := os.WriteFile(fn, buf, 0o600); err != nil {
+			return exit.Error(exit.IO, err, "failed to write %s: %s", fn, err)
+		}
+		out.Noticef(ctx, "Exported %d secrets to %s", len(exported), fn)
+	} else {
+		fmt.Fprint(stdout, string(buf))
+	}
+
+	if failed > 0 {
+		out.Warningf(ctx, "%d secrets failed to decrypt", failed)
+	}
+
+	return nil
+}
+
+// hasAnyPrefix reports whether name is covered by any of the given prefixes. An
+// empty prefix list matches everything. A prefix matches an exact name or a
+// folder below it, so "foo" matches "foo" and "foo/bar" but not "foobar".
+func hasAnyPrefix(name string, prefixes []string) bool {
+	if len(prefixes) == 0 {
+		return true
+	}
+
+	for _, p := range prefixes {
+		if name == p || strings.HasPrefix(name, strings.TrimSuffix(p, "/")+"/") {
+			return true
+		}
+	}
+
+	return false
+}

--- a/internal/action/export_test.go
+++ b/internal/action/export_test.go
@@ -1,0 +1,115 @@
+package action
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/fatih/color"
+	"github.com/gopasspw/gopass/internal/config"
+	"github.com/gopasspw/gopass/internal/out"
+	"github.com/gopasspw/gopass/pkg/ctxutil"
+	"github.com/gopasspw/gopass/pkg/gopass/secrets"
+	"github.com/gopasspw/gopass/tests/gptest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExport(t *testing.T) {
+	u := gptest.NewUnitTester(t)
+
+	ctx := config.NewContextInMemory()
+	ctx = ctxutil.WithAlwaysYes(ctx, true)
+	ctx = ctxutil.WithInteractive(ctx, false)
+
+	act, err := newMock(ctx, u.StoreDir(""))
+	require.NoError(t, err)
+	require.NotNil(t, act)
+	ctx = act.cfg.WithConfig(ctx)
+
+	buf := &bytes.Buffer{}
+	out.Stdout = buf
+	stdout = buf
+	defer func() {
+		stdout = os.Stdout
+		out.Stdout = os.Stdout
+	}()
+	color.NoColor = true
+
+	// add a second secret with a password and an attribute.
+	sec := secrets.NewAKV()
+	sec.SetPassword("123")
+	require.NoError(t, sec.Set("url", "https://example.com"))
+	require.NoError(t, act.Store.Set(ctx, "foo/bar", sec))
+
+	byName := func(t *testing.T, data []byte) map[string]exportedSecret {
+		t.Helper()
+		var got []exportedSecret
+		require.NoError(t, json.Unmarshal(data, &got))
+		m := make(map[string]exportedSecret, len(got))
+		for _, e := range got {
+			m[e.Name] = e
+		}
+
+		return m
+	}
+
+	t.Run("export the whole store", func(t *testing.T) {
+		buf.Reset()
+		require.NoError(t, act.Export(ctx, gptest.CliCtx(ctx, t)))
+
+		m := byName(t, buf.Bytes())
+		require.Len(t, m, 2)
+		require.Contains(t, m, "foo")
+		require.Contains(t, m, "foo/bar")
+		assert.Equal(t, "123", m["foo/bar"].Password)
+		assert.Equal(t, []string{"https://example.com"}, m["foo/bar"].Attributes["url"])
+	})
+
+	t.Run("filter by prefix", func(t *testing.T) {
+		buf.Reset()
+		require.NoError(t, act.Export(ctx, gptest.CliCtx(ctx, t, "foo/")))
+
+		m := byName(t, buf.Bytes())
+		require.Len(t, m, 1)
+		require.Contains(t, m, "foo/bar")
+		assert.NotContains(t, m, "foo")
+	})
+
+	t.Run("write to file", func(t *testing.T) {
+		buf.Reset()
+		fn := filepath.Join(t.TempDir(), "export.json")
+		require.NoError(t, act.Export(ctx, gptest.CliCtxWithFlags(ctx, t, map[string]string{"out": fn})))
+
+		data, err := os.ReadFile(fn)
+		require.NoError(t, err)
+		m := byName(t, data)
+		require.Contains(t, m, "foo")
+		require.Contains(t, m, "foo/bar")
+		// stdout stays clean when writing to a file.
+		assert.NotContains(t, buf.String(), "foo/bar")
+	})
+}
+
+func TestHasAnyPrefix(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		prefixes []string
+		want     bool
+	}{
+		{name: "foo", prefixes: nil, want: true},
+		{name: "foo", prefixes: []string{"foo"}, want: true},
+		{name: "foo/bar", prefixes: []string{"foo"}, want: true},
+		{name: "foo/bar", prefixes: []string{"foo/"}, want: true},
+		{name: "foobar", prefixes: []string{"foo"}, want: false},
+		{name: "baz", prefixes: []string{"foo", "baz"}, want: true},
+	}
+
+	for _, tc := range tests {
+		assert.Equal(t, tc.want, hasAnyPrefix(tc.name, tc.prefixes), tc.name)
+	}
+}

--- a/internal/action/handler_shims.go
+++ b/internal/action/handler_shims.go
@@ -81,6 +81,10 @@ func (s *Action) FindFuzzy(ctx context.Context, cmd *cli.Command) error {
 	return s.search.FindFuzzy(ctx, cmd)
 }
 
+func (s *Action) Export(ctx context.Context, cmd *cli.Command) error {
+	return s.search.Export(ctx, cmd)
+}
+
 func (s *Action) Grep(ctx context.Context, cmd *cli.Command) error { return s.search.Grep(ctx, cmd) }
 
 func (s *Action) List(ctx context.Context, cmd *cli.Command) error { return s.search.List(ctx, cmd) }


### PR DESCRIPTION
This adds a `gopass export` command for #3074. It walks the store, decrypts each secret and writes them out as a JSON array with the password, body and attributes, so nothing gets dropped on the way out. You can pass one or more folder prefixes to narrow it down, and `--out` to write to a file (0600) instead of stdout. The output is plaintext so it prints a warning to stderr first.

I went with a generic JSON shape rather than a Bitwarden-specific one, figuring it is easier to transform into whatever target format than to bake one importer in. Happy to change the shape or add a confirmation gate if you would rather have something different.

Tests cover the whole-store export, prefix filtering and the `--out` file path. `make test` and golangci-lint are clean.
