### PR TITLE
fix(config): Avoid overwriting the config when there is no need

### DIFF
--- a/internal/store/root/init.go
+++ b/internal/store/root/init.go
@@ -95,7 +95,7 @@ func (r *Store) initialize(ctx context.Context) error {
 	// initialize all mounts
 	for _, alias := range r.cfg.Mounts() {
 		path := fsutil.CleanPath(r.cfg.MountPath(alias))
-		if err := r.addMount(ctx, alias, path); err != nil {
+		if err := r.addMount(ctx, alias, path, false); err != nil {
 			out.Errorf(ctx, "Failed to initialize mount %s (%s). Ignoring: %s", alias, path, err)
 
 			continue

--- a/internal/store/root/init_test.go
+++ b/internal/store/root/init_test.go
@@ -33,3 +33,39 @@ func TestInit(t *testing.T) {
 	assert.True(t, inited)
 	require.NoError(t, rs.Init(ctx, "rs2", u.StoreDir("rs2"), "0xDEADBEEF"))
 }
+
+// TestInitializeDoesNotRewriteMountPaths guards against a regression where
+// initializing the root store persisted the (normalized) mount paths back to
+// the config on every invocation. Since gopass 1.17.2 mount paths are stored
+// relative to the home directory (~/...), so re-writing an unshrunk absolute
+// path from an existing config made gopass fail on read-only configs and
+// spam errors like "failed to set mount path: failed to write config".
+func TestInitializeDoesNotRewriteMountPaths(t *testing.T) {
+	u := gptest.NewUnitTester(t)
+	require.NoError(t, u.InitStore("sub1"))
+
+	// mimic a pre-existing config that stores an absolute, not yet shrunk
+	// mount path (as written by gopass releases before #3439)
+	absPath := u.StoreDir("sub1")
+
+	cfg := config.New()
+	require.NoError(t, cfg.Set("", "mounts.sub1.path", absPath))
+
+	// reload so the mount is picked up from the on-disk config
+	cfg = config.New()
+	require.Equal(t, absPath, cfg.Get("mounts.sub1.path"))
+
+	ctx := config.NewContextInMemory()
+	ctx = ctxutil.WithAlwaysYes(ctx, true)
+	ctx = ctxutil.WithHidden(ctx, true)
+	ctx = backend.WithCryptoBackend(ctx, backend.Plain)
+
+	rs := New(cfg)
+
+	// this triggers initialize(), which iterates over all configured mounts
+	_, err := rs.IsInitialized(ctx)
+	require.NoError(t, err)
+
+	// the mount path must be left untouched
+	assert.Equal(t, absPath, cfg.Get("mounts.sub1.path"))
+}

--- a/internal/store/root/mount.go
+++ b/internal/store/root/mount.go
@@ -16,7 +16,7 @@ import (
 
 // AddMount adds a new mount.
 func (r *Store) AddMount(ctx context.Context, alias, path string, keys ...string) error {
-	if err := r.addMount(ctx, alias, path, keys...); err != nil {
+	if err := r.addMount(ctx, alias, path, true, keys...); err != nil {
 		return fmt.Errorf("failed to add mount: %w", err)
 	}
 
@@ -24,7 +24,11 @@ func (r *Store) AddMount(ctx context.Context, alias, path string, keys ...string
 	return r.checkMounts()
 }
 
-func (r *Store) addMount(ctx context.Context, alias, path string, keys ...string) error {
+// addMount adds a mount to the root store. If persist is true the mount path is
+// written to the config. Existing mounts that are loaded on startup must not be
+// persisted, both to avoid needless writes and to keep gopass working with a
+// read-only config.
+func (r *Store) addMount(ctx context.Context, alias, path string, persist bool, keys ...string) error {
 	// disallow filepath separators in alias and always disallow regular slashes
 	// even on Windows, since these are used internally to separate folders.
 	if strings.HasSuffix(alias, "/") {
@@ -57,8 +61,10 @@ func (r *Store) addMount(ctx context.Context, alias, path string, keys ...string
 	}
 
 	r.mounts[alias] = s
-	if err := r.cfg.SetMountPath(alias, path); err != nil {
-		return fmt.Errorf("failed to set mount path: %w", err)
+	if persist {
+		if err := r.cfg.SetMountPath(alias, path); err != nil {
+			return fmt.Errorf("failed to set mount path: %w", err)
+		}
 	}
 
 	debug.Log("Added mount %s -> %s (%s)", alias, path, fullPath)


### PR DESCRIPTION
This commit changes the config handling to avoid needlessly writing to the config. We will still (need to) write the config on user initiated changes, but no longer during init.

Fixes #3593