### PR TITLE
Prevent REPL command dispatch loop

### DIFF
--- a/internal/action/repl.go
+++ b/internal/action/repl.go
@@ -151,7 +151,7 @@ type completionSpec int
 // nested command invocation. This prevents infinite loops as the nested
 // invocation would otherwise inherit the command currently being executed.
 type replContext struct {
-	context.Context
+	context.Context //nolint:containedctx
 }
 
 func (c replContext) Value(key any) any {

--- a/internal/action/repl.go
+++ b/internal/action/repl.go
@@ -86,7 +86,7 @@ READ:
 		default:
 		}
 
-		if err := cmd.Root().Run(ctx, append([]string{"gopass"}, args...)); err != nil {
+		if err := cmd.Root().Run(replContext{Context: ctx}, append([]string{"gopass"}, args...)); err != nil {
 			continue
 		}
 	}
@@ -146,6 +146,21 @@ func unescapeEntry(s string) string {
 
 // completionSpec describes what candidates a command should complete against.
 type completionSpec int
+
+// replContext filters out urfave/cli's private active-command value from a
+// nested command invocation. This prevents infinite loops as the nested
+// invocation would otherwise inherit the command currently being executed.
+type replContext struct {
+	context.Context
+}
+
+func (c replContext) Value(key any) any {
+	if fmt.Sprint(key) == "cli.context" {
+		return nil
+	}
+
+	return c.Context.Value(key)
+}
 
 const (
 	completeNone       completionSpec = iota


### PR DESCRIPTION
The problem: The interactive shell recursively invokes the root command for each line. The active command is stored in a private context value, so reusing the outer context without filtering makes the nested command inherit itself as its parent and causes command dispatch to loop indefinitely after input is submitted.

The fix: This patch wraps the REPL dispatch context to hide active-command while preserving the application context. This avoids the infinite loop and allows command dispatch to execute normally.

This fix might also fix #3491.  On my system, I can use the patched code to do otp as expected.