### PR TITLE
fix(show): keep metadata off stdout

### DIFF
--- a/internal/action/find.go
+++ b/internal/action/find.go
@@ -85,7 +85,7 @@ func (s *searchHandler) find(ctx context.Context, cmd *cli.Command, needle strin
 
 			return nil
 		}
-		out.OKf(ctx, "Found exact match in %q", choices[0])
+		out.PrintStderrf(ctx, "✅ Found exact match in %q", choices[0])
 
 		return cb(ctx, cmd, choices[0], false)
 	}

--- a/internal/action/find_test.go
+++ b/internal/action/find_test.go
@@ -35,11 +35,14 @@ func TestFind(t *testing.T) {
 	require.NoError(t, act.cfg.Set("", "generate.autoclip", "false"))
 
 	buf := &bytes.Buffer{}
+	stderrBuf := &bytes.Buffer{}
 	out.Stdout = buf
+	out.Stderr = stderrBuf
 	stdout = buf
 	defer func() {
 		stdout = os.Stdout
 		out.Stdout = os.Stdout
+		out.Stderr = os.Stderr
 	}()
 	color.NoColor = true
 
@@ -57,33 +60,38 @@ func TestFind(t *testing.T) {
 	// find fo (with fuzzy search)
 	c = gptest.CliCtxWithFlags(ctx, t, nil, "fo")
 	require.NoError(t, act.FindFuzzy(ctx, c))
-	assert.Contains(t, strings.TrimSpace(buf.String()), "Found exact match in \"foo\"\nsecret")
+	assert.Contains(t, strings.TrimSpace(buf.String()), "secret\nsecond\nthird")
+	assert.Contains(t, stderrBuf.String(), `Found exact match in "foo"`)
 	buf.Reset()
+	stderrBuf.Reset()
 
 	// find fo (no fuzzy search)
 	c = gptest.CliCtxWithFlags(ctx, t, nil, "fo")
 	require.NoError(t, act.Find(ctx, c))
 	assert.Equal(t, "foo", strings.TrimSpace(buf.String()))
 	buf.Reset()
+	stderrBuf.Reset()
 
 	// testing the safecontent case
 	require.NoError(t, act.cfg.Set("", "show.safecontent", "true"))
 	require.NoError(t, act.FindFuzzy(ctx, c))
 	buf.Reset()
+	stderrBuf.Reset()
 
 	// testing with the clip flag set
 	c = gptest.CliCtxWithFlags(ctx, t, map[string]string{"clip": "true"}, "fo")
 	require.NoError(t, act.FindFuzzy(ctx, c))
-	out := strings.TrimSpace(buf.String())
-	assert.Contains(t, out, "Found exact match in \"foo\"")
+	assert.Contains(t, stderrBuf.String(), `Found exact match in "foo"`)
 	buf.Reset()
+	stderrBuf.Reset()
 
 	// safecontent case with force flag set
 	c = gptest.CliCtxWithFlags(ctx, t, map[string]string{"unsafe": "true"}, "fo")
 	require.NoError(t, act.FindFuzzy(ctx, c))
-	out = strings.TrimSpace(buf.String())
-	assert.Contains(t, out, "Found exact match in \"foo\"\nsecret")
+	assert.Contains(t, strings.TrimSpace(buf.String()), "secret\nsecond\nthird")
+	assert.Contains(t, stderrBuf.String(), `Found exact match in "foo"`)
 	buf.Reset()
+	stderrBuf.Reset()
 
 	// stopping with the safecontent tests
 	require.NoError(t, act.cfg.Set("", "show.safecontent", "false"))

--- a/internal/action/show.go
+++ b/internal/action/show.go
@@ -320,7 +320,7 @@ func (s *secretHandler) showHandleOutput(ctx context.Context, name string, sec g
 		if HasKey(ctx) {
 			header += fmt.Sprintf("Key: %s\n", GetKey(ctx))
 		}
-		out.Print(ctx, header)
+		out.PrintStderr(ctx, header)
 	}
 
 	// output the actual secret, newlines are handled by ctx and Print.

--- a/internal/action/show_test.go
+++ b/internal/action/show_test.go
@@ -599,6 +599,39 @@ func TestShowHandleError(t *testing.T) {
 	buf.Reset()
 }
 
+func TestShowFuzzySearchOutputStreams(t *testing.T) {
+	u := gptest.NewUnitTester(t)
+
+	ctx := config.NewContextInMemory()
+	ctx = ctxutil.WithAlwaysYes(ctx, true)
+	ctx = ctxutil.WithTerminal(ctx, true)
+	ctx = ctxutil.WithInteractive(ctx, false)
+
+	act, err := newMock(ctx, u.StoreDir(""))
+	require.NoError(t, err)
+	require.NotNil(t, act)
+	ctx = act.cfg.WithConfig(ctx)
+
+	color.NoColor = true
+	stdoutBuf := &bytes.Buffer{}
+	stderrBuf := &bytes.Buffer{}
+	out.Stdout = stdoutBuf
+	out.Stderr = stderrBuf
+	stdout = stdoutBuf
+	defer func() {
+		stdout = os.Stdout
+		out.Stdout = os.Stdout
+		out.Stderr = os.Stderr
+	}()
+
+	c := gptest.CliCtx(ctx, t, "fo")
+	require.NoError(t, act.Show(ctx, c))
+	assert.Equal(t, "secret\nsecond\nthird\n\n", stdoutBuf.String())
+	assert.Contains(t, stderrBuf.String(), `Entry "fo" not found. Starting search...`)
+	assert.Contains(t, stderrBuf.String(), `Found exact match in "foo"`)
+	assert.Contains(t, stderrBuf.String(), "Secret: foo")
+}
+
 func TestShowHandleErrorFuzzySearchToggle(t *testing.T) {
 	u := gptest.NewUnitTester(t)
 

--- a/internal/out/print.go
+++ b/internal/out/print.go
@@ -56,6 +56,24 @@ func Printf(ctx context.Context, format string, args ...any) {
 	fmt.Fprintf(Stdout, Prefix(ctx)+format+newline(ctx), args...)
 }
 
+// PrintStderr prints the given string to stderr.
+func PrintStderr(ctx context.Context, arg any) {
+	if ctxutil.IsHidden(ctx) {
+		return
+	}
+	debug.LogN(1, "%s", arg)
+	fmt.Fprintf(Stderr, Prefix(ctx)+"%s"+newline(ctx), arg)
+}
+
+// PrintStderrf formats and prints the given string to stderr.
+func PrintStderrf(ctx context.Context, format string, args ...any) {
+	if ctxutil.IsHidden(ctx) {
+		return
+	}
+	debug.LogN(1, format, args...)
+	fmt.Fprintf(Stderr, Prefix(ctx)+format+newline(ctx), args...)
+}
+
 // Notice prints the string with an exclamation mark.
 func Notice(ctx context.Context, arg any) {
 	if ctxutil.IsHidden(ctx) {

--- a/internal/out/print_test.go
+++ b/internal/out/print_test.go
@@ -30,3 +30,23 @@ func TestPrint(t *testing.T) {
 	assert.Equal(t, "foo = 42", buf.String())
 	buf.Reset()
 }
+
+func TestPrintStderr(t *testing.T) {
+	ctx := config.NewContextInMemory()
+	buf := &bytes.Buffer{}
+	Stderr = buf
+	defer func() {
+		Stderr = os.Stderr
+	}()
+
+	PrintStderrf(ctx, "%s = %d", "foo", 42)
+	assert.Equal(t, "foo = 42\n", buf.String())
+	buf.Reset()
+
+	PrintStderr(ctxutil.WithHidden(ctx, true), "hidden")
+	assert.Empty(t, buf.String())
+	buf.Reset()
+
+	PrintStderr(WithNewline(ctx, false), "foo")
+	assert.Equal(t, "foo", buf.String())
+}


### PR DESCRIPTION
Fuzzy lookup status and the interactive `Secret:`/`Key:` header were written to stdout alongside the actual secret data. Route those messages to stderr and add stream-specific coverage so stdout remains safe to pipe.

The existing lookup failure already uses stderr.

Fixes #2667

Testing: `make test`
