### PR TITLE
refactor(deps): move HIBP client into pkg/hibp to break the module cycle

### DIFF
--- a/docs/adr/A-16-break-gopass-hibp-cycle.md
+++ b/docs/adr/A-16-break-gopass-hibp-cycle.md
@@ -1,8 +1,13 @@
 # A-16: Break the `gopass` ↔ `gopass-hibp` module dependency cycle
 
-**Status:** proposed  
+**Status:** partially implemented  
 **Source:** Maintainer discussion — the `gopass` module depends on `gopass-hibp`, while the
 `gopass-hibp` module depends on `gopass`.
+
+The `gopass` side is done: `pkg/hibp/api` and `pkg/hibp/dump` now live in this repository,
+`internal/audit` imports them locally, and the `gopass-hibp` module requirement has been
+removed. The follow-up is to point the standalone `gopass-hibp` repository at
+`gopass/pkg/hibp/*` and delete its now-duplicated `pkg/` tree.
 
 ---
 

--- a/docs/adr/A-16-break-gopass-hibp-cycle.md
+++ b/docs/adr/A-16-break-gopass-hibp-cycle.md
@@ -1,0 +1,235 @@
+# A-16: Break the `gopass` ↔ `gopass-hibp` module dependency cycle
+
+**Status:** proposed  
+**Source:** Maintainer discussion — the `gopass` module depends on `gopass-hibp`, while the
+`gopass-hibp` module depends on `gopass`.
+
+---
+
+## Background
+
+`github.com/gopasspw/gopass` and `github.com/gopasspw/gopass-hibp` currently require each
+other. Go tolerates this because the *package* import graph is still a DAG, but the *module*
+graph contains a cycle. The cycle is small and well understood, but it makes releases and
+dependency management awkward and it contradicts the component diagram in
+[`docs/components.dot`](../components.dot), which already draws a standalone `pkg/hibp` node.
+
+### Current facts
+
+The cycle has two edges.
+
+**Edge 1 — `gopass` consumes the HIBP client.** `internal/audit/audit.go` imports:
+
+```go
+"github.com/gopasspw/gopass-hibp/pkg/hibp/api"
+"github.com/gopasspw/gopass-hibp/pkg/hibp/dump"
+```
+
+* `api.Lookup` is used by the online HIBPv2 validator (`audit.hibp-use-api`).
+* `dump.New(...).LookupBatch` is used by the offline dump check (`audit.hibp-dump-file`).
+
+These are the only two import sites in the module.
+
+**Edge 2 — `gopass-hibp` consumes gopass.** The standalone CLI's `main.go`, `hibp.go` and
+`pkg/hibp/*` import gopass packages:
+
+| File in `gopass-hibp` | Imports from `gopass` |
+| --- | --- |
+| `pkg/hibp/api/client.go` | `pkg/debug` |
+| `pkg/hibp/api/downloader.go` | `pkg/debug`, `pkg/ctxutil`, `pkg/fsutil`, `pkg/termio` |
+| `pkg/hibp/dump/scanner.go` | `pkg/debug`, `pkg/fsutil` |
+| `hibp.go`, `main.go` (repo root) | `pkg/gopass/api` |
+
+### Constraints
+
+* There must not be a module cycle between the two projects.
+* The `gopass-hibp` binary must remain its own repository/binary; we do not want a second
+  binary target inside the `gopass` repository.
+* New external dependencies should be avoided (`AGENTS.md`, "Libraries and Frameworks").
+* `pkg/gopass` and friends have a documented stability contract ([A-12](A-12-pkg-api-stability.md)).
+
+### Why the cycle is a problem in practice
+
+* **Release ordering is circular.** A new `pkg/hibp` feature needs a `gopass-hibp` release
+  before `gopass` can consume it; a new `pkg/gopass` API needs a `gopass` release before
+  `gopass-hibp` can build. Neither can be released first in isolation.
+* **Tooling friction.** Dependency bots, `govulncheck`, `go mod tidy` diffs and licence
+  scanning all report the cycle as a repeated, noisy pair of changes.
+* **Architecture confusion.** It is unclear which module owns the HIBP client and which is the
+  consumer.
+
+---
+
+## Options considered
+
+### Option A — Extract a dependency-free `gopass-hibp-client` module
+
+Move `pkg/hibp/api` and `pkg/hibp/dump` into a new repository/module
+(`github.com/gopasspw/gopass-hibp-client`). Both `gopass` and `gopass-hibp` then depend on it,
+and only `gopass-hibp` depends on `gopass`.
+
+**Critical caveat:** this only breaks the cycle if the new client module has **no** gopass
+dependencies. Today the client imports `pkg/debug`, `pkg/ctxutil`, `pkg/fsutil` and
+`pkg/termio`. A straight copy would become `gopass → client → gopass` and the cycle would
+remain. The client must therefore be decoupled:
+
+* `debug.Log` → remove, or accept an injected `*slog.Logger`.
+* `fsutil.IsFile` / `fsutil.IsDir` → `os.Stat`.
+* `ctxutil.IsHidden(ctx)` → a plain `hidden bool` parameter (download only).
+* `termio.NewProgressBar` → drop, or accept an injected progress callback.
+
+That is roughly six call sites across three files — small, but it is a real API change.
+
+#### Option A — Pros
+
+* Cleanest layering: the HIBP domain code lives with the HIBP project, `gopass` stays a
+  password manager.
+* The client becomes reusable by any third party with zero gopass dependency.
+* `gopass-hibp` remains a separate binary/repo (constraint satisfied).
+
+#### Option A — Cons
+
+* New repository, CI, goreleaser config, licence linting and release pipeline to maintain.
+* Three-module release train (client → gopass, client → gopass-hibp) instead of two.
+* Requires changing/removing behaviour that is currently gopass-specific (progress bar, hidden
+  context handling), which slightly degrades the CLI UX unless a callback is threaded through.
+* The client's public API now needs its own stability policy.
+
+### Option B — Move the HIBP client library into the `gopass` module as `pkg/hibp`
+
+Relocate `pkg/hibp/api` and `pkg/hibp/dump` into this repository under `pkg/hibp/`. `gopass`
+then imports its own package; `gopass-hibp` imports `gopass/pkg/hibp/*` and
+`gopass/pkg/gopass/api` as it already imports the latter. The `gopass-hibp` binary stays in its
+own repository.
+
+#### Option B — Pros
+
+* Breaks the cycle with no new repository and no release-train expansion.
+* No decoupling refactor: `pkg/debug`, `pkg/fsutil`, `pkg/ctxutil` and `pkg/termio` are in the
+  same module, so the existing client code moves verbatim.
+* Matches [`docs/components.dot`](../components.dot), which already draws `pkg/hibp`.
+* `gopass-hibp` becomes a genuinely thin CLI; it already depends on `gopass` for `pkg/gopass/api`,
+  so no new coupling is introduced.
+* Only six files plus tests move; `internal/audit` only changes its import paths.
+
+#### Option B — Cons
+
+* `gopass` now hosts the HIBP client, which is arguably domain-specific to `gopass-hibp`.
+* Changes to the client ship on the `gopass` release cadence; `gopass-hibp` must bump `gopass`
+  to pick them up.
+* The library must be added to the A-12 stability scope (or explicitly excluded).
+
+### Option C — Keep the cycle
+
+Make no change and document that mutual module requirements are required.
+
+#### Option C — Pros
+
+* Zero effort. Compiles and runs today via MVS.
+
+#### Option C — Cons
+
+* All the release-ordering and tooling problems above persist.
+* Depends on Go continuing to tolerate cyclic module requirements indefinitely.
+
+### Option D — Fold `gopass-hibp` into `gopass` as a subcommand
+
+Move the CLI into `internal/action` (e.g. extend `gopass audit` with the `api`, `download` and
+`dump` sub-actions) and retire the separate repository.
+
+#### Option D — Pros
+
+* Single repository, single binary, no cycle, no client library to publish.
+* `gopass audit` already performs HIBP checks, so the functionality is a natural fit.
+
+#### Option D — Cons
+
+* Directly conflicts with the constraint of not maintaining multiple binaries in one repo —
+  and with the historical decision to keep integrations standalone ([A-12](A-12-pkg-api-stability.md)).
+* Loses the standalone `gopass-hibp` release cadence and its independent packaging.
+* Removing the standalone binary is a CLI-visible break.
+
+### Option E — Dependency inversion via interfaces
+
+`gopass` defines a lookup/scanner interface and the implementation is injected at runtime from
+`gopass-hibp`.
+
+#### Option E — Pros
+
+* Theoretically removes the compile-time dependency.
+
+#### Option E — Cons
+
+* Go links statically; there is no clean plugin boundary, and gopass cannot import an
+  implementation it does not depend on. This adds indirection without removing the edge.
+* Not recommended.
+
+---
+
+## Recommendation
+
+**Adopt Option B**, with **Option A** kept as the documented fallback if the library is later
+needed independently of gopass.
+
+Rationale:
+
+1. It breaks the cycle completely and permanently with no new repository or release train.
+2. It is the least invasive change — the HIBP client code moves without any refactor because
+   its helper dependencies are already in this module.
+3. It aligns with the existing component diagram, which already shows `pkg/hibp` as a gopass
+   package.
+4. It satisfies the "no second binary in the gopass repository" constraint: only library code
+   moves, the `gopass-hibp` binary stays where it is.
+
+Option A remains attractive on layering grounds, but its non-trivial decoupling work and the
+additional repository/release pipeline are not justified by the current maintenance capacity —
+the same reasoning A-12 applied when deferring full module semver.
+
+---
+
+## Implementation plan (Option B)
+
+1. **Move the library.** Relocate `pkg/hibp/api` and `pkg/hibp/dump` (including `_test.go`
+   files) from `gopass-hibp` into `gopass/pkg/hibp/api` and `gopass/pkg/hibp/dump` without
+   behavioural changes.
+2. **Update consumers in `gopass`.** Change `internal/audit/audit.go` imports to
+   `github.com/gopasspw/gopass/pkg/hibp/{api,dump}`. Add doc comments describing stability.
+3. **Update `gopass-hibp`.** Point its imports at `gopass/pkg/hibp/*`; remove the now-empty
+   `gopass-hibp/pkg` tree. `go.mod` keeps the single `gopass` requirement; delete the
+   `gopass-hibp → gopass-hibp` self-reference that does not exist.
+4. **Verify there is no residual cycle.** Run `go mod graph` in both repositories and confirm
+   `gopass` no longer lists `gopass-hibp`.
+5. **Documentation.** Update `docs/components.dot` if needed, `docs/hacking.md` (the API
+   example pointer) and the A-12 stability table to include `pkg/hibp`.
+6. **Release ordering.** Do a `gopass` minor release containing `pkg/hibp`, then release
+   `gopass-hibp` with the bumped dependency. This is a one-off ordering cost; afterwards the
+   train is linear.
+7. **Validation.** `make test`, `make codequality`, `make test-integration` in both
+   repositories; confirm the HIBP API and dump audit paths still work end to end.
+
+### Migration checklist
+
+* [ ] `gopass/pkg/hibp/api` and `gopass/pkg/hibp/dump` created
+* [ ] `internal/audit/audit.go` imports updated
+* [ ] `gopass-hibp` imports updated and `pkg/` removed
+* [ ] `go mod graph` shows no `gopass → gopass-hibp` edge
+* [ ] `docs/components.dot` and A-12 stability table updated
+* [ ] both repositories pass `make test` and `make codequality`
+
+---
+
+## Consequences
+
+* The module graph becomes acyclic, removing the release chicken-and-egg problem.
+* `gopass-hibp` becomes a thin CLI over `pkg/gopass/api` and `pkg/hibp`.
+* `pkg/hibp` joins the A-12 stability surface; changes there follow the same best-effort
+  policy and `PKG-BREAK:` conventions as `pkg/gopass`.
+* If the library later needs to be consumed outside gopass without pulling in the module,
+  it can be extracted per Option A; the move in this record does not preclude that.
+
+---
+
+## Affected packages
+
+`internal/audit`, new `pkg/hibp/api`, new `pkg/hibp/dump`; in `gopass-hibp`: `main.go`,
+`hibp.go`, and removal of `pkg/hibp/`.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -27,6 +27,7 @@ Update this index in the same commit that adds or supersedes a record.
 | [A-13](A-13-expired-gpg-key-handling.md) | Expired GPG key handling and recipient validity warnings | partially implemented | 2026-05-25 |
 | [A-14](A-14-team-workflows.md) | Effortless team workflows | implemented | 2026-06-06 |
 | [A-15](A-15-screenshot-build-tag.md) | `noscreenshot` build tag for OTP screen-capture feature | accepted | 2026-05-25 |
+| [A-16](A-16-break-gopass-hibp-cycle.md) | Break the `gopass` ↔ `gopass-hibp` module dependency cycle | proposed | 2026-09-10 |
 
 Status values are taken from each record's `**Status:**` line. Dates are the
 authoring commit dates reported by `git log --diff-filter=A --follow`.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -27,7 +27,7 @@ Update this index in the same commit that adds or supersedes a record.
 | [A-13](A-13-expired-gpg-key-handling.md) | Expired GPG key handling and recipient validity warnings | partially implemented | 2026-05-25 |
 | [A-14](A-14-team-workflows.md) | Effortless team workflows | implemented | 2026-06-06 |
 | [A-15](A-15-screenshot-build-tag.md) | `noscreenshot` build tag for OTP screen-capture feature | accepted | 2026-05-25 |
-| [A-16](A-16-break-gopass-hibp-cycle.md) | Break the `gopass` ↔ `gopass-hibp` module dependency cycle | proposed | 2026-09-10 |
+| [A-16](A-16-break-gopass-hibp-cycle.md) | Break the `gopass` ↔ `gopass-hibp` module dependency cycle | partially implemented | 2026-09-10 |
 
 Status values are taken from each record's `**Status:**` line. Dates are the
 authoring commit dates reported by `git log --diff-filter=A --follow`.

--- a/docs/components.dot
+++ b/docs/components.dot
@@ -33,6 +33,7 @@ digraph G {
   hibp -> api;
   hibp [label="gopass-hibp",shape=box];
   hibp -> pkghibp;
+  gopass -> pkghibp;
   pkghibp [label="pkg/hibp"];
   gitcreds -> api;
   gitcreds [label="git-credential-gopass",shape=box];

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,6 @@ require (
 	github.com/google/go-github/v61 v61.0.0
 	github.com/gopasspw/clipboard v0.0.5-0.20260524141134-6b387ae5aa1a
 	github.com/gopasspw/gitconfig v0.0.4
-	github.com/gopasspw/gopass-hibp v1.17.2
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/jsimonetti/pwscheme v0.0.0-20220922140336-67a4d090f150
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51

--- a/go.sum
+++ b/go.sum
@@ -78,8 +78,6 @@ github.com/gopasspw/clipboard v0.0.5-0.20260524141134-6b387ae5aa1a h1:L7qDnmetJ6
 github.com/gopasspw/clipboard v0.0.5-0.20260524141134-6b387ae5aa1a/go.mod h1:i0cShr7JEbOXZ/iKM5RyfBLbu1FPzouO8BTCJy0uHy8=
 github.com/gopasspw/gitconfig v0.0.4 h1:7JE0iTm92OdXCtkS33CnbqcAEqQXYWTUriYFf3sRTBk=
 github.com/gopasspw/gitconfig v0.0.4/go.mod h1:W5AHsZgCbBRsc8TnElO82GYflOz/l2dIndncymoCv+A=
-github.com/gopasspw/gopass-hibp v1.17.2 h1:TeTaLTLHUSNkTVBy2NaY2NKVTelHV0IG0AQQcM0pmE4=
-github.com/gopasspw/gopass-hibp v1.17.2/go.mod h1:NQiyuG2d+iA/wEykjFE8r8Px/wCXk+1y4ICBJ89hAUA=
 github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -12,8 +12,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/gopasspw/gopass-hibp/pkg/hibp/api"
-	"github.com/gopasspw/gopass-hibp/pkg/hibp/dump"
 	"github.com/gopasspw/gopass/internal/backend"
 	"github.com/gopasspw/gopass/internal/config"
 	"github.com/gopasspw/gopass/internal/hashsum"
@@ -22,6 +20,8 @@ import (
 	"github.com/gopasspw/gopass/pkg/debug"
 	"github.com/gopasspw/gopass/pkg/fsutil"
 	"github.com/gopasspw/gopass/pkg/gopass"
+	"github.com/gopasspw/gopass/pkg/hibp/api"
+	"github.com/gopasspw/gopass/pkg/hibp/dump"
 	"github.com/gopasspw/gopass/pkg/termio"
 	"github.com/muesli/crunchy"
 )

--- a/pkg/hibp/api/client.go
+++ b/pkg/hibp/api/client.go
@@ -1,0 +1,84 @@
+// Package api implements an HIBP API client.
+//
+// Stability: best-effort stable. It is consumed by internal/audit and by the
+// standalone gopass-hibp integration. Changes to its exported API follow the
+// policy in docs/adr/A-12-pkg-api-stability.md.
+package api
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/cenkalti/backoff/v4"
+	"github.com/gopasspw/gopass/pkg/debug"
+)
+
+// URL is the HIBPv2 API URL.
+var URL = "https://api.pwnedpasswords.com"
+
+// Lookup performs a lookup against the HIBP v2 API.
+func Lookup(shaSum string) (uint64, error) {
+	if len(shaSum) != 40 {
+		return 0, fmt.Errorf("invalid shasum")
+	}
+
+	shaSum = strings.ToUpper(shaSum)
+	prefix := shaSum[:5]
+	suffix := shaSum[5:]
+
+	var count uint64
+	url := fmt.Sprintf("%s/range/%s", URL, prefix)
+
+	op := func() error {
+		debug.Log("[%s] HTTP Request: %s", shaSum, url)
+		resp, err := http.Get(url)
+		if err != nil {
+			return err
+		}
+		defer func() {
+			_ = resp.Body.Close()
+		}()
+
+		if resp.StatusCode == http.StatusNotFound {
+			return nil
+		}
+
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return err
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			return fmt.Errorf("HTTP request failed: %s %s", resp.Status, body)
+		}
+
+		debug.Log("Body: %s", string(body))
+		for _, line := range strings.Split(string(body), "\n") {
+			line = strings.TrimSpace(line)
+			if len(line) < 37 {
+				continue
+			}
+			if line[:35] != suffix {
+				continue
+			}
+			if iv, err := strconv.ParseUint(line[36:], 10, 64); err == nil {
+				count = iv
+
+				return nil
+			}
+		}
+
+		return nil
+	}
+
+	bo := backoff.NewExponentialBackOff()
+	bo.MaxElapsedTime = 10 * time.Second
+
+	err := backoff.Retry(op, bo)
+
+	return count, err
+}

--- a/pkg/hibp/api/client_test.go
+++ b/pkg/hibp/api/client_test.go
@@ -1,0 +1,111 @@
+package api
+
+import (
+	"crypto/sha1"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Example() { //nolint:testableexamples
+	matches, err := Lookup("sha1sum of secret")
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Number of matches: %d", matches)
+}
+
+func TestLookup(t *testing.T) { //nolint:paralleltest
+	match := "match"
+	noMatch := "no match"
+	matchSum := sha1sum(match)
+	var matchCount uint64 = 324567
+
+	reqCnt := 0
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reqCnt++
+		if reqCnt < 2 {
+			http.Error(w, "fake error", http.StatusInternalServerError)
+
+			return
+		}
+		if strings.TrimPrefix(r.URL.String(), "/range/") == matchSum[:5] {
+			fmt.Fprintf(w, "%s", matchSum[5:10]+":1\r\n")         // invalid
+			fmt.Fprintf(w, "%s", matchSum[5:39]+":3234879\r\n")   // invalid
+			fmt.Fprintf(w, "%s", matchSum[5:]+":\r\n")            // invalid
+			fmt.Fprintf(w, "%s", matchSum[5:]+"\r\n")             // invalid
+			fmt.Fprintf(w, "%s:%d\r\n", matchSum[5:], matchCount) // valid
+
+			return
+		}
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+	defer ts.Close()
+	URL = ts.URL
+
+	// test with one entry
+	count, err := Lookup(matchSum)
+	require.NoError(t, err)
+	assert.Equal(t, matchCount, count)
+
+	// add another one
+	count, err = Lookup(sha1sum(noMatch))
+	require.NoError(t, err)
+	assert.Equal(t, uint64(0), count)
+
+	// invalid input
+	count, err = Lookup("")
+	require.Error(t, err)
+	assert.Equal(t, uint64(0), count)
+}
+
+func TestLookupCR(t *testing.T) { //nolint:paralleltest
+	match := "match"
+	noMatch := "no match"
+	matchSum := sha1sum(match)
+	var matchCount uint64 = 324567
+
+	reqCnt := 0
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reqCnt++
+		if reqCnt < 2 {
+			http.Error(w, "fake error", http.StatusInternalServerError)
+
+			return
+		}
+		if strings.TrimPrefix(r.URL.String(), "/range/") == matchSum[:5] {
+			fmt.Fprintf(w, "%s", matchSum[5:10]+":1\n")         // invalid
+			fmt.Fprintf(w, "%s", matchSum[5:39]+":3234879\n")   // invalid
+			fmt.Fprintf(w, "%s", matchSum[5:]+":\n")            // invalid
+			fmt.Fprintf(w, "%s", matchSum[5:]+"\n")             // invalid
+			fmt.Fprintf(w, "%s:%d\n", matchSum[5:], matchCount) // valid
+
+			return
+		}
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+	defer ts.Close()
+	URL = ts.URL
+
+	// test with one entry
+	count, err := Lookup(matchSum)
+	require.NoError(t, err)
+	assert.Equal(t, matchCount, count)
+
+	// add another one
+	count, err = Lookup(sha1sum(noMatch))
+	require.NoError(t, err)
+	assert.Equal(t, uint64(0), count)
+}
+
+func sha1sum(data string) string {
+	h := sha1.New()
+	_, _ = h.Write([]byte(data))
+
+	return fmt.Sprintf("%X", h.Sum(nil))
+}

--- a/pkg/hibp/api/downloader.go
+++ b/pkg/hibp/api/downloader.go
@@ -1,0 +1,215 @@
+package api
+
+import (
+	"compress/gzip"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/cenkalti/backoff/v4"
+	"github.com/gopasspw/gopass/pkg/ctxutil"
+	"github.com/gopasspw/gopass/pkg/debug"
+	"github.com/gopasspw/gopass/pkg/fsutil"
+	"github.com/gopasspw/gopass/pkg/termio"
+)
+
+// Download will download the list of all hashes from the API to a single, gzipped txt file.
+// This is inspired by the "official" .NET based download tool. It does exactly 16⁵ / 1024*1024 (1M) requests
+// to fetch all the possible prefixes.
+func Download(ctx context.Context, path string, keep bool) error {
+	if path == "" {
+		return fmt.Errorf("need output path")
+	}
+	if fsutil.IsDir(path) {
+		path = filepath.Join(path, fmt.Sprintf("pwned-passwords-sha1-ordered-by-hash-%s.txt.gz", time.Now().Format("2006-01-02")))
+	}
+	if !strings.HasSuffix(path, ".gz") {
+		path += ".gz"
+	}
+
+	dir := filepath.Join(filepath.Dir(path), ".hibp-dl")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+
+	fmt.Printf("Downloading hashes to %s ...", dir)
+
+	maxVal := 1024 * 1024
+	bar := termio.NewProgressBar(int64(maxVal))
+	bar.Hidden = ctxutil.IsHidden(ctx)
+
+	sem := make(chan struct{}, runtime.NumCPU()*4)
+	wg := &sync.WaitGroup{}
+	for i := range maxVal {
+		wg.Add(1)
+		go func() {
+			sem <- struct{}{}
+			defer func() {
+				bar.Inc()
+				<-sem
+				wg.Done()
+			}()
+			// check for context cancelation
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
+			if err := downloadChunk(i, dir, keep); err != nil {
+				fmt.Printf("Chunk %d failed: %s", i, err)
+			}
+		}()
+	}
+	wg.Wait()
+	bar.Done()
+
+	// check for context cancelation
+	select {
+	case <-ctx.Done():
+		return fmt.Errorf("user aborted")
+	default:
+	}
+
+	fmt.Println("Download done.")
+
+	fmt.Println("Assembling chunks ...")
+
+	if err := joinChunks(dir, path, keep); err != nil {
+		return err
+	}
+
+	fmt.Printf("Chunks assembled at %s\n", path)
+
+	return nil
+}
+
+func joinChunks(dir, path string, keep bool) error {
+	dirs, err := os.ReadDir(dir)
+	if err != nil {
+		return err
+	}
+
+	fh, err := os.OpenFile(path, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o644)
+	if err != nil {
+		return err
+	}
+	defer fh.Close() //nolint:errcheck
+
+	gzw := gzip.NewWriter(fh)
+	defer gzw.Close() //nolint:errcheck
+
+	bar := termio.NewProgressBar(int64(len(dirs)))
+
+	for _, de := range dirs {
+		// XXXXX.gz
+		if len(de.Name()) != 8 {
+			continue
+		}
+		if strings.HasPrefix(de.Name(), ".") {
+			continue
+		}
+		if !strings.HasSuffix(de.Name(), ".gz") {
+			continue
+		}
+		if err := copyChunk(gzw, filepath.Join(dir, de.Name())); err != nil {
+			return err
+		}
+
+		bar.Inc()
+	}
+	bar.Done()
+
+	if keep {
+		return nil
+	}
+
+	return os.RemoveAll(dir)
+}
+
+func copyChunk(w io.Writer, fn string) error {
+	fh, err := os.Open(fn)
+	if err != nil {
+		return err
+	}
+	defer fh.Close() //nolint:errcheck
+
+	gzr, err := gzip.NewReader(fh)
+	if err != nil {
+		return err
+	}
+	defer gzr.Close() //nolint:errcheck
+
+	n, err := io.Copy(w, gzr)
+	debug.Log("Copied %d bytes from %s", n, fn)
+
+	return err
+}
+
+func downloadChunk(chunk int, dir string, keep bool) error {
+	hex := fmt.Sprintf("%X", chunk)
+	prefix := strings.Repeat("0", 5-len(hex)) + hex
+
+	fn := filepath.Join(dir, prefix+".gz")
+	if keep && fsutil.IsFile(fn) {
+		debug.Log("re-using existing file for chunk #%d: %s", chunk, fn)
+
+		return nil
+	}
+
+	fh, err := os.OpenFile(fn, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o644)
+	if err != nil {
+		return err
+	}
+	defer fh.Close() //nolint:errcheck
+
+	gzw := gzip.NewWriter(fh)
+	defer gzw.Close() //nolint:errcheck
+
+	url := URL + "/range/" + prefix
+
+	op := func() error {
+		debug.Log("HTTP Request: %s", url)
+		resp, err := http.Get(url)
+		if err != nil {
+			return err
+		}
+		defer func() {
+			_ = resp.Body.Close()
+		}()
+
+		if resp.StatusCode == http.StatusNotFound {
+			return nil
+		}
+
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return err
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			return fmt.Errorf("HTTP request failed: %s %s", resp.Status, body)
+		}
+
+		for _, line := range strings.Split(string(body), "\n") {
+			line = strings.TrimSpace(line)
+			if len(line) < 37 {
+				continue
+			}
+			fmt.Fprintf(gzw, "%s%s\n", prefix, line)
+		}
+
+		return nil
+	}
+
+	bo := backoff.NewExponentialBackOff()
+	bo.MaxElapsedTime = 10 * time.Second
+
+	return backoff.Retry(op, bo)
+}

--- a/pkg/hibp/dump/merger.go
+++ b/pkg/hibp/dump/merger.go
@@ -1,0 +1,99 @@
+package dump
+
+import (
+	"compress/gzip"
+	"context"
+	"fmt"
+	"os"
+	"strings"
+)
+
+func (s *Scanner) Merge(ctx context.Context, outfile string) error { //nolint:cyclop
+	for _, dump := range s.dumps {
+		if !isSorted(dump) {
+			return fmt.Errorf("merging unsorted input files is not supported")
+		}
+	}
+	if len(s.dumps) != 2 {
+		return fmt.Errorf("nothing to merge")
+	}
+	if !strings.HasSuffix(outfile, ".gz") {
+		outfile += ".gz"
+	}
+
+	fmt.Printf("Merging %+v into %s\n", s.dumps, outfile)
+	fh, err := os.OpenFile(outfile, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o644)
+	if err != nil {
+		return err
+	}
+	defer fh.Close() //nolint:errcheck
+
+	gzw := gzip.NewWriter(fh)
+	defer gzw.Close() //nolint:errcheck
+
+	resLeft := make(chan string, 1024)
+	resRight := make(chan string, 1024)
+	go func() {
+		s.scanSortedFile(ctx, s.dumps[0], nil, resLeft)
+		close(resLeft)
+	}()
+	go func() {
+		s.scanSortedFile(ctx, s.dumps[1], nil, resRight)
+		close(resRight)
+	}()
+
+	for {
+		lv, lok := <-resLeft
+		rv, rok := <-resRight
+		if !lok && !rok {
+			// all done
+			break
+		}
+		// left needs to catch up
+		for lv[:40] < rv[:40] || !rok {
+			fmt.Fprintln(gzw, lv)
+			lv, lok = <-resLeft
+			if !lok {
+				break
+			}
+		}
+		// right needs to catch up
+		for rv[:40] < lv[:40] || !lok {
+			fmt.Fprintln(gzw, rv)
+			rv, rok = <-resRight
+			if !rok {
+				break
+			}
+		}
+		if lv[:40] == rv[:40] {
+			maxVal := max(rv[41:], lv[41:])
+			fmt.Fprintf(gzw, "%s:%s\n", lv[:40], maxVal)
+
+			continue
+		}
+		if lok && !rok {
+			fmt.Fprintln(gzw, lv)
+
+			continue
+		}
+		if !lok && rok {
+			fmt.Fprintln(gzw, rv)
+
+			continue
+		}
+		if lv[:40] < rv[:40] {
+			fmt.Fprintln(gzw, lv)
+			fmt.Fprintln(gzw, rv)
+
+			continue
+		}
+		if lv[:40] < rv[:40] {
+			fmt.Fprintln(gzw, rv)
+			fmt.Fprintln(gzw, lv)
+
+			continue
+		}
+	}
+
+	return nil
+}

--- a/pkg/hibp/dump/scanner.go
+++ b/pkg/hibp/dump/scanner.go
@@ -1,0 +1,312 @@
+// Package dump implements an haveibeenpwned.com dump scanner. It is designed
+// to operate on HIBP SHA-1 dumps which are ordered by hash. It will work with
+// dumps ordered by prevalence, too. But processing those will take much, much
+// longer.
+//
+// The HIBP dumps are not available for download anymore. This package is kept
+// for users that still have local dumps around (possibly manually curated).
+// Consider using the "download" command and the online API instead.
+//
+// Unfortunately these dumps need to be unpacked before use. Only plain text
+// and gzip compressed dumps are supported. Use 7z to extract the dumps and
+// (re-)compress them with gzip if necessary.
+//
+// Stability: best-effort stable. It is consumed by internal/audit and by the
+// standalone gopass-hibp integration. Changes to its exported API follow the
+// policy in docs/adr/A-12-pkg-api-stability.md.
+package dump
+
+import (
+	"bufio"
+	"compress/gzip"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"runtime"
+	"sort"
+	"strings"
+
+	"github.com/gopasspw/gopass/pkg/debug"
+	"github.com/gopasspw/gopass/pkg/fsutil"
+)
+
+// Scanner is a HIBP dump scanner.
+type Scanner struct {
+	dumps []string
+}
+
+// New creates a new scanner. Provide a list of filenames to HIBP SHA-1 dumps.
+// Those should be ordered by hash or lookups will take forever.
+func New(dumps ...string) (*Scanner, error) {
+	ok := make([]string, 0, len(dumps))
+	for _, dump := range dumps {
+		if !fsutil.IsFile(dump) {
+			continue
+		}
+		ok = append(ok, dump)
+	}
+	if len(ok) < 1 {
+		return nil, fmt.Errorf("no valid dumps given")
+	}
+
+	return &Scanner{
+		dumps: ok,
+	}, nil
+}
+
+// LookupBatch takes a slice SHA1 hashes and matches them against
+// the provided dumps.
+func (s *Scanner) LookupBatch(ctx context.Context, in []string) []string {
+	if len(in) < 1 {
+		return nil
+	}
+
+	sort.Strings(in)
+	for i, hash := range in {
+		in[i] = strings.ToUpper(hash)
+	}
+
+	out := make([]string, 0, len(in))
+	results := make(chan string, len(in))
+	done := make(chan struct{}, len(s.dumps))
+
+	for _, fn := range s.dumps {
+		go s.scanFile(ctx, fn, in, results, done)
+	}
+
+	go func() {
+		for result := range results {
+			out = append(out, result)
+		}
+		done <- struct{}{}
+	}()
+
+	for range s.dumps {
+		<-done
+	}
+	close(results)
+	<-done
+
+	return out
+}
+
+func (s *Scanner) scanFile(ctx context.Context, fn string, in []string, results chan string, done chan struct{}) {
+	defer func() {
+		done <- struct{}{}
+	}()
+
+	if isSorted(fn) {
+		debug.Log("file %s appears to be sorted", fn)
+		s.scanSortedFile(ctx, fn, in, results)
+
+		return
+	}
+	debug.Log("file %s is not sorted", fn)
+	s.scanUnsortedFile(ctx, fn, in, results)
+}
+
+// open opens the given dump file for reading. gzip compressed dumps are
+// transparently decompressed.
+func open(fn string) (io.ReadCloser, error) {
+	fh, err := os.Open(fn)
+	if err != nil {
+		return nil, err
+	}
+
+	if !strings.HasSuffix(fn, ".gz") {
+		return fh, nil
+	}
+
+	gzr, err := gzip.NewReader(fh)
+	if err != nil {
+		_ = fh.Close()
+
+		return nil, err
+	}
+
+	return &readCloser{Reader: gzr, closers: []io.Closer{gzr, fh}}, nil
+}
+
+type readCloser struct {
+	io.Reader
+	closers []io.Closer
+}
+
+func (rc *readCloser) Close() error {
+	for _, c := range rc.closers {
+		_ = c.Close()
+	}
+
+	return nil
+}
+
+func isSorted(fn string) bool {
+	rdr, err := open(fn)
+	if err != nil {
+		return false
+	}
+	defer func() {
+		_ = rdr.Close()
+	}()
+
+	lineNo := 0
+	lastLine := ""
+	scanner := bufio.NewScanner(rdr)
+	for scanner.Scan() {
+		lineNo++
+		if lineNo > 100 {
+			return true
+		}
+
+		line := scanner.Text()
+		if len(line) > 40 {
+			line = line[:40]
+		}
+		if line < lastLine {
+			return false
+		}
+		lastLine = line
+	}
+
+	if scanner.Err() != nil {
+		fmt.Printf("Failed to scan file %s: %s", fn, scanner.Err())
+	}
+
+	return true
+}
+
+func (s *Scanner) scanSortedFile(ctx context.Context, fn string, in []string, results chan string) {
+	rdr, err := open(fn)
+	if err != nil {
+		fmt.Printf("Failed to open file %s: %s", fn, err)
+
+		return
+	}
+	defer func() {
+		_ = rdr.Close()
+	}()
+
+	debug.Log("Checking file %s ...\n", fn)
+
+	// index in input (sorted SHA sums)
+	i := 0
+	lineNo := 0
+	numMatches := 0
+	scanner := bufio.NewScanner(rdr)
+SCAN:
+	for scanner.Scan() {
+		// check for context cancelation
+		select {
+		case <-ctx.Done():
+			break SCAN
+		default:
+		}
+
+		lineNo++
+		if in == nil {
+			results <- strings.TrimSpace(scanner.Text())
+
+			continue
+		}
+
+		if i >= len(in) {
+			break
+		}
+
+		line := strings.TrimSpace(scanner.Text())
+		hash := line[:40]
+
+		if hash == in[i] {
+			results <- hash
+			debug.Log("[%s] MATCH at line %d: %s", fn, lineNo, hash)
+			numMatches++
+			// advance to next sha sum from store and next line in file
+			i++
+
+			continue
+		}
+		// advance in sha sums from store until we've reached the position in
+		// the file
+		for i < len(in) && line > in[i] {
+			i++
+		}
+	}
+
+	if scanner.Err() != nil {
+		fmt.Printf("Failed to scan file %s: %s", fn, scanner.Err())
+	}
+
+	debug.Log("Finished checking file %s", fn)
+}
+
+func (s *Scanner) scanUnsortedFile(ctx context.Context, fn string, in []string, results chan string) {
+	rdr, err := open(fn)
+	if err != nil {
+		fmt.Printf("Failed to open file %s: %s", fn, err)
+
+		return
+	}
+	defer func() {
+		_ = rdr.Close()
+	}()
+
+	lines := make(chan string, 1024)
+	worker := runtime.NumCPU()
+	done := make(chan struct{}, worker)
+	for i := range worker {
+		debug.Log("[%d] Starting matcher ...", i)
+		go s.matcher(ctx, in, lines, results, done)
+	}
+
+	debug.Log("Checking file %s ...\n", fn)
+	scanner := bufio.NewScanner(rdr)
+SCAN:
+	for scanner.Scan() {
+		// check for context cancelation
+		select {
+		case <-ctx.Done():
+			break SCAN
+		default:
+		}
+
+		lines <- scanner.Text()
+	}
+	close(lines)
+
+	for range worker {
+		<-done
+	}
+
+	if scanner.Err() != nil {
+		fmt.Printf("Failed to scan file %s: %s", fn, scanner.Err())
+	}
+
+	debug.Log("Finished checking file %s", fn)
+}
+
+func (s *Scanner) matcher(ctx context.Context, in []string, lines chan string, results chan string, done chan struct{}) {
+	defer func() {
+		done <- struct{}{}
+	}()
+
+LINE:
+	for line := range lines {
+		// check for context cancelation
+		select {
+		case <-ctx.Done():
+			break LINE
+		default:
+		}
+
+		line := strings.ToUpper(strings.TrimSpace(line))
+		hash := line[:40]
+		for _, candidate := range in {
+			if candidate == hash {
+				results <- hash
+
+				continue LINE
+			}
+		}
+	}
+}

--- a/pkg/hibp/dump/scanner_test.go
+++ b/pkg/hibp/dump/scanner_test.go
@@ -1,0 +1,107 @@
+package dump
+
+import (
+	"compress/gzip"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testHibpSampleSorted = `000000005AD76BD555C1D6D771DE417A4B87E4B4
+00000000A8DAE4228F821FB418F59826079BF368:42
+00000000DD7F2A1C68A35673713783CA390C9E93:42
+00000001E225B908BAC31C56DB04D892E47536E0:42
+00000008CD1806EB7B9B46A8F87690B2AC16F617:42
+0000000A0E3B9F25FF41DE4B5AC238C2D545C7A8:42
+0000000A1D4B746FAA3FD526FF6D5BC8052FDB38:42
+0000000CAEF405439D57847A8657218C618160B2:42
+0000000FC1C08E6454BED24F463EA2129E254D43:42
+00000010F4B38525354491E099EB1796278544B1`
+
+const testHibpSampleUnsorted = `000000005AD76BD555C1D6D771DE417A4B87E4B4
+00000000A8DAE4228F821FB418F59826079BF368:42
+00000008CD1806EB7B9B46A8F87690B2AC16F617:42
+0000000A0E3B9F25FF41DE4B5AC238C2D545C7A8:42
+0000000A1D4B746FAA3FD526FF6D5BC8052FDB38:42
+0000000CAEF405439D57847A8657218C618160B2:42
+0000000FC1C08E6454BED24F463EA2129E254D43:42
+00000000DD7F2A1C68A35673713783CA390C9E93:42
+00000001E225B908BAC31C56DB04D892E47536E0:42
+00000010F4B38525354491E099EB1796278544B1`
+
+func Example() { //nolint:testableexamples
+	ctx := context.Background()
+	scanner, err := New("path/to/hibp-dump")
+	if err != nil {
+		panic(err)
+	}
+	matches := scanner.LookupBatch(ctx, []string{
+		"list",
+		"of",
+		"sha1",
+		"hashes",
+	})
+	fmt.Println(matches)
+}
+
+func TestScanner(t *testing.T) {
+	t.Parallel()
+
+	td := t.TempDir()
+
+	ctx := t.Context()
+
+	// no hibp dump, no scanner
+	_, err := New()
+	require.Error(t, err)
+
+	// setup file and env (sorted)
+	fn := filepath.Join(td, "dump.txt")
+	require.NoError(t, os.WriteFile(fn, []byte(testHibpSampleSorted), 0o644))
+
+	scanner, err := New(fn)
+	require.NoError(t, err)
+	assert.Equal(t, []string{}, scanner.LookupBatch(ctx, []string{"foobar"}))
+
+	// setup file and env (unsorted)
+	fn = filepath.Join(td, "dump.txt")
+	require.NoError(t, os.WriteFile(fn, []byte(testHibpSampleUnsorted), 0o644))
+
+	scanner, err = New(fn)
+	require.NoError(t, err)
+	assert.Equal(t, []string{}, scanner.LookupBatch(ctx, []string{"foobar"}))
+	assert.Equal(t, []string(nil), scanner.LookupBatch(ctx, []string{}))
+
+	// gzip
+	fn = filepath.Join(td, "dump.txt.gz")
+	require.NoError(t, testWriteGZ(fn, []byte(testHibpSampleSorted)))
+
+	scanner, err = New(fn)
+	require.NoError(t, err)
+	assert.Equal(t, []string{}, scanner.LookupBatch(ctx, []string{"foobar"}))
+}
+
+func testWriteGZ(fn string, buf []byte) error {
+	fh, err := os.OpenFile(fn, os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		_ = fh.Close()
+	}()
+
+	gzw := gzip.NewWriter(fh)
+	defer func() {
+		_ = gzw.Close()
+	}()
+
+	_, err = gzw.Write(buf)
+
+	return err
+}


### PR DESCRIPTION
gopass required gopass-hibp while gopass-hibp required gopass, forming a
module-level dependency cycle that made releases circular and tooling
noisy.

Move the HIBP client packages into this module as pkg/hibp/{api,dump}.
They move verbatim because their only gopass dependencies (pkg/debug,
pkg/fsutil, pkg/ctxutil, pkg/termio) live in the same module now.
internal/audit imports them locally and the gopass-hibp module
requirement is no longer needed.

The standalone gopass-hibp binary stays in its own repository and will
be repointed at gopass/pkg/hibp in a follow-up.