### PR TITLE
Faster, more specific recipients command

### DIFF
--- a/docs/commands/recipients.md
+++ b/docs/commands/recipients.md
@@ -11,6 +11,7 @@ For the full team workflow reference, see
 
 ```
 $ gopass recipients
+$ gopass recipients list [prefix]
 $ gopass recipients add [--store=<store>] <recipient-id>...
 $ gopass recipients remove [--store=<store>] <recipient-id>...
 $ gopass recipients update [--store=<store>] [<recipient-id>...]
@@ -20,9 +21,12 @@ $ gopass recipients ack [--store=<store>]
 
 ## Subcommands
 
-### `recipients list` (default — no subcommand)
+### `recipients list`
 
-Lists all existing recipients for every mounted store.
+Lists existing recipients. An optional prefix limits the output to that
+recipient subtree, for example `gopass recipients list path/to/subtree`.
+
+Running `gopass recipients` without a subcommand lists all recipients.
 
 ### `recipients add` (aliases: `authorize`)
 

--- a/internal/action/commands.go
+++ b/internal/action/commands.go
@@ -1057,6 +1057,27 @@ func (s *Action) GetCommands() []*cli.Command {
 			},
 			Commands: []*cli.Command{
 				{
+					Name:      "list",
+					Usage:     "List recipients in a subtree",
+					ArgsUsage: "[prefix]",
+					Description: "List recipients below an optional prefix. " +
+						"With no prefix, list all recipients.",
+					Before: s.IsInitialized,
+					Action: s.RecipientsList,
+					Flags: []cli.Flag{
+						&cli.BoolFlag{
+							Name:  "pretty",
+							Usage: "Pretty print recipients",
+							Value: true,
+						},
+						&cli.BoolFlag{
+							Name:    "json",
+							Aliases: []string{"j"},
+							Usage:   "Output recipients as JSON array",
+						},
+					},
+				},
+				{
 					Name:    "ack",
 					Aliases: []string{"acknowledge"},
 					Usage:   "Update recipients.hash",

--- a/internal/action/handler_shims.go
+++ b/internal/action/handler_shims.go
@@ -131,6 +131,10 @@ func (s *Action) RecipientsPrint(ctx context.Context, cmd *cli.Command) error {
 	return s.recipients.RecipientsPrint(ctx, cmd)
 }
 
+func (s *Action) RecipientsList(ctx context.Context, cmd *cli.Command) error {
+	return s.recipients.RecipientsList(ctx, cmd)
+}
+
 func (s *Action) RecipientsComplete(ctx context.Context, cmd *cli.Command) {
 	s.recipients.RecipientsComplete(ctx, cmd)
 }

--- a/internal/action/recipients.go
+++ b/internal/action/recipients.go
@@ -276,8 +276,9 @@ func (s *recipientHandler) recipientsSelectForRemoval(ctx context.Context, store
 
 	ids := s.Store.ListRecipients(ctx, store)
 	choices := make([]string, 0, len(ids))
+	formatted := crypto.FormatKeys(ctx, ids)
 	for _, id := range ids {
-		choices = append(choices, crypto.FormatKey(ctx, id, ""))
+		choices = append(choices, formatted[id])
 	}
 
 	if len(choices) < 1 {
@@ -300,8 +301,9 @@ func (s *recipientHandler) recipientsSelectForAdd(ctx context.Context, store str
 
 	kl, _ := crypto.FindRecipients(ctx)
 	choices := make([]string, 0, len(kl))
+	formatted := crypto.FormatKeys(ctx, kl)
 	for _, key := range kl {
-		choices = append(choices, crypto.FormatKey(ctx, key, ""))
+		choices = append(choices, formatted[key])
 	}
 
 	if len(choices) < 1 {

--- a/internal/action/recipients.go
+++ b/internal/action/recipients.go
@@ -2,6 +2,7 @@ package action
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/gopasspw/gopass/internal/action/exit"
@@ -35,22 +36,50 @@ credentials.
 
 // RecipientsPrint prints all recipients per store.
 func (s *recipientHandler) RecipientsPrint(ctx context.Context, cmd *cli.Command) error {
+	if cmd.Args().Len() > 0 {
+		return exit.Error(exit.Usage, nil, "Usage: %s recipients [--pretty] [--json]", s.Name)
+	}
+
+	return s.recipientsPrint(ctx, cmd, "")
+}
+
+// RecipientsList prints recipients below an optional prefix.
+func (s *recipientHandler) RecipientsList(ctx context.Context, cmd *cli.Command) error {
+	return s.recipientsPrint(ctx, cmd, cmd.Args().First())
+}
+
+func (s *recipientHandler) recipientsPrint(ctx context.Context, cmd *cli.Command, prefix string) error {
 	ctx = ctxutil.WithGlobalFlags(ctx, cmd)
 
-	if cmd.Bool("json") {
-		t, err := s.Store.RecipientsTree(ctx, false)
-		if err != nil {
-			return exit.Error(exit.List, err, "failed to list recipients: %s", err)
+	var t *tree.Root
+	var err error
+	if prefix == "" {
+		t, err = s.Store.RecipientsTree(ctx, cmd.Bool("pretty"))
+	} else {
+		t, err = s.Store.RecipientsTreePrefix(ctx, cmd.Bool("pretty"), prefix)
+	}
+	if err != nil {
+		if errors.Is(err, tree.ErrNotFound) {
+			return exit.Error(exit.NotFound, nil, "Recipient subtree %q not found", prefix)
 		}
 
+		return exit.Error(exit.List, err, "failed to list recipients: %s", err)
+	}
+
+	if prefix != "" {
+		t, err = t.FindFolder(prefix)
+		if err != nil {
+			return exit.Error(exit.NotFound, nil, "Recipient subtree %q not found", prefix)
+		}
+		t.SetName(prefix)
+	}
+
+	if cmd.Bool("json") {
 		return jsonWrite(stdout, t.List(tree.INF))
 	}
 
-	out.Printf(ctx, "Hint: run 'gopass sync' to import any missing public keys")
-
-	t, err := s.Store.RecipientsTree(ctx, cmd.Bool("pretty"))
-	if err != nil {
-		return exit.Error(exit.List, err, "failed to list recipients: %s", err)
+	if prefix == "" {
+		out.Printf(ctx, "Hint: run 'gopass sync' to import any missing public keys")
 	}
 
 	fmt.Fprintln(stdout, t.Format(tree.INF))

--- a/internal/backend/crypto.go
+++ b/internal/backend/crypto.go
@@ -38,6 +38,7 @@ type Keyring interface {
 
 	Fingerprint(ctx context.Context, id string) string
 	FormatKey(ctx context.Context, id, tpl string) string
+	FormatKeys(ctx context.Context, ids []string) map[string]string
 	ReadNamesFromKey(ctx context.Context, buf []byte) ([]string, error)
 	GetFingerprint(ctx context.Context, key []byte) (string, error)
 

--- a/internal/backend/crypto/age/unsupported.go
+++ b/internal/backend/crypto/age/unsupported.go
@@ -10,6 +10,16 @@ func (a *Age) FormatKey(ctx context.Context, id, tpl string) string {
 	return id
 }
 
+// FormatKeys returns the IDs.
+func (a *Age) FormatKeys(ctx context.Context, ids []string) map[string]string {
+	formatted := make(map[string]string, len(ids))
+	for _, id := range ids {
+		formatted[id] = id
+	}
+
+	return formatted
+}
+
 // Fingerprint returns the id.
 func (a *Age) Fingerprint(ctx context.Context, id string) string {
 	return id

--- a/internal/backend/crypto/gpg/cli/keyring.go
+++ b/internal/backend/crypto/gpg/cli/keyring.go
@@ -100,6 +100,30 @@ func (g *GPG) FormatKey(ctx context.Context, id, tpl string) string {
 	return buf.String()
 }
 
+// FormatKeys formats multiple key IDs using bulk keyring lookups.
+func (g *GPG) FormatKeys(ctx context.Context, ids []string) map[string]string {
+	formatted := make(map[string]string, len(ids))
+	if g.privKeys == nil {
+		g.privKeys, _ = g.listKeys(ctx, "secret")
+	}
+	if g.pubKeys == nil {
+		g.pubKeys, _ = g.listKeys(ctx, "public")
+	}
+
+	for _, id := range ids {
+		if k, err := g.privKeys.FindKey(id); err == nil {
+			formatted[id] = k.OneLine()
+
+			continue
+		}
+		if k, err := g.pubKeys.FindKey(id); err == nil {
+			formatted[id] = k.OneLine()
+		}
+	}
+
+	return formatted
+}
+
 // ReadNamesFromKey unmarshals and returns the names associated with the given public key.
 func (g *GPG) ReadNamesFromKey(ctx context.Context, buf []byte) ([]string, error) {
 	if len(buf) < 1 {

--- a/internal/backend/crypto/plain/backend.go
+++ b/internal/backend/crypto/plain/backend.go
@@ -128,6 +128,16 @@ func (m *Mocker) FormatKey(ctx context.Context, id, tpl string) string {
 	return id
 }
 
+// FormatKeys returns the IDs.
+func (m *Mocker) FormatKeys(ctx context.Context, ids []string) map[string]string {
+	formatted := make(map[string]string, len(ids))
+	for _, id := range ids {
+		formatted[id] = id
+	}
+
+	return formatted
+}
+
 // Initialized returns nil.
 func (m *Mocker) Initialized(context.Context) error {
 	return nil

--- a/internal/cui/recipients.go
+++ b/internal/cui/recipients.go
@@ -48,6 +48,7 @@ func AskForPrivateKey(ctx context.Context, crypto backend.Crypto, prompt string)
 	}
 
 	fmtStr := "[%" + strconv.Itoa((len(kl)/10)+1) + "d] %s - %s\n"
+	formatted := crypto.FormatKeys(ctx, kl)
 	for range maxTries {
 		if !ctxutil.IsTerminal(ctx) || !ctxutil.IsInteractive(ctx) {
 			return kl[0], nil
@@ -61,7 +62,7 @@ func AskForPrivateKey(ctx context.Context, crypto backend.Crypto, prompt string)
 
 		fmt.Fprintln(Stdout, prompt)
 		for i, k := range kl {
-			fmt.Fprintf(Stdout, fmtStr, i, crypto.Name(), crypto.FormatKey(ctx, k, ""))
+			fmt.Fprintf(Stdout, fmtStr, i, crypto.Name(), formatted[k])
 		}
 
 		iv, err := termio.AskForInt(ctx, fmt.Sprintf("Please enter the number of a key (0-%d, [q]uit)", len(kl)-1), 0)

--- a/internal/store/root/recipients.go
+++ b/internal/store/root/recipients.go
@@ -69,6 +69,39 @@ func (r *Store) addRecipient(ctx context.Context, prefix string, root *tree.Root
 	return root.AddFile(prefix+key, "gopass/recipient")
 }
 
+func (r *Store) addRecipients(ctx context.Context, prefix string, root *tree.Root, recps []string, pretty bool) error {
+	if !pretty {
+		for _, recp := range recps {
+			if err := r.addRecipient(ctx, prefix, root, recp, false); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	}
+
+	sub, _ := r.getStore(prefix)
+	formatted := sub.Crypto().FormatKeys(ctx, recps)
+	for _, recp := range recps {
+		key := formatted[recp]
+		if key == "" {
+			if err := r.addRecipient(ctx, prefix, root, recp, true); err != nil {
+				return err
+			}
+			continue
+		}
+		if !strings.HasPrefix(key, recp) {
+			key = recp + " => " + key
+		}
+		key = strings.ReplaceAll(key, "/", "")
+		if err := root.AddFile(prefix+key, "gopass/recipient"); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 // ImportMissingPublicKeys import missing public keys in any substore.
 func (r *Store) ImportMissingPublicKeys(ctx context.Context) error {
 	for alias, sub := range r.mounts {
@@ -103,10 +136,8 @@ func (r *Store) RecipientsTree(ctx context.Context, pretty bool) (*tree.Root, er
 
 		debug.Log("Store/Secret: %q -> Recipients: %v", name, recps)
 
-		for _, recp := range recps {
-			if err := r.addRecipient(ctx, name, root, recp, pretty); err != nil {
-				color.Yellow("Failed to add recipient to tree %s: %s", recp, err)
-			}
+		if err := r.addRecipients(ctx, name, root, recps, pretty); err != nil {
+			color.Yellow("Failed to add recipients to tree: %s", err)
 		}
 	}
 
@@ -130,10 +161,8 @@ func (r *Store) RecipientsTree(ctx context.Context, pretty bool) (*tree.Root, er
 				name += "/"
 			}
 
-			for _, recp := range recps {
-				if err := r.addRecipient(ctx, alias+"/"+name, root, recp, pretty); err != nil {
-					debug.Log("Failed to add recipient to tree %s: %s", recp, err)
-				}
+			if err := r.addRecipients(ctx, alias+"/"+name, root, recps, pretty); err != nil {
+				debug.Log("Failed to add recipients to tree: %s", err)
 			}
 		}
 	}

--- a/internal/store/root/recipients.go
+++ b/internal/store/root/recipients.go
@@ -66,6 +66,13 @@ func (r *Store) addRecipient(ctx context.Context, prefix string, root *tree.Root
 
 	debug.Log("adding %q to the tree", key)
 
+	return r.addFormattedRecipient(root, prefix, recp, key)
+}
+
+func (r *Store) addFormattedRecipient(root *tree.Root, prefix, recp, key string) error {
+	key = strings.ReplaceAll(key, "/", "")
+	debug.Log("adding %q to the tree", key)
+
 	return root.AddFile(prefix+key, "gopass/recipient")
 }
 
@@ -88,13 +95,13 @@ func (r *Store) addRecipients(ctx context.Context, prefix string, root *tree.Roo
 			if err := r.addRecipient(ctx, prefix, root, recp, true); err != nil {
 				return err
 			}
+
 			continue
 		}
 		if !strings.HasPrefix(key, recp) {
 			key = recp + " => " + key
 		}
-		key = strings.ReplaceAll(key, "/", "")
-		if err := root.AddFile(prefix+key, "gopass/recipient"); err != nil {
+		if err := r.addFormattedRecipient(root, prefix, recp, key); err != nil {
 			return err
 		}
 	}
@@ -164,6 +171,53 @@ func (r *Store) RecipientsTree(ctx context.Context, pretty bool) (*tree.Root, er
 			if err := r.addRecipients(ctx, alias+"/"+name, root, recps, pretty); err != nil {
 				debug.Log("Failed to add recipients to tree: %s", err)
 			}
+		}
+	}
+
+	return root, nil
+}
+
+// RecipientsTreePrefix returns a recipient tree limited to the store selected
+// by prefix. The prefix is still retained in the tree so callers can select a
+// further subtree from the result.
+func (r *Store) RecipientsTreePrefix(ctx context.Context, pretty bool, prefix string) (*tree.Root, error) {
+	sub, _ := r.getStore(prefix)
+	storePrefix := sub.Alias()
+	recipientTree := sub.RecipientsTree(ctx)
+
+	// Build an unformatted tree first. This lets callers reject a missing
+	// prefix without doing any GPG key lookups.
+	raw := tree.New("gopass")
+	for name, recps := range recipientTree {
+		path := storePrefix
+		if name != "" {
+			path += "/" + name
+		}
+		if path != "" {
+			path += "/"
+		}
+
+		if err := r.addRecipients(ctx, path, raw, recps, false); err != nil {
+			debug.Log("Failed to add recipients to tree: %s", err)
+		}
+	}
+	if _, err := raw.FindFolder(prefix); err != nil {
+		return nil, err
+	}
+
+	root := tree.New("gopass")
+
+	for name, recps := range recipientTree {
+		path := storePrefix
+		if name != "" {
+			path += "/" + name
+		}
+		if path != "" {
+			path += "/"
+		}
+
+		if err := r.addRecipients(ctx, path, root, recps, pretty); err != nil {
+			debug.Log("Failed to add recipients to tree: %s", err)
 		}
 	}
 


### PR DESCRIPTION
This is three commits that add up to two changes that build on each other.

In the first commit, I added `FormatKeys`, which does what `FormatKey` does but replaces multiple calls by batching.  Then the second commit adjusts the `recipients` command to use `FormatKeys`.  That yielded an instant 10x speed using my `.password-store` and keyring!  

The third commit implements prefix selectors so you can `gopass recipients list path/to/subtree`.  Now you don't have to wade through a ton of stuff to get to the bit you want.

See the invididual commit messages for details.

(I also have an unpushed commit that uses this in other places FormatKey might get called multiple times, but those are going to be much smaller improvements than with recipients so doing the adjustment is more about code consistency than performance.  I can push it here or separately or not at all, as you prefer.)