### PR TITLE
fix(store): Fix reencrypt when adding recipients

### DIFF
--- a/internal/store/leaf/reencrypt.go
+++ b/internal/store/leaf/reencrypt.go
@@ -86,6 +86,7 @@ func (s *Store) reencrypt(ctx context.Context) error {
 			}
 
 			e = strings.TrimPrefix(e, s.alias)
+			e = strings.TrimPrefix(e, "/")
 			jobs <- e
 		}
 		// We close the channel, so the workers will terminate


### PR DESCRIPTION
The reencryption logic when adding recipients was incorrectly trimming the mount prefix. It was not removing the leading slash, leading to write errors.

Fixes #3473