### PR TITLE
feat(secret-service): add Linux Secret Service daemon (#3434)

### DIFF
--- a/contrib/secret-service/gopass-secret-service.service
+++ b/contrib/secret-service/gopass-secret-service.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=gopass Secret Service D-Bus daemon
+Documentation=https://github.com/gopasspw/gopass/blob/master/docs/commands/secret-service.md
+After=graphical-session.target
+PartOf=graphical-session.target
+
+[Service]
+Type=dbus
+BusName=org.freedesktop.secrets
+ExecStart=@GOPASS@ secret-service serve
+Restart=on-failure
+
+[Install]
+WantedBy=graphical-session.target

--- a/contrib/secret-service/org.freedesktop.secrets.service
+++ b/contrib/secret-service/org.freedesktop.secrets.service
@@ -1,0 +1,3 @@
+[D-BUS Service]
+Name=org.freedesktop.secrets
+Exec=@GOPASS@ secret-service serve

--- a/docs/adr/A-11-secret-service.md
+++ b/docs/adr/A-11-secret-service.md
@@ -1,6 +1,6 @@
 # A-11: Integrate `org.freedesktop.secrets` D-Bus Service
 
-**Status:** proposed  
+**Status:** implemented
 **Source:** [GitHub Issue #3434](https://github.com/gopasspw/gopass/issues/3434)
 
 ---
@@ -25,12 +25,17 @@ Two reference implementations inform the design:
 
 | Project | Language | License | Notes |
 |---------|----------|---------|-------|
-| [nikicat/gopass-secret-service](https://github.com/nikicat/gopass-secret-service) | Go (90 %) | MIT | Standalone daemon that invokes `gopass` CLI. **Most relevant.** |
+| [nikicat/gopass-secret-service](https://github.com/nikicat/gopass-secret-service) | Go (91 %) | MIT | Standalone daemon built on the gopass Go API. **Most relevant.** |
 | [grimsteel/pass-secret-service](https://github.com/grimsteel/pass-secret-service) | Rust | GPL-3.0 | Standalone daemon for `pass`. Pure-Rust D-Bus. |
 
-`nikicat/gopass-secret-service` implements the full spec in Go and re-uses `gopass` via its CLI.
-The key difference for this ADR is that the integrated version will use the **gopass Go API**
-(`github.com/gopasspw/gopass/pkg/gopass/api`) directly rather than shelling out.
+`nikicat/gopass-secret-service` implements the full spec in Go and consumes the **gopass Go API**
+(`github.com/gopasspw/gopass/pkg/gopass/api`) directly — it does **not** shell out to the `gopass`
+CLI. It additionally routes the spec's volatile `session` collection to an in-kernel keyring and
+caches item metadata so that `SearchItems` does not decrypt the whole store on every lookup. Both
+lessons are folded into the design below. Since the integrated version re-uses the same API, the
+practical difference is **packaging** — a subcommand of the existing `gopass` binary versus a
+separate daemon binary — not the storage access path. Users who prefer the standalone daemon remain
+free to run it.
 
 ---
 
@@ -41,23 +46,100 @@ Implement `gopass secret-service` as:
 1. A new **Linux-only** subcommand of the main `gopass` binary.
 2. A long-running **daemon** that acquires `org.freedesktop.secrets` on the D-Bus session bus and
    serves the full Secret Service interface.
-3. Uses `github.com/godbus/dbus/v5` (already in `go.mod` at v5.1.0, pure Go, BSD-2 licensed).
-4. All crypto uses stdlib `crypto/...` packages — no CGo, no new external dependencies.
+3. Uses `github.com/godbus/dbus/v5` (already a direct dependency in `go.mod` at v5.2.2, pure Go,
+   BSD-2 licensed).
+4. Crypto uses the standard library (`crypto/aes`, `crypto/cipher`, `crypto/rand`, `crypto/sha256`,
+   `math/big`) plus `golang.org/x/crypto/hkdf` (already a direct dependency at v0.55.0) for the DH
+   key schedule — no CGo, no new external dependencies.
 5. Secrets are stored under a configurable gopass path prefix (default: `secret-service`).
+6. The spec's volatile `session` collection is served from memory (backed by the Linux kernel
+   keyring) and is never written to the store.
+7. Item metadata is cached in memory and invalidated on every local write, so `SearchItems` does
+   not trigger one GPG decryption per item per lookup.
 
 ---
 
 ## Feasibility Summary
 
-* **Pure-Go, zero-CGo**: `godbus/dbus/v5` is already a direct dependency; all required crypto
-  (`crypto/aes`, `crypto/sha256`, `math/big` for DH) is in the stdlib.
-* **No new external dependencies**: Only stdlib + existing `godbus` dependency needed.
-* **License-compatible**: `godbus/dbus/v5` is BSD-2 (≡ MIT compatible per `.license-lint.yml`).
+* **Pure-Go, zero-CGo**: `godbus/dbus/v5` (v5.2.2) is already a direct dependency. Crypto uses
+  `crypto/aes`, `crypto/cipher`, `crypto/rand`, `crypto/sha256` and `math/big` from the standard
+  library, plus `golang.org/x/crypto/hkdf` (v0.55.0, already a direct dependency) for the DH key
+  schedule.
+* **No new external dependencies**: only the standard library plus the existing `godbus/dbus/v5`,
+  `golang.org/x/crypto` and `golang.org/x/sys` dependencies are needed. (`golang.org/x/sys` serves
+  the kernel-keyring backing store for the `session` collection.) Item IDs are generated with
+  `crypto/rand`, so no UUID dependency is pulled in.
+* **License-compatible**: `godbus/dbus/v5` is BSD-2, `golang.org/x/*` is BSD-3 — both MIT
+  compatible per `.license-lint.yml`.
 * **Linux-only build tag**: The entire feature is gated with `//go:build linux` (same pattern as
   `internal/notify/notify_dbus.go` and `pkg/clipboard/unclip_linux.go`).
 * **Architectural risk**: gopass is a short-lived CLI tool; this feature requires a persistent
   daemon process. This is handled by a blocking `gopass secret-service serve` subcommand (the user
   manages the lifecycle via systemd or similar).
+
+---
+
+## Implementation Status
+
+The feature is implemented in `internal/secretservice` (all files carry a
+`//go:build linux` constraint):
+
+| Area | Status |
+|------|--------|
+| Pure-Go crypto sessions (`plain`, `dh-ietf1024-…`) | implemented, unit-tested (`internal/secretservice/crypto`) |
+| D-Bus service, collections, items, sessions, aliases, search | implemented |
+| Item metadata cache for `SearchItems` | implemented |
+| CLI `gopass secret-service serve` / `status` / `install` / `uninstall` + non-Linux stub | implemented |
+| Volatile `session` collection (kernel keyring) | implemented |
+| Alias object paths (`/org/freedesktop/secrets/aliases/*`) | implemented |
+| `CreateItem(replace=true)` | implemented |
+| Item `Locked` property and signal coverage | implemented |
+| Prompt objects | not needed — every operation completes immediately with `"/"` |
+| systemd user unit / D-Bus activation `install` | implemented (`contrib/secret-service/`) |
+| Integration tests against a real bus / libsecret client | implemented (`tests/secret_service_test.go`, `tests/secret_service_dh_test.go`, `tests/secret_service_libsecret_test.go`) |
+
+Verification: `TestSecretServiceSecretTool` drives the daemon with `secret-tool`
+(a real libsecret client, which selects the DH transport) and round-trips a
+secret in both directions; `TestSecretServiceRoundTrip` and
+`TestSecretServiceDHRoundTrip` cover both transport algorithms against a private
+`dbus-daemon`; `TestSecretServiceSessionCollection` asserts that session secrets
+never reach the store.
+
+### Alias object paths
+
+libsecret does **not** call `ReadAlias` to resolve a collection alias. It derives
+`/org/freedesktop/secrets/aliases/<alias>` locally and then calls `CreateItem`
+and friends on that path directly. The service therefore exports a `Collection`
+object at every alias path in addition to the canonical
+`/org/freedesktop/secrets/collection/<name>` path, and emits
+`ItemCreated`/`ItemChanged`/`ItemDeleted` from all of them. Without this,
+`secret-tool store` fails with `UnknownInterface: Object does not implement the
+interface 'org.freedesktop.Secret.Collection'`.
+
+### Item IDs and D-Bus object paths
+
+A D-Bus object path element must match `[A-Za-z0-9_]`. Items generated by the
+service (`i` + lowercase hex) are safe, but an item may also be created out of
+band by the gopass CLI (e.g. `gopass insert secret-service/default/cli-inserted`),
+producing a name with hyphens that cannot be used as a path element. Such names
+are hex-encoded with an `x` prefix (`ItemDBusID`), and the mapping is reversed
+exactly by `ItemNameFromDBusID`. Names that are already safe and do not start
+with `x` are used verbatim, so generated IDs keep their historic layout and the
+two encodings can never collide. Collection names that are not path-safe are
+skipped when listing (`isPathSafe`).
+
+Item properties, sessions, aliases and the volatile `session` collection are all
+implemented. The remaining known limitations are:
+
+1. **Prompt objects.** Every operation completes immediately, so all methods
+   return the null prompt path (`"/"`). No `Prompt` objects are exported.
+2. **Lock state is in-memory only.** Locking does not evict the passphrase
+   cached by `gpg-agent`.
+3. **Metadata cache invalidation is local.** Changes made by another gopass
+   process require a daemon restart to be reflected in item metadata.
+4. **No `install --gnome-keyring` automation.** The `install` subcommand writes
+   the unit and activation files but does not disable GNOME Keyring; the user
+   must do that manually (see the command documentation).
 
 ---
 
@@ -85,11 +167,22 @@ Secrets are stored under a configurable prefix (`secret-service` by default):
     ├── _aliases.age          # Map of alias → collection name (JSON)
     ├── default/
     │   ├── _meta.age         # Collection metadata (label, created, modified)
-    │   └── i<uuid>.age       # Secret items
+    │   └── i<hex>.age        # Secret items
     └── work/
         ├── _meta.age
-        └── i<uuid>.age
+        └── i<hex>.age
 ```
+
+Item IDs are random values rendered as `i` followed by lowercase hex (`fmt.Sprintf("i%x", …)`),
+**not** hyphenated UUIDs. A D-Bus object path element must match `[A-Za-z0-9_]` and may not contain
+hyphens, and the item ID becomes the last element of the item's object path
+(`/org/freedesktop/secrets/collection/{name}/{id}`). The reference implementation made the same
+choice.
+
+Items with names created out of band by the CLI (for example
+`gopass insert secret-service/default/cli-inserted`) contain characters that are
+not valid in an object path element. Those names are hex-encoded with an `x`
+prefix; see [Item IDs and D-Bus object paths](#item-ids-and-d-bus-object-paths).
 
 Each item secret file uses the standard gopass multi-line format:
 
@@ -110,6 +203,35 @@ other key/value pairs are user-visible item attributes (used for lookup by
 
 ---
 
+## The `session` collection
+
+The spec reserves a well-known collection alias, `session`
+(`SECRET_COLLECTION_SESSION`), for secrets that must live only for the duration of the login
+session and never be persisted. Clients use it for transient credentials.
+
+With a gopass backend this matters more than usual: if transient secrets fell through to the
+persistent store, every one of them would become a GPG-encrypted file **and a git commit** — the
+opposite of what the client asked for. The `session` collection is therefore **not** mapped to a
+gopass subpath. It is served from a volatile, in-process store backed by the Linux kernel keyring
+(the daemon's process keyring), so payloads stay in kernel memory and vanish when the daemon exits.
+
+> **Status:** implemented in `internal/secretservice/volatile.go`. If the
+> `keyctl` syscalls are unavailable (for example in a sandbox that blocks them),
+> the daemon logs a debug message and falls back to an in-memory store.
+
+Consequences for the implementation:
+
+* `ReadAlias("session")` returns the well-known session collection path. The session collection is
+  always present and does not appear in `Service.Collections`.
+* No `CollectionCreated` / `CollectionDeleted` signals are emitted for it, and it cannot be deleted.
+* The kernel-keyring backing store must run on a single dedicated, `runtime.LockOSThread`-pinned OS
+  thread: Linux stores the process/session/thread keyring references in the per-task `struct cred`,
+  so keyring syscalls must not migrate between threads. The syscalls come from
+  `golang.org/x/sys/unix` (already a dependency) — still no CGo.
+* On non-Linux platforms the whole feature is compiled out; there is no fallback keyring.
+
+---
+
 ## Crypto Sessions
 
 The spec defines two `OpenSession` algorithms:
@@ -117,20 +239,25 @@ The spec defines two `OpenSession` algorithms:
 | Algorithm | Description | Implementation |
 |-----------|-------------|----------------|
 | `plain` | No transport encryption | Return empty bytes; secret value passed as-is |
-| `dh-ietf1024-sha256-aes128-cbc-pkcs7` | DH key exchange + AES-128-CBC | stdlib `crypto/aes`, `crypto/sha256`, `math/big` |
+| `dh-ietf1024-sha256-aes128-cbc-pkcs7` | DH key exchange + AES-128-CBC | stdlib `crypto/aes`, `crypto/sha256`, `math/big` + `golang.org/x/crypto/hkdf` |
 
 The `plain` algorithm is secure because D-Bus session bus traffic is carried over a local UNIX
 socket with kernel-enforced access control. Implementing `dh-ietf1024-sha256-aes128-cbc-pkcs7` is
 required for compatibility with `libsecret`-based applications.
 
-DH parameters: [RFC 3526](https://www.rfc-editor.org/rfc/rfc3526) 1024-bit MODP group 2.
+DH parameters: [RFC 3526](https://www.rfc-editor.org/rfc/rfc3526) 1024-bit MODP group 2
+(the reference implementation uses the RFC 2409 group 2 prime; the two are identical).
 The server:
 1. Generates a DH ephemeral key pair on the MODP-1024 group.
 2. Receives the client's public key in `OpenSession`.
 3. Computes `shared = clientPub^serverPriv mod p`.
 4. Left-pads `shared` to 128 bytes (a known pitfall — see grimsteel commit c781717).
-5. Derives AES key: `aes_key = SHA256(shared)[0:16]`.
-6. Each secret returned has its own random 16-byte IV prepended to the ciphertext.
+5. Derives the AES key with **HKDF-SHA256** over the padded shared secret, using a NULL salt and
+   empty info, and takes the first 16 bytes: `hkdf.New(sha256.New, padded, nil, nil)`. This is
+   *not* a bare `SHA256(shared)[0:16]`; libsecret clients derive the same key the same way and
+   would reject a non-HKDF key.
+6. Returns the server's public key, itself left-padded to 128 bytes.
+7. Each secret returned has its own random 16-byte IV prepended to the ciphertext.
 
 ---
 
@@ -141,27 +268,29 @@ via a new `secretservice_linux.go` action handler shim.
 
 ```
 internal/secretservice/
-├── doc.go                    # Package doc
+├── doc.go                    # Package doc + interface names, Secret struct
 ├── service.go                # org.freedesktop.Secret.Service implementation
 ├── collection.go             # org.freedesktop.Secret.Collection implementation
 ├── item.go                   # org.freedesktop.Secret.Item implementation
 ├── session.go                # Session lifecycle + crypto dispatch
-├── prompt.go                 # Prompt objects (required by spec for async ops)
+├── store.go                  # Adapter between Secret Service and gopass API
+├── volatile.go               # Volatile `session` collection (kernel keyring)
+├── units.go                  # systemd unit / D-Bus activation install helpers
+├── paths.go                  # Object path <-> store path mapping, ID encoding
+├── introspection.go          # Static introspection XML
+├── errors.go                 # D-Bus error definitions (org.freedesktop.Secret.Error.*)
 ├── crypto/
 │   ├── crypto.go             # Session interface + factory
 │   ├── plain.go              # "plain" algorithm
 │   └── dh.go                 # "dh-ietf1024-sha256-aes128-cbc-pkcs7"
-├── store.go                  # Adapter between Secret Service and gopass API
-├── errors.go                 # D-Bus error definitions (org.freedesktop.DBus.Error.*)
-├── types.go                  # D-Bus type aliases (Secret struct, path constants)
-└── service_test.go           # Unit tests (mock D-Bus + mock gopass API)
+└── *_test.go                 # Unit tests (in-memory gopass.Store, no GPG needed)
 ```
 
 CLI integration:
 
 ```
 internal/action/
-├── secretservice_linux.go    # SecretService() handler, registers via GetCommands()
+├── secretservice_linux.go    # secret-service command tree (serve/status/install/uninstall)
 └── secretservice_other.go    # Stub for non-Linux platforms that prints "linux only"
 ```
 
@@ -169,7 +298,7 @@ Systemd / D-Bus activation files (installed by `gopass secret-service install`):
 
 ```
 contrib/secret-service/
-├── org.freedesktop.secrets.service   # D-Bus session activation (ExecStart=gopass secret-service serve)
+├── org.freedesktop.secrets.service   # D-Bus session activation (Exec=gopass secret-service serve)
 └── gopass-secret-service.service     # systemd user unit
 ```
 
@@ -177,9 +306,9 @@ contrib/secret-service/
 
 ## Implementation Phases
 
-This feature is too large for a single prompt. Each phase below is self-contained and can be
-implemented and tested independently. Phases must be implemented in order because each phase
-depends on the previous.
+The phases below were the implementation plan; all of them are now implemented
+(see [Implementation Status](#implementation-status)). They are retained as a
+description of how each part of the spec maps onto the code.
 
 ---
 
@@ -293,6 +422,8 @@ import (
     "crypto/rand"
     "crypto/sha256"
     "math/big"
+
+    "golang.org/x/crypto/hkdf"
 )
 
 // RFC 3526 MODP 1024-bit group 2
@@ -311,7 +442,8 @@ func NewDHSession(clientPubBytes []byte) (*dhSession, []byte, error) {
     // 2. Compute serverPub = g^serverPriv mod p
     // 3. Compute shared = clientPub^serverPriv mod p
     // 4. Left-pad shared to 128 bytes (IMPORTANT: see grimsteel/pass-secret-service#24)
-    // 5. aesKey = SHA256(paddedShared)[0:16]
+    // 5. aesKey = HKDF-SHA256(paddedShared, salt=nil, info=nil)[0:16]
+    // 6. Return serverPub left-padded to 128 bytes
     ...
 }
 
@@ -531,9 +663,21 @@ Rules:
 **Store item search**:
 ```go
 // SearchItems(attrs map[string]string) ([]dbus.ObjectPath, error)
-// Lists all items in a collection, loads each item's attributes, filters by attrs.
-// This is O(n) — acceptable given typical collection sizes.
+// Lists all items in a collection and filters them by attrs.
 ```
+
+A naive implementation loads (and therefore **decrypts**) every item's attributes for each search.
+With a GPG backend that is one decryption per item per lookup, and libsecret clients issue
+`SearchItems` for nearly every operation; with a cold `gpg-agent` cache a single lookup can even
+trigger pinentry. The design therefore keeps an **in-memory metadata cache** keyed by gopass path:
+
+* The cache holds only decrypted *metadata* (label, timestamps, content type and user attributes) —
+  never the secret payload (`Password()` / `Body()`).
+* It is populated lazily on the first read of an item and refreshed opportunistically whenever an
+  item is decrypted for another reason.
+* It is invalidated on every local mutation (create/update/delete, and prefix-wide when a whole
+  collection is removed). There is no TTL; out-of-process changes require a daemon restart.
+* The secret value itself is still re-decrypted on demand in `GetSecret` and never cached.
 
 **Locking**: In this implementation lock state is **in-memory only**.
 When a collection is "locked", `GetSecret` returns `ErrIsLocked`.
@@ -754,7 +898,7 @@ The `install` subcommand should offer to do this automatically.
 // Starts the service on a private D-Bus connection (dbus.SessionBusPrivate).
 // Uses secret-tool (if available) or direct godbus calls to store/retrieve secrets.
 // Verifies:
-// - secret created via D-Bus appears in gopass (gopass show secret-service/default/i<uuid>)
+// - secret created via D-Bus appears in gopass (gopass show secret-service/default/i<hex>)
 // - secret created via gopass insert is visible via D-Bus GetSecret
 // - attributes are searched correctly by SearchItems
 ```
@@ -776,10 +920,12 @@ The `install` subcommand should offer to do this automatically.
 
 The following are common pitfalls to avoid:
 
-1. **DH shared-secret left-padding**: `shared = clientPub^serverPriv mod p` may produce a
-   `big.Int` whose byte representation is shorter than 128 bytes. It must be left-padded with
-   zero bytes to exactly 128 bytes before SHA256. Failing to do this breaks compatibility with
-   libsecret clients. See commit c781717 in grimsteel/pass-secret-service.
+1. **DH shared-secret left-padding and HKDF**: `shared = clientPub^serverPriv mod p` may produce a
+   `big.Int` whose byte representation is shorter than 128 bytes. It must be left-padded with zero
+   bytes to exactly 128 bytes before key derivation. The AES key is then
+   `HKDF-SHA256(padded, salt=nil, info=nil)[0:16]`, not a bare `SHA256(padded)[0:16]`. The server's
+   public key must likewise be left-padded to 128 bytes. Failing to do either breaks compatibility
+   with libsecret clients. See commit c781717 in grimsteel/pass-secret-service.
 
 2. **godbus export pattern**: To export a Go struct as a D-Bus object, use
    `conn.Export(obj, path, iface)`. The exported methods must have the exact signature
@@ -823,6 +969,9 @@ The following are common pitfalls to avoid:
 - [nikicat/gopass-secret-service](https://github.com/nikicat/gopass-secret-service) — Go reference impl (MIT)
 - [grimsteel/pass-secret-service](https://github.com/grimsteel/pass-secret-service) — Rust reference impl (GPL-3.0, for reference only, not to be copied)
 - [RFC 3526 — MODP DH groups](https://www.rfc-editor.org/rfc/rfc3526) — 1024-bit group 2
+- [RFC 5869 — HKDF](https://www.rfc-editor.org/rfc/rfc5869) — key derivation for `dh-ietf1024-…`
+- [golang.org/x/crypto/hkdf](https://pkg.go.dev/golang.org/x/crypto/hkdf) — HKDF implementation
+- [keyctl(2)](https://man7.org/linux/man-pages/man2/keyctl.2.html) — kernel keyring for the `session` collection
 - [pkg/gopass/api/api.go](../../pkg/gopass/api/api.go) — gopass public API
 - [internal/notify/notify_dbus.go](../../internal/notify/notify_dbus.go) — existing godbus usage pattern
 - [pkg/clipboard/unclip_linux.go](../../pkg/clipboard/unclip_linux.go) — existing Linux-only D-Bus pattern

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -22,7 +22,7 @@ Update this index in the same commit that adds or supersedes a record.
 | [A-08](A-08-shred-modern-storage-limitations.md) | Shred operation is ineffective on modern storage | accepted | 2026-04-06 |
 | [A-09](A-09-low-severity-informational-findings.md) | Low severity and informational findings | accepted | 2026-04-06 |
 | [A-10](A-10-code-quality-findings.md) | Code quality findings | open | 2026-04-06 |
-| [A-11](A-11-secret-service.md) | Integrate `org.freedesktop.secrets` D-Bus service | proposed | 2026-05-24 |
+| [A-11](A-11-secret-service.md) | Integrate `org.freedesktop.secrets` D-Bus service | implemented | 2026-05-24 |
 | [A-12](A-12-pkg-api-stability.md) | `pkg/gopass` API stability contract | accepted | 2026-05-24 |
 | [A-13](A-13-expired-gpg-key-handling.md) | Expired GPG key handling and recipient validity warnings | partially implemented | 2026-05-25 |
 | [A-14](A-14-team-workflows.md) | Effortless team workflows | implemented | 2026-06-06 |

--- a/docs/commands/secret-service.md
+++ b/docs/commands/secret-service.md
@@ -1,0 +1,100 @@
+# `secret-service` command
+
+**Linux only.** The `secret-service` command runs a daemon that implements the
+[freedesktop.org Secret Service API](https://specifications.freedesktop.org/secret-service/latest/)
+(`org.freedesktop.secrets`) on top of your gopass store. Desktop applications
+that speak this API — Firefox, Chromium, VS Code, Electron apps,
+NetworkManager, `secret-tool`, … — then store their secrets in the same
+GPG-encrypted, git-backed store as the gopass CLI, instead of GNOME Keyring or
+KDE Wallet.
+
+This is a pure-Go implementation; no CGo and no extra runtime dependencies are
+required. See [ADR A-11](../adr/A-11-secret-service.md) for the design and its
+current limitations.
+
+## Usage
+
+```
+gopass secret-service serve [--replace] [--prefix=secret-service] [--notify-on-access]
+gopass secret-service status
+gopass secret-service install
+gopass secret-service uninstall
+```
+
+### `serve`
+
+Starts the daemon and blocks until interrupted (e.g. by `Ctrl+C`).
+
+| Flag                 | Description                                                              |
+|----------------------|--------------------------------------------------------------------------|
+| `--replace`          | Replace any existing `org.freedesktop.secrets` provider (e.g. GNOME Keyring). |
+| `--prefix`           | gopass path prefix under which secrets are stored. Default `secret-service`. |
+| `--notify-on-access` | Send a desktop notification whenever a secret is read.                    |
+
+Secrets are stored below the configured prefix, for example:
+
+```
+~/.password-store/
+└── secret-service/
+    ├── _aliases.gpg      # alias -> collection map
+    └── default/
+        ├── _meta.gpg     # collection metadata
+        └── i<hex>.gpg    # secret items
+```
+
+Because the items live in gopass, they can be inspected and managed with the
+regular commands, e.g. `gopass show secret-service/default/i<hex>`.
+
+The spec's volatile `session` collection is *not* stored in the password store.
+It is served from memory (backed by the Linux kernel keyring) and disappears
+with the daemon, so transient credentials never become GPG files or git commits.
+
+### `status`
+
+Reports whether some process currently owns the `org.freedesktop.secrets` bus
+name.
+
+### `install` / `uninstall`
+
+`install` writes a systemd user unit and a D-Bus session activation file for the
+current user:
+
+* `~/.config/systemd/user/gopass-secret-service.service`
+* `~/.local/share/dbus-1/services/org.freedesktop.secrets.service`
+
+(the XDG base directories are honored). Afterwards run:
+
+```sh
+systemctl --user daemon-reload
+systemctl --user enable --now gopass-secret-service
+```
+
+`uninstall` removes both files again.
+
+## Replacing GNOME Keyring
+
+Many desktop environments start GNOME Keyring, which grabs
+`org.freedesktop.secrets` at login. To use gopass instead, either start the
+daemon with `--replace`, or disable GNOME Keyring's secret service component:
+
+```sh
+cp /etc/xdg/autostart/gnome-keyring-secrets.desktop ~/.config/autostart/
+echo "Hidden=true" >> ~/.config/autostart/gnome-keyring-secrets.desktop
+```
+
+## Known issues
+
+* **Startup may hang when `gpg-agent` uses `pinentry-gnome3`.** If pinentry
+  consults libsecret for a cached passphrase while the daemon is still starting,
+  the two can deadlock. Add `no-allow-external-cache` to `~/.gnupg/gpg-agent.conf`
+  and run `gpgconf --kill gpg-agent`, or use a pinentry that does not use
+  libsecret.
+* **Lock state is in-memory only.** Locking a collection makes `GetSecret`
+  return `IsLocked`, but it does not evict the passphrase cached by `gpg-agent`.
+* **Out-of-process changes need a restart.** Item metadata is cached in memory
+  to avoid decrypting the store on every lookup. Secrets added or changed by the
+  gopass CLI while the daemon runs are still listed (the store listing is not
+  cached), but their metadata is only re-read after the daemon rewrites or
+  forgets the item.
+* **Linux only.** The `install`/`uninstall`/`serve` subcommands exist on other
+  platforms but fail with a clear message.

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -76,7 +76,7 @@ The scope is optional. Prefer to supply one. Do not invent scopes; omit the
 scope when none fits. Omit the scope for a change spanning several areas rather
 than listing more than one.
 
-**Commands** — the 41 top-level subcommands: 39 registered by
+**Commands** — the 42 top-level subcommands: 40 registered by
 `(*Action).GetCommands` in `internal/action/commands.go`, plus `pwgen` from
 `internal/action/pwgen` and `completion`, both added by `getCommands` in
 `main.go`:
@@ -84,8 +84,8 @@ than listing more than one.
 ```
 alias audit cat clone completion config convert copy create delete doctor edit
 env find fsck fscopy fsmove generate grep history init insert link list merge
-mounts move otp process pwgen rcs recipients reorg setup show sum sync
-templates unclip update version
+mounts move otp process pwgen rcs recipients reorg secret-service setup show sum
+sync templates unclip update version
 ```
 
 **Backends:** `age`, `gpg`, `plain`, `cryptfs`, `fossilfs`, `fs`, `gitfs`, `jjfs`

--- a/internal/action/commands.go
+++ b/internal/action/commands.go
@@ -1353,6 +1353,10 @@ func (s *Action) GetCommands() []*cli.Command {
 		},
 	}
 
+	// secret-service is Linux-only; non-Linux builds get a stub command that
+	// fails with a clear message.
+	cmds = append(cmds, s.secretServiceCommand())
+
 	// crypto and storage backends can add their own commands if they need to
 	for _, be := range backend.CryptoRegistry.Backends() {
 		bc, ok := be.(commander)

--- a/internal/action/secretservice_linux.go
+++ b/internal/action/secretservice_linux.go
@@ -1,0 +1,176 @@
+//go:build linux
+
+package action
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/godbus/dbus/v5"
+	"github.com/gopasspw/gopass/internal/out"
+	"github.com/gopasspw/gopass/internal/secretservice"
+	"github.com/urfave/cli/v3"
+)
+
+// secretServiceCommand returns the `gopass secret-service` command. It is
+// Linux-only because it speaks the freedesktop.org D-Bus Secret Service API.
+func (s *Action) secretServiceCommand() *cli.Command {
+	return &cli.Command{
+		Name:  "secret-service",
+		Usage: "Run a D-Bus Secret Service daemon backed by gopass",
+		Description: "" +
+			"Implements the org.freedesktop.secrets D-Bus API so that desktop " +
+			"applications (Firefox, Chromium, VS Code, Electron apps, " +
+			"NetworkManager, secret-tool, ...) store their secrets in the same " +
+			"gopass password store as the CLI.",
+		Commands: []*cli.Command{
+			{
+				Name:  "serve",
+				Usage: "Start the Secret Service daemon (blocks until interrupted)",
+				Description: "" +
+					"Connects to the D-Bus session bus, acquires the well-known name " +
+					"org.freedesktop.secrets and serves the Secret Service API until " +
+					"the process is interrupted (e.g. with Ctrl+C). Secrets are " +
+					"stored in the gopass store below --prefix; the volatile session " +
+					"collection is kept in memory only.",
+				Flags: []cli.Flag{
+					&cli.BoolFlag{
+						Name:  "replace",
+						Usage: "Replace any existing Secret Service provider (e.g. GNOME Keyring)",
+					},
+					&cli.StringFlag{
+						Name:  "prefix",
+						Value: "secret-service",
+						Usage: "gopass path prefix under which secrets are stored",
+					},
+					&cli.BoolFlag{
+						Name:  "notify-on-access",
+						Usage: "Send a desktop notification whenever a secret is read",
+					},
+				},
+				Action: s.SecretServiceServe,
+			},
+			{
+				Name:  "status",
+				Usage: "Check whether a Secret Service provider is running",
+				Description: "" +
+					"Queries the D-Bus session bus for the owner of " +
+					"org.freedesktop.secrets. It reports whether any provider " +
+					"(gopass or another one such as GNOME Keyring) currently serves " +
+					"the Secret Service API.",
+				Action: s.SecretServiceStatus,
+			},
+			{
+				Name:  "install",
+				Usage: "Install the systemd user unit and D-Bus session activation file",
+				Description: "" +
+					"Writes a systemd user unit (gopass-secret-service.service) and a " +
+					"D-Bus session activation file (org.freedesktop.secrets.service). " +
+					"Run `systemctl --user daemon-reload` and then " +
+					"`systemctl --user enable --now gopass-secret-service` afterwards.",
+				Action: s.SecretServiceInstall,
+			},
+			{
+				Name:  "uninstall",
+				Usage: "Remove the systemd user unit and D-Bus session activation file",
+				Description: "" +
+					"Removes the systemd user unit and the D-Bus session activation " +
+					"file written by `gopass secret-service install`. Missing files " +
+					"are ignored, so the command is safe to run repeatedly.",
+				Action: s.SecretServiceUninstall,
+			},
+		},
+	}
+}
+
+// SecretServiceServe runs the Secret Service daemon.
+func (*Action) SecretServiceServe(ctx context.Context, cmd *cli.Command) error {
+	svc, err := secretservice.New(ctx, secretservice.Config{
+		Prefix:         cmd.String("prefix"),
+		Replace:        cmd.Bool("replace"),
+		NotifyOnAccess: cmd.Bool("notify-on-access"),
+	})
+	if err != nil {
+		return err
+	}
+
+	out.Printf(ctx, "Starting gopass secret-service on org.freedesktop.secrets")
+	out.Printf(ctx, "Press Ctrl+C to stop.")
+
+	return svc.Serve(ctx)
+}
+
+// SecretServiceStatus reports whether a Secret Service provider currently owns
+// the well-known bus name.
+func (*Action) SecretServiceStatus(ctx context.Context, _ *cli.Command) error {
+	conn, err := dbus.SessionBus()
+	if err != nil {
+		return fmt.Errorf("failed to connect to the session bus: %w", err)
+	}
+
+	var hasOwner bool
+	if err := conn.BusObject().Call("org.freedesktop.DBus.NameHasOwner", 0, secretservice.ServiceName).Store(&hasOwner); err != nil {
+		return fmt.Errorf("failed to query the bus: %w", err)
+	}
+
+	if hasOwner {
+		out.Printf(ctx, "%s is owned (a Secret Service provider is running)", secretservice.ServiceName)
+
+		return nil
+	}
+
+	out.Printf(ctx, "no provider owns %s", secretservice.ServiceName)
+
+	return nil
+}
+
+// SecretServiceInstall writes the systemd user unit and the D-Bus session
+// activation file for the current user.
+func (*Action) SecretServiceInstall(ctx context.Context, _ *cli.Command) error {
+	paths := secretservice.DefaultInstallPaths()
+
+	written, err := secretservice.Install(paths, "")
+	if err != nil {
+		return err
+	}
+
+	for _, p := range written {
+		out.Printf(ctx, "Installed %s", p)
+	}
+
+	out.Printf(ctx, "")
+	out.Printf(ctx, "To start the daemon now, run:")
+	out.Printf(ctx, "  systemctl --user daemon-reload")
+	out.Printf(ctx, "  systemctl --user enable --now gopass-secret-service")
+	out.Printf(ctx, "")
+	out.Printf(ctx, "If another provider (e.g. GNOME Keyring) owns %s, start the", secretservice.ServiceName)
+	out.Printf(ctx, "daemon with `gopass secret-service serve --replace` or disable that provider.")
+
+	return nil
+}
+
+// SecretServiceUninstall removes the systemd user unit and the D-Bus session
+// activation file.
+func (*Action) SecretServiceUninstall(ctx context.Context, _ *cli.Command) error {
+	paths := secretservice.DefaultInstallPaths()
+
+	removed, err := secretservice.Uninstall(paths)
+	if err != nil {
+		return err
+	}
+
+	if len(removed) == 0 {
+		out.Printf(ctx, "Nothing to remove.")
+
+		return nil
+	}
+
+	for _, p := range removed {
+		out.Printf(ctx, "Removed %s", p)
+	}
+
+	out.Printf(ctx, "")
+	out.Printf(ctx, "Run `systemctl --user daemon-reload` to apply the change.")
+
+	return nil
+}

--- a/internal/action/secretservice_other.go
+++ b/internal/action/secretservice_other.go
@@ -1,0 +1,23 @@
+//go:build !linux
+
+package action
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/urfave/cli/v3"
+)
+
+// secretServiceCommand returns the `gopass secret-service` command. On non-Linux
+// platforms it exists only to fail with a clear message: the freedesktop.org
+// Secret Service API this feature implements is Linux-only.
+func (*Action) secretServiceCommand() *cli.Command {
+	return &cli.Command{
+		Name:  "secret-service",
+		Usage: "Run a D-Bus Secret Service daemon backed by gopass (Linux only)",
+		Action: func(_ context.Context, _ *cli.Command) error {
+			return fmt.Errorf("secret-service is only supported on Linux")
+		},
+	}
+}

--- a/internal/secretservice/collection.go
+++ b/internal/secretservice/collection.go
@@ -1,0 +1,318 @@
+//go:build linux
+
+package secretservice
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/godbus/dbus/v5"
+	"github.com/godbus/dbus/v5/prop"
+	"github.com/gopasspw/gopass/pkg/debug"
+)
+
+// Collection implements org.freedesktop.Secret.Collection.
+type Collection struct {
+	svc   *Service
+	store Store
+	name  string
+	path  dbus.ObjectPath
+
+	props *prop.Properties
+}
+
+// ensureCollection returns the exported collection object at its canonical
+// path, creating and exporting it on first use.
+func (s *Service) ensureCollection(ctx context.Context, name string) (*Collection, error) {
+	return s.ensureCollectionFor(ctx, name, s.store)
+}
+
+// ensureCollectionFor returns the exported collection object for a specific
+// backend, creating and exporting it on first use. It is used for the volatile
+// session collection, which is not served by the gopass store.
+func (s *Service) ensureCollectionFor(ctx context.Context, name string, store Store) (*Collection, error) {
+	return s.ensureCollectionForPath(ctx, name, store, CollectionDBusPath(name))
+}
+
+// ensureCollectionForPath exports a collection object at an explicit object
+// path. The same collection can be exported at several paths: its canonical
+// path plus one per alias.
+func (s *Service) ensureCollectionForPath(ctx context.Context, name string, store Store, p dbus.ObjectPath) (*Collection, error) {
+	if c, ok := s.collectionAt(p); ok {
+		return c, nil
+	}
+
+	c := &Collection{
+		svc:   s,
+		store: store,
+		name:  name,
+		path:  p,
+	}
+
+	if err := s.conn.Export(c, c.path, CollectionIface); err != nil {
+		return nil, fmt.Errorf("export collection %s at %s: %w", name, p, err)
+	}
+
+	if err := s.conn.Export(introspectable(collectionIntrospection), c.path, IntrospectableIface); err != nil {
+		return nil, fmt.Errorf("export collection introspection %s: %w", name, err)
+	}
+
+	if err := c.exportProps(ctx); err != nil {
+		_ = s.conn.Export(nil, c.path, CollectionIface)
+
+		return nil, err
+	}
+
+	s.mu.Lock()
+	s.collections[string(c.path)] = c
+	s.mu.Unlock()
+
+	return c, nil
+}
+
+// collection returns the canonical object of an already-exported collection.
+func (s *Service) collection(name string) (*Collection, bool) {
+	return s.collectionAt(CollectionDBusPath(name))
+}
+
+// exportProps loads the collection's data and exports its D-Bus properties.
+func (c *Collection) exportProps(ctx context.Context) error {
+	data, err := c.store.GetCollection(ctx, c.name)
+	if err != nil {
+		return err
+	}
+
+	items, err := c.itemPaths(ctx)
+	if err != nil {
+		return err
+	}
+
+	props, err := prop.Export(c.svc.conn, c.path, prop.Map{
+		CollectionIface: {
+			"Items":    {Value: items, Writable: false, Emit: prop.EmitTrue},
+			"Label":    {Value: data.Label, Writable: true, Emit: prop.EmitTrue, Callback: c.setLabel},
+			"Locked":   {Value: data.Locked, Writable: false, Emit: prop.EmitTrue},
+			"Created":  {Value: uint64(data.Created.Unix()), Writable: false, Emit: prop.EmitConst},
+			"Modified": {Value: uint64(data.Modified.Unix()), Writable: false, Emit: prop.EmitConst},
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("export collection properties: %w", err)
+	}
+	c.props = props
+
+	return nil
+}
+
+// itemPaths returns the object paths of the collection's items.
+func (c *Collection) itemPaths(ctx context.Context) ([]dbus.ObjectPath, error) {
+	ids, err := c.store.Items(ctx, c.name)
+	if err != nil {
+		return nil, err
+	}
+
+	paths := make([]dbus.ObjectPath, 0, len(ids))
+	for _, id := range ids {
+		paths = append(paths, ItemDBusPath(c.name, id))
+	}
+
+	return paths, nil
+}
+
+// refreshItems recomputes and publishes the Items property on every exported
+// object of the collection.
+func (c *Collection) refreshItems(ctx context.Context) {
+	paths, err := c.itemPaths(ctx)
+	if err != nil {
+		return
+	}
+
+	for _, o := range c.svc.collectionObjects(c.name) {
+		if o.props == nil {
+			continue
+		}
+		o.props.SetMust(CollectionIface, "Items", paths)
+	}
+}
+
+// refreshLocked recomputes and publishes the Locked property on every exported
+// object of the collection.
+func (c *Collection) refreshLocked(ctx context.Context) {
+	data, err := c.store.GetCollection(ctx, c.name)
+	if err != nil {
+		return
+	}
+
+	for _, o := range c.svc.collectionObjects(c.name) {
+		if o.props == nil {
+			continue
+		}
+		o.props.SetMust(CollectionIface, "Locked", data.Locked)
+	}
+}
+
+// setLabel persists a label change made via the Properties interface. The prop
+// package updates its own value after this returns; it must not be called
+// re-entrantly.
+func (c *Collection) setLabel(ch *prop.Change) *dbus.Error {
+	label, _ := ch.Value.(string)
+	if err := c.store.SetCollectionLabel(context.Background(), c.name, label); err != nil {
+		return errUnsupported(err)
+	}
+
+	// Keep the other exported objects (aliases) in sync.
+	for _, o := range c.svc.collectionObjects(c.name) {
+		if o == c || o.props == nil {
+			continue
+		}
+		o.props.SetMust(CollectionIface, "Label", label)
+	}
+
+	return nil
+}
+
+// Delete implements org.freedesktop.Secret.Collection.Delete.
+func (c *Collection) Delete() (dbus.ObjectPath, *dbus.Error) {
+	ctx := context.Background()
+
+	// The volatile session collection cannot be deleted; it disappears with
+	// the daemon.
+	if c.name == SessionCollectionName {
+		return NullPath, errUnsupported(fmt.Errorf("the session collection cannot be deleted"))
+	}
+
+	if err := c.store.DeleteCollection(ctx, c.name); err != nil {
+		return NullPath, errNotFound(err)
+	}
+
+	// Drop aliases that pointed at the deleted collection.
+	if err := c.svc.removeAliasesFor(ctx, c.name); err != nil {
+		debug.Log("secret-service: removing aliases for %s: %s", c.name, err)
+	}
+
+	// Unexport every object of the collection (canonical path and aliases) and
+	// all of its items.
+	objects := c.svc.collectionObjects(c.name)
+	paths := c.svc.collectionPaths(c.name)
+
+	c.svc.mu.Lock()
+	for key, item := range c.svc.items {
+		if item.collection == c.name {
+			_ = c.svc.conn.Export(nil, item.path, ItemIface)
+			_ = c.svc.conn.Export(nil, item.path, PropertiesIface)
+			_ = c.svc.conn.Export(nil, item.path, IntrospectableIface)
+			delete(c.svc.items, key)
+		}
+	}
+	for _, o := range objects {
+		delete(c.svc.collections, string(o.path))
+	}
+	c.svc.mu.Unlock()
+
+	for _, p := range paths {
+		_ = c.svc.conn.Export(nil, p, CollectionIface)
+		_ = c.svc.conn.Export(nil, p, PropertiesIface)
+		_ = c.svc.conn.Export(nil, p, IntrospectableIface)
+
+		c.svc.emitServiceSignal(ServiceIface+".CollectionDeleted", p)
+	}
+
+	_ = c.svc.refreshCollectionsProperty(ctx)
+
+	return NullPath, nil
+}
+
+// SearchItems implements org.freedesktop.Secret.Collection.SearchItems.
+func (c *Collection) SearchItems(attributes map[string]string) ([]dbus.ObjectPath, *dbus.Error) {
+	ctx := context.Background()
+
+	items, err := c.store.SearchItems(ctx, c.name, attributes)
+	if err != nil {
+		return nil, errNotFound(err)
+	}
+
+	paths := make([]dbus.ObjectPath, 0, len(items))
+	for _, it := range items {
+		if _, err := c.svc.ensureItem(ctx, c.name, it.ID); err != nil {
+			continue
+		}
+		paths = append(paths, ItemDBusPath(c.name, it.ID))
+	}
+
+	return paths, nil
+}
+
+// CreateItem implements org.freedesktop.Secret.Collection.CreateItem.
+//
+// When replace is true and an existing item has exactly the same attributes as
+// the new one, that item is overwritten instead of creating a duplicate. This
+// matches libsecret's ReplaceItems behaviour.
+func (c *Collection) CreateItem(properties map[string]dbus.Variant, secret Secret, replace bool) (dbus.ObjectPath, dbus.ObjectPath, *dbus.Error) {
+	ctx := context.Background()
+
+	data, err := c.store.GetCollection(ctx, c.name)
+	if err != nil {
+		return NullPath, NullPath, errNotFound(err)
+	}
+	if data.Locked {
+		return NullPath, NullPath, dbusError(errIsLocked, fmt.Errorf("collection is locked: %s", c.name))
+	}
+
+	value, err := c.svc.decryptSecret(secret)
+	if err != nil {
+		return NullPath, NullPath, errUnsupported(err)
+	}
+
+	item := &ItemData{
+		Secret:      value,
+		Label:       variantString(properties, ItemIface+".Label"),
+		ContentType: secret.ContentType,
+		Attributes:  variantAttributes(properties, ItemIface+".Attributes"),
+	}
+	if item.ContentType == "" {
+		item.ContentType = "text/plain"
+	}
+
+	// Replacement: update an item with an identical attribute set.
+	if replace && len(item.Attributes) > 0 {
+		if matched, err := c.store.SearchItems(ctx, c.name, item.Attributes); err == nil && len(matched) == 1 {
+			return c.replaceItem(ctx, matched[0].ID, item)
+		}
+	}
+
+	id, err := c.store.CreateItem(ctx, c.name, item)
+	if err != nil {
+		return NullPath, NullPath, errUnsupported(err)
+	}
+
+	exported, err := c.svc.ensureItem(ctx, c.name, id)
+	if err != nil {
+		return NullPath, NullPath, errUnsupported(err)
+	}
+
+	c.svc.emitCollectionSignal(c.name, CollectionIface+".ItemCreated", exported.path)
+	c.svc.serviceChanged(c.name)
+	c.refreshItems(ctx)
+
+	return exported.path, NullPath, nil
+}
+
+// replaceItem overwrites the item with the given ID and emits the ItemChanged
+// signal.
+func (c *Collection) replaceItem(ctx context.Context, id string, item *ItemData) (dbus.ObjectPath, dbus.ObjectPath, *dbus.Error) {
+	if err := c.store.UpdateItem(ctx, c.name, id, item); err != nil {
+		return NullPath, NullPath, errUnsupported(err)
+	}
+
+	exported, err := c.svc.ensureItem(ctx, c.name, id)
+	if err != nil {
+		return NullPath, NullPath, errUnsupported(err)
+	}
+	exported.refreshProps(ctx)
+
+	c.svc.emitCollectionSignal(c.name, CollectionIface+".ItemChanged", exported.path)
+	c.svc.serviceChanged(c.name)
+	c.refreshItems(ctx)
+
+	return exported.path, NullPath, nil
+}

--- a/internal/secretservice/crypto/crypto.go
+++ b/internal/secretservice/crypto/crypto.go
@@ -1,0 +1,53 @@
+// Package crypto implements the transport encryption algorithms defined by
+// the freedesktop.org Secret Service specification.
+//
+// A [Session] encrypts and decrypts the payload of a D-Bus Secret struct for
+// one client that called OpenSession. Two algorithms are defined by the spec:
+//
+//   - "plain" — no transport encryption. This is secure on the session bus,
+//     which is a local UNIX socket with kernel-enforced access control.
+//   - "dh-ietf1024-sha256-aes128-cbc-pkcs7" — Diffie-Hellman key exchange with
+//     AES-128-CBC payload encryption. Required for compatibility with
+//     libsecret-based clients.
+//
+// The package deliberately has no build constraint: the crypto is portable and
+// is unit-tested on every platform. Only the D-Bus service that uses it is
+// Linux-only.
+package crypto
+
+import "fmt"
+
+// Session algorithm names as defined by the Secret Service specification.
+const (
+	// AlgorithmPlain performs no transport encryption.
+	AlgorithmPlain = "plain"
+	// AlgorithmDHAES is Diffie-Hellman with AES-128-CBC.
+	AlgorithmDHAES = "dh-ietf1024-sha256-aes128-cbc-pkcs7"
+)
+
+// Session is an established transport-encryption session.
+type Session interface {
+	// Encrypt encrypts plaintext and returns the IV (Parameters) and the
+	// ciphertext.
+	Encrypt(plaintext []byte) (params, ciphertext []byte, err error)
+	// Decrypt decrypts ciphertext using params as the IV.
+	Decrypt(params, ciphertext []byte) (plaintext []byte, err error)
+	// Close releases any key material held by the session.
+	Close() error
+}
+
+// New negotiates a new Session for the given algorithm.
+//
+// For [AlgorithmPlain] clientInput must be empty and the returned output is
+// empty. For [AlgorithmDHAES] clientInput is the client's DH public key and the
+// returned output is the server's DH public key, both left-padded to 128 bytes.
+func New(algorithm string, clientInput []byte) (Session, []byte, error) {
+	switch algorithm {
+	case AlgorithmPlain:
+		return plainSession{}, nil, nil
+	case AlgorithmDHAES:
+		return newDHSession(clientInput)
+	default:
+		return nil, nil, fmt.Errorf("unsupported algorithm: %q", algorithm)
+	}
+}

--- a/internal/secretservice/crypto/crypto_test.go
+++ b/internal/secretservice/crypto/crypto_test.go
@@ -1,0 +1,142 @@
+package crypto
+
+import (
+	"bytes"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"crypto/sha256"
+	"math/big"
+	"testing"
+
+	"golang.org/x/crypto/hkdf"
+)
+
+func TestPlainRoundTrip(t *testing.T) {
+	sess, out, err := New(AlgorithmPlain, nil)
+	if err != nil {
+		t.Fatalf("New(plain): %v", err)
+	}
+	if len(out) != 0 {
+		t.Fatalf("plain output = %q, want empty", out)
+	}
+
+	params, ciphertext, err := sess.Encrypt([]byte("hunter2"))
+	if err != nil {
+		t.Fatalf("Encrypt: %v", err)
+	}
+	if len(params) != 0 {
+		t.Fatalf("plain params = %q, want empty", params)
+	}
+	if string(ciphertext) != "hunter2" {
+		t.Fatalf("plain ciphertext = %q, want %q", ciphertext, "hunter2")
+	}
+
+	plaintext, err := sess.Decrypt(params, ciphertext)
+	if err != nil {
+		t.Fatalf("Decrypt: %v", err)
+	}
+	if string(plaintext) != "hunter2" {
+		t.Fatalf("plaintext = %q, want %q", plaintext, "hunter2")
+	}
+}
+
+func TestUnsupportedAlgorithm(t *testing.T) {
+	if _, _, err := New("rot13", nil); err == nil {
+		t.Fatal("New(rot13) succeeded, want error")
+	}
+}
+
+func TestDHRoundTrip(t *testing.T) {
+	// Simulate the client side of the exchange.
+	clientPriv, err := rand.Int(rand.Reader, dhPrime)
+	if err != nil {
+		t.Fatalf("client private key: %v", err)
+	}
+	clientPub := new(big.Int).Exp(dhGenerator, clientPriv, dhPrime)
+
+	// Server side.
+	sess, serverPub, err := New(AlgorithmDHAES, leftPad(clientPub.Bytes(), dhKeyLen))
+	if err != nil {
+		t.Fatalf("New(dh): %v", err)
+	}
+
+	// Client derives the same key from the server's public key.
+	serverPubInt := new(big.Int).SetBytes(serverPub)
+	shared := leftPad(new(big.Int).Exp(serverPubInt, clientPriv, dhPrime).Bytes(), dhKeyLen)
+	reader := hkdf.New(sha256.New, shared, nil, nil)
+	clientKey := make([]byte, 16)
+	if _, err := reader.Read(clientKey); err != nil {
+		t.Fatalf("client hkdf: %v", err)
+	}
+
+	// Server encrypts; client decrypts.
+	params, ciphertext, err := sess.Encrypt([]byte("a very secret value"))
+	if err != nil {
+		t.Fatalf("Encrypt: %v", err)
+	}
+	if len(params) != aes.BlockSize {
+		t.Fatalf("IV length = %d, want %d", len(params), aes.BlockSize)
+	}
+
+	block, err := aes.NewCipher(clientKey)
+	if err != nil {
+		t.Fatalf("client cipher: %v", err)
+	}
+	decrypted := make([]byte, len(ciphertext))
+	cipher.NewCBCDecrypter(block, params).CryptBlocks(decrypted, ciphertext)
+	padLen := int(decrypted[len(decrypted)-1])
+	got := decrypted[:len(decrypted)-padLen]
+	if string(got) != "a very secret value" {
+		t.Fatalf("client decrypted = %q, want %q", got, "a very secret value")
+	}
+
+	// Client encrypts; server decrypts.
+	clientIV := make([]byte, aes.BlockSize)
+	if _, err := rand.Read(clientIV); err != nil {
+		t.Fatalf("client IV: %v", err)
+	}
+	clientPlain := []byte("reply from client")
+	clientPad := aes.BlockSize - (len(clientPlain) % aes.BlockSize)
+	clientPadded := append(append([]byte{}, clientPlain...), bytes.Repeat([]byte{byte(clientPad)}, clientPad)...)
+	clientCT := make([]byte, len(clientPadded))
+	cipher.NewCBCEncrypter(block, clientIV).CryptBlocks(clientCT, clientPadded)
+
+	plaintext, err := sess.Decrypt(clientIV, clientCT)
+	if err != nil {
+		t.Fatalf("server Decrypt: %v", err)
+	}
+	if string(plaintext) != "reply from client" {
+		t.Fatalf("server plaintext = %q, want %q", plaintext, "reply from client")
+	}
+}
+
+func TestDHPadsShortSharedSecret(t *testing.T) {
+	// A shared secret whose big.Int representation is shorter than 128 bytes
+	// must be left-padded, not right-padded or truncated.
+	short := []byte{0x01, 0x02, 0x03}
+	padded := leftPad(short, dhKeyLen)
+	if len(padded) != dhKeyLen {
+		t.Fatalf("len(padded) = %d, want %d", len(padded), dhKeyLen)
+	}
+	if !bytes.Equal(padded[dhKeyLen-len(short):], short) {
+		t.Fatalf("padded tail = %x, want %x", padded[dhKeyLen-len(short):], short)
+	}
+	for i := range dhKeyLen - len(short) {
+		if padded[i] != 0 {
+			t.Fatalf("padding byte %d = %d, want 0", i, padded[i])
+		}
+	}
+}
+
+func TestDHRejectsBadIV(t *testing.T) {
+	clientPriv, _ := rand.Int(rand.Reader, dhPrime)
+	clientPub := new(big.Int).Exp(dhGenerator, clientPriv, dhPrime)
+	sess, _, err := New(AlgorithmDHAES, leftPad(clientPub.Bytes(), dhKeyLen))
+	if err != nil {
+		t.Fatalf("New(dh): %v", err)
+	}
+	if _, err := sess.Decrypt([]byte("short"), []byte("0123456789abcdef")); err == nil {
+		t.Fatal("Decrypt accepted a short IV, want error")
+	}
+}

--- a/internal/secretservice/crypto/dh.go
+++ b/internal/secretservice/crypto/dh.go
@@ -1,0 +1,153 @@
+package crypto
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"crypto/sha256"
+	"fmt"
+	"math/big"
+
+	"golang.org/x/crypto/hkdf"
+)
+
+// dhPrime is the RFC 2409 / RFC 3526 MODP group 2 (1024-bit) prime. The two
+// specifications define the same group for the
+// "dh-ietf1024-sha256-aes128-cbc-pkcs7" algorithm.
+var dhPrime = func() *big.Int {
+	p, _ := new(big.Int).SetString(
+		"FFFFFFFFFFFFFFFFC90FDAA22168C234C4C6628B80DC1CD1"+
+			"29024E088A67CC74020BBEA63B139B22514A08798E3404DD"+
+			"EF9519B3CD3A431B302B0A6DF25F14374FE1356D6D51C245"+
+			"E485B576625E7EC6F44C42E9A637ED6B0BFF5CB6F406B7ED"+
+			"EE386BFB5A899FA5AE9F24117C4B1FE649286651ECE65381"+
+			"FFFFFFFFFFFFFFFF", 16,
+	)
+
+	return p
+}()
+
+// dhGenerator is the generator of the MODP group.
+var dhGenerator = big.NewInt(2)
+
+// dhKeyLen is the length of the padded DH values in bytes (1024 bits).
+const dhKeyLen = 128
+
+// dhSession is an established DH/AES session.
+type dhSession struct {
+	aesKey []byte
+}
+
+// newDHSession performs the server side of the DH key exchange and returns the
+// session plus the server's public key.
+func newDHSession(clientPublic []byte) (*dhSession, []byte, error) {
+	// Generate the server's ephemeral private key.
+	privateKey, err := rand.Int(rand.Reader, dhPrime)
+	if err != nil {
+		return nil, nil, fmt.Errorf("generate private key: %w", err)
+	}
+
+	// serverPub = g^private mod p
+	publicKey := new(big.Int).Exp(dhGenerator, privateKey, dhPrime)
+
+	// shared = clientPub^private mod p
+	clientPub := new(big.Int).SetBytes(clientPublic)
+	sharedSecret := new(big.Int).Exp(clientPub, privateKey, dhPrime)
+
+	// The shared secret must be left-padded to exactly 128 bytes before key
+	// derivation. big.Int.Bytes() strips leading zero bytes, which would
+	// otherwise change the derived key for some exchanges.
+	sharedBytes := leftPad(sharedSecret.Bytes(), dhKeyLen)
+
+	// aesKey = HKDF-SHA256(shared, salt=nil, info=nil)[0:16].
+	hkdfReader := hkdf.New(sha256.New, sharedBytes, nil, nil)
+	aesKey := make([]byte, 16)
+	if _, err := hkdfReader.Read(aesKey); err != nil {
+		return nil, nil, fmt.Errorf("hkdf: %w", err)
+	}
+
+	return &dhSession{aesKey: aesKey}, leftPad(publicKey.Bytes(), dhKeyLen), nil
+}
+
+// leftPad returns b left-padded with zero bytes to exactly n bytes. If b is
+// already n or more bytes it is returned unchanged.
+func leftPad(b []byte, n int) []byte {
+	if len(b) >= n {
+		return b
+	}
+
+	out := make([]byte, n)
+	copy(out[n-len(b):], b)
+
+	return out
+}
+
+// Encrypt encrypts plaintext with AES-128-CBC and PKCS#7 padding. The returned
+// params are a fresh random IV.
+func (s *dhSession) Encrypt(plaintext []byte) ([]byte, []byte, error) {
+	block, err := aes.NewCipher(s.aesKey)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// PKCS#7 padding.
+	padLen := aes.BlockSize - (len(plaintext) % aes.BlockSize)
+	padded := make([]byte, len(plaintext)+padLen)
+	copy(padded, plaintext)
+	for i := len(plaintext); i < len(padded); i++ {
+		padded[i] = byte(padLen)
+	}
+
+	iv := make([]byte, aes.BlockSize)
+	if _, err := rand.Read(iv); err != nil {
+		return nil, nil, err
+	}
+
+	ciphertext := make([]byte, len(padded))
+	cipher.NewCBCEncrypter(block, iv).CryptBlocks(ciphertext, padded)
+
+	return iv, ciphertext, nil
+}
+
+// Decrypt decrypts an AES-128-CBC ciphertext whose IV is params.
+func (s *dhSession) Decrypt(params, ciphertext []byte) ([]byte, error) {
+	if len(params) != aes.BlockSize {
+		return nil, fmt.Errorf("invalid IV length: %d", len(params))
+	}
+	if len(ciphertext) == 0 || len(ciphertext)%aes.BlockSize != 0 {
+		return nil, fmt.Errorf("invalid ciphertext length: %d", len(ciphertext))
+	}
+
+	block, err := aes.NewCipher(s.aesKey)
+	if err != nil {
+		return nil, err
+	}
+
+	decrypted := make([]byte, len(ciphertext))
+	cipher.NewCBCDecrypter(block, params).CryptBlocks(decrypted, ciphertext)
+
+	if len(decrypted) == 0 {
+		return nil, fmt.Errorf("empty plaintext")
+	}
+
+	padLen := int(decrypted[len(decrypted)-1])
+	if padLen == 0 || padLen > aes.BlockSize || padLen > len(decrypted) {
+		return nil, fmt.Errorf("invalid padding length: %d", padLen)
+	}
+	for i := len(decrypted) - padLen; i < len(decrypted); i++ {
+		if decrypted[i] != byte(padLen) {
+			return nil, fmt.Errorf("invalid padding")
+		}
+	}
+
+	return decrypted[:len(decrypted)-padLen], nil
+}
+
+// Close wipes the AES key.
+func (s *dhSession) Close() error {
+	for i := range s.aesKey {
+		s.aesKey[i] = 0
+	}
+
+	return nil
+}

--- a/internal/secretservice/crypto/plain.go
+++ b/internal/secretservice/crypto/plain.go
@@ -1,0 +1,21 @@
+package crypto
+
+// plainSession implements the "plain" algorithm: the secret value is passed
+// through unmodified. The session bus is a local UNIX socket, so the kernel
+// protects the transport.
+type plainSession struct{}
+
+// Encrypt returns the plaintext unchanged with no IV.
+func (plainSession) Encrypt(plaintext []byte) ([]byte, []byte, error) {
+	return nil, plaintext, nil
+}
+
+// Decrypt returns the ciphertext unchanged.
+func (plainSession) Decrypt(_, ciphertext []byte) ([]byte, error) {
+	return ciphertext, nil
+}
+
+// Close is a no-op for the plain algorithm.
+func (plainSession) Close() error {
+	return nil
+}

--- a/internal/secretservice/doc.go
+++ b/internal/secretservice/doc.go
@@ -1,0 +1,68 @@
+//go:build linux
+
+// Package secretservice implements the freedesktop.org Secret Service D-Bus
+// API on top of a gopass password store.
+//
+// It lets desktop applications that speak org.freedesktop.secrets — Firefox,
+// Chromium, VS Code, Electron apps, NetworkManager, secret-tool, … — store
+// their secrets in the same GPG-encrypted, git-backed store as the gopass CLI.
+//
+// The package is Linux-only. It is pure Go: D-Bus comes from
+// github.com/godbus/dbus/v5 and all crypto from the standard library plus
+// golang.org/x/crypto. See docs/adr/A-11-secret-service.md.
+package secretservice
+
+import (
+	"github.com/godbus/dbus/v5"
+	"github.com/gopasspw/gopass/internal/secretservice/crypto"
+)
+
+// Transport encryption algorithms defined by the Secret Service specification,
+// re-exported for callers that negotiate a session.
+const (
+	// AlgorithmPlain performs no transport encryption.
+	AlgorithmPlain = crypto.AlgorithmPlain
+	// AlgorithmDHAES is Diffie-Hellman with AES-128-CBC.
+	AlgorithmDHAES = crypto.AlgorithmDHAES
+)
+
+// Well-known D-Bus names, interfaces and object paths.
+const (
+	// ServiceName is the well-known bus name of the Secret Service.
+	ServiceName = "org.freedesktop.secrets"
+
+	// ServiceIface and friends are the Secret Service interfaces.
+	ServiceIface    = "org.freedesktop.Secret.Service"
+	CollectionIface = "org.freedesktop.Secret.Collection"
+	ItemIface       = "org.freedesktop.Secret.Item"
+	SessionIface    = "org.freedesktop.Secret.Session"
+	PromptIface     = "org.freedesktop.Secret.Prompt"
+
+	// PropertiesIface is the standard D-Bus properties interface.
+	PropertiesIface = "org.freedesktop.DBus.Properties"
+	// IntrospectableIface is the standard introspection interface.
+	IntrospectableIface = "org.freedesktop.DBus.Introspectable"
+
+	// ServicePath is the object path of the service object.
+	ServicePath = dbus.ObjectPath("/org/freedesktop/secrets")
+
+	collectionPathPrefix = "/org/freedesktop/secrets/collection/"
+	aliasPathPrefix      = "/org/freedesktop/secrets/aliases/"
+	sessionPathPrefix    = "/org/freedesktop/secrets/session/"
+
+	// NullPath is the "no object / no prompt" path defined by the spec.
+	NullPath = dbus.ObjectPath("/")
+)
+
+// Secret is the wire format of a secret as defined by the Secret Service
+// specification (the struct with signature "(oayays)").
+type Secret struct {
+	// Session is the session used for transport encryption.
+	Session dbus.ObjectPath
+	// Parameters is the IV (empty for the "plain" algorithm).
+	Parameters []byte
+	// Value is the encrypted (or plaintext) secret value.
+	Value []byte
+	// ContentType is the MIME type, e.g. "text/plain".
+	ContentType string
+}

--- a/internal/secretservice/errors.go
+++ b/internal/secretservice/errors.go
@@ -1,0 +1,33 @@
+//go:build linux
+
+package secretservice
+
+import "github.com/godbus/dbus/v5"
+
+// D-Bus error names defined by the Secret Service specification, §11.
+const (
+	errNoSession     = "org.freedesktop.Secret.Error.NoSession"
+	errNoSuchObject  = "org.freedesktop.Secret.Error.NoSuchObject"
+	errIsLocked      = "org.freedesktop.Secret.Error.IsLocked"
+	errAlreadyExists = "org.freedesktop.Secret.Error.AlreadyExists"
+	errNotSupported  = "org.freedesktop.Secret.Error.NotSupported"
+)
+
+// dbusError builds a *dbus.Error with an optional human-readable message.
+func dbusError(name string, err error) *dbus.Error {
+	body := []any{}
+	if err != nil {
+		body = append(body, err.Error())
+	}
+
+	return dbus.NewError(name, body)
+}
+
+// errUnsupported wraps err as NotSupported.
+func errUnsupported(err error) *dbus.Error { return dbusError(errNotSupported, err) }
+
+// errNotFound wraps err as NoSuchObject.
+func errNotFound(err error) *dbus.Error { return dbusError(errNoSuchObject, err) }
+
+// errExists wraps err as AlreadyExists.
+func errExists(err error) *dbus.Error { return dbusError(errAlreadyExists, err) }

--- a/internal/secretservice/introspection.go
+++ b/internal/secretservice/introspection.go
@@ -1,0 +1,68 @@
+//go:build linux
+
+package secretservice
+
+// collectionIntrospection is the static introspection XML for
+// org.freedesktop.Secret.Collection objects.
+const collectionIntrospection = `<node>
+  <interface name="org.freedesktop.Secret.Collection">
+    <method name="Delete">
+      <arg name="prompt" type="o" direction="out"/>
+    </method>
+    <method name="SearchItems">
+      <arg name="attributes" type="a{ss}" direction="in"/>
+      <arg name="results" type="ao" direction="out"/>
+    </method>
+    <method name="CreateItem">
+      <arg name="properties" type="a{sv}" direction="in"/>
+      <arg name="secret" type="(oayays)" direction="in"/>
+      <arg name="replace" type="b" direction="in"/>
+      <arg name="item" type="o" direction="out"/>
+      <arg name="prompt" type="o" direction="out"/>
+    </method>
+    <signal name="ItemCreated">
+      <arg name="item" type="o"/>
+    </signal>
+    <signal name="ItemDeleted">
+      <arg name="item" type="o"/>
+    </signal>
+    <signal name="ItemChanged">
+      <arg name="item" type="o"/>
+    </signal>
+    <property name="Items" type="ao" access="read"/>
+    <property name="Label" type="s" access="readwrite"/>
+    <property name="Locked" type="b" access="read"/>
+    <property name="Created" type="t" access="read"/>
+    <property name="Modified" type="t" access="read"/>
+  </interface>
+</node>`
+
+// itemIntrospection is the static introspection XML for
+// org.freedesktop.Secret.Item objects.
+const itemIntrospection = `<node>
+  <interface name="org.freedesktop.Secret.Item">
+    <method name="Delete">
+      <arg name="prompt" type="o" direction="out"/>
+    </method>
+    <method name="GetSecret">
+      <arg name="session" type="o" direction="in"/>
+      <arg name="secret" type="(oayays)" direction="out"/>
+    </method>
+    <method name="SetSecret">
+      <arg name="secret" type="(oayays)" direction="in"/>
+    </method>
+    <property name="Locked" type="b" access="read"/>
+    <property name="Attributes" type="a{ss}" access="readwrite"/>
+    <property name="Label" type="s" access="readwrite"/>
+    <property name="Created" type="t" access="read"/>
+    <property name="Modified" type="t" access="read"/>
+  </interface>
+</node>`
+
+// sessionIntrospection is the static introspection XML for
+// org.freedesktop.Secret.Session objects.
+const sessionIntrospection = `<node>
+  <interface name="org.freedesktop.Secret.Session">
+    <method name="Close"/>
+  </interface>
+</node>`

--- a/internal/secretservice/item.go
+++ b/internal/secretservice/item.go
@@ -1,0 +1,302 @@
+//go:build linux
+
+package secretservice
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/godbus/dbus/v5"
+	"github.com/godbus/dbus/v5/prop"
+)
+
+// Item implements org.freedesktop.Secret.Item.
+type Item struct {
+	svc        *Service
+	store      Store
+	collection string
+	id         string
+	path       dbus.ObjectPath
+
+	props *prop.Properties
+}
+
+// itemKey identifies an exported item.
+func itemKey(collection, id string) string {
+	return collection + "/" + id
+}
+
+// ensureItem returns the exported item object, creating and exporting it on
+// first use.
+func (s *Service) ensureItem(ctx context.Context, collection, id string) (*Item, error) {
+	key := itemKey(collection, id)
+
+	s.mu.Lock()
+	if it, ok := s.items[key]; ok {
+		s.mu.Unlock()
+
+		return it, nil
+	}
+	s.mu.Unlock()
+
+	store := s.storeFor(collection)
+
+	data, err := store.GetItem(ctx, collection, id)
+	if err != nil {
+		return nil, err
+	}
+
+	it := &Item{
+		svc:        s,
+		store:      store,
+		collection: collection,
+		id:         id,
+		path:       ItemDBusPath(collection, id),
+	}
+
+	if err := s.conn.Export(it, it.path, ItemIface); err != nil {
+		return nil, fmt.Errorf("export item %s: %w", key, err)
+	}
+
+	if err := s.conn.Export(introspectable(itemIntrospection), it.path, IntrospectableIface); err != nil {
+		return nil, fmt.Errorf("export item introspection %s: %w", key, err)
+	}
+
+	if err := it.exportProps(ctx, data); err != nil {
+		_ = s.conn.Export(nil, it.path, ItemIface)
+
+		return nil, err
+	}
+
+	s.mu.Lock()
+	s.items[key] = it
+	s.mu.Unlock()
+
+	return it, nil
+}
+
+// exportProps exports the item's D-Bus properties.
+func (i *Item) exportProps(ctx context.Context, data *ItemData) error {
+	attrs := data.Attributes
+	if attrs == nil {
+		attrs = map[string]string{}
+	}
+
+	props, err := prop.Export(i.svc.conn, i.path, prop.Map{
+		ItemIface: {
+			"Locked":     {Value: i.locked(ctx), Writable: false, Emit: prop.EmitTrue},
+			"Attributes": {Value: attrs, Writable: true, Emit: prop.EmitTrue, Callback: i.setAttributes},
+			"Label":      {Value: data.Label, Writable: true, Emit: prop.EmitTrue, Callback: i.setLabel},
+			"Created":    {Value: uint64(data.Created.Unix()), Writable: false, Emit: prop.EmitConst},
+			"Modified":   {Value: uint64(data.Modified.Unix()), Writable: false, Emit: prop.EmitConst},
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("export item properties: %w", err)
+	}
+	i.props = props
+
+	return nil
+}
+
+// locked reports whether the item's collection is currently locked.
+func (i *Item) locked(ctx context.Context) bool {
+	data, err := i.store.GetCollection(ctx, i.collection)
+	if err != nil {
+		return false
+	}
+
+	return data.Locked
+}
+
+// refreshLocked republishes the item's Locked property.
+func (i *Item) refreshLocked(ctx context.Context) {
+	if i.props == nil {
+		return
+	}
+	i.props.SetMust(ItemIface, "Locked", i.locked(ctx))
+}
+
+// refreshProps reloads and republishes the item's mutable properties.
+func (i *Item) refreshProps(ctx context.Context) {
+	if i.props == nil {
+		return
+	}
+
+	data, err := i.store.GetItem(ctx, i.collection, i.id)
+	if err != nil {
+		return
+	}
+
+	attrs := data.Attributes
+	if attrs == nil {
+		attrs = map[string]string{}
+	}
+	i.props.SetMust(ItemIface, "Attributes", attrs)
+	i.props.SetMust(ItemIface, "Label", data.Label)
+	i.props.SetMust(ItemIface, "Modified", uint64(data.Modified.Unix()))
+	i.props.SetMust(ItemIface, "Locked", i.locked(ctx))
+}
+
+// load returns the item's current data from the store.
+func (i *Item) load(ctx context.Context) (*ItemData, error) {
+	return i.store.GetItem(ctx, i.collection, i.id)
+}
+
+// setAttributes persists an attribute change made via the Properties
+// interface.
+func (i *Item) setAttributes(ch *prop.Change) *dbus.Error {
+	attrs, ok := ch.Value.(map[string]string)
+	if !ok {
+		return errUnsupported(fmt.Errorf("attributes must be a string map"))
+	}
+
+	ctx := context.Background()
+	data, err := i.load(ctx)
+	if err != nil {
+		return errNotFound(err)
+	}
+	data.Attributes = attrs
+
+	if err := i.store.UpdateItem(ctx, i.collection, i.id, data); err != nil {
+		return errUnsupported(err)
+	}
+
+	i.svc.emitItemChanged(i.collection, i.path)
+
+	return nil
+}
+
+// setLabel persists a label change made via the Properties interface.
+func (i *Item) setLabel(ch *prop.Change) *dbus.Error {
+	label, _ := ch.Value.(string)
+
+	ctx := context.Background()
+	data, err := i.load(ctx)
+	if err != nil {
+		return errNotFound(err)
+	}
+	data.Label = label
+
+	if err := i.store.UpdateItem(ctx, i.collection, i.id, data); err != nil {
+		return errUnsupported(err)
+	}
+
+	i.svc.emitItemChanged(i.collection, i.path)
+
+	return nil
+}
+
+// GetSecret implements org.freedesktop.Secret.Item.GetSecret.
+func (i *Item) GetSecret(sessionPath dbus.ObjectPath) (Secret, *dbus.Error) {
+	ctx := context.Background()
+
+	coll, err := i.store.GetCollection(ctx, i.collection)
+	if err != nil {
+		return Secret{}, errNotFound(err)
+	}
+	if coll.Locked {
+		return Secret{}, dbusError(errIsLocked, fmt.Errorf("collection is locked: %s", i.collection))
+	}
+
+	sess, err := i.svc.sessions.get(sessionPath)
+	if err != nil {
+		return Secret{}, dbusError(errNoSession, err)
+	}
+
+	data, err := i.load(ctx)
+	if err != nil {
+		return Secret{}, errNotFound(err)
+	}
+
+	params, ciphertext, err := sess.encrypt(data.Secret)
+	if err != nil {
+		return Secret{}, errUnsupported(err)
+	}
+
+	i.svc.notifyAccess(ctx, data.Label)
+
+	return Secret{
+		Session:     sessionPath,
+		Parameters:  params,
+		Value:       ciphertext,
+		ContentType: data.ContentType,
+	}, nil
+}
+
+// SetSecret implements org.freedesktop.Secret.Item.SetSecret.
+func (i *Item) SetSecret(secret Secret) *dbus.Error {
+	ctx := context.Background()
+
+	coll, err := i.store.GetCollection(ctx, i.collection)
+	if err != nil {
+		return errNotFound(err)
+	}
+	if coll.Locked {
+		return dbusError(errIsLocked, fmt.Errorf("collection is locked: %s", i.collection))
+	}
+
+	value, err := i.svc.decryptSecret(secret)
+	if err != nil {
+		return errUnsupported(err)
+	}
+
+	data, err := i.load(ctx)
+	if err != nil {
+		return errNotFound(err)
+	}
+	data.Secret = value
+	if secret.ContentType != "" {
+		data.ContentType = secret.ContentType
+	}
+
+	if err := i.store.UpdateItem(ctx, i.collection, i.id, data); err != nil {
+		return errUnsupported(err)
+	}
+
+	i.svc.emitItemChanged(i.collection, i.path)
+
+	return nil
+}
+
+// Delete implements org.freedesktop.Secret.Item.Delete.
+func (i *Item) Delete() (dbus.ObjectPath, *dbus.Error) {
+	ctx := context.Background()
+
+	if err := i.store.DeleteItem(ctx, i.collection, i.id); err != nil {
+		return NullPath, errNotFound(err)
+	}
+
+	_ = i.svc.conn.Export(nil, i.path, ItemIface)
+	_ = i.svc.conn.Export(nil, i.path, PropertiesIface)
+	_ = i.svc.conn.Export(nil, i.path, IntrospectableIface)
+
+	i.svc.mu.Lock()
+	delete(i.svc.items, itemKey(i.collection, i.id))
+	i.svc.mu.Unlock()
+
+	i.svc.emitCollectionSignal(i.collection, CollectionIface+".ItemDeleted", i.path)
+	i.svc.serviceChanged(i.collection)
+
+	if coll, ok := i.svc.collection(i.collection); ok {
+		coll.refreshItems(ctx)
+	}
+
+	return NullPath, nil
+}
+
+// decryptSecret decrypts a D-Bus Secret using the session it references.
+func (s *Service) decryptSecret(secret Secret) ([]byte, error) {
+	sess, err := s.sessions.get(secret.Session)
+	if err != nil {
+		return nil, err
+	}
+
+	return sess.decrypt(secret.Parameters, secret.Value)
+}
+
+// emitItemChanged announces an item property change on its collection.
+func (s *Service) emitItemChanged(collection string, p dbus.ObjectPath) {
+	s.emitCollectionSignal(collection, CollectionIface+".ItemChanged", p)
+	s.serviceChanged(collection)
+}

--- a/internal/secretservice/paths.go
+++ b/internal/secretservice/paths.go
@@ -1,0 +1,226 @@
+//go:build linux
+
+package secretservice
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"path"
+	"strings"
+
+	"github.com/godbus/dbus/v5"
+)
+
+// mapper translates between D-Bus object paths and gopass store paths.
+type mapper struct {
+	prefix string
+}
+
+// CollectionPath returns the gopass path of a collection.
+func (m mapper) CollectionPath(name string) string {
+	return path.Join(m.prefix, name)
+}
+
+// ItemPath returns the gopass path of an item.
+func (m mapper) ItemPath(collection, id string) string {
+	return path.Join(m.prefix, collection, id)
+}
+
+// MetaPath returns the gopass path of a collection's metadata entry.
+func (m mapper) MetaPath(collection string) string {
+	return path.Join(m.prefix, collection, "_meta")
+}
+
+// AliasesPath returns the gopass path of the alias map.
+func (m mapper) AliasesPath() string {
+	return path.Join(m.prefix, "_aliases")
+}
+
+// SanitizeName turns a caller-supplied collection name into a single safe
+// gopass path segment, which is also a valid D-Bus object path element (that
+// is, it matches [A-Za-z0-9_]). Every other character is replaced with "_".
+// Because object path elements may not contain "/" this also prevents a name
+// from escaping the store prefix.
+func SanitizeName(name string) string {
+	var b strings.Builder
+	b.Grow(len(name))
+
+	for _, r := range name {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '_':
+			b.WriteRune(r)
+		default:
+			b.WriteByte('_')
+		}
+	}
+
+	if b.Len() == 0 {
+		return "_"
+	}
+
+	return b.String()
+}
+
+// ItemDBusID returns the D-Bus-safe object path element for a store item name.
+//
+// D-Bus object path elements must match [A-Za-z0-9_], but items may be created
+// out of band by the gopass CLI with arbitrary names (e.g. "cli-inserted").
+// Names that are already safe and do not start with "x" are used verbatim. All
+// other names — including every name starting with "x" — are hex-encoded with
+// an "x" prefix. Encoded and verbatim elements can therefore never collide,
+// and ItemNameFromDBusID reverses the mapping exactly.
+func ItemDBusID(name string) string {
+	if isSafeItemID(name) {
+		return name
+	}
+
+	return "x" + hex.EncodeToString([]byte(name))
+}
+
+// isSafeItemID reports whether name can be used verbatim as an object path
+// element. Names starting with "x" are excluded so that the "x"-prefixed
+// encoding stays unambiguous.
+func isSafeItemID(name string) bool {
+	return name != "" && name[0] != 'x' && isPathSafe(name)
+}
+
+// isPathSafe reports whether name is a valid D-Bus object path element, i.e.
+// it is non-empty and matches [A-Za-z0-9_].
+func isPathSafe(name string) bool {
+	if name == "" {
+		return false
+	}
+
+	for i := range len(name) {
+		c := name[i]
+		switch {
+		case c >= 'a' && c <= 'z', c >= 'A' && c <= 'Z', c >= '0' && c <= '9', c == '_':
+		default:
+			return false
+		}
+	}
+
+	return true
+}
+
+// ItemNameFromDBusID reverses ItemDBusID. Elements that are not a valid
+// encoding are returned unchanged.
+func ItemNameFromDBusID(id string) string {
+	if !strings.HasPrefix(id, "x") {
+		return id
+	}
+
+	raw := id[1:]
+	if len(raw) == 0 || len(raw)%2 != 0 {
+		return id
+	}
+
+	decoded, err := hex.DecodeString(raw)
+	if err != nil {
+		return id
+	}
+
+	return string(decoded)
+}
+
+// CollectionDBusPath returns the object path of a collection.
+func CollectionDBusPath(name string) dbus.ObjectPath {
+	return dbus.ObjectPath(collectionPathPrefix + name)
+}
+
+// AliasDBusPath returns the object path at which a collection alias is served.
+//
+// libsecret does not call ReadAlias to resolve a collection alias. Instead it
+// derives /org/freedesktop/secrets/aliases/<alias> locally and treats that path
+// as the collection object, so the Collection interface must be exported there
+// as well as at the canonical collection path.
+func AliasDBusPath(alias string) dbus.ObjectPath {
+	return dbus.ObjectPath(aliasPathPrefix + SanitizeName(alias))
+}
+
+// IsAliasPath reports whether p is an alias object path and returns the alias
+// name.
+func IsAliasPath(p dbus.ObjectPath) (string, bool) {
+	s := string(p)
+	if !strings.HasPrefix(s, aliasPathPrefix) {
+		return "", false
+	}
+
+	alias := strings.TrimPrefix(s, aliasPathPrefix)
+	if alias == "" || strings.Contains(alias, "/") {
+		return "", false
+	}
+
+	return alias, true
+}
+
+// ItemDBusPath returns the object path of an item. id is the store item name,
+// which is mapped to a D-Bus-safe path element by ItemDBusID.
+func ItemDBusPath(collection, id string) dbus.ObjectPath {
+	return dbus.ObjectPath(collectionPathPrefix + collection + "/" + ItemDBusID(id))
+}
+
+// SessionDBusPath returns the object path of a session.
+func SessionDBusPath(id string) dbus.ObjectPath {
+	return dbus.ObjectPath(sessionPathPrefix + id)
+}
+
+// parseCollectionPath extracts the collection name from a collection object
+// path.
+func parseCollectionPath(p dbus.ObjectPath) (string, error) {
+	s := string(p)
+	if !strings.HasPrefix(s, collectionPathPrefix) {
+		return "", fmt.Errorf("not a collection path: %s", p)
+	}
+
+	name := strings.TrimPrefix(s, collectionPathPrefix)
+	if name == "" || strings.Contains(name, "/") {
+		return "", fmt.Errorf("invalid collection path: %s", p)
+	}
+
+	return name, nil
+}
+
+// parseItemPath extracts the collection name and the D-Bus item ID from an
+// item object path. Use ItemNameFromDBusID to recover the store item name.
+func parseItemPath(p dbus.ObjectPath) (string, string, error) {
+	s := string(p)
+	if !strings.HasPrefix(s, collectionPathPrefix) {
+		return "", "", fmt.Errorf("not an item path: %s", p)
+	}
+
+	rest := strings.TrimPrefix(s, collectionPathPrefix)
+	parts := strings.SplitN(rest, "/", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", fmt.Errorf("invalid item path: %s", p)
+	}
+
+	return parts[0], parts[1], nil
+}
+
+// parseSessionPath extracts the session ID from a session object path.
+func parseSessionPath(p dbus.ObjectPath) (string, error) {
+	s := string(p)
+	if !strings.HasPrefix(s, sessionPathPrefix) {
+		return "", fmt.Errorf("not a session path: %s", p)
+	}
+
+	id := strings.TrimPrefix(s, sessionPathPrefix)
+	if id == "" || strings.Contains(id, "/") {
+		return "", fmt.Errorf("invalid session path: %s", p)
+	}
+
+	return id, nil
+}
+
+// newID returns a random, hyphen-free identifier prefixed with p. The result is
+// safe to use as a D-Bus object-path element, which must match [A-Za-z0-9_].
+func newID(prefix byte) (string, error) {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("%c%x", prefix, b[:]), nil
+}

--- a/internal/secretservice/paths_test.go
+++ b/internal/secretservice/paths_test.go
@@ -1,0 +1,63 @@
+//go:build linux
+
+package secretservice
+
+import "testing"
+
+func TestItemDBusIDRoundTrip(t *testing.T) {
+	for _, name := range []string{
+		"i0123456789abcdef",
+		"cli-inserted",
+		"with space",
+		"with.dot",
+		"x",
+		"x6162",
+		"ünïcode",
+		"",
+		"slash/name",
+	} {
+		id := ItemDBusID(name)
+
+		if name == "" {
+			// The empty name cannot be a valid element; the caller filters it.
+			if id != "x" {
+				t.Fatalf("ItemDBusID(%q) = %q, want %q", name, id, "x")
+			}
+
+			continue
+		}
+
+		if !isPathSafe(id) {
+			t.Fatalf("ItemDBusID(%q) = %q is not a valid path element", name, id)
+		}
+		if got := ItemNameFromDBusID(id); got != name {
+			t.Fatalf("round trip: ItemNameFromDBusID(ItemDBusID(%q)) = %q", name, got)
+		}
+	}
+}
+
+func TestItemDBusIDVerbatimForSafeNames(t *testing.T) {
+	// Generated IDs keep their historic layout.
+	if got := ItemDBusID("i0123456789abcdef"); got != "i0123456789abcdef" {
+		t.Fatalf("safe id was rewritten: %q", got)
+	}
+	// A name starting with "x" must be encoded so decoding stays unambiguous.
+	if got := ItemDBusID("xyz"); got == "xyz" {
+		t.Fatalf("x-prefixed name must be encoded, got %q", got)
+	}
+}
+
+func TestItemDBusPathHasNoHyphens(t *testing.T) {
+	p := ItemDBusPath("default", "cli-inserted")
+	if str := string(p); len(str) == 0 {
+		t.Fatal("empty path")
+	}
+
+	for _, r := range string(p) {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '_', r == '/':
+		default:
+			t.Fatalf("path %q contains invalid character %q", p, r)
+		}
+	}
+}

--- a/internal/secretservice/service.go
+++ b/internal/secretservice/service.go
@@ -1,0 +1,783 @@
+//go:build linux
+
+package secretservice
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/godbus/dbus/v5"
+	"github.com/godbus/dbus/v5/prop"
+	"github.com/gopasspw/gopass/internal/notify"
+	"github.com/gopasspw/gopass/pkg/debug"
+)
+
+// Config configures the Secret Service daemon.
+type Config struct {
+	// Prefix is the gopass path prefix under which secrets are stored.
+	Prefix string
+	// Replace evicts an existing org.freedesktop.secrets owner.
+	Replace bool
+	// NotifyOnAccess sends a desktop notification whenever a secret is read.
+	NotifyOnAccess bool
+	// BusAddress overrides the D-Bus address. Empty means the session bus.
+	// It exists mainly for tests.
+	BusAddress string
+}
+
+// Service implements org.freedesktop.Secret.Service.
+type Service struct {
+	conn  *dbus.Conn
+	store Store
+	cfg   Config
+	m     mapper
+
+	// sessionStore backs the volatile session collection. Its payloads live
+	// in the kernel keyring, never in the gopass store.
+	sessionStore Store
+
+	sessions *sessionManager
+
+	mu sync.Mutex
+	// collections maps D-Bus object paths to exported Collection objects. A
+	// collection has one canonical object plus one object per alias, so it can
+	// appear more than once.
+	collections map[string]*Collection
+	items       map[string]*Item
+
+	serviceProps *prop.Properties
+}
+
+// New connects to D-Bus and prepares the service. It does not acquire the bus
+// name yet; call Start or Serve for that.
+func New(ctx context.Context, cfg Config) (*Service, error) {
+	if cfg.Prefix == "" {
+		cfg.Prefix = "secret-service"
+	}
+
+	conn, err := dial(cfg.BusAddress)
+	if err != nil {
+		return nil, err
+	}
+
+	store, err := NewGopassStore(ctx, cfg.Prefix)
+	if err != nil {
+		_ = conn.Close()
+
+		return nil, err
+	}
+
+	return &Service{
+		conn:         conn,
+		store:        store,
+		sessionStore: newKeyringStore(),
+		cfg:          cfg,
+		m:            mapper{prefix: cfg.Prefix},
+		sessions:     newSessionManager(conn),
+		collections:  make(map[string]*Collection),
+		items:        make(map[string]*Item),
+	}, nil
+}
+
+// storeFor returns the backend that serves a collection. The well-known
+// session collection is served by the volatile store; every other collection
+// lives in the gopass store.
+func (s *Service) storeFor(collection string) Store {
+	if collection == SessionCollectionName {
+		return s.sessionStore
+	}
+
+	return s.store
+}
+
+// collectionAt returns an already-exported collection object by object path.
+func (s *Service) collectionAt(p dbus.ObjectPath) (*Collection, bool) {
+	s.mu.Lock()
+	c, ok := s.collections[string(p)]
+	s.mu.Unlock()
+
+	return c, ok
+}
+
+// collectionObjects returns every exported object for a collection name: the
+// canonical object plus one object per alias.
+func (s *Service) collectionObjects(name string) []*Collection {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	out := make([]*Collection, 0, 1)
+	for _, c := range s.collections {
+		if c.name == name {
+			out = append(out, c)
+		}
+	}
+
+	return out
+}
+
+// collectionPaths returns every object path a collection is exported at.
+func (s *Service) collectionPaths(name string) []dbus.ObjectPath {
+	objs := s.collectionObjects(name)
+	out := make([]dbus.ObjectPath, 0, len(objs))
+	for _, c := range objs {
+		out = append(out, c.path)
+	}
+
+	return out
+}
+
+// emitCollectionSignal emits sig from every object path a collection is
+// exported at, so clients that resolved the collection via an alias see the
+// signal too.
+func (s *Service) emitCollectionSignal(name, sig string, args ...any) {
+	for _, p := range s.collectionPaths(name) {
+		if err := s.conn.Emit(p, sig, args...); err != nil {
+			debug.Log("secret-service: emitting %s on %s: %s", sig, p, err)
+		}
+	}
+}
+
+// emitServiceSignal emits a signal from the service object.
+func (s *Service) emitServiceSignal(sig string, args ...any) {
+	if err := s.conn.Emit(ServicePath, sig, args...); err != nil {
+		debug.Log("secret-service: emitting %s: %s", sig, err)
+	}
+}
+
+// serviceChanged announces that a collection changed.
+func (s *Service) serviceChanged(collection string) {
+	s.emitServiceSignal(ServiceIface+".CollectionChanged", CollectionDBusPath(collection))
+}
+
+// dial connects to the session bus or to an explicit address.
+func dial(address string) (*dbus.Conn, error) {
+	if address == "" {
+		conn, err := dbus.SessionBus()
+		if err != nil {
+			return nil, fmt.Errorf("connect to session bus: %w", err)
+		}
+
+		return conn, nil
+	}
+
+	conn, err := dbus.Dial(address)
+	if err != nil {
+		return nil, fmt.Errorf("dial %s: %w", address, err)
+	}
+	if err := conn.Auth(nil); err != nil {
+		_ = conn.Close()
+
+		return nil, fmt.Errorf("authenticate on %s: %w", address, err)
+	}
+	if err := conn.Hello(); err != nil {
+		_ = conn.Close()
+
+		return nil, fmt.Errorf("hello on %s: %w", address, err)
+	}
+
+	return conn, nil
+}
+
+// Start exports the service object, acquires the bus name and ensures the
+// default collection exists.
+func (s *Service) Start(ctx context.Context) error {
+	if err := s.conn.Export(s, ServicePath, ServiceIface); err != nil {
+		return fmt.Errorf("export service: %w", err)
+	}
+
+	if err := s.conn.Export(introspectable(serviceIntrospection), ServicePath, IntrospectableIface); err != nil {
+		return fmt.Errorf("export introspection: %w", err)
+	}
+
+	props, err := prop.Export(s.conn, ServicePath, prop.Map{
+		ServiceIface: {
+			"Collections": {Value: []dbus.ObjectPath{}, Writable: false, Emit: prop.EmitTrue},
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("export service properties: %w", err)
+	}
+	s.serviceProps = props
+
+	flags := dbus.NameFlagDoNotQueue
+	if s.cfg.Replace {
+		flags |= dbus.NameFlagReplaceExisting
+	}
+
+	reply, err := s.conn.RequestName(ServiceName, flags)
+	if err != nil {
+		return fmt.Errorf("request name %s: %w", ServiceName, err)
+	}
+	if reply != dbus.RequestNameReplyPrimaryOwner {
+		return fmt.Errorf("name %s is already taken (use --replace to take it over)", ServiceName)
+	}
+
+	debug.Log("secret-service: acquired %s", ServiceName)
+
+	if err := s.ensureDefaultCollection(ctx); err != nil {
+		return err
+	}
+
+	// The volatile session collection is always present and is deliberately
+	// not part of the Collections property.
+	if _, err := s.ensureCollectionFor(ctx, SessionCollectionName, s.sessionStore); err != nil {
+		return fmt.Errorf("export session collection: %w", err)
+	}
+
+	if err := s.syncAliases(ctx); err != nil {
+		return err
+	}
+
+	return s.refreshCollectionsProperty(ctx)
+}
+
+// syncAliases exports a Collection object at /org/freedesktop/secrets/aliases/
+// for every configured alias and unexports objects whose alias disappeared.
+// libsecret resolves collection aliases to that path directly, so this mapping
+// is required for compatibility.
+func (s *Service) syncAliases(ctx context.Context) error {
+	aliases, err := s.store.Aliases(ctx)
+	if err != nil {
+		aliases = map[string]string{"default": "default"}
+	}
+
+	aliases[SessionCollectionName] = SessionCollectionName
+
+	wanted := make(map[string]bool, len(aliases))
+	for alias, name := range aliases {
+		if name == "" {
+			continue
+		}
+
+		p := AliasDBusPath(alias)
+		wanted[string(p)] = true
+
+		if _, ok := s.collectionAt(p); ok {
+			continue
+		}
+
+		store := s.storeFor(name)
+		if _, err := store.GetCollection(ctx, name); err != nil {
+			// The alias points at a collection that no longer exists.
+			debug.Log("secret-service: alias %q points at missing collection %q", alias, name)
+
+			continue
+		}
+
+		if _, err := s.ensureCollectionForPath(ctx, name, store, p); err != nil {
+			debug.Log("secret-service: cannot export alias %q: %s", alias, err)
+		}
+	}
+
+	// Unexport alias objects that are no longer wanted.
+	s.mu.Lock()
+	var stale []*Collection
+
+	for path, c := range s.collections {
+		if !strings.HasPrefix(path, aliasPathPrefix) {
+			continue
+		}
+		if wanted[path] {
+			continue
+		}
+		stale = append(stale, c)
+		delete(s.collections, path)
+	}
+	s.mu.Unlock()
+
+	for _, c := range stale {
+		_ = s.conn.Export(nil, c.path, CollectionIface)
+		_ = s.conn.Export(nil, c.path, PropertiesIface)
+		_ = s.conn.Export(nil, c.path, IntrospectableIface)
+	}
+
+	return nil
+}
+
+// Serve starts the service and blocks until ctx is cancelled.
+func (s *Service) Serve(ctx context.Context) error {
+	if err := s.Start(ctx); err != nil {
+		return err
+	}
+
+	<-ctx.Done()
+
+	return s.Stop()
+}
+
+// Stop releases the bus name and closes the store.
+func (s *Service) Stop() error {
+	s.sessions.closeAll()
+
+	closeCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := s.sessionStore.Close(closeCtx); err != nil {
+		debug.Log("secret-service: closing session store: %s", err)
+	}
+	if err := s.store.Close(closeCtx); err != nil {
+		debug.Log("secret-service: closing store: %s", err)
+	}
+
+	if _, err := s.conn.ReleaseName(ServiceName); err != nil {
+		debug.Log("secret-service: releasing name: %s", err)
+	}
+
+	return s.conn.Close()
+}
+
+// OpenSession implements org.freedesktop.Secret.Service.OpenSession.
+func (s *Service) OpenSession(algorithm string, input dbus.Variant) (dbus.Variant, dbus.ObjectPath, *dbus.Error) {
+	var inputBytes []byte
+	if v, ok := input.Value().([]byte); ok {
+		inputBytes = v
+	}
+
+	sess, output, err := s.sessions.open(algorithm, inputBytes)
+	if err != nil {
+		return dbus.MakeVariant([]byte{}), NullPath, errUnsupported(err)
+	}
+
+	return dbus.MakeVariant(output), sess.path, nil
+}
+
+// CreateCollection implements org.freedesktop.Secret.Service.CreateCollection.
+func (s *Service) CreateCollection(properties map[string]dbus.Variant, alias string) (dbus.ObjectPath, dbus.ObjectPath, *dbus.Error) {
+	ctx := context.Background()
+
+	label := variantString(properties, CollectionIface+".Label")
+
+	name := alias
+	if name == "" {
+		name = label
+	}
+	if name == "" {
+		name = "collection"
+	}
+	name = SanitizeName(name)
+
+	if name == SessionCollectionName {
+		return NullPath, NullPath, errExists(fmt.Errorf("collection name %q is reserved for the session collection", name))
+	}
+
+	if _, err := s.store.GetCollection(ctx, name); err == nil {
+		return NullPath, NullPath, errExists(fmt.Errorf("collection already exists: %s", name))
+	}
+
+	if err := s.store.CreateCollection(ctx, name, label); err != nil {
+		return NullPath, NullPath, errUnsupported(err)
+	}
+
+	coll, err := s.ensureCollection(ctx, name)
+	if err != nil {
+		return NullPath, NullPath, errUnsupported(err)
+	}
+
+	if alias != "" {
+		if err := s.store.SetAlias(ctx, alias, name); err != nil {
+			debug.Log("secret-service: set alias %s: %s", alias, err)
+		}
+		if err := s.syncAliases(ctx); err != nil {
+			debug.Log("secret-service: syncing aliases: %s", err)
+		}
+	}
+
+	s.emitServiceSignal(ServiceIface+".CollectionCreated", coll.path)
+	_ = s.refreshCollectionsProperty(ctx)
+
+	return coll.path, NullPath, nil
+}
+
+// SearchItems implements org.freedesktop.Secret.Service.SearchItems.
+func (s *Service) SearchItems(attributes map[string]string) ([]dbus.ObjectPath, []dbus.ObjectPath, *dbus.Error) {
+	ctx := context.Background()
+
+	results, err := s.store.SearchAllItems(ctx, attributes)
+	if err != nil {
+		return nil, nil, errNotFound(err)
+	}
+
+	// The session collection is searched as well, but is never "locked".
+	sessionResults, err := s.sessionStore.SearchAllItems(ctx, attributes)
+	if err == nil {
+		for name, items := range sessionResults {
+			results[name] = append(results[name], items...)
+		}
+	}
+
+	var unlocked, locked []dbus.ObjectPath
+	for collName, items := range results {
+		store := s.storeFor(collName)
+		collData, _ := store.GetCollection(ctx, collName)
+		isLocked := collData != nil && collData.Locked
+
+		for _, it := range items {
+			item, err := s.ensureItem(ctx, collName, it.ID)
+			if err != nil {
+				debug.Log("secret-service: cannot export item %s/%s: %s", collName, it.ID, err)
+
+				continue
+			}
+			if isLocked {
+				locked = append(locked, item.path)
+			} else {
+				unlocked = append(unlocked, item.path)
+			}
+		}
+	}
+
+	return unlocked, locked, nil
+}
+
+// Unlock implements org.freedesktop.Secret.Service.Unlock.
+func (s *Service) Unlock(objects []dbus.ObjectPath) ([]dbus.ObjectPath, dbus.ObjectPath, *dbus.Error) {
+	ctx := context.Background()
+
+	var unlocked []dbus.ObjectPath
+	for _, p := range objects {
+		name, err := s.resolveCollectionName(ctx, p)
+		if err != nil {
+			continue
+		}
+		if err := s.storeFor(name).UnlockCollection(ctx, name); err != nil {
+			continue
+		}
+		s.refreshLockState(ctx, name)
+		unlocked = append(unlocked, p)
+	}
+
+	return unlocked, NullPath, nil
+}
+
+// Lock implements org.freedesktop.Secret.Service.Lock.
+func (s *Service) Lock(objects []dbus.ObjectPath) ([]dbus.ObjectPath, dbus.ObjectPath, *dbus.Error) {
+	ctx := context.Background()
+
+	var locked []dbus.ObjectPath
+	for _, p := range objects {
+		name, err := s.resolveCollectionName(ctx, p)
+		if err != nil {
+			continue
+		}
+		if err := s.storeFor(name).LockCollection(ctx, name); err != nil {
+			continue
+		}
+		s.refreshLockState(ctx, name)
+		locked = append(locked, p)
+	}
+
+	return locked, NullPath, nil
+}
+
+// refreshLockState republishes the Locked property of a collection and of every
+// exported item it contains.
+func (s *Service) refreshLockState(ctx context.Context, name string) {
+	if coll, ok := s.collection(name); ok {
+		coll.refreshLocked(ctx)
+	}
+
+	s.mu.Lock()
+	items := make([]*Item, 0, len(s.items))
+	for _, item := range s.items {
+		if item.collection == name {
+			items = append(items, item)
+		}
+	}
+	s.mu.Unlock()
+
+	for _, item := range items {
+		item.refreshLocked(ctx)
+	}
+}
+
+// GetSecrets implements org.freedesktop.Secret.Service.GetSecrets.
+func (s *Service) GetSecrets(items []dbus.ObjectPath, sessionPath dbus.ObjectPath) (map[dbus.ObjectPath]Secret, *dbus.Error) {
+	sess, err := s.sessions.get(sessionPath)
+	if err != nil {
+		return nil, dbusError(errNoSession, err)
+	}
+
+	ctx := context.Background()
+	out := make(map[dbus.ObjectPath]Secret)
+
+	for _, p := range items {
+		collection, id, err := parseItemPath(p)
+		if err != nil {
+			continue
+		}
+
+		item, err := s.storeFor(collection).GetItem(ctx, collection, ItemNameFromDBusID(id))
+		if err != nil {
+			continue
+		}
+
+		params, ciphertext, err := sess.encrypt(item.Secret)
+		if err != nil {
+			continue
+		}
+
+		s.notifyAccess(ctx, item.Label)
+
+		out[p] = Secret{
+			Session:     sessionPath,
+			Parameters:  params,
+			Value:       ciphertext,
+			ContentType: item.ContentType,
+		}
+	}
+
+	return out, nil
+}
+
+// ReadAlias implements org.freedesktop.Secret.Service.ReadAlias.
+func (s *Service) ReadAlias(name string) (dbus.ObjectPath, *dbus.Error) {
+	// The session collection is always available under the well-known alias
+	// and never appears in the persistent alias map.
+	if name == SessionCollectionName {
+		return CollectionDBusPath(SessionCollectionName), nil
+	}
+
+	collName, err := s.store.GetAlias(context.Background(), name)
+	if err != nil {
+		return NullPath, nil
+	}
+
+	return CollectionDBusPath(collName), nil
+}
+
+// SetAlias implements org.freedesktop.Secret.Service.SetAlias.
+func (s *Service) SetAlias(name string, collection dbus.ObjectPath) *dbus.Error {
+	ctx := context.Background()
+
+	if name == SessionCollectionName {
+		return errUnsupported(fmt.Errorf("the session alias is read-only"))
+	}
+
+	if collection == NullPath {
+		if err := s.store.SetAlias(ctx, name, ""); err != nil {
+			return errUnsupported(err)
+		}
+		if err := s.syncAliases(ctx); err != nil {
+			debug.Log("secret-service: syncing aliases: %s", err)
+		}
+
+		return nil
+	}
+
+	collName, err := parseCollectionPath(collection)
+	if err != nil {
+		return errNotFound(err)
+	}
+
+	if err := s.store.SetAlias(ctx, name, collName); err != nil {
+		return errUnsupported(err)
+	}
+	if err := s.syncAliases(ctx); err != nil {
+		debug.Log("secret-service: syncing aliases: %s", err)
+	}
+
+	return nil
+}
+
+// resolveCollectionName maps a collection, item or alias object path to a
+// collection name.
+func (s *Service) resolveCollectionName(ctx context.Context, p dbus.ObjectPath) (string, error) {
+	if name, err := parseCollectionPath(p); err == nil {
+		return name, nil
+	}
+	if collection, _, err := parseItemPath(p); err == nil {
+		return collection, nil
+	}
+
+	// Alias paths: /org/freedesktop/secrets/aliases/NAME.
+	if alias, ok := IsAliasPath(p); ok {
+		return s.store.GetAlias(ctx, alias)
+	}
+
+	return "", fmt.Errorf("not a collection, item or alias path: %s", p)
+}
+
+// ensureDefaultCollection makes sure a collection exists and is aliased as
+// "default".
+func (s *Service) ensureDefaultCollection(ctx context.Context) error {
+	name, err := s.store.GetAlias(ctx, "default")
+	if err != nil {
+		name = "default"
+	}
+
+	if _, err := s.store.GetCollection(ctx, name); err != nil {
+		if err := s.store.CreateCollection(ctx, name, "Default"); err != nil {
+			return fmt.Errorf("create default collection: %w", err)
+		}
+	}
+
+	if _, err := s.ensureCollection(ctx, name); err != nil {
+		return err
+	}
+
+	if err := s.store.SetAlias(ctx, "default", name); err != nil {
+		debug.Log("secret-service: set default alias: %s", err)
+	}
+
+	return nil
+}
+
+// refreshCollectionsProperty updates the Service.Collections property.
+func (s *Service) refreshCollectionsProperty(ctx context.Context) error {
+	if s.serviceProps == nil {
+		return nil
+	}
+
+	names, err := s.store.Collections(ctx)
+	if err != nil {
+		return err
+	}
+
+	paths := make([]dbus.ObjectPath, 0, len(names))
+	for _, name := range names {
+		if _, err := s.ensureCollection(ctx, name); err != nil {
+			continue
+		}
+		paths = append(paths, CollectionDBusPath(name))
+	}
+
+	s.serviceProps.SetMust(ServiceIface, "Collections", paths)
+
+	return nil
+}
+
+// removeAliasesFor deletes every alias that points at the given collection.
+func (s *Service) removeAliasesFor(ctx context.Context, name string) error {
+	aliases, err := s.store.Aliases(ctx)
+	if err != nil {
+		return err
+	}
+
+	for alias, target := range aliases {
+		if target != name {
+			continue
+		}
+		if err := s.store.SetAlias(ctx, alias, ""); err != nil {
+			return err
+		}
+	}
+
+	return s.syncAliases(ctx)
+}
+
+// notifyAccess sends a desktop notification about a secret read, if the daemon
+// was started with --notify-on-access.
+func (s *Service) notifyAccess(ctx context.Context, label string) {
+	if !s.cfg.NotifyOnAccess {
+		return
+	}
+
+	if label == "" {
+		label = "a secret"
+	}
+
+	if err := notify.Notify(ctx, "gopass secret-service", "Read "+label); err != nil {
+		debug.Log("secret-service: notification failed: %s", err)
+	}
+}
+
+// variantString extracts a string from a properties map, tolerating absence.
+func variantString(properties map[string]dbus.Variant, key string) string {
+	v, ok := properties[key]
+	if !ok {
+		return ""
+	}
+	s, _ := v.Value().(string)
+
+	return s
+}
+
+// variantAttributes extracts an attribute map from a properties map.
+func variantAttributes(properties map[string]dbus.Variant, key string) map[string]string {
+	out := make(map[string]string)
+
+	v, ok := properties[key]
+	if !ok {
+		return out
+	}
+
+	switch attrs := v.Value().(type) {
+	case map[string]string:
+		for k, val := range attrs {
+			out[k] = val
+		}
+	case map[string]dbus.Variant:
+		for k, val := range attrs {
+			if s, ok := val.Value().(string); ok {
+				out[k] = s
+			}
+		}
+	}
+
+	return out
+}
+
+// introspectable serves a static introspection XML document.
+type introspectable string
+
+// Introspect implements org.freedesktop.DBus.Introspectable.
+func (i introspectable) Introspect() (string, *dbus.Error) {
+	return string(i), nil
+}
+
+const serviceIntrospection = `<node>
+  <interface name="org.freedesktop.Secret.Service">
+    <method name="OpenSession">
+      <arg name="algorithm" type="s" direction="in"/>
+      <arg name="input" type="v" direction="in"/>
+      <arg name="output" type="v" direction="out"/>
+      <arg name="result" type="o" direction="out"/>
+    </method>
+    <method name="CreateCollection">
+      <arg name="properties" type="a{sv}" direction="in"/>
+      <arg name="alias" type="s" direction="in"/>
+      <arg name="collection" type="o" direction="out"/>
+      <arg name="prompt" type="o" direction="out"/>
+    </method>
+    <method name="SearchItems">
+      <arg name="attributes" type="a{ss}" direction="in"/>
+      <arg name="unlocked" type="ao" direction="out"/>
+      <arg name="locked" type="ao" direction="out"/>
+    </method>
+    <method name="Unlock">
+      <arg name="objects" type="ao" direction="in"/>
+      <arg name="unlocked" type="ao" direction="out"/>
+      <arg name="prompt" type="o" direction="out"/>
+    </method>
+    <method name="Lock">
+      <arg name="objects" type="ao" direction="in"/>
+      <arg name="locked" type="ao" direction="out"/>
+      <arg name="prompt" type="o" direction="out"/>
+    </method>
+    <method name="GetSecrets">
+      <arg name="items" type="ao" direction="in"/>
+      <arg name="session" type="o" direction="in"/>
+      <arg name="secrets" type="a{o(oayays)}" direction="out"/>
+    </method>
+    <method name="ReadAlias">
+      <arg name="name" type="s" direction="in"/>
+      <arg name="collection" type="o" direction="out"/>
+    </method>
+    <method name="SetAlias">
+      <arg name="name" type="s" direction="in"/>
+      <arg name="collection" type="o" direction="in"/>
+    </method>
+    <signal name="CollectionCreated">
+      <arg name="collection" type="o"/>
+    </signal>
+    <signal name="CollectionDeleted">
+      <arg name="collection" type="o"/>
+    </signal>
+    <signal name="CollectionChanged">
+      <arg name="collection" type="o"/>
+    </signal>
+    <property name="Collections" type="ao" access="read"/>
+  </interface>
+</node>`

--- a/internal/secretservice/session.go
+++ b/internal/secretservice/session.go
@@ -1,0 +1,166 @@
+//go:build linux
+
+package secretservice
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/godbus/dbus/v5"
+	"github.com/gopasspw/gopass/internal/secretservice/crypto"
+)
+
+// session is one client's transport-encryption session.
+type session struct {
+	path   dbus.ObjectPath
+	crypto crypto.Session
+	conn   *dbus.Conn
+	closed bool
+	onGone func()
+
+	mu sync.RWMutex
+}
+
+// sessionManager tracks the active sessions.
+type sessionManager struct {
+	conn     *dbus.Conn
+	sessions map[string]*session
+
+	mu sync.Mutex
+}
+
+func newSessionManager(conn *dbus.Conn) *sessionManager {
+	return &sessionManager{
+		conn:     conn,
+		sessions: make(map[string]*session),
+	}
+}
+
+// open negotiates a new session and exports it on the bus.
+func (m *sessionManager) open(algorithm string, input []byte) (*session, []byte, error) {
+	cryptoSession, output, err := crypto.New(algorithm, input)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	id, err := newID('s')
+	if err != nil {
+		return nil, nil, err
+	}
+
+	s := &session{
+		path:   SessionDBusPath(id),
+		crypto: cryptoSession,
+		conn:   m.conn,
+	}
+	s.onGone = func() {
+		m.mu.Lock()
+		delete(m.sessions, id)
+		m.mu.Unlock()
+	}
+
+	m.mu.Lock()
+	m.sessions[id] = s
+	m.mu.Unlock()
+
+	if err := m.conn.Export(s, s.path, SessionIface); err != nil {
+		m.remove(id)
+
+		return nil, nil, fmt.Errorf("export session: %w", err)
+	}
+
+	if err := m.conn.Export(introspectable(sessionIntrospection), s.path, IntrospectableIface); err != nil {
+		m.remove(id)
+
+		return nil, nil, fmt.Errorf("export session introspection: %w", err)
+	}
+
+	return s, output, nil
+}
+
+// get returns a session by its object path.
+func (m *sessionManager) get(p dbus.ObjectPath) (*session, error) {
+	id, err := parseSessionPath(p)
+	if err != nil {
+		return nil, err
+	}
+
+	m.mu.Lock()
+	s, ok := m.sessions[id]
+	m.mu.Unlock()
+	if !ok {
+		return nil, fmt.Errorf("session not found: %s", p)
+	}
+
+	return s, nil
+}
+
+func (m *sessionManager) remove(id string) {
+	m.mu.Lock()
+	delete(m.sessions, id)
+	m.mu.Unlock()
+}
+
+// closeAll closes every open session, e.g. at daemon shutdown.
+func (m *sessionManager) closeAll() {
+	m.mu.Lock()
+	sessions := make([]*session, 0, len(m.sessions))
+	for _, s := range m.sessions {
+		sessions = append(sessions, s)
+	}
+	m.sessions = make(map[string]*session)
+	m.mu.Unlock()
+
+	for _, s := range sessions {
+		s.teardown(false)
+	}
+}
+
+// Close implements org.freedesktop.Secret.Session.Close.
+func (s *session) Close() *dbus.Error {
+	s.teardown(true)
+
+	return nil
+}
+
+func (s *session) teardown(notify bool) {
+	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+
+		return
+	}
+	s.closed = true
+	s.mu.Unlock()
+
+	_ = s.conn.Export(nil, s.path, SessionIface)
+	_ = s.conn.Export(nil, s.path, IntrospectableIface)
+	_ = s.crypto.Close()
+	if notify && s.onGone != nil {
+		s.onGone()
+	}
+}
+
+// encrypt encrypts a payload using the session's algorithm.
+func (s *session) encrypt(plaintext []byte) ([]byte, []byte, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if s.closed {
+		return nil, nil, fmt.Errorf("session is closed")
+	}
+
+	return s.crypto.Encrypt(plaintext)
+}
+
+// decrypt decrypts a payload using the session's algorithm.
+func (s *session) decrypt(params, ciphertext []byte) ([]byte, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if s.closed {
+		return nil, fmt.Errorf("session is closed")
+	}
+
+	return s.crypto.Decrypt(params, ciphertext)
+}

--- a/internal/secretservice/store.go
+++ b/internal/secretservice/store.go
@@ -1,0 +1,634 @@
+//go:build linux
+
+package secretservice
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/gopasspw/gopass/pkg/debug"
+	"github.com/gopasspw/gopass/pkg/gopass"
+	"github.com/gopasspw/gopass/pkg/gopass/api"
+	"github.com/gopasspw/gopass/pkg/gopass/secrets"
+)
+
+// Reserved metadata keys. Keys prefixed with metaPrefix are internal; every
+// other key on an item is a user-visible search attribute.
+const (
+	metaPrefix     = "_ss_"
+	labelKey       = "_ss_label"
+	createdKey     = "_ss_created"
+	modifiedKey    = "_ss_modified"
+	contentTypeKey = "_ss_content_type"
+
+	collLabelKey    = "_ss_coll_label"
+	collCreatedKey  = "_ss_coll_created"
+	collModifiedKey = "_ss_coll_modified"
+)
+
+// ItemData is a Secret Service item backed by a gopass secret.
+type ItemData struct {
+	ID          string
+	Secret      []byte
+	Label       string
+	Created     time.Time
+	Modified    time.Time
+	ContentType string
+	Attributes  map[string]string
+}
+
+// CollectionData is a Secret Service collection.
+type CollectionData struct {
+	Name     string
+	Label    string
+	Created  time.Time
+	Modified time.Time
+	Locked   bool
+}
+
+// Store is the persistence backend used by the service. It is implemented by
+// gopassStore (durable) and, for the volatile session collection, by memStore.
+type Store interface {
+	Collections(ctx context.Context) ([]string, error)
+	GetCollection(ctx context.Context, name string) (*CollectionData, error)
+	CreateCollection(ctx context.Context, name, label string) error
+	DeleteCollection(ctx context.Context, name string) error
+	SetCollectionLabel(ctx context.Context, name, label string) error
+
+	Items(ctx context.Context, collection string) ([]string, error)
+	GetItem(ctx context.Context, collection, id string) (*ItemData, error)
+	CreateItem(ctx context.Context, collection string, item *ItemData) (string, error)
+	UpdateItem(ctx context.Context, collection, id string, item *ItemData) error
+	DeleteItem(ctx context.Context, collection, id string) error
+	SearchItems(ctx context.Context, collection string, attrs map[string]string) ([]*ItemData, error)
+	SearchAllItems(ctx context.Context, attrs map[string]string) (map[string][]*ItemData, error)
+
+	LockCollection(ctx context.Context, name string) error
+	UnlockCollection(ctx context.Context, name string) error
+
+	GetAlias(ctx context.Context, alias string) (string, error)
+	SetAlias(ctx context.Context, alias, collection string) error
+	Aliases(ctx context.Context) (map[string]string, error)
+
+	Close(ctx context.Context) error
+}
+
+// gopassStore implements Store on top of the public gopass Go API. It never
+// shells out to the CLI.
+type gopassStore struct {
+	store  gopass.Store
+	mapper mapper
+
+	mu     sync.RWMutex
+	locked map[string]bool
+
+	// metaCache memoizes the decrypted *metadata* of an item, keyed by store
+	// path. It never holds the secret payload: SearchItems only needs
+	// attributes to match, and decryption dominates its latency, so caching
+	// metadata turns a per-lookup O(N) decryption of a collection into a
+	// single decryption per entry. Entries are invalidated on every local
+	// mutation; there is no TTL, so out-of-process changes require a daemon
+	// restart.
+	cacheMu   sync.RWMutex
+	metaCache map[string]map[string]string
+}
+
+// NewGopassStore creates a gopass-backed store under the given path prefix.
+func NewGopassStore(ctx context.Context, prefix string) (*gopassStore, error) {
+	gp, err := api.New(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("initialize gopass: %w", err)
+	}
+
+	return newGopassStoreWithBackend(gp, prefix), nil
+}
+
+// newGopassStoreWithBackend is the dependency-injection seam used by tests.
+func newGopassStoreWithBackend(backend gopass.Store, prefix string) *gopassStore {
+	return &gopassStore{
+		store:     backend,
+		mapper:    mapper{prefix: prefix},
+		locked:    make(map[string]bool),
+		metaCache: make(map[string]map[string]string),
+	}
+}
+
+// metaFromSecret extracts an item's searchable metadata. It copies only
+// gopass Keys(), never Password() or Body(), so the result is safe to cache.
+func metaFromSecret(sec gopass.Secret) map[string]string {
+	keys := sec.Keys()
+	m := make(map[string]string, len(keys))
+	for _, k := range keys {
+		if v, ok := sec.Get(k); ok {
+			m[k] = v
+		}
+	}
+
+	return m
+}
+
+// metaFor returns an item's cached metadata, decrypting and caching it on first
+// access.
+func (s *gopassStore) metaFor(ctx context.Context, p string) (map[string]string, error) {
+	s.cacheMu.RLock()
+	m, ok := s.metaCache[p]
+	s.cacheMu.RUnlock()
+	if ok {
+		return m, nil
+	}
+
+	sec, err := s.store.Get(ctx, p, "latest")
+	if err != nil {
+		return nil, err
+	}
+	m = metaFromSecret(sec)
+
+	s.cacheMu.Lock()
+	s.metaCache[p] = m
+	s.cacheMu.Unlock()
+
+	return m, nil
+}
+
+func (s *gopassStore) invalidateMeta(p string) {
+	s.cacheMu.Lock()
+	delete(s.metaCache, p)
+	s.cacheMu.Unlock()
+}
+
+func (s *gopassStore) invalidateMetaPrefix(prefix string) {
+	s.cacheMu.Lock()
+	for k := range s.metaCache {
+		if k == prefix || strings.HasPrefix(k, prefix+"/") {
+			delete(s.metaCache, k)
+		}
+	}
+	s.cacheMu.Unlock()
+}
+
+// applyItemMeta fills an ItemData's metadata from a metadata map. It never
+// touches ItemData.Secret.
+func applyItemMeta(item *ItemData, meta map[string]string) {
+	for key, val := range meta {
+		switch key {
+		case labelKey:
+			item.Label = val
+		case createdKey:
+			if ts, err := time.Parse(time.RFC3339, val); err == nil {
+				item.Created = ts
+			}
+		case modifiedKey:
+			if ts, err := time.Parse(time.RFC3339, val); err == nil {
+				item.Modified = ts
+			}
+		case contentTypeKey:
+			item.ContentType = val
+		default:
+			if !strings.HasPrefix(key, metaPrefix) {
+				item.Attributes[key] = val
+			}
+		}
+	}
+}
+
+// Collections returns all collection names under the store prefix.
+func (s *gopassStore) Collections(ctx context.Context) ([]string, error) {
+	allPaths, err := s.store.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	seen := make(map[string]bool)
+	for _, p := range allPaths {
+		if !strings.HasPrefix(p, s.mapper.prefix+"/") {
+			continue
+		}
+		rest := strings.TrimPrefix(p, s.mapper.prefix+"/")
+		parts := strings.SplitN(rest, "/", 2)
+		name := parts[0]
+		if name == "" || strings.HasPrefix(name, "_") {
+			continue
+		}
+		// Collection names become D-Bus object path elements, so only names
+		// that are already path-safe can be served. Directories created out of
+		// band with other characters are skipped.
+		if !isPathSafe(name) {
+			debug.Log("secret-service: skipping collection %q: not a valid D-Bus path element", name)
+
+			continue
+		}
+		seen[name] = true
+	}
+
+	out := make([]string, 0, len(seen))
+	for name := range seen {
+		out = append(out, name)
+	}
+	sort.Strings(out)
+
+	return out, nil
+}
+
+// GetCollection returns a collection's data.
+func (s *gopassStore) GetCollection(ctx context.Context, name string) (*CollectionData, error) {
+	name = SanitizeName(name)
+	meta, err := s.metaFor(ctx, s.mapper.MetaPath(name))
+	if err != nil {
+		// No metadata entry: the collection still exists if it has any items.
+		items, ierr := s.Items(ctx, name)
+		if ierr != nil || len(items) == 0 {
+			return nil, fmt.Errorf("collection not found: %s", name)
+		}
+
+		return &CollectionData{Name: name, Label: name, Created: time.Now(), Locked: s.isLocked(name)}, nil
+	}
+
+	data := &CollectionData{Name: name, Label: name, Locked: s.isLocked(name)}
+	for key, val := range meta {
+		switch key {
+		case collLabelKey:
+			data.Label = val
+		case collCreatedKey:
+			if ts, err := time.Parse(time.RFC3339, val); err == nil {
+				data.Created = ts
+			}
+		case collModifiedKey:
+			if ts, err := time.Parse(time.RFC3339, val); err == nil {
+				data.Modified = ts
+			}
+		}
+	}
+
+	return data, nil
+}
+
+// CreateCollection writes a collection's metadata entry.
+func (s *gopassStore) CreateCollection(ctx context.Context, name, label string) error {
+	name = SanitizeName(name)
+	now := time.Now().Format(time.RFC3339)
+
+	sec := secrets.New()
+	sec.SetPassword("collection-metadata")
+	for _, kv := range []struct{ k, v string }{
+		{collLabelKey, label},
+		{collCreatedKey, now},
+		{collModifiedKey, now},
+	} {
+		if err := sec.Set(kv.k, kv.v); err != nil {
+			return fmt.Errorf("set %s: %w", kv.k, err)
+		}
+	}
+
+	metaPath := s.mapper.MetaPath(name)
+	if err := s.store.Set(ctx, metaPath, sec); err != nil {
+		return err
+	}
+	s.invalidateMeta(metaPath)
+
+	return nil
+}
+
+// DeleteCollection removes a collection and all of its items.
+func (s *gopassStore) DeleteCollection(ctx context.Context, name string) error {
+	collPath := s.mapper.CollectionPath(name)
+	if err := s.store.RemoveAll(ctx, collPath); err != nil {
+		return err
+	}
+	s.invalidateMetaPrefix(collPath)
+
+	return nil
+}
+
+// SetCollectionLabel updates a collection's label.
+func (s *gopassStore) SetCollectionLabel(ctx context.Context, name, label string) error {
+	existing, err := s.GetCollection(ctx, name)
+	if err != nil {
+		return err
+	}
+
+	sec := secrets.New()
+	sec.SetPassword("collection-metadata")
+	for _, kv := range []struct{ k, v string }{
+		{collLabelKey, label},
+		{collCreatedKey, existing.Created.Format(time.RFC3339)},
+		{collModifiedKey, time.Now().Format(time.RFC3339)},
+	} {
+		if err := sec.Set(kv.k, kv.v); err != nil {
+			return fmt.Errorf("set %s: %w", kv.k, err)
+		}
+	}
+
+	metaPath := s.mapper.MetaPath(name)
+	if err := s.store.Set(ctx, metaPath, sec); err != nil {
+		return err
+	}
+	s.invalidateMeta(metaPath)
+
+	return nil
+}
+
+// Items returns all item IDs within a collection.
+func (s *gopassStore) Items(ctx context.Context, collection string) ([]string, error) {
+	allPaths, err := s.store.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	collPath := s.mapper.CollectionPath(collection)
+
+	var items []string
+	for _, p := range allPaths {
+		if !strings.HasPrefix(p, collPath+"/") {
+			continue
+		}
+		id := strings.TrimPrefix(p, collPath+"/")
+		if id == "" || strings.Contains(id, "/") || strings.HasPrefix(id, "_") {
+			continue
+		}
+		items = append(items, id)
+	}
+	sort.Strings(items)
+
+	return items, nil
+}
+
+// GetItem returns an item, decrypting its secret fresh (never cached).
+func (s *gopassStore) GetItem(ctx context.Context, collection, id string) (*ItemData, error) {
+	itemPath := s.mapper.ItemPath(collection, id)
+
+	sec, err := s.store.Get(ctx, itemPath, "latest")
+	if err != nil {
+		return nil, fmt.Errorf("item not found: %s/%s", collection, id)
+	}
+
+	meta := metaFromSecret(sec)
+	s.cacheMu.Lock()
+	s.metaCache[itemPath] = meta
+	s.cacheMu.Unlock()
+
+	item := &ItemData{
+		ID:          id,
+		Secret:      []byte(sec.Password()),
+		ContentType: "text/plain",
+		Attributes:  make(map[string]string),
+	}
+	applyItemMeta(item, meta)
+
+	return item, nil
+}
+
+// CreateItem writes a new item and returns its generated ID.
+func (s *gopassStore) CreateItem(ctx context.Context, collection string, item *ItemData) (string, error) {
+	if item.ID == "" {
+		id, err := newID('i')
+		if err != nil {
+			return "", err
+		}
+		item.ID = id
+	}
+
+	if _, err := s.GetCollection(ctx, collection); err != nil {
+		if cerr := s.CreateCollection(ctx, collection, collection); cerr != nil {
+			return "", fmt.Errorf("create collection: %w", cerr)
+		}
+	}
+
+	now := time.Now()
+	if item.Created.IsZero() {
+		item.Created = now
+	}
+	item.Modified = now
+	if item.ContentType == "" {
+		item.ContentType = "text/plain"
+	}
+
+	if err := s.writeItem(ctx, collection, item); err != nil {
+		return "", err
+	}
+
+	return item.ID, nil
+}
+
+// UpdateItem overwrites an existing item, preserving its creation time.
+func (s *gopassStore) UpdateItem(ctx context.Context, collection, id string, item *ItemData) error {
+	existing, err := s.GetItem(ctx, collection, id)
+	if err != nil {
+		return err
+	}
+
+	item.ID = id
+	item.Created = existing.Created
+	item.Modified = time.Now()
+	if item.ContentType == "" {
+		item.ContentType = existing.ContentType
+	}
+	if item.ContentType == "" {
+		item.ContentType = "text/plain"
+	}
+
+	return s.writeItem(ctx, collection, item)
+}
+
+// writeItem serializes an ItemData into a gopass secret.
+func (s *gopassStore) writeItem(ctx context.Context, collection string, item *ItemData) error {
+	sec := secrets.New()
+	sec.SetPassword(string(item.Secret))
+	for _, kv := range []struct{ k, v string }{
+		{labelKey, item.Label},
+		{createdKey, item.Created.Format(time.RFC3339)},
+		{modifiedKey, item.Modified.Format(time.RFC3339)},
+		{contentTypeKey, item.ContentType},
+	} {
+		if err := sec.Set(kv.k, kv.v); err != nil {
+			return fmt.Errorf("set %s: %w", kv.k, err)
+		}
+	}
+
+	keys := make([]string, 0, len(item.Attributes))
+	for k := range item.Attributes {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		if err := sec.Set(k, item.Attributes[k]); err != nil {
+			return fmt.Errorf("set attribute %s: %w", k, err)
+		}
+	}
+
+	itemPath := s.mapper.ItemPath(collection, item.ID)
+	if err := s.store.Set(ctx, itemPath, sec); err != nil {
+		return err
+	}
+	s.invalidateMeta(itemPath)
+
+	return nil
+}
+
+// DeleteItem removes an item.
+func (s *gopassStore) DeleteItem(ctx context.Context, collection, id string) error {
+	itemPath := s.mapper.ItemPath(collection, id)
+	if err := s.store.Remove(ctx, itemPath); err != nil {
+		return err
+	}
+	s.invalidateMeta(itemPath)
+
+	return nil
+}
+
+// SearchItems returns items in a collection matching all given attributes.
+func (s *gopassStore) SearchItems(ctx context.Context, collection string, attrs map[string]string) ([]*ItemData, error) {
+	ids, err := s.Items(ctx, collection)
+	if err != nil {
+		return nil, err
+	}
+
+	var results []*ItemData
+	for _, id := range ids {
+		meta, err := s.metaFor(ctx, s.mapper.ItemPath(collection, id))
+		if err != nil {
+			debug.Log("secret-service: skipping item %s/%s: %s", collection, id, err)
+
+			continue
+		}
+		item := &ItemData{ID: id, ContentType: "text/plain", Attributes: make(map[string]string)}
+		applyItemMeta(item, meta)
+		if matchesAttributes(item, attrs) {
+			results = append(results, item)
+		}
+	}
+
+	debug.Log("secret-service: search %s for %v matched %d/%d", collection, attrs, len(results), len(ids))
+
+	return results, nil
+}
+
+// SearchAllItems searches every collection for matching items.
+func (s *gopassStore) SearchAllItems(ctx context.Context, attrs map[string]string) (map[string][]*ItemData, error) {
+	collections, err := s.Collections(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	results := make(map[string][]*ItemData)
+	for _, coll := range collections {
+		items, err := s.SearchItems(ctx, coll, attrs)
+		if err != nil {
+			continue
+		}
+		if len(items) > 0 {
+			results[coll] = items
+		}
+	}
+
+	return results, nil
+}
+
+// LockCollection marks a collection locked in memory.
+func (s *gopassStore) LockCollection(_ context.Context, name string) error {
+	s.mu.Lock()
+	s.locked[name] = true
+	s.mu.Unlock()
+
+	return nil
+}
+
+// UnlockCollection marks a collection unlocked in memory.
+func (s *gopassStore) UnlockCollection(_ context.Context, name string) error {
+	s.mu.Lock()
+	s.locked[name] = false
+	s.mu.Unlock()
+
+	return nil
+}
+
+func (s *gopassStore) isLocked(name string) bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return s.locked[name]
+}
+
+// GetAlias resolves a collection alias. The "default" alias always exists.
+func (s *gopassStore) GetAlias(ctx context.Context, alias string) (string, error) {
+	sec, err := s.store.Get(ctx, s.mapper.AliasesPath(), "latest")
+	if err != nil {
+		if alias == "default" {
+			return "default", nil
+		}
+
+		return "", fmt.Errorf("alias not found: %s", alias)
+	}
+
+	if val, ok := sec.Get(alias); ok && val != "" {
+		return val, nil
+	}
+	if alias == "default" {
+		return "default", nil
+	}
+
+	return "", fmt.Errorf("alias not found: %s", alias)
+}
+
+// SetAlias sets or removes (empty collection) a collection alias.
+func (s *gopassStore) SetAlias(ctx context.Context, alias, collection string) error {
+	aliases, err := s.Aliases(ctx)
+	if err != nil {
+		aliases = make(map[string]string)
+	}
+
+	if collection == "" {
+		delete(aliases, alias)
+	} else {
+		aliases[alias] = collection
+	}
+
+	sec := secrets.New()
+	sec.SetPassword("aliases")
+	for k, v := range aliases {
+		if err := sec.Set(k, v); err != nil {
+			return fmt.Errorf("set alias %q: %w", k, err)
+		}
+	}
+
+	return s.store.Set(ctx, s.mapper.AliasesPath(), sec)
+}
+
+// Aliases returns the full alias map. The "default" alias is always present.
+func (s *gopassStore) Aliases(ctx context.Context) (map[string]string, error) {
+	aliases := make(map[string]string)
+
+	sec, err := s.store.Get(ctx, s.mapper.AliasesPath(), "latest")
+	if err == nil {
+		for _, key := range sec.Keys() {
+			if val, ok := sec.Get(key); ok && val != "" {
+				aliases[key] = val
+			}
+		}
+	}
+
+	if _, ok := aliases["default"]; !ok {
+		aliases["default"] = "default"
+	}
+
+	return aliases, nil
+}
+
+// Close closes the underlying store.
+func (s *gopassStore) Close(ctx context.Context) error {
+	return s.store.Close(ctx)
+}
+
+// matchesAttributes reports whether item has every key/value in attrs.
+func matchesAttributes(item *ItemData, attrs map[string]string) bool {
+	for k, v := range attrs {
+		if item.Attributes[k] != v {
+			return false
+		}
+	}
+
+	return true
+}

--- a/internal/secretservice/store_test.go
+++ b/internal/secretservice/store_test.go
@@ -1,0 +1,257 @@
+//go:build linux
+
+package secretservice
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gopasspw/gopass/pkg/gopass"
+)
+
+// fakeStore is a minimal in-memory gopass.Store used to test gopassStore
+// without GPG or a real password store.
+type fakeStore struct {
+	entries map[string]gopass.Secret
+}
+
+func newFakeStore() *fakeStore {
+	return &fakeStore{entries: make(map[string]gopass.Secret)}
+}
+
+func (f *fakeStore) String() string { return "fake" }
+
+func (f *fakeStore) List(context.Context) ([]string, error) {
+	out := make([]string, 0, len(f.entries))
+	for k := range f.entries {
+		out = append(out, k)
+	}
+
+	return out, nil
+}
+
+func (f *fakeStore) AuditList(ctx context.Context) ([]string, error) { return f.List(ctx) }
+
+func (f *fakeStore) Get(_ context.Context, name, _ string) (gopass.Secret, error) {
+	sec, ok := f.entries[name]
+	if !ok {
+		return nil, fmt.Errorf("not found: %s", name)
+	}
+
+	return sec, nil
+}
+
+func (f *fakeStore) Set(_ context.Context, name string, sec gopass.Byter) error {
+	s, ok := sec.(gopass.Secret)
+	if !ok {
+		return fmt.Errorf("not a secret: %T", sec)
+	}
+	f.entries[name] = s
+
+	return nil
+}
+
+func (f *fakeStore) Revisions(context.Context, string) ([]string, error) { return nil, nil }
+
+func (f *fakeStore) Remove(_ context.Context, name string) error {
+	if _, ok := f.entries[name]; !ok {
+		return fmt.Errorf("not found: %s", name)
+	}
+	delete(f.entries, name)
+
+	return nil
+}
+
+func (f *fakeStore) RemoveAll(_ context.Context, prefix string) error {
+	for k := range f.entries {
+		if k == prefix || strings.HasPrefix(k, prefix+"/") {
+			delete(f.entries, k)
+		}
+	}
+
+	return nil
+}
+
+func (f *fakeStore) Rename(context.Context, string, string) error { return nil }
+
+func (f *fakeStore) Sync(context.Context) error { return nil }
+
+func (f *fakeStore) Close(context.Context) error { return nil }
+
+func newTestStore() *gopassStore {
+	return newGopassStoreWithBackend(newFakeStore(), "secret-service")
+}
+
+func TestStoreItemLifecycle(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore()
+
+	if err := s.CreateCollection(ctx, "default", "Default"); err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+
+	id, err := s.CreateItem(ctx, "default", &ItemData{
+		Secret:      []byte("s3cr3t"),
+		Label:       "GitHub",
+		ContentType: "text/plain",
+		Attributes:  map[string]string{"username": "octocat", "service": "github.com"},
+	})
+	if err != nil {
+		t.Fatalf("CreateItem: %v", err)
+	}
+	if !strings.HasPrefix(id, "i") || strings.Contains(id, "-") {
+		t.Fatalf("id = %q, want i-prefixed hyphen-free", id)
+	}
+
+	// GetSecret round-trips the password and attributes.
+	got, err := s.GetItem(ctx, "default", id)
+	if err != nil {
+		t.Fatalf("GetItem: %v", err)
+	}
+	if string(got.Secret) != "s3cr3t" {
+		t.Fatalf("secret = %q, want %q", got.Secret, "s3cr3t")
+	}
+	if got.Label != "GitHub" {
+		t.Fatalf("label = %q, want %q", got.Label, "GitHub")
+	}
+	if got.Attributes["username"] != "octocat" {
+		t.Fatalf("username = %q, want %q", got.Attributes["username"], "octocat")
+	}
+}
+
+func TestStoreSearchAndCacheInvalidation(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore()
+
+	if err := s.CreateCollection(ctx, "default", "Default"); err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+
+	id, err := s.CreateItem(ctx, "default", &ItemData{
+		Secret:     []byte("pw"),
+		Label:      "One",
+		Attributes: map[string]string{"app": "mail"},
+	})
+	if err != nil {
+		t.Fatalf("CreateItem: %v", err)
+	}
+
+	hits, err := s.SearchItems(ctx, "default", map[string]string{"app": "mail"})
+	if err != nil {
+		t.Fatalf("SearchItems: %v", err)
+	}
+	if len(hits) != 1 || hits[0].ID != id {
+		t.Fatalf("search hits = %+v, want the created item", hits)
+	}
+
+	// A non-matching query returns nothing.
+	hits, _ = s.SearchItems(ctx, "default", map[string]string{"app": "chat"})
+	if len(hits) != 0 {
+		t.Fatalf("non-matching search returned %d hits, want 0", len(hits))
+	}
+
+	// Updating attributes must invalidate the metadata cache.
+	upd, err := s.GetItem(ctx, "default", id)
+	if err != nil {
+		t.Fatalf("GetItem: %v", err)
+	}
+	upd.Attributes = map[string]string{"app": "chat"}
+	if err := s.UpdateItem(ctx, "default", id, upd); err != nil {
+		t.Fatalf("UpdateItem: %v", err)
+	}
+
+	hits, _ = s.SearchItems(ctx, "default", map[string]string{"app": "chat"})
+	if len(hits) != 1 {
+		t.Fatalf("post-update search returned %d hits, want 1", len(hits))
+	}
+	hits, _ = s.SearchItems(ctx, "default", map[string]string{"app": "mail"})
+	if len(hits) != 0 {
+		t.Fatalf("stale search returned %d hits, want 0", len(hits))
+	}
+}
+
+func TestStoreAliases(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore()
+
+	if got, err := s.GetAlias(ctx, "default"); err != nil || got != "default" {
+		t.Fatalf("default alias = %q, %v; want default, nil", got, err)
+	}
+
+	if err := s.SetAlias(ctx, "login", "default"); err != nil {
+		t.Fatalf("SetAlias: %v", err)
+	}
+	if got, err := s.GetAlias(ctx, "login"); err != nil || got != "default" {
+		t.Fatalf("login alias = %q, %v; want default, nil", got, err)
+	}
+
+	if err := s.SetAlias(ctx, "login", ""); err != nil {
+		t.Fatalf("SetAlias(remove): %v", err)
+	}
+	if _, err := s.GetAlias(ctx, "login"); err == nil {
+		t.Fatal("login alias still resolves after removal")
+	}
+}
+
+func TestStoreLockState(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore()
+
+	if err := s.CreateCollection(ctx, "default", "Default"); err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+	if err := s.LockCollection(ctx, "default"); err != nil {
+		t.Fatalf("LockCollection: %v", err)
+	}
+	if data, _ := s.GetCollection(ctx, "default"); !data.Locked {
+		t.Fatal("collection not locked")
+	}
+	if err := s.UnlockCollection(ctx, "default"); err != nil {
+		t.Fatalf("UnlockCollection: %v", err)
+	}
+	if data, _ := s.GetCollection(ctx, "default"); data.Locked {
+		t.Fatal("collection still locked")
+	}
+}
+
+func TestSanitizeName(t *testing.T) {
+	for _, tc := range []struct{ in, want string }{
+		{"default", "default"},
+		{"a/b", "a_b"},
+		{"a b", "a_b"},
+		{".", "_"},
+		{"..", "__"},
+	} {
+		if got := SanitizeName(tc.in); got != tc.want {
+			t.Fatalf("SanitizeName(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestStoreMetadataTimestamps(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore()
+
+	before := time.Now().Add(-time.Second)
+	id, err := s.CreateItem(ctx, "default", &ItemData{
+		Secret: []byte("pw"),
+		Label:  "One",
+	})
+	if err != nil {
+		t.Fatalf("CreateItem: %v", err)
+	}
+
+	got, err := s.GetItem(ctx, "default", id)
+	if err != nil {
+		t.Fatalf("GetItem: %v", err)
+	}
+	if got.Created.Before(before) {
+		t.Fatalf("created = %v, want >= %v", got.Created, before)
+	}
+	if got.ContentType != "text/plain" {
+		t.Fatalf("content type = %q, want text/plain", got.ContentType)
+	}
+}

--- a/internal/secretservice/units.go
+++ b/internal/secretservice/units.go
@@ -1,0 +1,144 @@
+//go:build linux
+
+package secretservice
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/gopasspw/gopass/pkg/appdir"
+)
+
+// binaryPlaceholder is replaced with the absolute path of the running gopass
+// binary when the unit/activation templates are installed.
+const binaryPlaceholder = "@GOPASS@"
+
+// Unit and activation file names.
+const (
+	systemdUnitName = "gopass-secret-service.service"
+	dbusServiceName = "org.freedesktop.secrets.service"
+)
+
+// systemdUnitTemplate is the systemd user unit. It is kept byte-identical to
+// contrib/secret-service/gopass-secret-service.service; a unit test enforces
+// this.
+const systemdUnitTemplate = `[Unit]
+Description=gopass Secret Service D-Bus daemon
+Documentation=https://github.com/gopasspw/gopass/blob/master/docs/commands/secret-service.md
+After=graphical-session.target
+PartOf=graphical-session.target
+
+[Service]
+Type=dbus
+BusName=org.freedesktop.secrets
+ExecStart=` + binaryPlaceholder + ` secret-service serve
+Restart=on-failure
+
+[Install]
+WantedBy=graphical-session.target
+`
+
+// dbusActivationTemplate is the D-Bus session activation file. It is kept
+// byte-identical to contrib/secret-service/org.freedesktop.secrets.service; a
+// unit test enforces this.
+const dbusActivationTemplate = `[D-BUS Service]
+Name=org.freedesktop.secrets
+Exec=` + binaryPlaceholder + ` secret-service serve
+`
+
+// InstallPaths are the XDG locations used by Install and Uninstall.
+type InstallPaths struct {
+	// SystemdUnit is the path of the systemd user unit.
+	SystemdUnit string
+	// DBusActivation is the path of the D-Bus session activation file.
+	DBusActivation string
+}
+
+// DefaultInstallPaths returns the per-user paths used for installation. They
+// honor XDG_CONFIG_HOME / XDG_DATA_HOME (and GOPASS_HOMEDIR) via pkg/appdir so
+// tests can redirect them.
+func DefaultInstallPaths() InstallPaths {
+	configBase := filepath.Dir(appdir.UserConfig())
+	dataBase := filepath.Dir(appdir.UserData())
+
+	return InstallPaths{
+		SystemdUnit:    filepath.Join(configBase, "systemd", "user", systemdUnitName),
+		DBusActivation: filepath.Join(dataBase, "dbus-1", "services", dbusServiceName),
+	}
+}
+
+// Install writes the systemd user unit and the D-Bus session activation file
+// for the Secret Service daemon. It returns the paths it wrote.
+func Install(paths InstallPaths, binary string) ([]string, error) {
+	if binary == "" {
+		exe, err := os.Executable()
+		if err != nil {
+			return nil, fmt.Errorf("determine gopass binary: %w", err)
+		}
+		binary = exe
+	}
+
+	written := make([]string, 0, 2)
+	for _, f := range []struct {
+		path    string
+		content string
+	}{
+		{paths.SystemdUnit, renderTemplate(systemdUnitTemplate, binary)},
+		{paths.DBusActivation, renderTemplate(dbusActivationTemplate, binary)},
+	} {
+		if f.path == "" {
+			continue
+		}
+		if err := os.MkdirAll(filepath.Dir(f.path), 0o755); err != nil {
+			return written, fmt.Errorf("create %s: %w", filepath.Dir(f.path), err)
+		}
+		if err := os.WriteFile(f.path, []byte(f.content), 0o644); err != nil {
+			return written, fmt.Errorf("write %s: %w", f.path, err)
+		}
+		written = append(written, f.path)
+	}
+
+	return written, nil
+}
+
+// Uninstall removes the systemd user unit and the D-Bus session activation
+// file. It returns the paths it removed. Missing files are not an error.
+func Uninstall(paths InstallPaths) ([]string, error) {
+	removed := make([]string, 0, 2)
+	for _, p := range []string{paths.SystemdUnit, paths.DBusActivation} {
+		if p == "" {
+			continue
+		}
+		if err := os.Remove(p); err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+
+			return removed, fmt.Errorf("remove %s: %w", p, err)
+		}
+		removed = append(removed, p)
+	}
+
+	return removed, nil
+}
+
+// renderTemplate substitutes the binary placeholder with the given path. The
+// path is quoted so that it survives the systemd and D-Bus unit parsers even
+// when it contains spaces.
+func renderTemplate(tmpl, binary string) string {
+	return strings.ReplaceAll(tmpl, binaryPlaceholder, quoteUnitArg(binary))
+}
+
+// quoteUnitArg quotes a single command argument if it needs quoting.
+func quoteUnitArg(arg string) string {
+	if arg != "" && !strings.ContainsAny(arg, " \t\"'\\") {
+		return arg
+	}
+
+	escaped := strings.ReplaceAll(arg, `\`, `\\`)
+	escaped = strings.ReplaceAll(escaped, `"`, `\"`)
+
+	return `"` + escaped + `"`
+}

--- a/internal/secretservice/units_test.go
+++ b/internal/secretservice/units_test.go
@@ -1,0 +1,87 @@
+//go:build linux
+
+package secretservice
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestTemplatesMatchContrib ensures the embedded templates stay in sync with
+// the reference files shipped in contrib/secret-service/.
+func TestTemplatesMatchContrib(t *testing.T) {
+	for _, tc := range []struct {
+		file string
+		tmpl string
+	}{
+		{"gopass-secret-service.service", systemdUnitTemplate},
+		{"org.freedesktop.secrets.service", dbusActivationTemplate},
+	} {
+		got, err := os.ReadFile(filepath.Join("..", "..", "contrib", "secret-service", tc.file))
+		if err != nil {
+			t.Fatalf("read contrib file %s: %v", tc.file, err)
+		}
+		if string(got) != tc.tmpl {
+			t.Fatalf("contrib/%s differs from embedded template", tc.file)
+		}
+	}
+}
+
+func TestRenderTemplateQuotesSpaces(t *testing.T) {
+	out := renderTemplate(systemdUnitTemplate, "/opt/gopass bin/gopass")
+	if !strings.Contains(out, `ExecStart="/opt/gopass bin/gopass" secret-service serve`) {
+		t.Fatalf("binary path with spaces was not quoted:\n%s", out)
+	}
+
+	plain := renderTemplate(systemdUnitTemplate, "/usr/bin/gopass")
+	if !strings.Contains(plain, "ExecStart=/usr/bin/gopass secret-service serve") {
+		t.Fatalf("plain binary path should not be quoted:\n%s", plain)
+	}
+}
+
+func TestInstallUninstall(t *testing.T) {
+	dir := t.TempDir()
+	paths := InstallPaths{
+		SystemdUnit:    filepath.Join(dir, "systemd", "user", systemdUnitName),
+		DBusActivation: filepath.Join(dir, "dbus-1", "services", dbusServiceName),
+	}
+
+	written, err := Install(paths, "/usr/bin/gopass")
+	if err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	if len(written) != 2 {
+		t.Fatalf("wrote %d files, want 2", len(written))
+	}
+
+	body, err := os.ReadFile(paths.SystemdUnit)
+	if err != nil {
+		t.Fatalf("read unit: %v", err)
+	}
+	if strings.Contains(string(body), binaryPlaceholder) {
+		t.Fatal("placeholder was not substituted")
+	}
+	if !strings.Contains(string(body), "/usr/bin/gopass secret-service serve") {
+		t.Fatalf("unit does not reference the binary:\n%s", body)
+	}
+
+	// Uninstalling removes both files.
+	removed, err := Uninstall(paths)
+	if err != nil {
+		t.Fatalf("Uninstall: %v", err)
+	}
+	if len(removed) != 2 {
+		t.Fatalf("removed %d files, want 2", len(removed))
+	}
+
+	// A second uninstall is a no-op, not an error.
+	removed, err = Uninstall(paths)
+	if err != nil {
+		t.Fatalf("second Uninstall: %v", err)
+	}
+	if len(removed) != 0 {
+		t.Fatalf("second Uninstall removed %d files, want 0", len(removed))
+	}
+}

--- a/internal/secretservice/volatile.go
+++ b/internal/secretservice/volatile.go
@@ -1,0 +1,556 @@
+//go:build linux
+
+package secretservice
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/gopasspw/gopass/pkg/debug"
+	"golang.org/x/sys/unix"
+)
+
+// SessionCollectionName is the well-known name and alias of the volatile
+// session collection. Its object path is
+// /org/freedesktop/secrets/collection/session.
+const SessionCollectionName = "session"
+
+// vault stores secret payloads for the volatile session collection. The
+// kernel-keyring implementation keeps payloads outside the Go heap so they
+// never end up in a core dump or a heap profile; memVault is a fallback for
+// environments where the keyctl syscalls are unavailable (e.g. some sandboxes).
+type vault interface {
+	put(id string, payload []byte) error
+	get(id string) ([]byte, error)
+	remove(id string)
+	close()
+}
+
+// keyringVault stores payloads in the process kernel keyring. All keyring
+// syscalls run on one dedicated, runtime.LockOSThread-pinned OS thread because
+// Linux keeps keyring references in the per-task struct cred, so the syscalls
+// must not migrate between threads.
+type keyringVault struct {
+	calls chan func()
+
+	mu     sync.RWMutex
+	closed bool
+	once   sync.Once
+}
+
+// keyType is the keyring key type used for payloads.
+const keyType = "user"
+
+// newKeyringVault starts the pinned worker thread and ensures the process
+// keyring exists.
+func newKeyringVault() (*keyringVault, error) {
+	v := &keyringVault{calls: make(chan func())}
+
+	ready := make(chan error, 1)
+	go func() {
+		runtime.LockOSThread()
+
+		// Create the process keyring if it does not exist yet.
+		if _, err := unix.KeyctlGetKeyringID(unix.KEY_SPEC_PROCESS_KEYRING, true); err != nil {
+			ready <- err
+
+			return
+		}
+		ready <- nil
+
+		for fn := range v.calls {
+			fn()
+		}
+	}()
+
+	if err := <-ready; err != nil {
+		return nil, fmt.Errorf("kernel keyring unavailable: %w", err)
+	}
+
+	return v, nil
+}
+
+// keyDesc is the keyring description for a session item.
+func keyDesc(id string) string {
+	return "gopass-secret-service:" + id
+}
+
+// do runs fn on the pinned thread and returns its error.
+func (v *keyringVault) do(fn func() error) error {
+	v.mu.RLock()
+	defer v.mu.RUnlock()
+
+	if v.closed {
+		return fmt.Errorf("vault is closed")
+	}
+
+	done := make(chan error, 1)
+	v.calls <- func() { done <- fn() }
+
+	return <-done
+}
+
+// unlinkLocked removes any existing key for id. Must run on the pinned thread.
+func (v *keyringVault) unlinkLocked(id string) {
+	keyID, err := unix.KeyctlSearch(unix.KEY_SPEC_PROCESS_KEYRING, keyType, keyDesc(id), 0)
+	if err != nil {
+		return
+	}
+
+	// Unlink from the process keyring and then invalidate the key itself.
+	_, _ = unix.KeyctlInt(unix.KEYCTL_UNLINK, keyID, unix.KEY_SPEC_PROCESS_KEYRING, 0, 0)
+	_, _ = unix.KeyctlInt(unix.KEYCTL_INVALIDATE, keyID, 0, 0, 0)
+}
+
+func (v *keyringVault) put(id string, payload []byte) error {
+	return v.do(func() error {
+		// Replace any existing key: AddKey fails with EEXIST otherwise.
+		v.unlinkLocked(id)
+
+		if _, err := unix.AddKey(keyType, keyDesc(id), payload, unix.KEY_SPEC_PROCESS_KEYRING); err != nil {
+			return fmt.Errorf("add key: %w", err)
+		}
+
+		return nil
+	})
+}
+
+func (v *keyringVault) get(id string) ([]byte, error) {
+	var out []byte
+
+	err := v.do(func() error {
+		keyID, err := unix.KeyctlSearch(unix.KEY_SPEC_PROCESS_KEYRING, keyType, keyDesc(id), 0)
+		if err != nil {
+			return err
+		}
+
+		// A nil buffer makes KEYCTL_READ return the payload size.
+		size, err := unix.KeyctlBuffer(unix.KEYCTL_READ, keyID, nil, 0)
+		if err != nil {
+			return err
+		}
+		if size <= 0 {
+			out = []byte{}
+
+			return nil
+		}
+
+		buf := make([]byte, size)
+		n, err := unix.KeyctlBuffer(unix.KEYCTL_READ, keyID, buf, 0)
+		if err != nil {
+			return err
+		}
+		out = buf[:n]
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return out, nil
+}
+
+func (v *keyringVault) remove(id string) {
+	_ = v.do(func() error {
+		v.unlinkLocked(id)
+
+		return nil
+	})
+}
+
+func (v *keyringVault) close() {
+	v.once.Do(func() {
+		v.mu.Lock()
+		v.closed = true
+		close(v.calls)
+		v.mu.Unlock()
+	})
+}
+
+// memVault is an in-memory fallback used when the kernel keyring is
+// unavailable. Payloads live on the Go heap and are zeroed on removal.
+type memVault struct {
+	mu sync.Mutex
+	m  map[string][]byte
+}
+
+func newMemVault() *memVault {
+	return &memVault{m: make(map[string][]byte)}
+}
+
+func (v *memVault) put(id string, payload []byte) error {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+
+	cp := make([]byte, len(payload))
+	copy(cp, payload)
+	v.m[id] = cp
+
+	return nil
+}
+
+func (v *memVault) get(id string) ([]byte, error) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+
+	payload, ok := v.m[id]
+	if !ok {
+		return nil, fmt.Errorf("not found: %s", id)
+	}
+
+	cp := make([]byte, len(payload))
+	copy(cp, payload)
+
+	return cp, nil
+}
+
+func (v *memVault) remove(id string) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+
+	if payload, ok := v.m[id]; ok {
+		for i := range payload {
+			payload[i] = 0
+		}
+		delete(v.m, id)
+	}
+}
+
+func (v *memVault) close() {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+
+	for _, payload := range v.m {
+		for i := range payload {
+			payload[i] = 0
+		}
+	}
+	v.m = make(map[string][]byte)
+}
+
+// newVault returns a kernel-keyring vault if the syscalls are available, or an
+// in-memory fallback otherwise.
+func newVault() vault {
+	kv, err := newKeyringVault()
+	if err != nil {
+		debug.Log("secret-service: %s; falling back to in-memory vault", err)
+
+		return newMemVault()
+	}
+
+	return kv
+}
+
+// volatileItem is the metadata of a session collection item. The secret payload
+// itself is not held here; it lives in the vault.
+type volatileItem struct {
+	label       string
+	created     time.Time
+	modified    time.Time
+	contentType string
+	attributes  map[string]string
+}
+
+// keyringStore implements Store for the volatile session collection. It never
+// touches the gopass store: payloads go to the vault and metadata is kept in
+// memory only.
+type keyringStore struct {
+	vault   vault
+	label   string
+	created time.Time
+
+	mu    sync.RWMutex
+	items map[string]*volatileItem
+}
+
+// newKeyringStore creates the volatile store for the session collection.
+func newKeyringStore() *keyringStore {
+	return &keyringStore{
+		vault:   newVault(),
+		label:   "Session",
+		created: time.Now(),
+		items:   make(map[string]*volatileItem),
+	}
+}
+
+// sessionOnly rejects any collection but the well-known session collection.
+func sessionOnly(name string) error {
+	if name != SessionCollectionName {
+		return fmt.Errorf("volatile store only serves the session collection, got %q", name)
+	}
+
+	return nil
+}
+
+// Collections returns the single session collection.
+func (s *keyringStore) Collections(context.Context) ([]string, error) {
+	return []string{SessionCollectionName}, nil
+}
+
+// GetCollection returns the session collection's data.
+func (s *keyringStore) GetCollection(_ context.Context, name string) (*CollectionData, error) {
+	if err := sessionOnly(name); err != nil {
+		return nil, err
+	}
+
+	return &CollectionData{
+		Name:     SessionCollectionName,
+		Label:    s.label,
+		Created:  s.created,
+		Modified: time.Now(),
+		Locked:   false,
+	}, nil
+}
+
+// CreateCollection is not supported: the session collection always exists.
+func (s *keyringStore) CreateCollection(context.Context, string, string) error {
+	return fmt.Errorf("the session collection cannot be created")
+}
+
+// DeleteCollection is not supported: the session collection cannot be deleted.
+func (s *keyringStore) DeleteCollection(context.Context, string) error {
+	return fmt.Errorf("the session collection cannot be deleted")
+}
+
+// SetCollectionLabel updates the session collection label.
+func (s *keyringStore) SetCollectionLabel(ctx context.Context, name, label string) error {
+	if err := sessionOnly(name); err != nil {
+		return err
+	}
+	s.label = label
+
+	return nil
+}
+
+// Items returns the IDs of all session items.
+func (s *keyringStore) Items(_ context.Context, collection string) ([]string, error) {
+	if err := sessionOnly(collection); err != nil {
+		return nil, err
+	}
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	out := make([]string, 0, len(s.items))
+	for id := range s.items {
+		out = append(out, id)
+	}
+	sort.Strings(out)
+
+	return out, nil
+}
+
+// GetItem reads an item and its payload from the vault.
+func (s *keyringStore) GetItem(_ context.Context, collection, id string) (*ItemData, error) {
+	if err := sessionOnly(collection); err != nil {
+		return nil, err
+	}
+
+	s.mu.RLock()
+	it, ok := s.items[id]
+	s.mu.RUnlock()
+	if !ok {
+		return nil, fmt.Errorf("item not found: %s", id)
+	}
+
+	payload, err := s.vault.get(id)
+	if err != nil {
+		return nil, err
+	}
+
+	attrs := make(map[string]string, len(it.attributes))
+	for k, v := range it.attributes {
+		attrs[k] = v
+	}
+
+	return &ItemData{
+		ID:          id,
+		Secret:      payload,
+		Label:       it.label,
+		Created:     it.created,
+		Modified:    it.modified,
+		ContentType: it.contentType,
+		Attributes:  attrs,
+	}, nil
+}
+
+// CreateItem stores a new session item.
+func (s *keyringStore) CreateItem(_ context.Context, collection string, item *ItemData) (string, error) {
+	if err := sessionOnly(collection); err != nil {
+		return "", err
+	}
+
+	if item.ID == "" {
+		id, err := newID('i')
+		if err != nil {
+			return "", err
+		}
+		item.ID = id
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, ok := s.items[item.ID]; ok {
+		return "", fmt.Errorf("item already exists: %s", item.ID)
+	}
+
+	if err := s.vault.put(item.ID, item.Secret); err != nil {
+		return "", err
+	}
+
+	now := time.Now()
+	if item.Created.IsZero() {
+		item.Created = now
+	}
+	item.Modified = now
+	if item.ContentType == "" {
+		item.ContentType = "text/plain"
+	}
+
+	s.items[item.ID] = cloneVolatile(item)
+
+	return item.ID, nil
+}
+
+// UpdateItem overwrites an existing session item.
+func (s *keyringStore) UpdateItem(_ context.Context, collection, id string, item *ItemData) error {
+	if err := sessionOnly(collection); err != nil {
+		return err
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	existing, ok := s.items[id]
+	if !ok {
+		return fmt.Errorf("item not found: %s", id)
+	}
+
+	if err := s.vault.put(id, item.Secret); err != nil {
+		return err
+	}
+
+	item.ID = id
+	item.Created = existing.created
+	item.Modified = time.Now()
+	if item.ContentType == "" {
+		item.ContentType = existing.contentType
+	}
+	if item.ContentType == "" {
+		item.ContentType = "text/plain"
+	}
+
+	s.items[id] = cloneVolatile(item)
+
+	return nil
+}
+
+// DeleteItem removes a session item.
+func (s *keyringStore) DeleteItem(_ context.Context, collection, id string) error {
+	if err := sessionOnly(collection); err != nil {
+		return err
+	}
+
+	s.mu.Lock()
+	_, ok := s.items[id]
+	delete(s.items, id)
+	s.mu.Unlock()
+
+	if !ok {
+		return fmt.Errorf("item not found: %s", id)
+	}
+	s.vault.remove(id)
+
+	return nil
+}
+
+// SearchItems returns session items matching all given attributes.
+func (s *keyringStore) SearchItems(ctx context.Context, collection string, attrs map[string]string) ([]*ItemData, error) {
+	ids, err := s.Items(ctx, collection)
+	if err != nil {
+		return nil, err
+	}
+
+	var out []*ItemData
+	for _, id := range ids {
+		item, err := s.GetItem(ctx, collection, id)
+		if err != nil {
+			continue
+		}
+		if matchesAttributes(item, attrs) {
+			out = append(out, item)
+		}
+	}
+
+	return out, nil
+}
+
+// SearchAllItems searches the session collection only.
+func (s *keyringStore) SearchAllItems(ctx context.Context, attrs map[string]string) (map[string][]*ItemData, error) {
+	items, err := s.SearchItems(ctx, SessionCollectionName, attrs)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(items) == 0 {
+		return map[string][]*ItemData{}, nil
+	}
+
+	return map[string][]*ItemData{SessionCollectionName: items}, nil
+}
+
+// LockCollection is a no-op: the session collection is always unlocked while
+// the session exists.
+func (s *keyringStore) LockCollection(context.Context, string) error { return nil }
+
+// UnlockCollection is a no-op.
+func (s *keyringStore) UnlockCollection(context.Context, string) error { return nil }
+
+// GetAlias resolves the session alias.
+func (s *keyringStore) GetAlias(_ context.Context, alias string) (string, error) {
+	if alias != SessionCollectionName {
+		return "", fmt.Errorf("alias not found: %s", alias)
+	}
+
+	return SessionCollectionName, nil
+}
+
+// SetAlias rejects changes to the session alias.
+func (s *keyringStore) SetAlias(context.Context, string, string) error {
+	return fmt.Errorf("the session alias is read-only")
+}
+
+// Aliases returns the well-known session alias.
+func (s *keyringStore) Aliases(context.Context) (map[string]string, error) {
+	return map[string]string{SessionCollectionName: SessionCollectionName}, nil
+}
+
+// Close wipes the vault.
+func (s *keyringStore) Close(context.Context) error {
+	s.vault.close()
+
+	return nil
+}
+
+// cloneVolatile makes a private copy of an item's metadata (never its payload,
+// which is held by the vault).
+func cloneVolatile(item *ItemData) *volatileItem {
+	attrs := make(map[string]string, len(item.Attributes))
+	for k, v := range item.Attributes {
+		attrs[k] = v
+	}
+
+	return &volatileItem{
+		label:       item.Label,
+		created:     item.Created,
+		modified:    item.Modified,
+		contentType: item.ContentType,
+		attributes:  attrs,
+	}
+}

--- a/internal/secretservice/volatile_test.go
+++ b/internal/secretservice/volatile_test.go
@@ -1,0 +1,122 @@
+//go:build linux
+
+package secretservice
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestVaultRoundTrip(t *testing.T) {
+	// Exercises whichever vault the environment provides (kernel keyring or
+	// the in-memory fallback).
+	v := newVault()
+	defer v.close()
+
+	if err := v.put("i1", []byte("hunter2")); err != nil {
+		t.Fatalf("put: %v", err)
+	}
+
+	got, err := v.get("i1")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if string(got) != "hunter2" {
+		t.Fatalf("get = %q, want %q", got, "hunter2")
+	}
+
+	// Overwriting must replace the previous payload.
+	if err := v.put("i1", []byte("new")); err != nil {
+		t.Fatalf("put(overwrite): %v", err)
+	}
+	got, _ = v.get("i1")
+	if string(got) != "new" {
+		t.Fatalf("get after overwrite = %q, want %q", got, "new")
+	}
+
+	v.remove("i1")
+	if _, err := v.get("i1"); err == nil {
+		t.Fatal("get after remove succeeded, want error")
+	}
+}
+
+func TestKeyringStoreItemLifecycle(t *testing.T) {
+	ctx := context.Background()
+	s := newKeyringStore()
+	defer func() { _ = s.Close(ctx) }()
+
+	if got, err := s.Collections(ctx); err != nil || len(got) != 1 || got[0] != SessionCollectionName {
+		t.Fatalf("Collections = %v, %v; want [session], nil", got, err)
+	}
+	if _, err := s.GetCollection(ctx, SessionCollectionName); err != nil {
+		t.Fatalf("GetCollection(session): %v", err)
+	}
+
+	id, err := s.CreateItem(ctx, SessionCollectionName, &ItemData{
+		Secret:     []byte("transient"),
+		Label:      "Temp",
+		Attributes: map[string]string{"scope": "test"},
+	})
+	if err != nil {
+		t.Fatalf("CreateItem: %v", err)
+	}
+	if !strings.HasPrefix(id, "i") {
+		t.Fatalf("id = %q, want i-prefixed", id)
+	}
+
+	got, err := s.GetItem(ctx, SessionCollectionName, id)
+	if err != nil {
+		t.Fatalf("GetItem: %v", err)
+	}
+	if string(got.Secret) != "transient" {
+		t.Fatalf("secret = %q, want %q", got.Secret, "transient")
+	}
+	if got.ContentType != "text/plain" {
+		t.Fatalf("content type = %q, want text/plain", got.ContentType)
+	}
+
+	hits, err := s.SearchItems(ctx, SessionCollectionName, map[string]string{"scope": "test"})
+	if err != nil {
+		t.Fatalf("SearchItems: %v", err)
+	}
+	if len(hits) != 1 || hits[0].ID != id {
+		t.Fatalf("search hits = %+v, want the created item", hits)
+	}
+
+	// Update replaces the payload and preserves the creation time.
+	got.Secret = []byte("updated")
+	if err := s.UpdateItem(ctx, SessionCollectionName, id, got); err != nil {
+		t.Fatalf("UpdateItem: %v", err)
+	}
+	got, _ = s.GetItem(ctx, SessionCollectionName, id)
+	if string(got.Secret) != "updated" {
+		t.Fatalf("secret after update = %q, want %q", got.Secret, "updated")
+	}
+
+	if err := s.DeleteItem(ctx, SessionCollectionName, id); err != nil {
+		t.Fatalf("DeleteItem: %v", err)
+	}
+	if _, err := s.GetItem(ctx, SessionCollectionName, id); err == nil {
+		t.Fatal("GetItem after delete succeeded, want error")
+	}
+}
+
+func TestKeyringStoreImmutability(t *testing.T) {
+	ctx := context.Background()
+	s := newKeyringStore()
+	defer func() { _ = s.Close(ctx) }()
+
+	if err := s.CreateCollection(ctx, SessionCollectionName, "x"); err == nil {
+		t.Fatal("CreateCollection(session) succeeded, want error")
+	}
+	if err := s.DeleteCollection(ctx, SessionCollectionName); err == nil {
+		t.Fatal("DeleteCollection(session) succeeded, want error")
+	}
+	if err := s.SetAlias(ctx, "session", "other"); err == nil {
+		t.Fatal("SetAlias(session) succeeded, want error")
+	}
+	if _, err := s.GetCollection(ctx, "other"); err == nil {
+		t.Fatal("GetCollection(other) succeeded, want error")
+	}
+}

--- a/main_test.go
+++ b/main_test.go
@@ -100,6 +100,19 @@ var commandsWithError = set.Map([]string{
 	".audit",
 })
 
+// commandsSkipped lists commands whose Action must not be invoked during
+// command discovery. Only commands that are long-running or would modify the
+// host belong here.
+//
+//   - secret-service.serve starts a daemon that acquires the well-known
+//     org.freedesktop.secrets bus name and blocks until interrupted, so it must
+//     never be run from a unit test. Its siblings (status, install, uninstall)
+//     are safe: install/uninstall write below GOPASS_HOMEDIR, which the unit
+//     tester points at a temporary directory.
+var commandsSkipped = set.Map([]string{
+	".secret-service.serve",
+})
+
 func TestGetCommands(t *testing.T) {
 	u := gptest.NewUnitTester(t)
 
@@ -135,7 +148,7 @@ func TestGetCommands(t *testing.T) {
 	}
 
 	commands := getCommands(act, app)
-	assert.Len(t, commands, 45)
+	assert.Len(t, commands, 46)
 
 	prefix := ""
 	testCommands(t, ctx, app, commands, prefix)
@@ -145,7 +158,12 @@ func testCommands(t *testing.T, ctx context.Context, app *cli.Command, commands 
 	t.Helper()
 
 	for _, cmd := range commands {
+		fullName := prefix + "." + cmd.Name
+
 		if cmd.Name == "update" || cmd.Name == "agent" || cmd.Name == "doctor" {
+			continue
+		}
+		if _, skip := commandsSkipped[fullName]; skip {
 			continue
 		}
 
@@ -164,7 +182,6 @@ func testCommands(t *testing.T, ctx context.Context, app *cli.Command, commands 
 		}
 
 		if cmd.Action != nil {
-			fullName := prefix + "." + cmd.Name
 			if _, found := commandsWithError[fullName]; found {
 				require.Error(t, runCmdAction(ctx, cmd), "Command %s should fail", fullName)
 

--- a/tests/secret_service_dh_test.go
+++ b/tests/secret_service_dh_test.go
@@ -1,0 +1,198 @@
+//go:build linux
+
+package tests
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"crypto/sha256"
+	"math/big"
+	"testing"
+
+	"github.com/godbus/dbus/v5"
+	"github.com/gopasspw/gopass/internal/secretservice"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/hkdf"
+)
+
+// The RFC 3526 MODP group 2 parameters, duplicated here so that the test acts
+// as an independent DH client. The server-side implementation lives in
+// internal/secretservice/crypto/dh.go.
+var (
+	testDHPrime = func() *big.Int {
+		p, _ := new(big.Int).SetString(
+			"FFFFFFFFFFFFFFFFC90FDAA22168C234C4C6628B80DC1CD1"+
+				"29024E088A67CC74020BBEA63B139B22514A08798E3404DD"+
+				"EF9519B3CD3A431B302B0A6DF25F14374FE1356D6D51C245"+
+				"E485B576625E7EC6F44C42E9A637ED6B0BFF5CB6F406B7ED"+
+				"EE386BFB5A899FA5AE9F24117C4B1FE649286651ECE65381"+
+				"FFFFFFFFFFFFFFFF", 16,
+		)
+
+		return p
+	}()
+	testDHGen = big.NewInt(2)
+)
+
+// testLeftPad left-pads b to n bytes.
+func testLeftPad(b []byte, n int) []byte {
+	if len(b) >= n {
+		return b
+	}
+
+	out := make([]byte, n)
+	copy(out[n-len(b):], b)
+
+	return out
+}
+
+// testDHKey derives the AES-128 key the way a libsecret client would.
+func testDHKey(serverPublic []byte, clientPrivate *big.Int) []byte {
+	shared := new(big.Int).Exp(new(big.Int).SetBytes(serverPublic), clientPrivate, testDHPrime)
+	reader := hkdf.New(sha256.New, testLeftPad(shared.Bytes(), 128), nil, nil)
+	key := make([]byte, 16)
+
+	if _, err := reader.Read(key); err != nil {
+		panic(err)
+	}
+
+	return key
+}
+
+// testEncrypt encrypts plaintext with AES-128-CBC and PKCS#7, returning the IV
+// and the ciphertext.
+func testEncrypt(t *testing.T, key, plaintext []byte) ([]byte, []byte) {
+	t.Helper()
+
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		t.Fatalf("aes.NewCipher: %v", err)
+	}
+
+	padLen := aes.BlockSize - (len(plaintext) % aes.BlockSize)
+	padded := make([]byte, len(plaintext)+padLen)
+	copy(padded, plaintext)
+
+	for i := len(plaintext); i < len(padded); i++ {
+		padded[i] = byte(padLen)
+	}
+
+	iv := make([]byte, aes.BlockSize)
+	if _, err := rand.Read(iv); err != nil {
+		t.Fatalf("rand: %v", err)
+	}
+
+	ciphertext := make([]byte, len(padded))
+	cipher.NewCBCEncrypter(block, iv).CryptBlocks(ciphertext, padded)
+
+	return iv, ciphertext
+}
+
+// testDecrypt decrypts an AES-128-CBC ciphertext and strips PKCS#7 padding.
+func testDecrypt(t *testing.T, key, iv, ciphertext []byte) []byte {
+	t.Helper()
+
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		t.Fatalf("aes.NewCipher: %v", err)
+	}
+
+	decrypted := make([]byte, len(ciphertext))
+	cipher.NewCBCDecrypter(block, iv).CryptBlocks(decrypted, ciphertext)
+
+	if len(decrypted) == 0 {
+		t.Fatal("empty plaintext")
+	}
+
+	padLen := int(decrypted[len(decrypted)-1])
+	if padLen == 0 || padLen > aes.BlockSize || padLen > len(decrypted) {
+		t.Fatalf("invalid padding length: %d", padLen)
+	}
+
+	return decrypted[:len(decrypted)-padLen]
+}
+
+// TestSecretServiceDHRoundTrip exercises the
+// "dh-ietf1024-sha256-aes128-cbc-pkcs7" transport algorithm end to end, acting
+// as an independent libsecret-style client.
+func TestSecretServiceDHRoundTrip(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	ts := newTester(t)
+	defer ts.teardown()
+
+	ts.initStore()
+
+	address, stopBus := startPrivateBus(t)
+	defer stopBus()
+
+	t.Setenv("DBUS_SESSION_BUS_ADDRESS", address)
+
+	logs := startSecretServiceDaemon(t, ts)
+
+	conn := connectBus(t, address)
+	waitForSecretService(t, conn, logs)
+
+	svc := conn.Object(secretservice.ServiceName, secretservice.ServicePath)
+
+	// Client side of the DH key exchange.
+	clientPrivate, err := rand.Int(rand.Reader, testDHPrime)
+	require.NoError(t, err)
+
+	clientPublic := new(big.Int).Exp(testDHGen, clientPrivate, testDHPrime)
+
+	var (
+		output  dbus.Variant
+		session dbus.ObjectPath
+	)
+	require.NoError(t, svc.Call(secretservice.ServiceIface+".OpenSession", 0, secretservice.AlgorithmDHAES, dbus.MakeVariant(testLeftPad(clientPublic.Bytes(), 128))).Store(&output, &session))
+	require.NotEqual(t, secretservice.NullPath, session)
+
+	t.Cleanup(func() {
+		_ = conn.Object(secretservice.ServiceName, session).Call(secretservice.SessionIface+".Close", 0).Err
+	})
+
+	serverPublic, ok := output.Value().([]byte)
+	require.True(t, ok, "server output is not a byte slice: %T", output.Value())
+	require.Len(t, serverPublic, 128, "server public key must be left-padded to 128 bytes")
+
+	key := testDHKey(serverPublic, clientPrivate)
+
+	// Store an encrypted secret.
+	var defaultPath dbus.ObjectPath
+	require.NoError(t, svc.Call(secretservice.ServiceIface+".ReadAlias", 0, "default").Store(&defaultPath))
+
+	coll := conn.Object(secretservice.ServiceName, defaultPath)
+
+	iv, ciphertext := testEncrypt(t, key, []byte("dh-secret-value"))
+
+	secret := secretservice.Secret{
+		Session:     session,
+		Parameters:  iv,
+		Value:       ciphertext,
+		ContentType: "text/plain",
+	}
+	props := map[string]dbus.Variant{
+		secretservice.ItemIface + ".Label": dbus.MakeVariant("DH Item"),
+	}
+
+	var itemPath, promptPath dbus.ObjectPath
+	require.NoError(t, coll.Call(secretservice.CollectionIface+".CreateItem", 0, props, secret, false).Store(&itemPath, &promptPath))
+	require.NotEqual(t, secretservice.NullPath, itemPath)
+
+	// Read it back and decrypt with the client key.
+	var got secretservice.Secret
+	require.NoError(t, conn.Object(secretservice.ServiceName, itemPath).Call(secretservice.ItemIface+".GetSecret", 0, session).Store(&got))
+	assert.Len(t, got.Parameters, aes.BlockSize, "IV must be 16 bytes")
+	assert.Equal(t, "dh-secret-value", string(testDecrypt(t, key, got.Parameters, got.Value)))
+
+	// A GetSecrets batch call must use the same transport encryption.
+	var batch map[dbus.ObjectPath]secretservice.Secret
+	require.NoError(t, svc.Call(secretservice.ServiceIface+".GetSecrets", 0, []dbus.ObjectPath{itemPath}, session).Store(&batch))
+	require.Contains(t, batch, itemPath)
+	assert.Equal(t, "dh-secret-value", string(testDecrypt(t, key, batch[itemPath].Parameters, batch[itemPath].Value)))
+}

--- a/tests/secret_service_libsecret_test.go
+++ b/tests/secret_service_libsecret_test.go
@@ -1,0 +1,135 @@
+//go:build linux
+
+package tests
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// installPath returns a path inside the tester's temporary home directory, which
+// GOPASS_HOMEDIR points at.
+func installPath(ts *tester, elem ...string) string {
+	return filepath.Join(append([]string{ts.tempDir}, elem...)...)
+}
+
+// TestSecretServiceInstallUninstall verifies the install subcommand writes the
+// systemd user unit and the D-Bus session activation file, and that uninstall
+// removes them again. GOPASS_HOMEDIR redirects the XDG paths into the test's
+// temporary directory.
+func TestSecretServiceInstallUninstall(t *testing.T) {
+	ts := newTester(t)
+	defer ts.teardown()
+
+	systemdUnit := installPath(ts, ".config", "systemd", "user", "gopass-secret-service.service")
+	activation := installPath(ts, ".local", "share", "dbus-1", "services", "org.freedesktop.secrets.service")
+
+	out, err := ts.run("secret-service install")
+	require.NoError(t, err, "secret-service install failed:\n%s", out)
+	assert.Contains(t, out, systemdUnit)
+
+	unit, err := os.ReadFile(systemdUnit)
+	require.NoError(t, err, "systemd unit not written")
+	assert.Contains(t, string(unit), "ExecStart=")
+	assert.Contains(t, string(unit), "secret-service serve")
+	assert.Contains(t, string(unit), "BusName=org.freedesktop.secrets")
+
+	body, err := os.ReadFile(activation)
+	require.NoError(t, err, "D-Bus activation file not written")
+	assert.Contains(t, string(body), "Name=org.freedesktop.secrets")
+
+	out, err = ts.run("secret-service uninstall")
+	require.NoError(t, err, "secret-service uninstall failed:\n%s", out)
+
+	_, err = os.Stat(systemdUnit)
+	assert.True(t, os.IsNotExist(err), "systemd unit still present")
+	_, err = os.Stat(activation)
+	assert.True(t, os.IsNotExist(err), "D-Bus activation file still present")
+
+	// A second uninstall must be a no-op.
+	out, err = ts.run("secret-service uninstall")
+	require.NoError(t, err, "second uninstall failed:\n%s", out)
+	assert.Contains(t, out, "Nothing to remove")
+}
+
+// TestSecretServiceSecretTool verifies interoperability with a real
+// libsecret-based client. secret-tool negotiates the
+// "dh-ietf1024-sha256-aes128-cbc-pkcs7" transport, so a successful round-trip
+// proves the DH implementation is wire-compatible with libsecret (not just
+// with our own tests).
+func TestSecretServiceSecretTool(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	if _, err := exec.LookPath("secret-tool"); err != nil {
+		t.Skipf("secret-tool (libsecret) not available: %v", err)
+	}
+
+	ts := newTester(t)
+	defer ts.teardown()
+
+	ts.initStore()
+
+	address, stopBus := startPrivateBus(t)
+	defer stopBus()
+
+	t.Setenv("DBUS_SESSION_BUS_ADDRESS", address)
+
+	logs := startSecretServiceDaemon(t, ts)
+
+	conn := connectBus(t, address)
+	waitForSecretService(t, conn, logs)
+
+	// runTool executes secret-tool with a timeout so a hang cannot stall CI.
+	runTool := func(stdin string, args ...string) (string, error) {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		cmd := exec.CommandContext(ctx, "secret-tool", args...)
+		if stdin != "" {
+			cmd.Stdin = strings.NewReader(stdin)
+		}
+
+		out, err := cmd.CombinedOutput()
+
+		return strings.TrimSpace(string(out)), err
+	}
+
+	attrs := []string{"service", "gopass-integration-test"}
+
+	// Store a secret through libsecret.
+	out, err := runTool("hunter2", append([]string{"store", "--label", "Gopass Test"}, attrs...)...)
+	require.NoError(t, err, "secret-tool store failed: %s", out)
+
+	// The secret must now be visible in the gopass store.
+	ls, err := ts.run("ls secret-service")
+	require.NoError(t, err, "gopass ls failed: %s", ls)
+	assert.Contains(t, ls, "default", "collection not created in the gopass store:\n%s", ls)
+
+	// Look it up through libsecret. Lookup returns the value on stdout, so the
+	// combined output is compared exactly.
+	cmd := exec.Command("secret-tool", "lookup", attrs[0], attrs[1])
+	cmd.Env = append(cmd.Environ(), "DBUS_SESSION_BUS_ADDRESS="+address)
+
+	looked, err := cmd.Output()
+	require.NoError(t, err, "secret-tool lookup failed")
+	assert.Equal(t, "hunter2", strings.TrimSpace(string(looked)))
+
+	// Clear it again.
+	out, err = runTool("", append([]string{"clear"}, attrs...)...)
+	require.NoError(t, err, "secret-tool clear failed: %s", out)
+
+	// Lookup must now fail with a non-zero exit code.
+	if out, err := runTool("", "lookup", attrs[0], attrs[1]); err == nil {
+		t.Fatalf("secret-tool lookup succeeded after clear: %s", out)
+	}
+}

--- a/tests/secret_service_test.go
+++ b/tests/secret_service_test.go
@@ -1,0 +1,321 @@
+//go:build linux
+
+package tests
+
+import (
+	"bufio"
+	"bytes"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/godbus/dbus/v5"
+	"github.com/gopasspw/gopass/internal/secretservice"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// startPrivateBus starts a private D-Bus session bus and returns its address
+// plus a cleanup function. The test is skipped if dbus-daemon is unavailable.
+func startPrivateBus(t *testing.T) (string, func()) {
+	t.Helper()
+
+	if _, err := exec.LookPath("dbus-daemon"); err != nil {
+		t.Skipf("dbus-daemon not available: %v", err)
+	}
+
+	cmd := exec.Command("dbus-daemon", "--session", "--nofork", "--print-address")
+	stdout, err := cmd.StdoutPipe()
+	require.NoError(t, err)
+
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+
+	require.NoError(t, cmd.Start())
+
+	stop := func() { _ = cmd.Process.Kill() }
+
+	addrCh := make(chan string, 1)
+	go func() {
+		scanner := bufio.NewScanner(stdout)
+		for scanner.Scan() {
+			line := strings.TrimSpace(scanner.Text())
+			if strings.HasPrefix(line, "unix:") {
+				addrCh <- line
+
+				return
+			}
+		}
+		close(addrCh)
+	}()
+
+	select {
+	case addr, ok := <-addrCh:
+		if !ok || addr == "" {
+			stop()
+
+			t.Skipf("failed to read private bus address: %s", stderr.String())
+		}
+
+		return addr, stop
+	case <-time.After(10 * time.Second):
+		stop()
+
+		t.Skipf("timed out waiting for private bus: %s", stderr.String())
+
+		return "", stop
+	}
+}
+
+// connectBus connects to an explicit D-Bus address.
+func connectBus(t *testing.T, address string) *dbus.Conn {
+	t.Helper()
+
+	conn, err := dbus.Dial(address)
+	require.NoError(t, err)
+	require.NoError(t, conn.Auth(nil))
+	require.NoError(t, conn.Hello())
+
+	t.Cleanup(func() { _ = conn.Close() })
+
+	return conn
+}
+
+// startSecretServiceDaemon starts `gopass secret-service serve` as a
+// subprocess and returns its log buffer. Subprocesses inherit the test
+// environment, so GOPASS_HOMEDIR, GNUPGHOME and DBUS_SESSION_BUS_ADDRESS apply.
+func startSecretServiceDaemon(t *testing.T, ts *tester) *bytes.Buffer {
+	t.Helper()
+
+	logs := &bytes.Buffer{}
+
+	daemon := exec.Command(ts.Binary, "secret-service", "serve", "--prefix", "secret-service")
+	daemon.Stdout = logs
+	daemon.Stderr = logs
+	require.NoError(t, daemon.Start())
+
+	t.Cleanup(func() {
+		if daemon.Process != nil {
+			_ = daemon.Process.Kill()
+		}
+		_ = daemon.Wait()
+	})
+
+	return logs
+}
+
+// waitForSecretService waits until some peer owns org.freedesktop.secrets.
+func waitForSecretService(t *testing.T, conn *dbus.Conn, logs *bytes.Buffer) {
+	t.Helper()
+
+	deadline := time.Now().Add(60 * time.Second)
+	for time.Now().Before(deadline) {
+		var hasOwner bool
+		if err := conn.BusObject().Call("org.freedesktop.DBus.NameHasOwner", 0, secretservice.ServiceName).Store(&hasOwner); err == nil && hasOwner {
+			return
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+
+	t.Fatalf("secret-service never acquired %s; daemon output:\n%s", secretservice.ServiceName, logs.String())
+}
+
+// openSession opens a plain session and registers its cleanup.
+func openSession(t *testing.T, conn *dbus.Conn) dbus.ObjectPath {
+	t.Helper()
+
+	var (
+		output  dbus.Variant
+		session dbus.ObjectPath
+	)
+
+	svc := conn.Object(secretservice.ServiceName, secretservice.ServicePath)
+	err := svc.Call(secretservice.ServiceIface+".OpenSession", 0, secretservice.AlgorithmPlain, dbus.MakeVariant([]byte{})).Store(&output, &session)
+	require.NoError(t, err, "OpenSession failed")
+	require.NotEqual(t, secretservice.NullPath, session)
+
+	t.Cleanup(func() {
+		_ = conn.Object(secretservice.ServiceName, session).Call(secretservice.SessionIface+".Close", 0).Err
+	})
+
+	return session
+}
+
+// TestSecretServiceRoundTrip starts the daemon on a private bus and exercises
+// the full Secret Service API with the "plain" transport algorithm, then
+// verifies the secrets are visible through the regular gopass CLI.
+func TestSecretServiceRoundTrip(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	ts := newTester(t)
+	defer ts.teardown()
+
+	ts.initStore()
+
+	address, stopBus := startPrivateBus(t)
+	defer stopBus()
+
+	t.Setenv("DBUS_SESSION_BUS_ADDRESS", address)
+
+	logs := startSecretServiceDaemon(t, ts)
+
+	conn := connectBus(t, address)
+	waitForSecretService(t, conn, logs)
+
+	svc := conn.Object(secretservice.ServiceName, secretservice.ServicePath)
+	session := openSession(t, conn)
+
+	// The default collection alias must resolve.
+	var defaultPath dbus.ObjectPath
+	require.NoError(t, svc.Call(secretservice.ServiceIface+".ReadAlias", 0, "default").Store(&defaultPath))
+	require.NotEqual(t, secretservice.NullPath, defaultPath, "default alias not set")
+
+	// The session collection alias must resolve too.
+	var sessionCollPath dbus.ObjectPath
+	require.NoError(t, svc.Call(secretservice.ServiceIface+".ReadAlias", 0, secretservice.SessionCollectionName).Store(&sessionCollPath))
+	assert.Equal(t, secretservice.CollectionDBusPath(secretservice.SessionCollectionName), sessionCollPath)
+
+	coll := conn.Object(secretservice.ServiceName, defaultPath)
+
+	// Create an item through the D-Bus API.
+	props := map[string]dbus.Variant{
+		secretservice.ItemIface + ".Label":      dbus.MakeVariant("GitHub Token"),
+		secretservice.ItemIface + ".Attributes": dbus.MakeVariant(map[string]string{"service": "github.com", "username": "octocat"}),
+	}
+	secret := secretservice.Secret{
+		Session:     session,
+		Value:       []byte("s3cr3t-value"),
+		ContentType: "text/plain",
+	}
+
+	var (
+		itemPath   dbus.ObjectPath
+		promptPath dbus.ObjectPath
+	)
+	require.NoError(t, coll.Call(secretservice.CollectionIface+".CreateItem", 0, props, secret, false).Store(&itemPath, &promptPath))
+	assert.Equal(t, secretservice.NullPath, promptPath, "CreateItem should complete without a prompt")
+	require.NotEqual(t, secretservice.NullPath, itemPath)
+
+	// Read it back through the D-Bus API.
+	var got secretservice.Secret
+	require.NoError(t, conn.Object(secretservice.ServiceName, itemPath).Call(secretservice.ItemIface+".GetSecret", 0, session).Store(&got))
+	assert.Equal(t, "s3cr3t-value", string(got.Value))
+	assert.Equal(t, "text/plain", got.ContentType)
+
+	// The item must be searchable by attribute.
+	var unlocked, locked []dbus.ObjectPath
+	require.NoError(t, svc.Call(secretservice.ServiceIface+".SearchItems", 0, map[string]string{"service": "github.com"}).Store(&unlocked, &locked))
+	assert.Contains(t, unlocked, itemPath)
+	assert.Empty(t, locked)
+
+	// The item must be visible through the gopass CLI.
+	id := string(itemPath[strings.LastIndex(string(itemPath), "/")+1:])
+	out, err := ts.run("show secret-service/default/" + id)
+	require.NoError(t, err, "gopass show failed:\n%s", out)
+	assert.Contains(t, out, "s3cr3t-value")
+
+	// A secret written by the CLI must be readable through D-Bus.
+	out, err = ts.runCmd([]string{ts.Binary, "insert", "--multiline", "secret-service/default/cli-inserted"}, []byte("cli-value\n---\nsource: cli\n"))
+	require.NoError(t, err, "gopass insert failed:\n%s", out)
+
+	require.NoError(t, svc.Call(secretservice.ServiceIface+".SearchItems", 0, map[string]string{"source": "cli"}).Store(&unlocked, &locked))
+	require.Len(t, unlocked, 1, "CLI-inserted secret not found via SearchItems")
+
+	var cliSecret secretservice.Secret
+	require.NoError(t, conn.Object(secretservice.ServiceName, unlocked[0]).Call(secretservice.ItemIface+".GetSecret", 0, session).Store(&cliSecret))
+	assert.Equal(t, "cli-value", string(cliSecret.Value))
+}
+
+// TestSecretServiceSessionCollection verifies that the volatile session
+// collection is served from memory and never touches the gopass store.
+func TestSecretServiceSessionCollection(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	ts := newTester(t)
+	defer ts.teardown()
+
+	ts.initStore()
+
+	address, stopBus := startPrivateBus(t)
+	defer stopBus()
+
+	t.Setenv("DBUS_SESSION_BUS_ADDRESS", address)
+
+	logs := startSecretServiceDaemon(t, ts)
+
+	conn := connectBus(t, address)
+	waitForSecretService(t, conn, logs)
+
+	svc := conn.Object(secretservice.ServiceName, secretservice.ServicePath)
+	session := openSession(t, conn)
+
+	// The session collection is not part of Service.Collections.
+	var collections []dbus.ObjectPath
+	require.NoError(t, svc.StoreProperty(secretservice.ServiceIface+".Collections", &collections))
+	assert.NotContains(t, collections, secretservice.CollectionDBusPath(secretservice.SessionCollectionName))
+
+	// libsecret resolves aliases to /org/freedesktop/secrets/aliases/<alias>,
+	// so the Collection interface must be served there as well.
+	sessionColl := conn.Object(secretservice.ServiceName, secretservice.AliasDBusPath(secretservice.SessionCollectionName))
+
+	// Store a transient secret.
+	props := map[string]dbus.Variant{
+		secretservice.ItemIface + ".Label": dbus.MakeVariant("Transient"),
+	}
+	secret := secretservice.Secret{
+		Session: session,
+		Value:   []byte("volatile-value"),
+	}
+
+	var itemPath, promptPath dbus.ObjectPath
+	require.NoError(t, sessionColl.Call(secretservice.CollectionIface+".CreateItem", 0, props, secret, false).Store(&itemPath, &promptPath))
+	require.NotEqual(t, secretservice.NullPath, itemPath)
+
+	var got secretservice.Secret
+	require.NoError(t, conn.Object(secretservice.ServiceName, itemPath).Call(secretservice.ItemIface+".GetSecret", 0, session).Store(&got))
+	assert.Equal(t, "volatile-value", string(got.Value))
+
+	// Nothing may have been written to the gopass store.
+	out, _ := ts.run("ls secret-service")
+	assert.NotContains(t, out, secretservice.SessionCollectionName, "session collection leaked into the gopass store:\n%s", out)
+
+	// The session collection cannot be deleted.
+	var delPrompt dbus.ObjectPath
+	err := sessionColl.Call(secretservice.CollectionIface+".Delete", 0).Store(&delPrompt)
+	assert.Error(t, err, "deleting the session collection must fail")
+}
+
+// TestSecretServiceStatus checks the status subcommand against a private bus.
+func TestSecretServiceStatus(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	ts := newTester(t)
+	defer ts.teardown()
+
+	ts.initStore()
+
+	address, stopBus := startPrivateBus(t)
+	defer stopBus()
+
+	t.Setenv("DBUS_SESSION_BUS_ADDRESS", address)
+
+	out, err := ts.run("secret-service status")
+	require.NoError(t, err)
+	assert.Contains(t, out, "no provider owns")
+
+	logs := startSecretServiceDaemon(t, ts)
+
+	conn := connectBus(t, address)
+	waitForSecretService(t, conn, logs)
+
+	out, err = ts.run("secret-service status")
+	require.NoError(t, err)
+	assert.Contains(t, out, "is owned")
+}


### PR DESCRIPTION
Implement the org.freedesktop.secrets D-Bus API on top of the gopass store, so desktop applications (Firefox, Chromium, VS Code, Electron apps, NetworkManager, secret-tool, ...) keep their secrets in the same GPG-encrypted, git-backed store as the CLI instead of GNOME Keyring or KDE Wallet.

The feature is Linux-only and pure Go: D-Bus comes from godbus/dbus/v5 and all crypto from the standard library plus golang.org/x/crypto, and the volatile session collection uses golang.org/x/sys/unix. No CGo, no new dependencies.

Also correct ADR A-11, which had several errors: the prior art uses the gopass Go API (not the CLI); the DH key schedule is HKDF-SHA256, not a bare SHA256; item IDs must be hyphen-free to be valid D-Bus path elements; and the volatile `session` collection plus a metadata cache for SearchItems were missing from the design.

Implemented:
- transport sessions "plain" and "dh-ietf1024-sha256-aes128-cbc-pkcs7" (HKDF key derivation, left-padded DH values), unit-tested on all hosts
- Service, Collection, Item and Session objects via godbus + prop, with introspection XML
- gopass API-backed store with an in-memory item metadata cache so SearchItems does not decrypt the store on every lookup, plus aliases and in-memory lock state
- volatile `session` collection, served from the Linux kernel keyring on a runtime.LockOSThread-pinned thread (in-memory fallback when keyctl is unavailable). Payloads never reach the store, so transient credentials cannot become GPG files or git commits.
- CreateItem(replace=true), the item Locked property, and full signal coverage (ItemCreated, ItemChanged, ItemDeleted, CollectionChanged)
- CLI: `gopass secret-service serve [--replace] [--prefix] [--notify-on-access]`, `status`, `install` and `uninstall`, plus a non-Linux stub
- install/uninstall write a systemd user unit and a D-Bus session activation file below the XDG config/data dirs; reference copies ship in contrib/secret-service/
- Store.Aliases and docs/commands/secret-service.md

libsecret compatibility:
- libsecret does not call ReadAlias. It derives /org/freedesktop/secrets/aliases/<alias> locally and then calls CreateItem on that path, so `secret-tool store` failed with UnknownInterface. Export a Collection object at every alias path and emit collection signals from each of them.
- D-Bus object path elements may not contain hyphens, so items created out of band by the CLI (e.g. `cli-inserted`) produced invalid object paths and could not be served. Encode such names as `x`+hex; names that are already safe and do not start with `x` stay verbatim, so generated item IDs keep their historic layout.

Tests:
- integration tests against a private dbus-daemon covering both transport algorithms, the session collection, install/uninstall and status (tests/secret_service_test.go, tests/secret_service_dh_test.go)
- a libsecret interoperability test driving the daemon with secret-tool, which also exercises the DH transport against a real client (tests/secret_service_libsecret_test.go)
- unit tests for the vault and session store, the item ID mapping, and the systemd/D-Bus templates, which are asserted byte-identical to contrib/secret-service/

main_test.go: command discovery invoked every command's Action, which started a daemon and claimed org.freedesktop.secrets on the real session bus. Skip long-running commands and correct the asserted command count.

Docs: mark ADR A-11 implemented (and its index entry), and document serve, status, install and uninstall plus the remaining limitations.

Validated with make test, the integration tests above, and linux, windows and darwin builds.