### PR TITLE
feat(api): Add new AuditList method

### DIFF
--- a/internal/action/audit.go
+++ b/internal/action/audit.go
@@ -45,12 +45,24 @@ func (s *auditHandler) Audit(ctx context.Context, cmd *cli.Command) error {
 		return nil
 	}
 
-	var excludes string
-	st := s.Store.Storage(ctx, cmd.Args().First())
-	if buf, err := st.Get(ctx, ".gopass-audit-ignore"); err == nil && buf != nil {
-		excludes = string(buf)
+	nList, err := audit.FilteredList(ctx, s.Store)
+	if err != nil {
+		return exit.Error(exit.List, err, "failed to list secrets: %s", err)
 	}
-	nList := audit.FilterExcludes(excludes, list)
+	// if a filter was given, restrict the audit to the matching subtree
+	if filter := cmd.Args().First(); filter != "" {
+		allowed := make(map[string]struct{}, len(list))
+		for _, name := range list {
+			allowed[name] = struct{}{}
+		}
+		filtered := make([]string, 0, len(nList))
+		for _, name := range nList {
+			if _, ok := allowed[name]; ok {
+				filtered = append(filtered, name)
+			}
+		}
+		nList = filtered
+	}
 	if len(nList) < len(list) {
 		out.Warningf(ctx, "Excluding %d secrets based on .gopass-audit-ignore", len(list)-len(nList))
 	}

--- a/internal/audit/excludes.go
+++ b/internal/audit/excludes.go
@@ -1,9 +1,15 @@
 package audit
 
 import (
+	"context"
+	"fmt"
 	"regexp"
+	"sort"
 	"strings"
 
+	"github.com/gopasspw/gopass/internal/store"
+	"github.com/gopasspw/gopass/internal/store/root"
+	"github.com/gopasspw/gopass/internal/tree"
 	"github.com/gopasspw/gopass/pkg/debug"
 )
 
@@ -19,6 +25,63 @@ func (r res) Matches(s string) bool {
 	}
 
 	return false
+}
+
+// FilteredList returns a list of all secrets in the given store, filtered against the .gopass-audit-ignore file in each mount point.
+func FilteredList(ctx context.Context, rs *root.Store) ([]string, error) {
+	t, err := rs.Tree(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get store tree: %w", err)
+	}
+
+	list := t.List(tree.INF)
+	if len(list) < 1 {
+		return list, nil
+	}
+
+	// Collect the exclude patterns for every mount point (including the root store).
+	// The longer a mount point the more specific it is, so we sort them by descending
+	// length to make sure the most specific mount point wins for every secret.
+	mps := rs.MountPoints()
+	sort.Sort(sort.Reverse(store.ByPathLen(mps)))
+
+	excludes := make(map[string]string, len(mps)+1)
+	for _, mp := range mps {
+		excludes[mp] = loadExcludes(ctx, rs, mp)
+	}
+	// the root store is the fallback for secrets not in any mount
+	excludes[""] = loadExcludes(ctx, rs, "")
+
+	// Group the secrets by their mount point, so that each excludes file
+	// only needs to be parsed once.
+	byMount := make(map[string][]string, len(mps)+1)
+	for _, name := range list {
+		mp := rs.MountPoint(name)
+		byMount[mp] = append(byMount[mp], name)
+	}
+
+	out := make([]string, 0, len(list))
+	for mp, secrets := range byMount {
+		out = append(out, FilterExcludes(excludes[mp], secrets)...)
+	}
+	sort.Strings(out)
+
+	return out, nil
+}
+
+// loadExcludes returns the content of the .gopass-audit-ignore file at the
+// root of the given mount point, if any.
+func loadExcludes(ctx context.Context, rs *root.Store, mp string) string {
+	st := rs.Storage(ctx, mp)
+	if st == nil {
+		return ""
+	}
+	buf, err := st.Get(ctx, ".gopass-audit-ignore")
+	if err != nil || buf == nil {
+		return ""
+	}
+
+	return string(buf)
 }
 
 // FilterExcludes filters the given list of secrets against the given exclude patterns (RE2 syntax).

--- a/pkg/gopass/api/api.go
+++ b/pkg/gopass/api/api.go
@@ -16,6 +16,7 @@ import (
 	// load crypto backends.
 	_ "github.com/gopasspw/gopass/internal/backend/crypto"
 	// load storage backends.
+	"github.com/gopasspw/gopass/internal/audit"
 	_ "github.com/gopasspw/gopass/internal/backend/storage"
 	"github.com/gopasspw/gopass/internal/config"
 	"github.com/gopasspw/gopass/internal/queue"
@@ -66,6 +67,14 @@ func New(ctx context.Context) (*Gopass, error) {
 // List returns a list of all secret names.
 func (g *Gopass) List(ctx context.Context) ([]string, error) {
 	return g.rs.List(ctx, tree.INF) //nolint:wrapcheck
+}
+
+// AuditList returns a list of all secret names, filtered against the optional
+// .gopass-audit-ignore file at the root of each mount point. Secrets matching
+// any of the exclude patterns (RE2 syntax) in the file of their mount point
+// are omitted from the result.
+func (g *Gopass) AuditList(ctx context.Context) ([]string, error) {
+	return audit.FilteredList(ctx, g.rs)
 }
 
 // Get returns a single, encrypted secret. It must be unwrapped before use.


### PR DESCRIPTION
This new method will return the list of all secrets in the store but apply automatic filtering against .gopass-audit-ignore files if they exist in each mount point.