### PR TITLE
docs: update deprecated iOS repo link

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -455,7 +455,7 @@ gopass config mounts.path "~/Google Drive/Password-Store"
 Because gopass is fully backwards compatible with pass, you can use some existing graphical user interfaces / frontends:
 
 * Android - [Password Store](https://github.com/agrahn/Android-Password-Store)
-* iOS - [Pass for iOS](https://github.com/davidjb/pass-ios#readme)
+* iOS - [Pass for iOS](https://github.com/mssun/passforios)
 * Windows / MacOS / Linux -  [QtPass](https://qtpass.org/)
 
 There is also [Gopass UI](https://github.com/codecentric/gopass-ui) which was exclusively implemented for gopass and is available for MacOS, Linux and Windows.


### PR DESCRIPTION
Documentation about iOS mobile app uses a link to the old project repository: `pass-ios` instead of the actual `passforios`. Replace this link