### PR TITLE
fix(gpg): make identity selection deterministic

### DIFF
--- a/internal/backend/crypto/gpg/colons/parse_colons.go
+++ b/internal/backend/crypto/gpg/colons/parse_colons.go
@@ -150,6 +150,7 @@ func parseColonIdentity(fields []string) gpg.Identity {
 
 	id := fields[9]
 	ni := gpg.Identity{
+		UID:            id,
 		Name:           id,
 		CreationDate:   parseTS(fields[5]),
 		ExpirationDate: parseTS(fields[6]),

--- a/internal/backend/crypto/gpg/colons/parse_colons_test.go
+++ b/internal/backend/crypto/gpg/colons/parse_colons_test.go
@@ -12,30 +12,35 @@ func TestParseColonIdentity(t *testing.T) {
 
 	for _, tc := range []struct {
 		in      string
+		uid     string
 		name    string
 		comment string
 		email   string
 	}{
 		{
 			in:      "uid:-::::1460666077::780A2FDD0570B3E52E5B1E24EBB406B68526CAFD::ThisIsNotAnAlias:",
+			uid:     "ThisIsNotAnAlias",
 			name:    "ThisIsNotAnAlias",
 			comment: "",
 			email:   "",
 		},
 		{
 			in:      "uid:::::1441103821::AEFC3F5B6CAD79A946D7F0FF83BB8B7E10B578CA::John Doe <john.doe@example.com>:",
+			uid:     "John Doe <john.doe@example.com>",
 			name:    "John Doe",
 			comment: "",
 			email:   "john.doe@example.com",
 		},
 		{
 			in:      "uid:::::1441103821::AEFC3F5B6CAD79A946D7F0FF83BB8B7E10B578CA::John Doe (user) <john.doe@example.com>:",
+			uid:     "John Doe (user) <john.doe@example.com>",
 			name:    "John Doe",
 			comment: "user",
 			email:   "john.doe@example.com",
 		},
 		{
 			in:      "uid:::::1441103821::AEFC3F5B6CAD79A946D7F0FF83BB8B7E10B578CA::John Doe (user):",
+			uid:     "John Doe (user)",
 			name:    "John Doe",
 			comment: "user",
 			email:   "",
@@ -45,6 +50,7 @@ func TestParseColonIdentity(t *testing.T) {
 			t.Parallel()
 
 			gi := parseColonIdentity(strings.Split(tc.in, ":"))
+			assert.Equal(t, tc.uid, gi.UID)
 			assert.Equal(t, tc.name, gi.Name)
 			assert.Equal(t, tc.comment, gi.Comment)
 			assert.Equal(t, tc.email, gi.Email)

--- a/internal/backend/crypto/gpg/identity.go
+++ b/internal/backend/crypto/gpg/identity.go
@@ -4,6 +4,7 @@ import "time"
 
 // Identity is a GPG identity, one key can have many IDs.
 type Identity struct {
+	UID            string
 	Name           string
 	Comment        string
 	Email          string

--- a/internal/backend/crypto/gpg/key.go
+++ b/internal/backend/crypto/gpg/key.go
@@ -96,7 +96,11 @@ func (k Key) Identity() Identity {
 	}
 
 	sort.Slice(ids, func(i, j int) bool {
-		return ids[i].CreationDate.After(ids[j].CreationDate)
+		if !ids[i].CreationDate.Equal(ids[j].CreationDate) {
+			return ids[i].CreationDate.After(ids[j].CreationDate)
+		}
+
+		return ids[i].UID < ids[j].UID
 	})
 
 	for _, i := range ids {

--- a/internal/backend/crypto/gpg/key_test.go
+++ b/internal/backend/crypto/gpg/key_test.go
@@ -109,6 +109,7 @@ func TestIdentitySort(t *testing.T) {
 
 	k := genTestKey()
 	k.Identities["Foo Bar"] = Identity{
+		UID:            "Foo Bar (foo) <foo.bar@example.com>",
 		Name:           "Foo Bar",
 		Comment:        "foo",
 		Email:          "foo.bar@example.com",
@@ -116,6 +117,18 @@ func TestIdentitySort(t *testing.T) {
 		ExpirationDate: expiration,
 	}
 	assert.Equal(t, "0x62AF4031C82E0039 - John Doe (johnny) <john.doe@example.org>", k.OneLine())
+}
+
+func TestIdentitySortUsesUIDAsTieBreaker(t *testing.T) {
+	t.Parallel()
+
+	creation := time.Date(2017, 1, 1, 1, 1, 1, 0, time.UTC)
+	k := Key{Identities: map[string]Identity{
+		"z": {UID: "z", Name: "Z", CreationDate: creation},
+		"a": {UID: "a", Name: "A", CreationDate: creation},
+	}}
+
+	assert.Equal(t, "A", k.Identity().Name)
 }
 
 func TestUseability(t *testing.T) {


### PR DESCRIPTION
## The Problem

When selecting a user ID for displaying GPG info, a key might have multiple user identities.  We currently select the newest, but in the case of multiple identities with the same timestamp we select one according to map iteration order, which has no deterministic order.  This makes identity non-deterministic, which can trigger crude audit tooling looking for diffs in the output.

Multiple IDs with the same creation time does happen. Encountering this in the wild is how we discovered the bug.

One way this occurs is when a key has two UIDs added in rapid succession:

```
gpg --quick-add-uid KEYID 'Alice <alice@example.com>'; gpg --quick-add-uid KEYID 'Alice <alice@work.example.com>'
```

GPG gives us time down to the second.  If both operations occur within the same second, GPG can emit:

```
uid:u::::1700000000::...::Alice <alice@example.com>:
uid:u::::1700000000::...::Alice <alice@work.example.com>:
```

Both UIDs end up with the same parsed CreationDate.

## The Fix

Retain each parsed user's ID so identity selection has a stable tie-breaker when multiple UIDs share a creation timestamp.
